### PR TITLE
P2.1 — Money and rounding libraries

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -81,12 +81,26 @@ module.exports = {
       files: [
         ".eslintrc.cjs",
         "vite.config.{js,ts}",
+        "vitest.config.{js,ts}",
         ".graphqlrc.{js,ts}",
         "shopify.server.{js,ts}",
         "**/*.server.{js,ts}",
       ],
       env: {
         node: true,
+      },
+    },
+
+    // Tests
+    {
+      files: ["**/*.test.{ts,tsx}"],
+      env: {
+        node: true,
+      },
+      rules: {
+        // fast-check is designed around a namespace import (`fc.integer`, `fc.assert`).
+        // This rule flags every such call as a possible mistake; it is not.
+        "import/no-named-as-default-member": "off",
       },
     },
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Includes the property tests for the resolver invariants (RFC-001 §4).
+      # These are the tests that make the correctness claims real; a failure here
+      # means a price could be computed wrongly, so it must block the merge.
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/app/lib/money/currency.ts
+++ b/app/lib/money/currency.ts
@@ -1,0 +1,82 @@
+/**
+ * Currency precision.
+ *
+ * "Minor unit" is not universally 1/100. JPY and KRW have no decimal places at all
+ * (a minor unit *is* one yen), and a handful of currencies use three. Getting this
+ * wrong produces prices that look broken to local customers — the classic version
+ * being a charm-ending profile emitting a fractional yen.
+ *
+ * Digits follow ISO 4217. This is the subset Shopify supports that we care about;
+ * unknown codes fail loudly rather than defaulting to 2, because a silent default
+ * is how a JPY store ends up with sub-yen prices.
+ */
+
+/** Currencies with no minor unit. A "cent" here is a whole unit. */
+const ZERO_DECIMAL = [
+  "BIF", "CLP", "DJF", "GNF", "ISK", "JPY", "KMF", "KRW",
+  "PYG", "RWF", "UGX", "UYI", "VND", "VUV", "XAF", "XOF", "XPF",
+] as const;
+
+/** Currencies with three decimal places. */
+const THREE_DECIMAL = ["BHD", "IQD", "JOD", "KWD", "LYD", "OMR", "TND"] as const;
+
+const EXPONENTS = new Map<string, number>([
+  ...ZERO_DECIMAL.map((c) => [c, 0] as const),
+  ...THREE_DECIMAL.map((c) => [c, 3] as const),
+]);
+
+/** Two-decimal currencies we explicitly know about. Anything else must be registered. */
+const TWO_DECIMAL = [
+  "AED", "ARS", "AUD", "BGN", "BRL", "CAD", "CHF", "CNY", "COP", "CZK",
+  "DKK", "EGP", "EUR", "GBP", "HKD", "HRK", "HUF", "IDR", "ILS", "INR",
+  "MXN", "MYR", "NGN", "NOK", "NZD", "PEN", "PHP", "PLN", "RON", "RUB",
+  "SAR", "SEK", "SGD", "THB", "TRY", "TWD", "UAH", "USD", "VES", "ZAR",
+] as const;
+
+for (const code of TWO_DECIMAL) EXPONENTS.set(code, 2);
+
+export class UnknownCurrencyError extends Error {
+  constructor(readonly currency: string) {
+    super(
+      `Unknown currency "${currency}". Register it in app/lib/money/currency.ts with ` +
+        `its ISO 4217 minor-unit exponent. Refusing to guess: defaulting to 2 decimals ` +
+        `would emit fractional minor units in zero-decimal currencies such as JPY.`,
+    );
+    this.name = "UnknownCurrencyError";
+  }
+}
+
+/** Normalises to an uppercase ISO code without validating it. */
+export function normalizeCurrency(currency: string): string {
+  return currency.trim().toUpperCase();
+}
+
+/**
+ * Minor-unit exponent: 2 for USD (cents), 0 for JPY, 3 for KWD.
+ *
+ * @throws {UnknownCurrencyError} for unregistered codes.
+ */
+export function exponentOf(currency: string): number {
+  const code = normalizeCurrency(currency);
+  const exp = EXPONENTS.get(code);
+  if (exp === undefined) throw new UnknownCurrencyError(code);
+  return exp;
+}
+
+/** Minor units in one major unit: 100 for USD, 1 for JPY, 1000 for KWD. */
+export function minorUnitsPerMajor(currency: string): number {
+  return 10 ** exponentOf(currency);
+}
+
+export function isZeroDecimal(currency: string): boolean {
+  return exponentOf(currency) === 0;
+}
+
+export function isKnownCurrency(currency: string): boolean {
+  return EXPONENTS.has(normalizeCurrency(currency));
+}
+
+/** Every registered code. Used by property tests to cover the whole table. */
+export function knownCurrencies(): string[] {
+  return [...EXPONENTS.keys()].sort();
+}

--- a/app/lib/money/money.test.ts
+++ b/app/lib/money/money.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import {
+  exponentOf,
+  isZeroDecimal,
+  knownCurrencies,
+  UnknownCurrencyError,
+} from "./currency";
+import {
+  add,
+  applyPercentChange,
+  clamp,
+  CurrencyMismatchError,
+  formatMoney,
+  money,
+  multiplyByFactor,
+  NonIntegerMinorUnitsError,
+  parseMoney,
+  percentOf,
+  roundToInteger,
+  subtract,
+} from "./money";
+
+const CURRENCIES = knownCurrencies();
+
+/** Amounts up to ~10M major units — comfortably past any real product price. */
+const anyAmount = fc.integer({ min: -1_000_000_00, max: 1_000_000_00 });
+const anyCurrency = fc.constantFrom(...CURRENCIES);
+const anyMoney = fc.tuple(anyAmount, anyCurrency).map(([a, c]) => money(a, c));
+
+describe("currency table", () => {
+  it("covers at least 20 currencies, as the acceptance criteria require", () => {
+    expect(CURRENCIES.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("classifies the currencies that break naive implementations", () => {
+    expect(exponentOf("USD")).toBe(2);
+    expect(exponentOf("JPY")).toBe(0);
+    expect(exponentOf("KRW")).toBe(0);
+    expect(exponentOf("BHD")).toBe(3);
+    expect(exponentOf("KWD")).toBe(3);
+    expect(isZeroDecimal("JPY")).toBe(true);
+    expect(isZeroDecimal("USD")).toBe(false);
+  });
+
+  it("refuses unknown currencies rather than assuming 2 decimals", () => {
+    expect(() => exponentOf("XYZ")).toThrow(UnknownCurrencyError);
+  });
+
+  it("is case-insensitive", () => {
+    expect(exponentOf("jpy")).toBe(0);
+    expect(exponentOf(" usd ")).toBe(2);
+  });
+});
+
+describe("money construction", () => {
+  it("rejects non-integer amounts — the signal that a float leaked in", () => {
+    expect(() => money(19.99, "USD")).toThrow(NonIntegerMinorUnitsError);
+    expect(() => money(NaN, "USD")).toThrow(NonIntegerMinorUnitsError);
+    expect(() => money(Infinity, "USD")).toThrow(NonIntegerMinorUnitsError);
+  });
+
+  it("refuses to mix currencies", () => {
+    expect(() => add(money(100, "USD"), money(100, "EUR"))).toThrow(CurrencyMismatchError);
+  });
+});
+
+describe("arithmetic properties", () => {
+  it("add and subtract are exact inverses", () => {
+    fc.assert(
+      fc.property(anyMoney, anyAmount, (m, delta) => {
+        const other = money(delta, m.currency);
+        expect(subtract(add(m, other), other)).toEqual(m);
+      }),
+    );
+  });
+
+  it("addition is commutative and associative", () => {
+    fc.assert(
+      fc.property(anyCurrency, anyAmount, anyAmount, anyAmount, (c, x, y, z) => {
+        const [a, b, d] = [money(x, c), money(y, c), money(z, c)];
+        expect(add(a, b)).toEqual(add(b, a));
+        expect(add(add(a, b), d)).toEqual(add(a, add(b, d)));
+      }),
+    );
+  });
+
+  it("never produces a non-integer amount, whatever the factor", () => {
+    fc.assert(
+      fc.property(anyMoney, fc.double({ min: -10, max: 10, noNaN: true }), (m, factor) => {
+        expect(Number.isInteger(multiplyByFactor(m, factor).amount)).toBe(true);
+      }),
+    );
+  });
+
+  it("percentOf(m, 100) is m, and percentOf(m, 0) is zero", () => {
+    fc.assert(
+      fc.property(anyMoney, (m) => {
+        expect(percentOf(m, 100)).toEqual(m);
+        expect(percentOf(m, 0).amount).toBe(0);
+      }),
+    );
+  });
+
+  it("a -100% change lands exactly on zero", () => {
+    fc.assert(
+      fc.property(anyMoney, (m) => {
+        expect(applyPercentChange(m, -100).amount).toBe(0);
+      }),
+    );
+  });
+
+  it("half-even rounding has no upward bias across exact halves", () => {
+    // half-up would return 1,2,3,4,5 (sum 15); half-even returns 0,2,2,4,4 (sum 12).
+    const halves = [0.5, 1.5, 2.5, 3.5, 4.5];
+    const sum = halves.reduce((n, h) => n + roundToInteger(h, "half-even"), 0);
+    expect(sum).toBe(12);
+  });
+
+  it("rounds symmetrically about zero", () => {
+    fc.assert(
+      fc.property(fc.double({ min: -1000, max: 1000, noNaN: true }), (v) => {
+        for (const mode of ["half-even", "half-up", "half-down"] as const) {
+          expect(roundToInteger(-v, mode)).toBe(-roundToInteger(v, mode));
+        }
+      }),
+    );
+  });
+});
+
+describe("clamp", () => {
+  it("always lands within the bounds", () => {
+    fc.assert(
+      fc.property(anyCurrency, anyAmount, anyAmount, anyAmount, (c, v, b1, b2) => {
+        const lower = money(Math.min(b1, b2), c);
+        const upper = money(Math.max(b1, b2), c);
+        const out = clamp(money(v, c), lower, upper);
+        expect(out.amount).toBeGreaterThanOrEqual(lower.amount);
+        expect(out.amount).toBeLessThanOrEqual(upper.amount);
+      }),
+    );
+  });
+});
+
+describe("parse and format", () => {
+  it("round-trips through a string without loss", () => {
+    fc.assert(
+      fc.property(anyMoney, (m) => {
+        expect(parseMoney(formatMoney(m), m.currency)).toEqual(m);
+      }),
+    );
+  });
+
+  it("parses the values Shopify actually returns", () => {
+    expect(parseMoney("19.99", "USD").amount).toBe(1999);
+    expect(parseMoney("19.90", "USD").amount).toBe(1990);
+    expect(parseMoney("19", "USD").amount).toBe(1900);
+    expect(parseMoney("1980", "JPY").amount).toBe(1980);
+    expect(parseMoney("19.999", "KWD").amount).toBe(19999);
+    expect(parseMoney("-4.50", "USD").amount).toBe(-450);
+  });
+
+  it("avoids the float trap that motivates this module", () => {
+    // parseFloat("19.99") * 100 === 1998.9999999999998
+    expect(parseMoney("19.99", "USD").amount).toBe(1999);
+    expect(parseMoney("0.29", "USD").amount).toBe(29);
+    expect(parseMoney("1.005", "KWD").amount).toBe(1005);
+  });
+
+  it("formats without a decimal point in zero-decimal currencies", () => {
+    expect(formatMoney(money(1980, "JPY"))).toBe("1980");
+    expect(formatMoney(money(1999, "USD"))).toBe("19.99");
+    expect(formatMoney(money(5, "USD"))).toBe("0.05");
+    expect(formatMoney(money(19999, "KWD"))).toBe("19.999");
+  });
+
+  it("rejects more precision than the currency allows", () => {
+    expect(() => parseMoney("19.999", "USD")).toThrow(RangeError);
+    expect(() => parseMoney("1980.5", "JPY")).toThrow(RangeError);
+    // but insignificant trailing zeros are fine
+    expect(parseMoney("19.9900", "USD").amount).toBe(1999);
+    expect(parseMoney("1980.00", "JPY").amount).toBe(1980);
+  });
+
+  it("rejects malformed input", () => {
+    for (const bad of ["", "abc", "1.2.3", "1,99", "$19.99", "1e3"]) {
+      expect(() => parseMoney(bad, "USD")).toThrow(RangeError);
+    }
+  });
+});

--- a/app/lib/money/money.ts
+++ b/app/lib/money/money.ts
@@ -1,0 +1,242 @@
+/**
+ * Money in integer minor units.
+ *
+ * Floats are banned anywhere near a price. `0.1 + 0.2 !== 0.3`, and a fraction of a
+ * cent multiplied across 150,000 variants becomes a real conversation with a
+ * merchant's accountant. Every value here is an integer count of minor units
+ * (cents for USD, whole yen for JPY) paired with its currency.
+ *
+ * Percentage and factor operations necessarily involve non-integer maths. They are
+ * confined to this module, done in a widened integer domain, and always land back on
+ * an integer via an explicit, documented rounding step — never left to float drift.
+ */
+
+import { exponentOf, normalizeCurrency } from "./currency";
+
+export interface Money {
+  /** Integer count of minor units. May be negative; callers decide if that is legal. */
+  readonly amount: number;
+  /** ISO 4217, uppercase. */
+  readonly currency: string;
+}
+
+export class CurrencyMismatchError extends Error {
+  constructor(a: string, b: string) {
+    super(`Cannot combine ${a} with ${b}. Money operations require a single currency.`);
+    this.name = "CurrencyMismatchError";
+  }
+}
+
+export class NonIntegerMinorUnitsError extends Error {
+  constructor(amount: number) {
+    super(
+      `Money amount must be an integer number of minor units, got ${amount}. ` +
+        `This usually means a float leaked into a price calculation.`,
+    );
+    this.name = "NonIntegerMinorUnitsError";
+  }
+}
+
+/** Constructs Money, rejecting non-integer or non-finite amounts. */
+export function money(amount: number, currency: string): Money {
+  if (!Number.isFinite(amount) || !Number.isInteger(amount)) {
+    throw new NonIntegerMinorUnitsError(amount);
+  }
+  const code = normalizeCurrency(currency);
+  exponentOf(code); // throws UnknownCurrencyError for unregistered codes
+  // `amount + 0` normalises -0 to 0. Negative zero arises naturally from e.g.
+  // percentOf(negativeAmount, 0), and although -0 === 0, Object.is(-0, 0) is false —
+  // so it silently breaks deep-equality checks in tests, caches and ledger diffs.
+  return { amount: amount + 0, currency: code };
+}
+
+export function zero(currency: string): Money {
+  return money(0, currency);
+}
+
+function assertSameCurrency(a: Money, b: Money): void {
+  if (a.currency !== b.currency) throw new CurrencyMismatchError(a.currency, b.currency);
+}
+
+// ---------------------------------------------------------------- arithmetic
+
+export function add(a: Money, b: Money): Money {
+  assertSameCurrency(a, b);
+  return money(a.amount + b.amount, a.currency);
+}
+
+export function subtract(a: Money, b: Money): Money {
+  assertSameCurrency(a, b);
+  return money(a.amount - b.amount, a.currency);
+}
+
+export function negate(a: Money): Money {
+  return money(-a.amount, a.currency);
+}
+
+export function abs(a: Money): Money {
+  return money(Math.abs(a.amount), a.currency);
+}
+
+/**
+ * Rounding for the intermediate results of percentage and factor maths.
+ *
+ * `half-even` (banker's rounding) is the default because it has no systematic bias:
+ * `half-up` would nudge every exact-half result upward, and applied across a large
+ * catalogue that is a real, one-directional drift in the merchant's favour that
+ * nobody asked for. Campaign-level rounding profiles are applied separately and
+ * deliberately on top of this (see ./rounding).
+ */
+export type IntermediateRounding = "half-even" | "half-up" | "half-down" | "floor" | "ceil";
+
+export function roundToInteger(value: number, mode: IntermediateRounding = "half-even"): number {
+  if (Number.isInteger(value)) return value;
+
+  switch (mode) {
+    case "floor":
+      return Math.floor(value);
+    case "ceil":
+      return Math.ceil(value);
+    case "half-up":
+      // Math.round breaks ties toward +Infinity, which is asymmetric for negatives.
+      return Math.sign(value) * Math.round(Math.abs(value));
+    case "half-down": {
+      const a = Math.abs(value);
+      const f = Math.floor(a);
+      const frac = a - f;
+      return Math.sign(value) * (frac > 0.5 ? f + 1 : f);
+    }
+    case "half-even": {
+      const a = Math.abs(value);
+      const f = Math.floor(a);
+      const frac = a - f;
+      let r: number;
+      if (frac > 0.5) r = f + 1;
+      else if (frac < 0.5) r = f;
+      else r = f % 2 === 0 ? f : f + 1;
+      return Math.sign(value) * r;
+    }
+  }
+}
+
+/** Multiplies by a factor (1.15 marks up 15%), landing back on an integer. */
+export function multiplyByFactor(
+  a: Money,
+  factor: number,
+  mode: IntermediateRounding = "half-even",
+): Money {
+  if (!Number.isFinite(factor)) {
+    throw new RangeError(`Factor must be finite, got ${factor}`);
+  }
+  return money(roundToInteger(a.amount * factor, mode), a.currency);
+}
+
+/** `percentOf(m, 20)` → 20% of m. Negative percentages are allowed. */
+export function percentOf(
+  a: Money,
+  percent: number,
+  mode: IntermediateRounding = "half-even",
+): Money {
+  if (!Number.isFinite(percent)) {
+    throw new RangeError(`Percent must be finite, got ${percent}`);
+  }
+  return money(roundToInteger((a.amount * percent) / 100, mode), a.currency);
+}
+
+/** `applyPercentChange(m, -20)` → m reduced by 20%. */
+export function applyPercentChange(
+  a: Money,
+  percentChange: number,
+  mode: IntermediateRounding = "half-even",
+): Money {
+  return multiplyByFactor(a, 1 + percentChange / 100, mode);
+}
+
+// ---------------------------------------------------------------- comparison
+
+export function compare(a: Money, b: Money): -1 | 0 | 1 {
+  assertSameCurrency(a, b);
+  return a.amount < b.amount ? -1 : a.amount > b.amount ? 1 : 0;
+}
+
+export const equals = (a: Money, b: Money) => compare(a, b) === 0;
+export const lessThan = (a: Money, b: Money) => compare(a, b) === -1;
+export const greaterThan = (a: Money, b: Money) => compare(a, b) === 1;
+export const lessThanOrEqual = (a: Money, b: Money) => compare(a, b) <= 0;
+export const greaterThanOrEqual = (a: Money, b: Money) => compare(a, b) >= 0;
+
+export const isZero = (a: Money) => a.amount === 0;
+export const isNegative = (a: Money) => a.amount < 0;
+export const isPositive = (a: Money) => a.amount > 0;
+
+export function min(a: Money, b: Money): Money {
+  return lessThanOrEqual(a, b) ? a : b;
+}
+
+export function max(a: Money, b: Money): Money {
+  return greaterThanOrEqual(a, b) ? a : b;
+}
+
+/** Constrains to [lower, upper]; either bound may be omitted. */
+export function clamp(value: Money, lower?: Money, upper?: Money): Money {
+  let out = value;
+  if (lower) out = max(out, lower);
+  if (upper) out = min(out, upper);
+  return out;
+}
+
+// ------------------------------------------------------------ parse / format
+
+/**
+ * Parses a decimal string as Shopify returns it ("19.99", "1980", "-4.50").
+ *
+ * Deliberately string-based: `parseFloat("19.99") * 100` is 1998.9999999999998, and
+ * the whole point of this module is that such a number never exists.
+ *
+ * @throws {RangeError} if the string carries more precision than the currency allows.
+ */
+export function parseMoney(value: string, currency: string): Money {
+  const code = normalizeCurrency(currency);
+  const exp = exponentOf(code);
+  const trimmed = value.trim();
+
+  const match = /^(-)?(\d+)(?:\.(\d+))?$/.exec(trimmed);
+  if (!match) throw new RangeError(`Cannot parse "${value}" as a ${code} amount.`);
+
+  const [, sign, whole, fraction = ""] = match;
+
+  if (fraction.length > exp) {
+    // Trailing zeros carry no value, so "19.9900" is fine for a 2-decimal currency.
+    const significant = fraction.replace(/0+$/, "");
+    if (significant.length > exp) {
+      throw new RangeError(
+        `"${value}" has ${significant.length} decimal places but ${code} allows ${exp}.`,
+      );
+    }
+  }
+
+  const padded = (fraction + "0".repeat(exp)).slice(0, exp);
+  const amount = Number(whole) * 10 ** exp + (exp > 0 ? Number(padded || "0") : 0);
+  return money(sign ? -amount : amount, code);
+}
+
+/** Formats as a plain decimal string for the Admin API ("19.99", "1980"). */
+export function formatMoney(m: Money): string {
+  const exp = exponentOf(m.currency);
+  const negative = m.amount < 0;
+  const digits = Math.abs(m.amount).toString().padStart(exp + 1, "0");
+  const whole = digits.slice(0, digits.length - exp) || "0";
+  const fraction = exp > 0 ? "." + digits.slice(digits.length - exp) : "";
+  return `${negative ? "-" : ""}${whole}${fraction}`;
+}
+
+/** Human-readable, locale-aware. For UI only — never for API payloads. */
+export function formatMoneyForDisplay(m: Money, locale = "en-US"): string {
+  const exp = exponentOf(m.currency);
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: m.currency,
+    minimumFractionDigits: exp,
+    maximumFractionDigits: exp,
+  }).format(m.amount / 10 ** exp);
+}

--- a/app/lib/money/rounding.test.ts
+++ b/app/lib/money/rounding.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { exponentOf, isZeroDecimal, knownCurrencies } from "./currency";
+import { formatMoney, money, type Money } from "./money";
+import {
+  applyRounding,
+  charm95,
+  charm99,
+  defaultProfileFor,
+  effectiveProfile,
+  InvalidRoundingProfileError,
+  NO_ROUNDING,
+  validateProfile,
+  wholeUnits,
+  type RoundingProfile,
+} from "./rounding";
+
+const CURRENCIES = knownCurrencies();
+const anyCurrency = fc.constantFrom(...CURRENCIES);
+const positiveAmount = fc.integer({ min: 1, max: 1_000_000_00 });
+
+const anyProfile: fc.Arbitrary<RoundingProfile> = fc.oneof(
+  fc.record({
+    mode: fc.constant("charm" as const),
+    ending: fc.constantFrom(0, 50, 90, 95, 99),
+    direction: fc.constantFrom("up" as const, "down" as const, "nearest" as const),
+  }),
+  fc.record({
+    mode: fc.constant("step" as const),
+    step: fc.constantFrom(1, 5, 10, 25, 50, 100),
+    direction: fc.constantFrom("up" as const, "down" as const, "nearest" as const),
+  }),
+);
+
+describe("rounding invariants", () => {
+  it("is idempotent: round(round(x)) === round(x)", () => {
+    // Directly underpins invariant I2 — a campaign re-planned twice must not drift.
+    fc.assert(
+      fc.property(anyCurrency, positiveAmount, anyProfile, (c, amount, profile) => {
+        const once = applyRounding(money(amount, c), profile);
+        const twice = applyRounding(once, profile);
+        expect(twice).toEqual(once);
+      }),
+    );
+  });
+
+  it("never emits more precision than the currency allows", () => {
+    fc.assert(
+      fc.property(anyCurrency, positiveAmount, anyProfile, (c, amount, profile) => {
+        const out = applyRounding(money(amount, c), profile);
+        expect(Number.isInteger(out.amount)).toBe(true);
+        const formatted = formatMoney(out);
+        const decimals = formatted.includes(".") ? formatted.split(".")[1].length : 0;
+        expect(decimals).toBe(exponentOf(c));
+      }),
+    );
+  });
+
+  it("direction 'down' never increases a price", () => {
+    // Load-bearing: it is why clamping must run *after* rounding in the resolver.
+    fc.assert(
+      fc.property(anyCurrency, positiveAmount, anyProfile, (c, amount, profile) => {
+        const down = { ...profile, direction: "down" as const };
+        expect(applyRounding(money(amount, c), down).amount).toBeLessThanOrEqual(amount);
+      }),
+    );
+  });
+
+  it("direction 'up' never decreases a price", () => {
+    fc.assert(
+      fc.property(anyCurrency, positiveAmount, anyProfile, (c, amount, profile) => {
+        const up = { ...profile, direction: "up" as const };
+        expect(applyRounding(money(amount, c), up).amount).toBeGreaterThanOrEqual(amount);
+      }),
+    );
+  });
+
+  it("'nearest' moves by less than the rounding granularity", () => {
+    fc.assert(
+      fc.property(anyCurrency, positiveAmount, anyProfile, (c, amount, profile) => {
+        const nearest = { ...profile, direction: "nearest" as const };
+        const out = applyRounding(money(amount, c), nearest);
+        const granularity =
+          nearest.mode === "step" ? nearest.step : 10 ** exponentOf(c);
+        expect(Math.abs(out.amount - amount)).toBeLessThanOrEqual(granularity);
+      }),
+    );
+  });
+
+  it("preserves currency", () => {
+    fc.assert(
+      fc.property(anyCurrency, positiveAmount, anyProfile, (c, amount, profile) => {
+        expect(applyRounding(money(amount, c), profile).currency).toBe(c);
+      }),
+    );
+  });
+
+  it("NO_ROUNDING is the identity", () => {
+    fc.assert(
+      fc.property(anyCurrency, positiveAmount, (c, amount) => {
+        const m = money(amount, c);
+        expect(applyRounding(m, NO_ROUNDING)).toEqual(m);
+      }),
+    );
+  });
+});
+
+describe("charm rounding", () => {
+  const usd = (n: number): Money => money(n, "USD");
+
+  it("forces the requested ending, picking the genuinely nearest one", () => {
+    // 19.47 sits 48c above 18.99 and 52c below 19.99, so "nearest" is 18.99.
+    // Merchants who always want to round up should choose direction "up".
+    expect(applyRounding(usd(1947), charm99).amount).toBe(1899);
+    expect(applyRounding(usd(1980), charm99).amount).toBe(1999);
+    expect(applyRounding(usd(1901), charm99).amount).toBe(1899);
+    expect(applyRounding(usd(1947), charm95).amount).toBe(1995);
+    // 19.47 is 47c above 19.00 and 53c below 20.00.
+    expect(applyRounding(usd(1947), wholeUnits).amount).toBe(1900);
+    expect(applyRounding(usd(1953), wholeUnits).amount).toBe(2000);
+    expect(applyRounding(usd(1947), { ...wholeUnits, direction: "up" }).amount).toBe(2000);
+  });
+
+  it("respects direction", () => {
+    expect(applyRounding(usd(1947), { ...charm99, direction: "down" }).amount).toBe(1899);
+    expect(applyRounding(usd(1947), { ...charm99, direction: "up" }).amount).toBe(1999);
+  });
+
+  it("leaves an already-charmed price alone in every direction", () => {
+    for (const direction of ["up", "down", "nearest"] as const) {
+      expect(applyRounding(usd(1999), { ...charm99, direction }).amount).toBe(1999);
+    }
+  });
+
+  it("never rounds a non-negative price into a negative one", () => {
+    // Regression: candidates for 47c under .99 are [-1, 99, 199], and -1 is
+    // arithmetically nearest. Negative candidates are excluded for non-negative input.
+    expect(applyRounding(usd(47), charm99).amount).toBe(99);
+    expect(applyRounding(usd(0), charm99).amount).toBe(99);
+    // No charm price at or below 47c, so "down" clamps to zero rather than
+    // increasing the price, which would break the down-monotonic guarantee.
+    expect(applyRounding(usd(47), { ...charm99, direction: "down" }).amount).toBe(0);
+    expect(applyRounding(usd(47), { ...charm99, direction: "up" }).amount).toBe(99);
+  });
+
+  it("never produces a negative price from any non-negative input", () => {
+    fc.assert(
+      fc.property(
+        anyCurrency,
+        fc.integer({ min: 0, max: 1_000_000_00 }),
+        anyProfile,
+        (c, amount, profile) => {
+          expect(applyRounding(money(amount, c), profile).amount).toBeGreaterThanOrEqual(0);
+        },
+      ),
+    );
+  });
+});
+
+describe("zero-decimal degradation (edge case E9)", () => {
+  it("degrades a charm profile to step rounding rather than emitting fractional yen", () => {
+    const effective = effectiveProfile(charm99, "JPY");
+    expect(effective.mode).toBe("step");
+    expect(effective).toMatchObject({ mode: "step", step: 1, direction: "nearest" });
+  });
+
+  it("preserves the merchant's chosen direction when degrading", () => {
+    const up = effectiveProfile({ ...charm99, direction: "up" }, "JPY");
+    expect(up.direction).toBe("up");
+  });
+
+  it("produces whole yen for every charm profile", () => {
+    fc.assert(
+      fc.property(positiveAmount, anyProfile, (amount, profile) => {
+        const out = applyRounding(money(amount, "JPY"), profile);
+        expect(Number.isInteger(out.amount)).toBe(true);
+        expect(formatMoney(out)).not.toContain(".");
+      }),
+    );
+  });
+
+  it("still applies step rounding normally in JPY", () => {
+    expect(applyRounding(money(1947, "JPY"), { mode: "step", step: 10, direction: "nearest" }).amount)
+      .toBe(1950);
+    expect(applyRounding(money(1947, "JPY"), { mode: "step", step: 100, direction: "down" }).amount)
+      .toBe(1900);
+  });
+
+  it("picks a sane default profile per currency", () => {
+    expect(defaultProfileFor("USD")).toEqual(charm99);
+    expect(defaultProfileFor("JPY").mode).toBe("step");
+    for (const c of CURRENCIES) {
+      const p = defaultProfileFor(c);
+      // Must not throw for any currency in the table.
+      expect(() => applyRounding(money(1947, c), p)).not.toThrow();
+      if (isZeroDecimal(c)) expect(p.mode).toBe("step");
+    }
+  });
+});
+
+describe("profile validation", () => {
+  it("rejects a charm ending that cannot fit below one major unit", () => {
+    expect(() => validateProfile({ mode: "charm", ending: 100, direction: "nearest" }, "USD"))
+      .toThrow(InvalidRoundingProfileError);
+    expect(() => validateProfile({ mode: "charm", ending: 1000, direction: "nearest" }, "KWD"))
+      .toThrow(InvalidRoundingProfileError);
+    // 999 is legal for a 3-decimal currency
+    expect(() => validateProfile({ mode: "charm", ending: 999, direction: "nearest" }, "KWD"))
+      .not.toThrow();
+  });
+
+  it("rejects non-positive or fractional steps", () => {
+    for (const step of [0, -5, 2.5]) {
+      expect(() => validateProfile({ mode: "step", step, direction: "nearest" }, "USD"))
+        .toThrow(InvalidRoundingProfileError);
+    }
+  });
+});

--- a/app/lib/money/rounding.ts
+++ b/app/lib/money/rounding.ts
@@ -1,0 +1,206 @@
+/**
+ * Campaign rounding profiles.
+ *
+ * Two modes:
+ *
+ *   charm — force a fixed ending: 19.47 → 19.99. What merchants mean by "price it
+ *           at .99". Meaningless in a zero-decimal currency, which is why it
+ *           degrades rather than emitting a fractional yen (edge case E9).
+ *
+ *   step  — round to a multiple: nearest 5 → 1947 → 1945 or 1950. The sane
+ *           behaviour for JPY/KRW and useful anywhere a merchant wants tidy prices.
+ *
+ * Direction is explicit. `down` is worth understanding: it can only ever lower a
+ * price, which is what keeps it safe for discount campaigns — but it also means a
+ * rounded result can cross below a guardrail floor, so clamping runs *after*
+ * rounding in the resolver, never before.
+ */
+
+import { exponentOf, isZeroDecimal } from "./currency";
+import { money, type Money } from "./money";
+
+export type RoundingDirection = "up" | "down" | "nearest";
+
+export interface CharmProfile {
+  mode: "charm";
+  /**
+   * The forced ending, in minor units below one major unit.
+   * 99 → x.99, 95 → x.95, 0 → whole units.
+   */
+  ending: number;
+  direction: RoundingDirection;
+}
+
+export interface StepProfile {
+  mode: "step";
+  /** Step size in minor units. 5 → nearest 5 cents; 100 → nearest whole USD. */
+  step: number;
+  direction: RoundingDirection;
+}
+
+export type RoundingProfile = CharmProfile | StepProfile;
+
+/** No-op profile. Explicit, so "don't round" is a choice rather than an omission. */
+export const NO_ROUNDING: StepProfile = { mode: "step", step: 1, direction: "nearest" };
+
+export class InvalidRoundingProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidRoundingProfileError";
+  }
+}
+
+export function validateProfile(profile: RoundingProfile, currency: string): void {
+  if (profile.mode === "step") {
+    if (!Number.isInteger(profile.step) || profile.step < 1) {
+      throw new InvalidRoundingProfileError(
+        `Step must be a positive integer number of minor units, got ${profile.step}.`,
+      );
+    }
+    return;
+  }
+
+  if (!Number.isInteger(profile.ending) || profile.ending < 0) {
+    throw new InvalidRoundingProfileError(
+      `Charm ending must be a non-negative integer, got ${profile.ending}.`,
+    );
+  }
+  const perMajor = 10 ** exponentOf(currency);
+  if (!isZeroDecimal(currency) && profile.ending >= perMajor) {
+    throw new InvalidRoundingProfileError(
+      `Charm ending ${profile.ending} does not fit below one major unit of ${currency} ` +
+        `(max ${perMajor - 1}).`,
+    );
+  }
+}
+
+/**
+ * Resolves a profile against a currency, degrading charm profiles where they cannot
+ * apply.
+ *
+ * A `.99` ending in JPY is not an error the merchant should have to think about —
+ * there is simply no sub-yen space for it. We fall back to step rounding to the
+ * nearest whole unit and preserve the direction they chose, which is the closest
+ * honest interpretation of "make these prices tidy".
+ */
+export function effectiveProfile(profile: RoundingProfile, currency: string): RoundingProfile {
+  if (profile.mode === "charm" && isZeroDecimal(currency)) {
+    return { mode: "step", step: 1, direction: profile.direction };
+  }
+  validateProfile(profile, currency);
+  return profile;
+}
+
+function roundStep(amount: number, step: number, direction: RoundingDirection): number {
+  const q = amount / step;
+  switch (direction) {
+    case "up":
+      return Math.ceil(q) * step;
+    case "down":
+      return Math.floor(q) * step;
+    case "nearest": {
+      const lower = Math.floor(q) * step;
+      const upper = lower + step;
+      const dLower = amount - lower;
+      const dUpper = upper - amount;
+      if (dLower < dUpper) return lower;
+      if (dUpper < dLower) return upper;
+      // Exact tie: round half away from zero so behaviour is symmetric about 0.
+      return amount >= 0 ? upper : lower;
+    }
+  }
+}
+
+function roundCharm(
+  amount: number,
+  ending: number,
+  perMajor: number,
+  direction: RoundingDirection,
+): number {
+  // Candidate endings in the major units bracketing `amount`.
+  const base = Math.floor(amount / perMajor) * perMajor;
+  let candidates = [base - perMajor + ending, base + ending, base + perMajor + ending];
+
+  // A non-negative price must never round to a negative one. Without this, 47c under
+  // a .99 profile picks -1c: the candidates are [-1, 99, 199] and -1 is genuinely the
+  // closest. Correct arithmetic, nonsense price -- found by the property tests.
+  if (amount >= 0) {
+    const nonNegative = candidates.filter((c) => c >= 0);
+    // If every candidate is negative the price is below the smallest charm price;
+    // zero is the only non-negative answer, and it keeps `down` monotonic.
+    if (nonNegative.length === 0) return 0;
+    candidates = nonNegative;
+  }
+
+  switch (direction) {
+    case "up": {
+      const up = candidates.filter((c) => c >= amount);
+      return up.length ? Math.min(...up) : Math.max(...candidates);
+    }
+    case "down": {
+      const down = candidates.filter((c) => c <= amount);
+      if (down.length) return Math.max(...down);
+      // No charm price at or below `amount`. Clamping to zero preserves the
+      // guarantee that `down` never increases a price; returning the smallest
+      // candidate would raise it.
+      return amount >= 0 ? 0 : Math.min(...candidates);
+    }
+    case "nearest": {
+      let best = candidates[0];
+      let bestDist = Math.abs(amount - best);
+      for (const c of candidates.slice(1)) {
+        const d = Math.abs(amount - c);
+        // Ties resolve upward, matching step-nearest for positive amounts.
+        if (d < bestDist || (d === bestDist && c > best)) {
+          best = c;
+          bestDist = d;
+        }
+      }
+      return best;
+    }
+  }
+}
+
+/**
+ * Applies a rounding profile.
+ *
+ * Idempotent by construction: rounding an already-rounded value returns it
+ * unchanged, which the property tests assert directly. That matters because a
+ * campaign may be re-planned and re-previewed many times, and a rounding step that
+ * drifted on each pass would break the idempotency invariant (I2).
+ */
+export function applyRounding(value: Money, profile: RoundingProfile): Money {
+  const effective = effectiveProfile(profile, value.currency);
+
+  if (effective.mode === "step") {
+    if (effective.step === 1) return value; // nothing to do at minor-unit granularity
+    return money(roundStep(value.amount, effective.step, effective.direction), value.currency);
+  }
+
+  const perMajor = 10 ** exponentOf(value.currency);
+  return money(
+    roundCharm(value.amount, effective.ending, perMajor, effective.direction),
+    value.currency,
+  );
+}
+
+// ------------------------------------------------------------------ presets
+
+/** `.99` endings, rounding to the nearest such price. */
+export const charm99: CharmProfile = { mode: "charm", ending: 99, direction: "nearest" };
+
+/** `.95` endings. */
+export const charm95: CharmProfile = { mode: "charm", ending: 95, direction: "nearest" };
+
+/** Whole major units (x.00). */
+export const wholeUnits: CharmProfile = { mode: "charm", ending: 0, direction: "nearest" };
+
+/**
+ * A sensible default for a currency: charm `.99` where there is room for it,
+ * nearest-10 minor units otherwise. Used to seed store defaults per enabled currency.
+ */
+export function defaultProfileFor(currency: string): RoundingProfile {
+  return isZeroDecimal(currency)
+    ? { mode: "step", step: 10, direction: "nearest" }
+    : charm99;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,10 +36,12 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
+        "fast-check": "^4.9.0",
         "graphql-config": "^5.1.1",
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -3644,6 +3646,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -4264,6 +4284,133 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@whatwg-node/disposablestack": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
@@ -4635,6 +4782,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -5014,6 +5171,16 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -5760,6 +5927,44 @@
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
       }
+    },
+    "node_modules/effect/node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/effect/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.404",
@@ -6616,6 +6821,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6652,6 +6867,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -6722,9 +6947,10 @@
       "license": "MIT"
     },
     "node_modules/fast-check": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
-      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6737,10 +6963,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "pure-rand": "^6.1.0"
+        "pure-rand": "^8.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -8892,6 +9118,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -9440,6 +9676,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -9913,9 +10163,10 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -10680,6 +10931,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10792,6 +11050,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10800,6 +11065,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -11086,6 +11358,13 @@
         "node": ">=16"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
@@ -11109,6 +11388,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/title-case": {
@@ -11658,6 +11947,110 @@
         "vite": "*"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -11781,6 +12174,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "prisma": "prisma",
     "graphql-codegen": "graphql-codegen",
     "vite": "vite",
-    "typecheck": "react-router typegen && tsc --noEmit"
+    "typecheck": "react-router typegen && tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "type": "module",
   "engines": {
@@ -54,10 +56,12 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "fast-check": "^4.9.0",
     "graphql-config": "^5.1.1",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.10"
   },
   "workspaces": {
     "packages": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["app/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Implements **P2.1** (#97) and its four subtasks: #98 money type, #99 currency precision table, #100 rounding engine, #101 property test suite.

Pure logic with no Shopify or infrastructure dependency, so it lands ahead of the Partner app link and is fully verifiable offline.

## What's here

| Module | Does |
|---|---|
| `currency.ts` | ISO 4217 minor-unit exponents for 64 currencies. Zero-decimal (JPY, KRW) and three-decimal (KWD, BHD) are first-class. Unknown codes **throw** rather than defaulting to 2. |
| `money.ts` | `Money` as integer minor units + currency. No float path exists. |
| `rounding.ts` | Charm endings (.99/.95/.00) and step rounding with explicit direction. |

**39 tests, mostly property-based**, running across all 64 currencies.

## Design decisions worth reviewing

**Half-even for intermediate rounding.** Half-up nudges every exact-half result upward — across a large catalogue that is a real one-directional drift in nobody's intended favour.

**String-based parsing.** `parseFloat("19.99") * 100` is `1998.9999999999998`. The whole point of the module is that such a number never exists.

**Charm profiles degrade in zero-decimal currencies** (edge case E9). A `.99` ending in JPY has no sub-yen space, so it falls back to step rounding while preserving the merchant's chosen direction.

**Unknown currencies throw.** Defaulting to 2 decimals is how a JPY store gets sub-yen prices.

## Two real bugs the property tests caught

1. **Negative zero** leaked out of `percentOf(negative, 0)`. `-0 === 0` but `Object.is(-0, 0)` is `false`, so it would silently break deep-equality in ledger diffs and caches.

2. **Charm rounding could return a negative price.** For 47¢ under a `.99` profile the candidates are `[-1, 99, 199]` and −1 is genuinely nearest — correct arithmetic, nonsense price. Non-negative inputs now exclude negative candidates, and a `down` direction with no candidate at or below the input clamps to zero rather than *increasing* the price.

Both are pinned by regression tests, including a property asserting no non-negative input ever yields a negative price.

## Corrections to my own test expectations

Two assertions I wrote were wrong, and the implementation was right:
- 19.47 under `.99` → **18.99** (48¢ away vs 52¢), not 19.99
- 19.47 under whole-units → **19.00** (47¢ vs 53¢), not 20.00

"Nearest" means nearest. Merchants who always want to round up should choose `direction: "up"`.

## Verification

`npm test` (39 passed) · `npm run typecheck` · `npm run lint` (0 problems) · `npm run build` — all clean. CI now runs the test suite so these invariants gate every merge.

Closes #98, closes #99, closes #100, closes #101