### PR TITLE
P2.2 — Resolver, rule engine and guardrail clamping

### DIFF
--- a/app/lib/pricing/guardrails.ts
+++ b/app/lib/pricing/guardrails.ts
@@ -1,0 +1,130 @@
+/**
+ * Guardrail floors — the machinery behind invariant I6.
+ *
+ * A floor is the highest of everything that applies: an absolute minimum price, cost
+ * itself, and the price implied by a minimum margin. Clamping runs *after* rounding,
+ * because a downward rounding profile can push an otherwise-legal price below the
+ * floor.
+ */
+
+import { greaterThan, max, money, multiplyByFactor, type Money } from "../money/money";
+import type { Baseline, Guardrails } from "./types";
+
+export class MissingCostError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MissingCostError";
+  }
+}
+
+/**
+ * Merges store and campaign guardrails. Campaign settings may only **tighten**.
+ *
+ * Without this rule a campaign could disable a store-wide "never below cost" policy,
+ * making the store setting decorative. Loosening is possible only by changing the
+ * store setting, which is a deliberate, audit-logged action.
+ */
+export function mergeGuardrails(store?: Guardrails, campaign?: Guardrails): Guardrails {
+  if (!store) return campaign ?? {};
+  if (!campaign) return store;
+
+  return {
+    // Either side may switch it on; neither may switch it off.
+    neverBelowCost: store.neverBelowCost || campaign.neverBelowCost,
+    minMarginPercent: pickTighter(store.minMarginPercent, campaign.minMarginPercent),
+    minPrice: pickHigher(store.minPrice, campaign.minPrice),
+    missingCostPolicy: campaign.missingCostPolicy ?? store.missingCostPolicy,
+  };
+}
+
+function pickTighter(a?: number, b?: number): number | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+}
+
+function pickHigher(a?: Money, b?: Money): Money | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return max(a, b);
+}
+
+/**
+ * The effective floor for a variant, or `undefined` when nothing constrains it.
+ *
+ * A price is always required to be **strictly positive**, so the implicit floor is
+ * one minor unit even with no guardrails configured. A zero or negative price is
+ * never a legitimate outcome (edge case E10).
+ *
+ * @throws {MissingCostError} when a cost-dependent guardrail applies to a variant
+ * with no cost and the policy is "error".
+ */
+export function computeFloor(
+  baseline: Baseline,
+  guardrails: Guardrails,
+): Money | undefined {
+  const candidates: Money[] = [];
+
+  if (guardrails.minPrice) candidates.push(guardrails.minPrice);
+
+  const needsCost =
+    guardrails.neverBelowCost === true || guardrails.minMarginPercent !== undefined;
+
+  if (needsCost && !baseline.cost) {
+    if (guardrails.missingCostPolicy === "error") {
+      throw new MissingCostError(
+        `A cost-dependent guardrail applies but this variant has no cost per item. ` +
+          `Set a cost, relax the guardrail, or use missingCostPolicy "skip".`,
+      );
+    }
+    // "skip" (and the default) leave the cost-derived floors out; the resolver turns
+    // this into a skipped variant rather than pricing it unguarded.
+    return candidates.length ? candidates.reduce(max) : undefined;
+  }
+
+  if (baseline.cost) {
+    if (guardrails.neverBelowCost) {
+      candidates.push(baseline.cost);
+    }
+    if (guardrails.minMarginPercent !== undefined) {
+      candidates.push(priceForMargin(baseline.cost, guardrails.minMarginPercent));
+    }
+  }
+
+  if (candidates.length === 0) return undefined;
+  return candidates.reduce(max);
+}
+
+/**
+ * Lowest price achieving a given gross margin: `cost / (1 - margin/100)`.
+ *
+ * Rounds up, so the resulting price always *meets or exceeds* the target margin —
+ * rounding down would produce a floor that itself violates the guardrail.
+ */
+export function priceForMargin(cost: Money, marginPercent: number): Money {
+  if (marginPercent >= 100) {
+    throw new RangeError(
+      `A minimum margin of ${marginPercent}% is unreachable: margin is a share of the ` +
+        `selling price, so 100% would require an infinite price.`,
+    );
+  }
+  return multiplyByFactor(cost, 1 / (1 - marginPercent / 100), "ceil");
+}
+
+/** True when `price` sits below `floor`. */
+export function violatesFloor(price: Money, floor: Money | undefined): boolean {
+  if (!floor) return false;
+  return greaterThan(floor, price);
+}
+
+/** Smallest strictly-positive amount in a currency: one minor unit. */
+export function smallestPositive(currency: string): Money {
+  return money(1, currency);
+}
+
+/** True when a cost-dependent guardrail applies but the variant has no cost. */
+export function needsCostButMissing(baseline: Baseline, guardrails: Guardrails): boolean {
+  const needsCost =
+    guardrails.neverBelowCost === true || guardrails.minMarginPercent !== undefined;
+  return needsCost && !baseline.cost;
+}

--- a/app/lib/pricing/resolver.test.ts
+++ b/app/lib/pricing/resolver.test.ts
@@ -1,0 +1,500 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { money } from "../money/money";
+import { charm99, NO_ROUNDING, type RoundingProfile } from "../money/rounding";
+import { compareCampaigns, resolve, resolveWithout, selectWinner } from "./resolver";
+import { selectRule } from "./rules";
+import type {
+  AdjustmentRule,
+  Baseline,
+  Guardrails,
+  ResolvableCampaign,
+  ResolveInput,
+  Surface,
+} from "./types";
+
+const USD: Surface = { kind: "base", currency: "USD" };
+const usd = (n: number) => money(n, "USD");
+
+function campaign(over: Partial<ResolvableCampaign> = {}): ResolvableCampaign {
+  return {
+    id: "c1",
+    priority: 100,
+    startAt: 1_000,
+    ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -20 } }],
+    compareAtPolicy: { kind: "leave" },
+    compareAtViolationPolicy: "clear",
+    roundingProfile: NO_ROUNDING,
+    guardrailViolationPolicy: "clamp",
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------- generators
+
+const anyRule: fc.Arbitrary<AdjustmentRule> = fc.oneof(
+  fc.record({
+    kind: fc.constant("percent-change" as const),
+    percent: fc.integer({ min: -95, max: 200 }),
+  }),
+  fc.record({
+    kind: fc.constant("fixed-change" as const),
+    amount: fc.integer({ min: -5000, max: 5000 }).map(usd),
+  }),
+  fc.record({
+    kind: fc.constant("set-exact" as const),
+    amount: fc.integer({ min: 1, max: 100_000 }).map(usd),
+  }),
+  fc.record({
+    kind: fc.constant("from-cost-multiplier" as const),
+    factor: fc.double({ min: 0.5, max: 5, noNaN: true }),
+  }),
+  fc.record({
+    kind: fc.constant("from-cost-margin" as const),
+    marginPercent: fc.integer({ min: -50, max: 90 }),
+  }),
+);
+
+const anyProfile: fc.Arbitrary<RoundingProfile> = fc.oneof(
+  fc.record({
+    mode: fc.constant("charm" as const),
+    ending: fc.constantFrom(0, 95, 99),
+    direction: fc.constantFrom("up" as const, "down" as const, "nearest" as const),
+  }),
+  fc.record({
+    mode: fc.constant("step" as const),
+    step: fc.constantFrom(1, 5, 100),
+    direction: fc.constantFrom("up" as const, "down" as const, "nearest" as const),
+  }),
+);
+
+const anyBaseline: fc.Arbitrary<Baseline> = fc.record({
+  price: fc.integer({ min: 1, max: 500_000 }).map(usd),
+  compareAtPrice: fc.option(fc.integer({ min: 1, max: 600_000 }).map(usd), {
+    nil: undefined,
+  }),
+  cost: fc.option(fc.integer({ min: 1, max: 200_000 }).map(usd), { nil: undefined }),
+});
+
+const anyGuardrails: fc.Arbitrary<Guardrails> = fc.record({
+  neverBelowCost: fc.boolean(),
+  minMarginPercent: fc.option(fc.integer({ min: 0, max: 80 }), { nil: undefined }),
+  minPrice: fc.option(fc.integer({ min: 1, max: 10_000 }).map(usd), { nil: undefined }),
+  missingCostPolicy: fc.constantFrom("skip" as const, "error" as const),
+});
+
+const anyCampaign: fc.Arbitrary<ResolvableCampaign> = fc
+  .tuple(
+    fc.string({ minLength: 1, maxLength: 6 }),
+    fc.integer({ min: 0, max: 300 }),
+    fc.integer({ min: 0, max: 100_000 }),
+    anyRule,
+    anyProfile,
+  )
+  .map(([id, priority, startAt, rule, roundingProfile]) =>
+    campaign({ id, priority, startAt, ruleRows: [{ segmentIds: [], rule }], roundingProfile }),
+  );
+
+const anyInput: fc.Arbitrary<ResolveInput> = fc
+  .tuple(anyBaseline, fc.array(anyCampaign, { maxLength: 4 }), anyGuardrails)
+  .map(([baseline, campaigns, storeGuardrails]) => ({
+    baseline,
+    surface: USD,
+    campaigns,
+    storeGuardrails,
+  }));
+
+// ---------------------------------------------------------------- invariants
+
+describe("invariant I1 — determinism", () => {
+  it("identical inputs always produce identical output", () => {
+    fc.assert(
+      fc.property(anyInput, (input) => {
+        expect(resolve(input)).toEqual(resolve(input));
+      }),
+    );
+  });
+
+  it("is insensitive to the order campaigns are supplied in", () => {
+    // Winner selection must be a total order, not an artefact of array position.
+    fc.assert(
+      fc.property(anyInput, (input) => {
+        const reversed = { ...input, campaigns: [...input.campaigns].reverse() };
+        expect(resolve(reversed)).toEqual(resolve(input));
+      }),
+    );
+  });
+});
+
+describe("invariant I2 — idempotency", () => {
+  it("re-resolving from the resolved price yields the same price", () => {
+    // The heart of the product: because the resolver reads the baseline and never
+    // the live price, feeding its own output back changes nothing. This is what
+    // competitors get wrong -- their re-runs compound.
+    fc.assert(
+      fc.property(anyInput, (input) => {
+        const first = resolve(input);
+        if (first.meta.outcome !== "priced" && first.meta.outcome !== "baseline") return;
+
+        // Simulate the storefront now sitting at the resolved price, exactly as it
+        // would after a real apply, and resolve again.
+        const afterApply: ResolveInput = {
+          ...input,
+          baseline: { ...input.baseline },
+        };
+        expect(resolve(afterApply)).toEqual(first);
+      }),
+    );
+  });
+
+  it("does not compound when the same campaign is applied repeatedly", () => {
+    const baseline: Baseline = { price: usd(10_000) };
+    const input: ResolveInput = {
+      baseline,
+      surface: USD,
+      campaigns: [campaign({ ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -20 } }] })],
+    };
+
+    // Three consecutive resolutions all give 80.00, never 64.00 then 51.20.
+    for (let i = 0; i < 3; i++) {
+      expect(resolve(input).price).toEqual(usd(8_000));
+    }
+  });
+});
+
+describe("invariant I6 — floor totality", () => {
+  it("a priced result is never below its floor", () => {
+    fc.assert(
+      fc.property(anyInput, (input) => {
+        const clampInput: ResolveInput = {
+          ...input,
+          campaigns: input.campaigns.map((c) => ({
+            ...c,
+            guardrailViolationPolicy: "clamp" as const,
+          })),
+        };
+        const result = resolve(clampInput);
+        if (result.meta.outcome !== "priced" || !result.price) return;
+        if (result.meta.floor) {
+          expect(result.price.amount).toBeGreaterThanOrEqual(result.meta.floor.amount);
+        }
+      }),
+    );
+  });
+
+  it("never writes a zero or negative price under any policy", () => {
+    fc.assert(
+      fc.property(anyInput, (input) => {
+        const result = resolve(input);
+        if (result.price) expect(result.price.amount).toBeGreaterThan(0);
+      }),
+    );
+  });
+
+  it("never prices below cost when neverBelowCost is set", () => {
+    fc.assert(
+      fc.property(anyBaseline, anyRule, anyProfile, (baseline, rule, profile) => {
+        if (!baseline.cost) return;
+        const result = resolve({
+          baseline,
+          surface: USD,
+          campaigns: [
+            campaign({
+              ruleRows: [{ segmentIds: [], rule }],
+              roundingProfile: profile,
+              guardrailViolationPolicy: "clamp",
+            }),
+          ],
+          storeGuardrails: { neverBelowCost: true },
+        });
+        if (result.meta.outcome === "priced" && result.price) {
+          expect(result.price.amount).toBeGreaterThanOrEqual(baseline.cost.amount);
+        }
+      }),
+    );
+  });
+
+  it("respects a minimum margin", () => {
+    const result = resolve({
+      baseline: { price: usd(10_000), cost: usd(6_000) },
+      surface: USD,
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -50 } }],
+        }),
+      ],
+      storeGuardrails: { minMarginPercent: 25 },
+    });
+    // -50% would be 50.00, but 25% margin on a 60.00 cost needs at least 80.00.
+    expect(result.price).toEqual(usd(8_000));
+    expect(result.meta.clamped).toBe(true);
+  });
+});
+
+describe("invariant I3 — revert recomputes", () => {
+  it("removing the winner falls through to the next campaign, not the baseline", () => {
+    const baseline: Baseline = { price: usd(10_000) };
+    const high = campaign({
+      id: "high",
+      priority: 200,
+      ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -50 } }],
+    });
+    const low = campaign({
+      id: "low",
+      priority: 100,
+      ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -10 } }],
+    });
+    const input: ResolveInput = { baseline, surface: USD, campaigns: [high, low] };
+
+    expect(resolve(input).price).toEqual(usd(5_000));
+    // Ending the high-priority campaign must leave the still-running sale in place,
+    // NOT restore full price.
+    expect(resolveWithout(input, "high").price).toEqual(usd(9_000));
+    // Ending both returns to baseline.
+    expect(
+      resolve({ ...input, campaigns: [] }).price,
+    ).toEqual(usd(10_000));
+  });
+
+  it("removing every campaign always returns exactly the baseline", () => {
+    fc.assert(
+      fc.property(anyInput, (input) => {
+        const bare = resolve({ ...input, campaigns: [] });
+        expect(bare.price).toEqual(input.baseline.price);
+        expect(bare.meta.outcome).toBe("baseline");
+      }),
+    );
+  });
+});
+
+// ------------------------------------------------------------ winner selection
+
+describe("winner selection", () => {
+  it("never stacks — exactly one campaign controls a variant", () => {
+    const baseline: Baseline = { price: usd(10_000) };
+    const result = resolve({
+      baseline,
+      surface: USD,
+      campaigns: [
+        campaign({ id: "a", priority: 100, ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -20 } }] }),
+        campaign({ id: "b", priority: 100, ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -30 } }] }),
+      ],
+    });
+    // Not -44% (stacked); one winner only.
+    expect([usd(8_000), usd(7_000)]).toContainEqual(result.price);
+  });
+
+  it("orders by priority, then latest start, then id", () => {
+    const base: Partial<ResolvableCampaign> = {
+      ruleRows: [],
+      compareAtPolicy: { kind: "leave" },
+    };
+    const a = campaign({ ...base, id: "a", priority: 100, startAt: 1 });
+    const b = campaign({ ...base, id: "b", priority: 200, startAt: 1 });
+    expect(selectWinner([a, b])?.id).toBe("b");
+
+    const c = campaign({ ...base, id: "c", priority: 100, startAt: 5 });
+    expect(selectWinner([a, c])?.id).toBe("c");
+
+    const d = campaign({ ...base, id: "d", priority: 100, startAt: 1 });
+    expect(selectWinner([a, d])?.id).toBe("d"); // "d" > "a"
+  });
+
+  it("comparison is a total order", () => {
+    fc.assert(
+      fc.property(anyCampaign, anyCampaign, (x, y) => {
+        const ab = compareCampaigns(x, y);
+        const ba = compareCampaigns(y, x);
+        if (x.id === y.id && x.priority === y.priority && x.startAt === y.startAt) {
+          expect(ab).toBe(0);
+        } else {
+          expect(Math.sign(ab)).toBe(-Math.sign(ba));
+        }
+      }),
+    );
+  });
+});
+
+// ------------------------------------------------------------------ rules
+
+describe("rule engine", () => {
+  const baseline: Baseline = {
+    price: usd(10_000),
+    compareAtPrice: usd(12_000),
+    cost: usd(4_000),
+  };
+  const withRule = (rule: AdjustmentRule, over: Partial<ResolvableCampaign> = {}) =>
+    resolve({
+      baseline,
+      surface: USD,
+      campaigns: [campaign({ ruleRows: [{ segmentIds: [], rule }], ...over })],
+    });
+
+  it("applies every adjustment kind", () => {
+    expect(withRule({ kind: "percent-change", percent: -25 }).price).toEqual(usd(7_500));
+    expect(withRule({ kind: "percent-change", percent: 10 }).price).toEqual(usd(11_000));
+    expect(withRule({ kind: "fixed-change", amount: usd(-1_500) }).price).toEqual(usd(8_500));
+    expect(withRule({ kind: "set-exact", amount: usd(9_999) }).price).toEqual(usd(9_999));
+    expect(withRule({ kind: "from-cost-multiplier", factor: 2.5 }).price).toEqual(usd(10_000));
+    // 60% margin on 40.00 cost -> 40 / 0.4 = 100.00
+    expect(withRule({ kind: "from-cost-margin", marginPercent: 60 }).price).toEqual(usd(10_000));
+    expect(withRule({ kind: "percent-of-compare-at", percent: -50 }).price).toEqual(usd(6_000));
+  });
+
+  it("skips rather than pricing at zero when cost is missing", () => {
+    const result = resolve({
+      baseline: { price: usd(10_000) },
+      surface: USD,
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "from-cost-multiplier", factor: 2 } }],
+        }),
+      ],
+    });
+    expect(result.meta.outcome).toBe("skipped");
+    expect(result.meta.reason).toBe("missing-cost");
+    expect(result.price).toBeUndefined();
+  });
+
+  it("rejects an unreachable margin target", () => {
+    const result = withRule({ kind: "from-cost-margin", marginPercent: 100 });
+    expect(result.meta.outcome).toBe("skipped");
+    expect(result.meta.reason).toBe("invalid-margin");
+  });
+
+  it("last matching rule row wins (edge case E16)", () => {
+    const rows = [
+      { segmentIds: [], rule: { kind: "percent-change", percent: -10 } as AdjustmentRule },
+      { segmentIds: ["seg-a"], rule: { kind: "percent-change", percent: -20 } as AdjustmentRule },
+      { segmentIds: ["seg-a"], rule: { kind: "percent-change", percent: -30 } as AdjustmentRule },
+    ];
+    expect(selectRule(rows, ["seg-a"])).toEqual({ kind: "percent-change", percent: -30 });
+    expect(selectRule(rows, ["seg-b"])).toEqual({ kind: "percent-change", percent: -10 });
+    expect(selectRule(rows, [])).toEqual({ kind: "percent-change", percent: -10 });
+  });
+});
+
+// -------------------------------------------------------------- compare-at
+
+describe("compare-at policy", () => {
+  const baseline: Baseline = { price: usd(10_000), compareAtPrice: usd(12_000) };
+  const withPolicy = (
+    compareAtPolicy: ResolvableCampaign["compareAtPolicy"],
+    over: Partial<ResolvableCampaign> = {},
+  ) =>
+    resolve({
+      baseline,
+      surface: USD,
+      campaigns: [campaign({ compareAtPolicy, ...over })],
+    });
+
+  it("set-to-baseline produces a strike-through at the old price", () => {
+    const result = withPolicy({ kind: "set-to-baseline" });
+    expect(result.price).toEqual(usd(8_000));
+    expect(result.compareAtPrice).toEqual(usd(10_000));
+  });
+
+  it("distinguishes clear (null) from leave (undefined)", () => {
+    // Conflating these either wipes a merchant's compare-at or fails to set one.
+    expect(withPolicy({ kind: "clear" }).compareAtPrice).toBeNull();
+    expect(withPolicy({ kind: "leave" }).compareAtPrice).toBeUndefined();
+  });
+
+  it("never writes a compare-at at or below the price (edge case E11)", () => {
+    // A -90% sale then compare-at set from a rule that lands under the price.
+    const result = resolve({
+      baseline: { price: usd(10_000), compareAtPrice: usd(12_000) },
+      surface: USD,
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "set-exact", amount: usd(15_000) } }],
+          compareAtPolicy: { kind: "set-to-baseline" },
+          compareAtViolationPolicy: "clear",
+        }),
+      ],
+    });
+    // Price 150.00 with a baseline compare-at of 100.00 would show a negative saving.
+    expect(result.price).toEqual(usd(15_000));
+    expect(result.compareAtPrice).toBeNull();
+  });
+
+  it("can skip the variant instead of clearing an invalid compare-at", () => {
+    const result = resolve({
+      baseline: { price: usd(10_000) },
+      surface: USD,
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "set-exact", amount: usd(15_000) } }],
+          compareAtPolicy: { kind: "set-to-baseline" },
+          compareAtViolationPolicy: "skip",
+        }),
+      ],
+    });
+    expect(result.meta.outcome).toBe("skipped");
+    expect(result.meta.reason).toBe("invalid-compare-at");
+  });
+
+  it("a computed compare-at always exceeds the written price", () => {
+    fc.assert(
+      fc.property(anyInput, (input) => {
+        const result = resolve(input);
+        // Scoped to computed prices deliberately. The baseline path is exempt --
+        // see the passthrough test below.
+        if (result.meta.outcome !== "priced") return;
+        if (result.price && result.compareAtPrice) {
+          expect(result.compareAtPrice.amount).toBeGreaterThan(result.price.amount);
+        }
+      }),
+    );
+  });
+
+  it("passes pre-existing baseline data through untouched when no campaign applies", () => {
+    // A merchant may legitimately have compare-at <= price already. We validate what
+    // we COMPUTE, never retroactively "fix" their data -- and this same path is what
+    // a revert writes, where faithfully restoring the original state is the whole
+    // point. Silently clearing their compare-at on revert would be data loss.
+    const odd: Baseline = { price: usd(1_000), compareAtPrice: usd(1_000) };
+    const result = resolve({ baseline: odd, surface: USD, campaigns: [] });
+    expect(result.meta.outcome).toBe("baseline");
+    expect(result.price).toEqual(usd(1_000));
+    expect(result.compareAtPrice).toEqual(usd(1_000));
+  });
+});
+
+// -------------------------------------------------------------- rounding
+
+describe("rounding and clamping order", () => {
+  it("clamps after rounding, so a downward profile cannot breach the floor", () => {
+    // -20% of 100.00 is 80.00; rounding down to the nearest 10.00 gives 80.00, but a
+    // floor of 85.00 must still win.
+    const result = resolve({
+      baseline: { price: usd(10_000) },
+      surface: USD,
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -20 } }],
+          roundingProfile: { mode: "step", step: 1_000, direction: "down" },
+        }),
+      ],
+      storeGuardrails: { minPrice: usd(8_500) },
+    });
+    expect(result.price).toEqual(usd(8_500));
+    expect(result.meta.clamped).toBe(true);
+  });
+
+  it("reports the unrounded price for preview explanations", () => {
+    const result = resolve({
+      baseline: { price: usd(10_000) },
+      surface: USD,
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -33 } }],
+          roundingProfile: charm99,
+        }),
+      ],
+    });
+    expect(result.meta.unroundedPrice).toEqual(usd(6_700));
+    expect(result.price).toEqual(usd(6_699));
+  });
+});

--- a/app/lib/pricing/resolver.ts
+++ b/app/lib/pricing/resolver.ts
@@ -1,0 +1,327 @@
+/**
+ * The resolver. One pure function, four consumers:
+ *
+ *   preview        renders its output
+ *   the planner    diffs it against live values to build ledger rows
+ *   revert         calls it with the ending campaign removed
+ *   reconciliation compares live values against it
+ *
+ * One implementation means a preview can never disagree with what execution does.
+ *
+ * Order of operations is deliberate and load-bearing:
+ *
+ *   baseline -> rule -> round -> clamp -> compare-at
+ *
+ * Rounding before clamping, because a downward rounding profile can push a legal
+ * price below a guardrail floor; clamping last guarantees invariant I6 holds on the
+ * value actually written.
+ */
+
+import { applyRounding } from "../money/rounding";
+import { isPositive, lessThanOrEqual, max, type Money } from "../money/money";
+import {
+  computeFloor,
+  MissingCostError,
+  mergeGuardrails,
+  needsCostButMissing,
+  smallestPositive,
+  violatesFloor,
+} from "./guardrails";
+import { applyRule, RuleNotApplicableError, selectRule } from "./rules";
+import type {
+  CompareAtPolicy,
+  Resolution,
+  ResolvableCampaign,
+  ResolveInput,
+} from "./types";
+
+/**
+ * Picks the campaign controlling a variant. Never stacks — exactly one wins.
+ *
+ * Order: highest priority, then latest start, then largest id. The id tie-break
+ * exists so the ordering is *total*: two campaigns created in the same millisecond
+ * with equal priority must still resolve deterministically, or preview and execution
+ * could disagree.
+ */
+export function selectWinner(
+  campaigns: ResolvableCampaign[],
+): ResolvableCampaign | undefined {
+  if (campaigns.length === 0) return undefined;
+
+  return campaigns.reduce((best, candidate) =>
+    compareCampaigns(candidate, best) > 0 ? candidate : best,
+  );
+}
+
+/** Positive when `a` outranks `b`. Total and stable. */
+export function compareCampaigns(a: ResolvableCampaign, b: ResolvableCampaign): number {
+  if (a.priority !== b.priority) return a.priority - b.priority;
+  if (a.startAt !== b.startAt) return a.startAt - b.startAt;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+export function resolve(input: ResolveInput): Resolution {
+  const { baseline, surface, campaigns, storeGuardrails, variantSegmentIds } = input;
+  const currency = surface.currency;
+
+  const winner = selectWinner(campaigns);
+
+  // Nothing controls this variant: it sits at its baseline.
+  //
+  // Baseline values pass through unvalidated, deliberately. A merchant may already
+  // have a compare-at at or below their price; that is their data, not something we
+  // computed, and this same path is what a revert writes -- where faithfully
+  // restoring the original state is the entire point. Compare-at validation applies
+  // to values this resolver produces (see resolveCompareAt), not to pre-existing ones.
+  if (!winner) {
+    return {
+      price: baseline.price,
+      compareAtPrice: baseline.compareAtPrice ?? null,
+      meta: { outcome: "baseline", clamped: false },
+    };
+  }
+
+  const guardrails = mergeGuardrails(storeGuardrails, winner.guardrails);
+
+  // A cost-dependent guardrail with no cost cannot be evaluated. Pricing anyway
+  // would mean writing a price the merchant explicitly asked us to guard.
+  if (needsCostButMissing(baseline, guardrails)) {
+    if (guardrails.missingCostPolicy === "error") {
+      return blocked(winner, "missing-cost");
+    }
+    return skipped(winner, "missing-cost");
+  }
+
+  const rule = selectRule(winner.ruleRows, variantSegmentIds);
+  if (!rule) {
+    // No rule row matched. The campaign does not price this variant.
+    return {
+      price: baseline.price,
+      compareAtPrice: baseline.compareAtPrice ?? null,
+      meta: { outcome: "baseline", clamped: false },
+    };
+  }
+
+  let unrounded: Money;
+  try {
+    unrounded = applyRule(rule, baseline);
+  } catch (error) {
+    if (error instanceof RuleNotApplicableError) {
+      const reason = error.reason === "invalid-margin" ? "invalid-margin" : "missing-cost";
+      return winner.guardrailViolationPolicy === "block"
+        ? blocked(winner, reason, rule)
+        : skipped(winner, reason, rule);
+    }
+    throw error;
+  }
+
+  const rounded = applyRounding(unrounded, winner.roundingProfile);
+
+  let floor: Money | undefined;
+  try {
+    floor = computeFloor(baseline, guardrails);
+  } catch (error) {
+    if (error instanceof MissingCostError) return blocked(winner, "missing-cost", rule);
+    throw error;
+  }
+
+  // A price must always be strictly positive, guardrails or not (edge case E10).
+  const effectiveFloor = floor ? max(floor, smallestPositive(currency)) : undefined;
+
+  let price = rounded;
+  let clamped = false;
+
+  if (violatesFloor(price, effectiveFloor)) {
+    switch (winner.guardrailViolationPolicy) {
+      case "block":
+        return blocked(winner, "below-floor", rule, effectiveFloor, unrounded);
+      case "skip":
+        return skipped(winner, "below-floor", rule, effectiveFloor, unrounded);
+      case "clamp":
+        price = effectiveFloor as Money;
+        clamped = true;
+        break;
+    }
+  }
+
+  // With no guardrails configured there is no floor, but a non-positive price is
+  // still never a legitimate outcome.
+  if (!isPositive(price)) {
+    switch (winner.guardrailViolationPolicy) {
+      case "block":
+        return blocked(winner, "non-positive-price", rule, effectiveFloor, unrounded);
+      case "skip":
+        return skipped(winner, "non-positive-price", rule, effectiveFloor, unrounded);
+      case "clamp":
+        price = smallestPositive(currency);
+        clamped = true;
+        break;
+    }
+  }
+
+  const compareAt = resolveCompareAt(winner, baseline, price);
+
+  if (compareAt.blocked) {
+    return blocked(winner, "invalid-compare-at", rule, effectiveFloor, unrounded);
+  }
+  if (compareAt.skipVariant) {
+    return skipped(winner, "invalid-compare-at", rule, effectiveFloor, unrounded);
+  }
+
+  return {
+    price,
+    compareAtPrice: compareAt.value,
+    meta: {
+      outcome: "priced",
+      controlledBy: winner.id,
+      appliedRule: rule,
+      clamped,
+      floor: effectiveFloor,
+      unroundedPrice: unrounded,
+    },
+  };
+}
+
+interface CompareAtOutcome {
+  /** `undefined` leaves it untouched; `null` clears it. */
+  value?: Money | null;
+  skipVariant?: boolean;
+  blocked?: boolean;
+}
+
+/**
+ * Applies the compare-at policy and validates the result.
+ *
+ * A compare-at at or below the price renders as a strike-through that shows no
+ * saving — or worse, an apparent price increase. Competitors ship this bug; a
+ * one-star review on one of them is exactly this complaint, so it is validated
+ * rather than trusted (edge case E11).
+ */
+function resolveCompareAt(
+  campaign: ResolvableCampaign,
+  baseline: { price: Money; compareAtPrice?: Money; cost?: Money },
+  finalPrice: Money,
+): CompareAtOutcome {
+  const policy: CompareAtPolicy = campaign.compareAtPolicy;
+
+  let candidate: Money | null | undefined;
+
+  switch (policy.kind) {
+    case "leave":
+      return { value: undefined };
+
+    case "clear":
+      return { value: null };
+
+    case "set-to-baseline":
+      candidate = baseline.price;
+      break;
+
+    case "adjust": {
+      if (!baseline.compareAtPrice) {
+        // Nothing to adjust. Leaving it alone is the least surprising outcome.
+        return { value: undefined };
+      }
+      try {
+        candidate = applyRule(policy.rule, baseline);
+      } catch (error) {
+        if (error instanceof RuleNotApplicableError) return { value: undefined };
+        throw error;
+      }
+      break;
+    }
+  }
+
+  if (candidate == null) return { value: candidate };
+
+  // Must strictly exceed the price to display a genuine saving.
+  if (lessThanOrEqual(candidate, finalPrice)) {
+    switch (campaign.compareAtViolationPolicy) {
+      case "block":
+        return { blocked: true };
+      case "skip":
+        return { skipVariant: true };
+      case "clear":
+        return { value: null };
+    }
+  }
+
+  return { value: candidate };
+}
+
+function skipped(
+  campaign: ResolvableCampaign,
+  reason: Resolution["meta"]["reason"],
+  rule?: Resolution["meta"]["appliedRule"],
+  floor?: Money,
+  unroundedPrice?: Money,
+): Resolution {
+  return {
+    meta: {
+      outcome: "skipped",
+      controlledBy: campaign.id,
+      appliedRule: rule,
+      clamped: false,
+      floor,
+      reason,
+      unroundedPrice,
+    },
+  };
+}
+
+function blocked(
+  campaign: ResolvableCampaign,
+  reason: Resolution["meta"]["reason"],
+  rule?: Resolution["meta"]["appliedRule"],
+  floor?: Money,
+  unroundedPrice?: Money,
+): Resolution {
+  return {
+    meta: {
+      outcome: "blocked",
+      controlledBy: campaign.id,
+      appliedRule: rule,
+      clamped: false,
+      floor,
+      reason,
+      unroundedPrice,
+    },
+  };
+}
+
+/**
+ * Resolution with a campaign removed — what "revert" means.
+ *
+ * Reverting is *not* restoring saved numbers. If a lower-priority campaign is still
+ * running, blind restore would put full price back on a storefront that should still
+ * be on sale; if the baseline moved via drift adoption, it would reinstate a stale
+ * number. Recomputing handles overlap, recurrence and partial failure with one
+ * mechanism. This is invariant I3.
+ */
+export function resolveWithout(input: ResolveInput, campaignId: string): Resolution {
+  return resolve({
+    ...input,
+    campaigns: input.campaigns.filter((c) => c.id !== campaignId),
+  });
+}
+
+/** True when two resolutions would write the same values — used to skip no-ops. */
+export function isSameOutcome(a: Resolution, b: Resolution): boolean {
+  const samePrice =
+    (a.price === undefined && b.price === undefined) ||
+    (a.price !== undefined &&
+      b.price !== undefined &&
+      a.price.amount === b.price.amount &&
+      a.price.currency === b.price.currency);
+
+  // `undefined` (leave alone) and `null` (clear) are different instructions, so they
+  // must not compare equal.
+  const sameCompareAt =
+    a.compareAtPrice === b.compareAtPrice ||
+    (a.compareAtPrice != null &&
+      b.compareAtPrice != null &&
+      a.compareAtPrice.amount === b.compareAtPrice.amount &&
+      a.compareAtPrice.currency === b.compareAtPrice.currency);
+
+  return samePrice && sameCompareAt;
+}

--- a/app/lib/pricing/rules.ts
+++ b/app/lib/pricing/rules.ts
@@ -1,0 +1,122 @@
+/**
+ * The rule engine: baseline + rule -> an unrounded price.
+ *
+ * Every rule reads the baseline (or cost, or baseline compare-at). None reads the
+ * current live price, which is what makes re-running a campaign idempotent.
+ */
+
+import {
+  add,
+  applyPercentChange,
+  money,
+  multiplyByFactor,
+  type Money,
+} from "../money/money";
+import type { AdjustmentRule, Baseline, RuleRow } from "./types";
+
+export class RuleNotApplicableError extends Error {
+  constructor(
+    readonly reason: "missing-cost" | "missing-compare-at" | "invalid-margin",
+    message: string,
+  ) {
+    super(message);
+    this.name = "RuleNotApplicableError";
+  }
+}
+
+/**
+ * Selects the rule for a variant: the **last** matching row wins.
+ *
+ * Rows with no segment ids apply to the whole campaign scope. Last-wins gives a
+ * total, deterministic order for overlapping rows rather than an error the merchant
+ * would have to resolve mid-campaign (edge case E16).
+ */
+export function selectRule(
+  ruleRows: RuleRow[],
+  variantSegmentIds: string[] = [],
+): AdjustmentRule | undefined {
+  const segments = new Set(variantSegmentIds);
+  let selected: AdjustmentRule | undefined;
+
+  for (const row of ruleRows) {
+    const matches =
+      row.segmentIds.length === 0 || row.segmentIds.some((id) => segments.has(id));
+    if (matches) selected = row.rule;
+  }
+
+  return selected;
+}
+
+/**
+ * Computes the unrounded price for a rule.
+ *
+ * @throws {RuleNotApplicableError} when required inputs are absent. Cost-based rules
+ * on a variant with no cost must never silently treat cost as zero — that would
+ * price the item at nothing and report success.
+ */
+export function applyRule(rule: AdjustmentRule, baseline: Baseline): Money {
+  switch (rule.kind) {
+    case "percent-change":
+      return applyPercentChange(baseline.price, rule.percent);
+
+    case "fixed-change":
+      return add(baseline.price, rule.amount);
+
+    case "set-exact":
+      return rule.amount;
+
+    case "from-cost-multiplier": {
+      const cost = requireCost(baseline, "from-cost-multiplier");
+      return multiplyByFactor(cost, rule.factor);
+    }
+
+    case "from-cost-margin": {
+      const cost = requireCost(baseline, "from-cost-margin");
+      // Gross margin is a percentage of the selling price, so
+      //   margin = (price - cost) / price   =>   price = cost / (1 - margin/100).
+      // At 100% the divisor is zero and the price is unbounded; above it, negative.
+      if (rule.marginPercent >= 100 || rule.marginPercent <= -Infinity) {
+        throw new RuleNotApplicableError(
+          "invalid-margin",
+          `A target margin of ${rule.marginPercent}% is unreachable: margin is a share of ` +
+            `the selling price, so 100% would require an infinite price.`,
+        );
+      }
+      return multiplyByFactor(cost, 1 / (1 - rule.marginPercent / 100));
+    }
+
+    case "percent-of-compare-at": {
+      if (!baseline.compareAtPrice) {
+        throw new RuleNotApplicableError(
+          "missing-compare-at",
+          `Rule "percent-of-compare-at" needs a baseline compare-at price, and this ` +
+            `variant has none.`,
+        );
+      }
+      return applyPercentChange(baseline.compareAtPrice, rule.percent);
+    }
+  }
+
+  // Unreachable for well-typed input; guards against a future rule kind slipping
+  // through unhandled and silently returning the baseline.
+  throw new RuleNotApplicableError(
+    "invalid-margin",
+    `Unhandled rule kind: ${(rule as { kind: string }).kind}`,
+  );
+}
+
+function requireCost(baseline: Baseline, ruleKind: string): Money {
+  if (!baseline.cost) {
+    throw new RuleNotApplicableError(
+      "missing-cost",
+      `Rule "${ruleKind}" needs a cost per item, and this variant has none. ` +
+        `Refusing to treat cost as zero: that would price the item at nothing.`,
+    );
+  }
+  return baseline.cost;
+}
+
+/** Zero in the given currency, for callers that need an explicit floor. */
+export function zeroIn(currency: string): Money {
+  return money(0, currency);
+}

--- a/app/lib/pricing/types.ts
+++ b/app/lib/pricing/types.ts
@@ -1,0 +1,188 @@
+/**
+ * Domain types for price resolution.
+ *
+ * Everything the resolver needs is passed in. It reads no database, no clock and no
+ * environment — which is what makes it property-testable and what makes a preview
+ * trustworthy. In particular, note what is *absent*: the variant's current live
+ * price. The resolver cannot see it, so it structurally cannot compute a discount
+ * relative to an already-discounted price. That is the compounding bug this whole
+ * product exists to prevent, eliminated by the type signature rather than by care.
+ */
+
+import type { Money } from "../money/money";
+import type { RoundingProfile } from "../money/rounding";
+
+/** Which price surface a resolution targets. */
+export type SurfaceKind = "base" | "market" | "b2b";
+
+export interface Surface {
+  kind: SurfaceKind;
+  /** Price list gid for market/b2b surfaces; absent for base. */
+  priceListId?: string;
+  currency: string;
+}
+
+/**
+ * The durable reference price. Campaign maths reads this, never the live price.
+ */
+export interface Baseline {
+  price: Money;
+  compareAtPrice?: Money;
+  /** Cost per item. Frequently absent on real catalogues — never assume zero. */
+  cost?: Money;
+}
+
+// ------------------------------------------------------------------- rules
+
+export type AdjustmentRule =
+  /** Percentage change from the baseline price. -20 reduces by 20%. */
+  | { kind: "percent-change"; percent: number }
+  /** Fixed change from the baseline price, in the surface currency. */
+  | { kind: "fixed-change"; amount: Money }
+  /** Ignore the baseline; set this exact price. */
+  | { kind: "set-exact"; amount: Money }
+  /** cost × factor. 2.5 is a 2.5x markup. */
+  | { kind: "from-cost-multiplier"; factor: number }
+  /**
+   * Price giving this gross margin on cost: price = cost / (1 - margin/100).
+   * Margin is a percentage of the *selling price*, the usual retail convention.
+   */
+  | { kind: "from-cost-margin"; marginPercent: number }
+  /** Percentage change from the baseline compare-at price. */
+  | { kind: "percent-of-compare-at"; percent: number };
+
+/**
+ * A rule scoped to a subset of a campaign's variants.
+ *
+ * A campaign may carry several ("-20% on Collection A, -30% on Collection B").
+ * Where a variant matches more than one, the *last* matching row wins — a total,
+ * deterministic order rather than an error, so the outcome is always predictable
+ * (edge case E16). The UI surfaces overlaps in the preview.
+ */
+export interface RuleRow {
+  /** Segment ids this row applies to. Empty means the whole campaign scope. */
+  segmentIds: string[];
+  rule: AdjustmentRule;
+}
+
+// --------------------------------------------------------------- compare-at
+
+export type CompareAtPolicy =
+  /** Copy the baseline price into compare-at, producing a strike-through sale. */
+  | { kind: "set-to-baseline" }
+  /** Derive compare-at from the baseline compare-at by rule. */
+  | { kind: "adjust"; rule: AdjustmentRule }
+  /** Remove any compare-at. */
+  | { kind: "clear" }
+  /** Do not write compare-at at all. */
+  | { kind: "leave" };
+
+/** What to do when the computed compare-at would not exceed the final price. */
+export type CompareAtViolationPolicy = "skip" | "clear" | "block";
+
+// --------------------------------------------------------------- guardrails
+
+/**
+ * Floors below which a price must never be written.
+ *
+ * Campaign-level guardrails may only *tighten* store-level ones; the merge helper
+ * enforces that. A campaign able to relax a store-wide "never below cost" rule would
+ * make the store setting meaningless.
+ */
+export interface Guardrails {
+  /** Never price at or below cost. Requires cost to be present. */
+  neverBelowCost?: boolean;
+  /** Minimum gross margin as a percentage of selling price. */
+  minMarginPercent?: number;
+  /** Absolute minimum price. */
+  minPrice?: Money;
+  /**
+   * What to do when a variant has no cost but a cost-dependent guardrail applies.
+   * "skip" excludes the variant; "error" fails the run. Never silently treat cost
+   * as zero — that would let a campaign price below cost while reporting success.
+   */
+  missingCostPolicy?: "skip" | "error";
+}
+
+/** What happens when a computed price violates a floor. */
+export type GuardrailViolationPolicy = "clamp" | "skip" | "block";
+
+// ---------------------------------------------------------------- campaigns
+
+/**
+ * A campaign as the resolver sees it: already known to be active and to target this
+ * surface, with this variant already known to be enrolled. Filtering by status and
+ * enrollment happens in the planner, where the clock and the database live.
+ */
+export interface ResolvableCampaign {
+  id: string;
+  /** Higher wins. Defaults to 100 in the UI. */
+  priority: number;
+  /** Tie-break for equal priority: later start wins. Epoch milliseconds. */
+  startAt: number;
+  ruleRows: RuleRow[];
+  compareAtPolicy: CompareAtPolicy;
+  compareAtViolationPolicy: CompareAtViolationPolicy;
+  roundingProfile: RoundingProfile;
+  /** Tightens the store guardrails for this campaign only. */
+  guardrails?: Guardrails;
+  guardrailViolationPolicy: GuardrailViolationPolicy;
+}
+
+// ------------------------------------------------------------------ results
+
+export type ResolutionOutcome =
+  /** A price was computed and should be written. */
+  | "priced"
+  /** No campaign controls this variant; it sits at baseline. */
+  | "baseline"
+  /** Excluded by a guardrail or compare-at policy. Nothing is written. */
+  | "skipped"
+  /** A policy set to "block" was violated. The run must not proceed. */
+  | "blocked";
+
+export interface ResolutionMeta {
+  outcome: ResolutionOutcome;
+  /** Campaign id controlling this variant, if any. */
+  controlledBy?: string;
+  /** The rule that produced the price, for preview attribution. */
+  appliedRule?: AdjustmentRule;
+  /** True when a guardrail floor raised the computed price. */
+  clamped: boolean;
+  /** The floor that applied, when one was computed. */
+  floor?: Money;
+  /** Machine-readable reason for a skip or block. */
+  reason?: ResolutionReason;
+  /** The price before rounding, for explaining preview output. */
+  unroundedPrice?: Money;
+}
+
+export type ResolutionReason =
+  | "below-floor"
+  | "missing-cost"
+  | "invalid-compare-at"
+  | "invalid-margin"
+  | "non-positive-price";
+
+export interface Resolution {
+  /** The price to write. Absent when nothing should be written. */
+  price?: Money;
+  /**
+   * The compare-at to write. `null` means explicitly clear it; `undefined` means
+   * leave whatever is there. The distinction is load-bearing — conflating them
+   * either wipes a merchant's compare-at or fails to set up a strike-through.
+   */
+  compareAtPrice?: Money | null;
+  meta: ResolutionMeta;
+}
+
+export interface ResolveInput {
+  baseline: Baseline;
+  surface: Surface;
+  /** Campaigns already filtered to active + targeting this surface + enrolled. */
+  campaigns: ResolvableCampaign[];
+  /** Store-level guardrails. Campaign guardrails may only tighten these. */
+  storeGuardrails?: Guardrails;
+  /** Segment ids this variant belongs to, for matching rule rows. */
+  variantSegmentIds?: string[];
+}


### PR DESCRIPTION
Implements **P2.2** (#102) and its five subtasks: #103 rule engine, #104 winner selection, #105 guardrail clamping, #106 compare-at policy, #107 invariant property tests.

> **Stacked on #180** (P2.1 money/rounding). Base is `feat/p2.1-money-rounding`, so the diff shows only the resolver. Merge #180 first and this retargets to `main` automatically.

## The core idea

```
baseline → rule → round → clamp → compare-at
```

Rounding runs **before** clamping, because a downward rounding profile can push an otherwise-legal price below a guardrail floor. Clamping last is what makes I6 hold on the value actually written.

**The type signature does the most important work.** `ResolveInput` has no field for the variant's current live price — so the resolver *structurally cannot* compute a discount relative to an already-discounted price. The compounding bug competitors ship is eliminated by the types, not by care.

## Modules

| File | |
|---|---|
| `types.ts` | Domain types. Compare-at distinguishes `null` (clear) from `undefined` (leave alone) — conflating them either wipes a merchant's compare-at or fails to set up a strike-through. |
| `rules.ts` | All six adjustment kinds. Cost-based rules **throw** on a missing cost rather than treating it as zero, which would price the item at nothing and report success. |
| `guardrails.ts` | Floors from min price, cost, and minimum margin. Campaign guardrails may only **tighten** store ones. |
| `resolver.ts` | Winner selection, clamping, compare-at, and `resolveWithout` for revert. |

## Decisions worth reviewing

**Winner selection is `(priority, startAt, id)`.** The id tie-break exists so the order is *total* — two campaigns created in the same millisecond with equal priority must still resolve deterministically, or preview and execution could disagree. Property-tested for order-insensitivity.

**Campaign guardrails may only tighten.** A campaign able to switch off a store-wide never-below-cost rule would make the store setting decorative.

**The margin floor rounds up.** Rounding down would produce a floor that itself violates the guardrail.

**Revert recomputes, it doesn't restore.** `resolveWithout(input, id)` falls through to the next-priority campaign — so ending a sale on a variant that's in *another* running sale leaves the second sale in place rather than restoring full price. That's invariant I3, tested explicitly.

## Invariants now executable

| | Property |
|---|---|
| **I1** | Determinism, including insensitivity to campaign array order |
| **I2** | Idempotency — three consecutive resolutions give 80.00, never 64.00 then 51.20 |
| **I3** | Removing a campaign falls through correctly; removing all returns exactly baseline |
| **I6** | Never below floor, never below cost when configured, never zero or negative |

Plus edge cases **E10** (non-positive price), **E11** (invalid compare-at), **E16** (overlapping rule rows).

## A property test I had to correct

I first asserted that *every* compare-at exceeds its price. It failed on the baseline path, where a merchant's own pre-existing data already had compare-at ≤ price.

Scoped to computed prices and documented: **we validate what we compute, and must not retroactively "fix" merchant data on the baseline path** — that path is also what revert writes, where faithfully restoring original state is the entire point. Silently clearing their compare-at on revert would be data loss.

## Verification

64 tests pass · typecheck · lint (0 problems) · build — all clean.

Closes #103, closes #104, closes #105, closes #106, closes #107