### PR TITLE
P2.3 — Run planner core and write-path selection

### DIFF
--- a/app/lib/planning/plan.test.ts
+++ b/app/lib/planning/plan.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { money } from "../money/money";
+import { NO_ROUNDING } from "../money/rounding";
+import type { ResolvableCampaign } from "../pricing/types";
+import { planRun, priceDelta, refKey, rowsNeedingWrite } from "./plan";
+import { DEFAULT_THRESHOLD, selectWritePath, thresholdFromEnv } from "./write-path";
+import type { PlanCandidate, PlanInput, SurfaceRef } from "./types";
+
+const usd = (n: number) => money(n, "USD");
+
+const baseRef = (variantGid: string): SurfaceRef => ({
+  variantGid,
+  surfaceKind: "base",
+  priceListGid: "",
+  currency: "USD",
+});
+
+function candidate(over: Partial<PlanCandidate> = {}): PlanCandidate {
+  return {
+    ref: baseRef("gid://Variant/1"),
+    baseline: { price: usd(10_000) },
+    livePrice: usd(10_000),
+    ...over,
+  };
+}
+
+function campaign(over: Partial<ResolvableCampaign> = {}): ResolvableCampaign {
+  return {
+    id: "c1",
+    priority: 100,
+    startAt: 1_000,
+    ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -20 } }],
+    compareAtPolicy: { kind: "leave" },
+    compareAtViolationPolicy: "clear",
+    roundingProfile: NO_ROUNDING,
+    guardrailViolationPolicy: "clamp",
+    ...over,
+  };
+}
+
+describe("resolve-diff", () => {
+  it("emits a row when the intended price differs from live", () => {
+    const out = planRun({ campaigns: [campaign()], candidates: [candidate()] });
+    expect(out.kind).toBe("ok");
+    if (out.kind !== "ok") return;
+
+    expect(out.rows).toHaveLength(1);
+    expect(out.rows[0].intendedPrice).toEqual(usd(8_000));
+    expect(out.rows[0].beforePrice).toEqual(usd(10_000));
+    expect(out.counts).toMatchObject({ planned: 1, noop: 0 });
+  });
+
+  it("skips no-ops where the storefront already shows the intended price", () => {
+    // The second run of a recurring campaign: everything is already correct.
+    const out = planRun({
+      campaigns: [campaign()],
+      candidates: [candidate({ livePrice: usd(8_000) })],
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+
+    expect(out.rows).toHaveLength(0);
+    expect(out.counts).toMatchObject({ planned: 0, noop: 1 });
+  });
+
+  it("does NOT treat a missing live value as a match", () => {
+    // We have no record of what is live, so the safe assumption is that a write is
+    // needed. Wrongly skipping would leave a stale price up for the whole campaign.
+    const out = planRun({
+      campaigns: [campaign()],
+      candidates: [candidate({ livePrice: undefined })],
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.rows).toHaveLength(1);
+    expect(out.counts.noop).toBe(0);
+  });
+
+  it("sets up a strike-through alongside the discount", () => {
+    const out = planRun({
+      campaigns: [campaign({ compareAtPolicy: { kind: "set-to-baseline" } })],
+      candidates: [candidate({ livePrice: usd(10_000), liveCompareAt: undefined })],
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.rows).toHaveLength(1);
+    expect(out.rows[0].intendedPrice).toEqual(usd(8_000));
+    expect(out.rows[0].intendedCompareAtSet).toBe(true);
+    expect(out.rows[0].intendedCompareAt).toEqual(usd(10_000));
+  });
+
+  it("a 0% change cannot create a strike-through, and produces no write", () => {
+    // compare-at would equal the price, which shows no saving (E11), so it is
+    // cleared -- and clearing an absent compare-at is a no-op. Worth pinning: it is
+    // a tempting way to "just add compare-at" that silently does nothing.
+    const out = planRun({
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: 0 } }],
+          compareAtPolicy: { kind: "set-to-baseline" },
+        }),
+      ],
+      candidates: [candidate({ livePrice: usd(10_000), liveCompareAt: undefined })],
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.counts).toMatchObject({ planned: 0, noop: 1 });
+  });
+
+  it("distinguishes clear-compare-at from leave-alone", () => {
+    const cleared = planRun({
+      campaigns: [campaign({ compareAtPolicy: { kind: "clear" } })],
+      candidates: [candidate({ liveCompareAt: usd(12_000) })],
+    });
+    if (cleared.kind !== "ok") throw new Error("expected ok");
+    expect(cleared.rows[0].intendedCompareAtSet).toBe(true);
+    expect(cleared.rows[0].intendedCompareAt).toBeNull();
+
+    const left = planRun({
+      campaigns: [campaign({ compareAtPolicy: { kind: "leave" } })],
+      candidates: [candidate({ liveCompareAt: usd(12_000) })],
+    });
+    if (left.kind !== "ok") throw new Error("expected ok");
+    expect(left.rows[0].intendedCompareAtSet).toBe(false);
+    expect(left.rows[0].intendedCompareAt).toBeUndefined();
+  });
+
+  it("clearing an already-absent compare-at is a no-op", () => {
+    const out = planRun({
+      campaigns: [
+        campaign({
+          ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: 0 } }],
+          compareAtPolicy: { kind: "clear" },
+        }),
+      ],
+      candidates: [candidate({ livePrice: usd(10_000), liveCompareAt: undefined })],
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.counts).toMatchObject({ planned: 0, noop: 1 });
+  });
+});
+
+describe("guardrail policy at plan time", () => {
+  it("records clamped rows with a reason and still writes them", () => {
+    const out = planRun({
+      campaigns: [campaign({ guardrailViolationPolicy: "clamp" })],
+      candidates: [candidate({ baseline: { price: usd(10_000), cost: usd(9_000) } })],
+      storeGuardrails: { neverBelowCost: true },
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+
+    expect(out.rows[0].status).toBe("clamped");
+    expect(out.rows[0].intendedPrice).toEqual(usd(9_000));
+    expect(out.counts).toMatchObject({ planned: 1, clamped: 1 });
+  });
+
+  it("records skipped rows without an intended price", () => {
+    const out = planRun({
+      campaigns: [campaign({ guardrailViolationPolicy: "skip" })],
+      candidates: [candidate({ baseline: { price: usd(10_000), cost: usd(9_000) } })],
+      storeGuardrails: { neverBelowCost: true },
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+
+    expect(out.rows[0].status).toBe("skipped");
+    expect(out.rows[0].intendedPrice).toBeUndefined();
+    expect(out.rows[0].reason).toBe("below-floor");
+    expect(out.counts.skipped).toBe(1);
+  });
+
+  it("a blocking violation aborts the whole plan, returning no rows", () => {
+    // Returning partial rows would let a caller write some of them, which is
+    // precisely what "block" has to prevent.
+    const out = planRun({
+      campaigns: [campaign({ guardrailViolationPolicy: "block" })],
+      candidates: [
+        candidate({ ref: baseRef("gid://Variant/1") }),
+        candidate({
+          ref: baseRef("gid://Variant/2"),
+          baseline: { price: usd(10_000), cost: usd(9_000) },
+        }),
+      ],
+      storeGuardrails: { neverBelowCost: true },
+    });
+
+    expect(out.kind).toBe("blocked");
+    if (out.kind !== "blocked") return;
+    expect(out.reason).toBe("below-floor");
+    expect(out.ref.variantGid).toBe("gid://Variant/2");
+    expect(out).not.toHaveProperty("rows");
+  });
+});
+
+describe("revert planning (invariant I3)", () => {
+  it("excluding a campaign falls through to the next, not to baseline", () => {
+    const high = campaign({
+      id: "high",
+      priority: 200,
+      ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -50 } }],
+    });
+    const low = campaign({
+      id: "low",
+      priority: 100,
+      ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -10 } }],
+    });
+
+    const out = planRun({
+      campaigns: [high, low],
+      candidates: [candidate({ livePrice: usd(5_000) })],
+      excludeCampaignId: "high",
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+
+    // 90.00 from the still-running sale, NOT 100.00.
+    expect(out.rows[0].intendedPrice).toEqual(usd(9_000));
+  });
+
+  it("excluding the only campaign restores the baseline", () => {
+    const out = planRun({
+      campaigns: [campaign({ id: "only" })],
+      candidates: [candidate({ livePrice: usd(8_000) })],
+      excludeCampaignId: "only",
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.rows[0].intendedPrice).toEqual(usd(10_000));
+  });
+});
+
+describe("plan properties", () => {
+  const anyCandidates = fc.array(
+    fc
+      .tuple(
+        fc.integer({ min: 1, max: 100_000 }),
+        fc.option(fc.integer({ min: 1, max: 100_000 }), { nil: undefined }),
+        fc.string({ minLength: 1, maxLength: 8 }),
+      )
+      .map(([basePrice, live, id]) =>
+        candidate({
+          ref: baseRef(`gid://Variant/${id}`),
+          baseline: { price: usd(basePrice) },
+          livePrice: live === undefined ? undefined : usd(live),
+        }),
+      ),
+    { maxLength: 25 },
+  );
+
+  const anyPlan: fc.Arbitrary<PlanInput> = anyCandidates.map((candidates) => ({
+    campaigns: [campaign()],
+    candidates,
+  }));
+
+  it("counts account for every distinct candidate exactly once", () => {
+    fc.assert(
+      fc.property(anyPlan, (input) => {
+        const out = planRun(input);
+        if (out.kind !== "ok") return;
+        const distinct = new Set(input.candidates.map((c) => refKey(c.ref))).size;
+        const { planned, noop, skipped } = out.counts;
+        expect(planned + noop + skipped).toBe(distinct);
+      }),
+    );
+  });
+
+  it("emits at most one row per candidate", () => {
+    fc.assert(
+      fc.property(anyPlan, (input) => {
+        const out = planRun(input);
+        if (out.kind !== "ok") return;
+        expect(out.rows.length).toBeLessThanOrEqual(input.candidates.length);
+        const keys = out.rows.map((r) => r.ref.variantGid);
+        expect(new Set(keys).size).toBe(keys.length);
+      }),
+    );
+  });
+
+  it("is deterministic", () => {
+    fc.assert(
+      fc.property(anyPlan, (input) => {
+        expect(planRun(input)).toEqual(planRun(input));
+      }),
+    );
+  });
+
+  it("re-planning after applying produces nothing (idempotency, I2)", () => {
+    // The property that makes recurring campaigns cheap and re-runs safe.
+    fc.assert(
+      fc.property(anyPlan, (input) => {
+        const first = planRun(input);
+        if (first.kind !== "ok") return;
+
+        // Simulate every planned row having been written successfully.
+        const applied = input.candidates.map((c) => {
+          const row = first.rows.find((r) => r.ref.variantGid === c.ref.variantGid);
+          if (!row?.intendedPrice) return c;
+          return {
+            ...c,
+            livePrice: row.intendedPrice,
+            liveCompareAt:
+              row.intendedCompareAtSet && row.intendedCompareAt
+                ? row.intendedCompareAt
+                : c.liveCompareAt,
+          };
+        });
+
+        const second = planRun({ ...input, candidates: applied });
+        if (second.kind !== "ok") return;
+        expect(second.counts.planned).toBe(0);
+      }),
+    );
+  });
+
+  it("every planned row carries a price to write", () => {
+    fc.assert(
+      fc.property(anyPlan, (input) => {
+        const out = planRun(input);
+        if (out.kind !== "ok") return;
+        for (const row of out.rows) {
+          if (row.status === "skipped") expect(row.intendedPrice).toBeUndefined();
+          else expect(row.intendedPrice).toBeDefined();
+        }
+      }),
+    );
+  });
+});
+
+describe("helpers", () => {
+  it("rowsNeedingWrite excludes skipped rows", () => {
+    const out = planRun({
+      campaigns: [campaign({ guardrailViolationPolicy: "skip" })],
+      candidates: [
+        // Needs a cost of its own: with neverBelowCost set store-wide, a variant
+        // with no cost is skipped rather than priced unguarded.
+        candidate({ ref: baseRef("v1"), baseline: { price: usd(10_000), cost: usd(2_000) } }),
+        candidate({
+          ref: baseRef("v2"),
+          baseline: { price: usd(10_000), cost: usd(9_000) },
+        }),
+      ],
+      storeGuardrails: { neverBelowCost: true },
+    });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.rows).toHaveLength(2);
+    expect(rowsNeedingWrite(out.rows)).toHaveLength(1);
+  });
+
+  it("collapses duplicate candidates for the same cell", () => {
+    // Upstream queries should never produce these, but a duplicate would violate the
+    // ledger's unique constraint at INSERT -- an opaque failure deep in the executor.
+    const dup = candidate({ ref: baseRef("dupe") });
+    const out = planRun({ campaigns: [campaign()], candidates: [dup, dup] });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(out.rows).toHaveLength(1);
+    expect(out.counts.planned).toBe(1);
+  });
+
+  it("priceDelta reports the net change", () => {
+    const out = planRun({ campaigns: [campaign()], candidates: [candidate()] });
+    if (out.kind !== "ok") throw new Error("expected ok");
+    expect(priceDelta(out.rows[0])).toEqual(usd(-2_000));
+  });
+});
+
+describe("write-path selection", () => {
+  it("uses sync below the threshold and bulk above it", () => {
+    expect(selectWritePath(500).path).toBe("sync");
+    expect(selectWritePath(DEFAULT_THRESHOLD).path).toBe("sync");
+    expect(selectWritePath(DEFAULT_THRESHOLD + 1).path).toBe("bulk");
+  });
+
+  it("prefers bulk when a sync run would not fit the observed budget", () => {
+    // 800 rows is under the row threshold, but at 50 points/s a standard shop needs
+    // far longer than the 60s ceiling -- row count alone is a poor proxy.
+    const decision = selectWritePath(800, {
+      restoreRatePerSecond: 50,
+      availablePoints: 1_000,
+    });
+    expect(decision.path).toBe("bulk");
+    expect(decision.reason).toContain("rate-limit budget");
+  });
+
+  it("keeps the same run on sync for a shop with a faster restore rate", () => {
+    const decision = selectWritePath(20, {
+      restoreRatePerSecond: 100,
+      availablePoints: 2_000,
+    });
+    expect(decision.path).toBe("sync");
+  });
+
+  it("handles an empty plan", () => {
+    expect(selectWritePath(0).path).toBe("sync");
+    expect(selectWritePath(0).reason).toContain("Nothing");
+  });
+
+  it("reads the threshold from the environment, ignoring nonsense", () => {
+    expect(thresholdFromEnv({ BULK_PATH_ROW_THRESHOLD: "250" })).toBe(250);
+    expect(thresholdFromEnv({})).toBe(DEFAULT_THRESHOLD);
+    expect(thresholdFromEnv({ BULK_PATH_ROW_THRESHOLD: "nope" })).toBe(DEFAULT_THRESHOLD);
+    expect(thresholdFromEnv({ BULK_PATH_ROW_THRESHOLD: "-5" })).toBe(DEFAULT_THRESHOLD);
+  });
+});

--- a/app/lib/planning/plan.ts
+++ b/app/lib/planning/plan.ts
@@ -1,0 +1,187 @@
+/**
+ * The run planner's pure core.
+ *
+ * For each enrolled variant × surface it resolves the intended state, diffs it
+ * against the mirrored live values, and emits a ledger row where they differ.
+ *
+ * Two properties matter more than anything else here:
+ *
+ *   Write-ahead. Rows are materialised BEFORE any Admin API call (invariant I4). If
+ *   the worker dies between writing the row and calling the API, verification finds
+ *   an unverified row and retries. The other order would change a merchant's
+ *   storefront with no record that we did it — unrecoverable, and precisely how
+ *   competitors end up unable to explain what happened.
+ *
+ *   No-ops are skipped. If the live value already equals the intended value there is
+ *   nothing to write. On a recurring campaign over a large catalogue, most rows are
+ *   no-ops on the second and subsequent runs; writing them anyway would multiply the
+ *   API cost of every recurrence for no benefit.
+ */
+
+import { equals, type Money } from "../money/money";
+import { resolve } from "../pricing/resolver";
+import type { Resolution } from "../pricing/types";
+import type {
+  PlanCandidate,
+  PlanCounts,
+  PlanInput,
+  PlanOutcome,
+  PlannedRow,
+} from "./types";
+
+/** Stable identity of one writable cell, matching the ledger's unique constraint. */
+export function refKey(ref: {
+  variantGid: string;
+  surfaceKind: string;
+  priceListGid: string;
+}): string {
+  return `${ref.variantGid}|${ref.surfaceKind}|${ref.priceListGid}`;
+}
+
+export function planRun(input: PlanInput): PlanOutcome {
+  const { candidates, storeGuardrails, excludeCampaignId } = input;
+
+  // Revert is resolution with the ending campaign removed, not a restore of saved
+  // numbers (invariant I3).
+  const campaigns = excludeCampaignId
+    ? input.campaigns.filter((c) => c.id !== excludeCampaignId)
+    : input.campaigns;
+
+  const rows: PlannedRow[] = [];
+  const counts: PlanCounts = { planned: 0, noop: 0, skipped: 0, clamped: 0 };
+
+  // `variant_changes` is unique on (runId, variantGid, surfaceKind, priceListGid).
+  // Two candidates for the same cell would violate that at INSERT, surfacing as an
+  // opaque constraint error deep inside the write path. Upstream queries should
+  // never produce duplicates, but collapsing them here makes the guarantee explicit
+  // and keeps the failure mode out of the executor entirely. First occurrence wins,
+  // so the result stays deterministic.
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    const key = refKey(candidate.ref);
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const resolution = resolve({
+      baseline: candidate.baseline,
+      surface: {
+        kind: candidate.ref.surfaceKind,
+        priceListId: candidate.ref.priceListGid || undefined,
+        currency: candidate.ref.currency,
+      },
+      // Callers pass campaigns already filtered to active, targeting this surface,
+      // and with this variant enrolled -- matching the resolver's documented
+      // contract. Enrollment in particular is pinned at plan time, so a product
+      // tagged mid-campaign is not priced by a run that never planned for it, and
+      // one untagged mid-campaign is still reverted (edge cases E5, E6). Those
+      // decisions need the clock and the database, so they live in the caller.
+      campaigns,
+      storeGuardrails,
+      variantSegmentIds: candidate.segmentIds,
+    });
+
+    // A blocking policy stops the whole run. Returning partial rows here would let
+    // a caller write some of them, which is exactly what "block" must prevent.
+    if (resolution.meta.outcome === "blocked") {
+      return {
+        kind: "blocked",
+        reason: resolution.meta.reason ?? "below-floor",
+        ref: candidate.ref,
+        counts,
+      };
+    }
+
+    if (resolution.meta.outcome === "skipped") {
+      counts.skipped++;
+      rows.push({
+        ref: candidate.ref,
+        beforePrice: candidate.livePrice,
+        beforeCompareAt: candidate.liveCompareAt,
+        intendedCompareAtSet: false,
+        status: "skipped",
+        reason: resolution.meta.reason,
+        campaignId: resolution.meta.controlledBy,
+      });
+      continue;
+    }
+
+    if (isNoop(resolution, candidate)) {
+      counts.noop++;
+      continue;
+    }
+
+    const compareAtSet = resolution.compareAtPrice !== undefined;
+
+    rows.push({
+      ref: candidate.ref,
+      beforePrice: candidate.livePrice,
+      beforeCompareAt: candidate.liveCompareAt,
+      intendedPrice: resolution.price,
+      intendedCompareAt: compareAtSet ? resolution.compareAtPrice : undefined,
+      intendedCompareAtSet: compareAtSet,
+      status: resolution.meta.clamped ? "clamped" : "pending",
+      reason: resolution.meta.clamped ? "below-floor" : undefined,
+      campaignId: resolution.meta.controlledBy,
+    });
+
+    counts.planned++;
+    if (resolution.meta.clamped) counts.clamped++;
+  }
+
+  return { kind: "ok", rows, counts };
+}
+
+/**
+ * True when the storefront already shows the intended values.
+ *
+ * A missing live value is deliberately NOT treated as a match. We have no record of
+ * what is live, so the safe assumption is that a write is needed — asserting the
+ * intended value costs one API call, while wrongly skipping leaves a stale price up
+ * for the length of a campaign.
+ */
+function isNoop(resolution: Resolution, candidate: PlanCandidate): boolean {
+  if (!resolution.price) return false;
+  if (!candidate.livePrice) return false;
+  if (!equals(resolution.price, candidate.livePrice)) return false;
+
+  // undefined means "leave compare-at alone", so price equality settles it.
+  if (resolution.compareAtPrice === undefined) return true;
+
+  // null means "clear it": a no-op only if there is nothing there already.
+  if (resolution.compareAtPrice === null) return candidate.liveCompareAt === undefined;
+
+  return (
+    candidate.liveCompareAt !== undefined &&
+    equals(resolution.compareAtPrice, candidate.liveCompareAt)
+  );
+}
+
+/** Groups rows by product, since `productVariantsBulkUpdate` is a per-product call. */
+export function groupByProduct<T extends { ref: { variantGid: string } }>(
+  rows: T[],
+  productOf: (variantGid: string) => string,
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const row of rows) {
+    const product = productOf(row.ref.variantGid);
+    const existing = groups.get(product);
+    if (existing) existing.push(row);
+    else groups.set(product, [row]);
+  }
+  return groups;
+}
+
+/** Rows that still need writing, for planning a resume (edge case E2). */
+export function rowsNeedingWrite(rows: PlannedRow[]): PlannedRow[] {
+  return rows.filter((r) => r.status !== "skipped");
+}
+
+/** Convenience for previews: the net change a row represents. */
+export function priceDelta(row: PlannedRow): Money | undefined {
+  if (!row.intendedPrice || !row.beforePrice) return undefined;
+  return {
+    amount: row.intendedPrice.amount - row.beforePrice.amount,
+    currency: row.intendedPrice.currency,
+  };
+}

--- a/app/lib/planning/types.ts
+++ b/app/lib/planning/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Planning types.
+ *
+ * The planner turns a campaign into concrete ledger rows. Its core is kept pure —
+ * it takes already-fetched inputs and returns rows to write, doing no I/O itself —
+ * so the diffing and policy logic is property-testable without a database. The
+ * streaming and persistence layer sits around it.
+ */
+
+import type { Money } from "../money/money";
+import type {
+  Baseline,
+  Guardrails,
+  ResolvableCampaign,
+  ResolutionReason,
+  SurfaceKind,
+} from "../pricing/types";
+
+/** Identifies one writable cell: a variant on a surface. */
+export interface SurfaceRef {
+  variantGid: string;
+  surfaceKind: SurfaceKind;
+  /** Empty string for the base surface, matching the schema's non-null column. */
+  priceListGid: string;
+  currency: string;
+}
+
+/** A variant's current mirrored state on one surface, plus its baseline. */
+export interface PlanCandidate {
+  ref: SurfaceRef;
+  baseline: Baseline;
+  /** Live values from the mirror. Absent means we have no record of a live value. */
+  livePrice?: Money;
+  liveCompareAt?: Money;
+  /** Segments this variant belongs to, for matching campaign rule rows. */
+  segmentIds?: string[];
+}
+
+export type PlannedRowStatus = "pending" | "skipped" | "clamped";
+
+/**
+ * A row destined for `variant_changes`.
+ *
+ * `intendedCompareAtSet` mirrors the schema's boolean: a null `intendedCompareAt`
+ * with the flag set means "clear it", and the flag unset means "leave it alone".
+ * A nullable column alone cannot carry both instructions.
+ */
+export interface PlannedRow {
+  ref: SurfaceRef;
+
+  beforePrice?: Money;
+  beforeCompareAt?: Money;
+
+  intendedPrice?: Money;
+  intendedCompareAt?: Money | null;
+  intendedCompareAtSet: boolean;
+
+  status: PlannedRowStatus;
+  /** Set for skipped and clamped rows so the merchant gets a named reason. */
+  reason?: ResolutionReason;
+  /** Campaign that produced this row. */
+  campaignId?: string;
+}
+
+export interface PlanCounts {
+  /** Rows that will be written. */
+  planned: number;
+  /** Already at the intended value; nothing to do. */
+  noop: number;
+  /** Excluded by policy, with reasons. */
+  skipped: number;
+  /** Written, but raised to a guardrail floor. */
+  clamped: number;
+}
+
+export type PlanOutcome =
+  | { kind: "ok"; rows: PlannedRow[]; counts: PlanCounts }
+  /**
+   * A "block" policy was violated. No rows are returned and nothing may be written —
+   * a blocking guardrail must stop the entire run, not merely the offending variant.
+   */
+  | { kind: "blocked"; reason: ResolutionReason; ref: SurfaceRef; counts: PlanCounts };
+
+export interface PlanInput {
+  campaigns: ResolvableCampaign[];
+  candidates: PlanCandidate[];
+  storeGuardrails?: Guardrails;
+  /**
+   * The campaign being reverted, if this is a revert plan. Excluded from resolution
+   * so the result is `resolve(without C)` — invariant I3.
+   */
+  excludeCampaignId?: string;
+}
+
+export type WritePath = "sync" | "bulk";
+
+export interface WritePathDecision {
+  path: WritePath;
+  rowCount: number;
+  reason: string;
+}

--- a/app/lib/planning/write-path.ts
+++ b/app/lib/planning/write-path.ts
@@ -1,0 +1,114 @@
+/**
+ * Choosing between the two write paths.
+ *
+ *   sync — `productVariantsBulkUpdate` called directly, grouped per product.
+ *          Immediate, but every call spends rate-limit budget.
+ *
+ *   bulk — `bulkOperationRunMutation` with a staged JSONL upload. Costs **zero**
+ *          rate-limit points, but carries real startup overhead (submit, queue,
+ *          poll, download, parse) and is processed FIFO, so a busy queue can add
+ *          minutes before the first row is touched.
+ *
+ * The crossover is around a thousand rows. Below it the bulk round-trip is slower
+ * than simply making the calls; above it, bulk wins on every dimension — and given
+ * the real budget is a 1,000-point bucket restoring at 50 points/second on standard
+ * plans, large synchronous runs are not merely slow but infeasible.
+ */
+
+import type { WritePathDecision } from "./types";
+
+export interface WritePathOptions {
+  /** Row count above which bulk is used. Default 1,000 (`BULK_PATH_ROW_THRESHOLD`). */
+  threshold?: number;
+  /**
+   * Points the shop's bucket restores per second, read from
+   * `extensions.cost.throttleStatus`. Never hardcode a plan's limit — Advanced and
+   * Plus restore at 100/s where standard restores at 50/s, and we do not know the
+   * merchant's plan in advance.
+   */
+  restoreRatePerSecond?: number;
+  /** Currently available points, likewise observed rather than assumed. */
+  availablePoints?: number;
+  /** Estimated cost of one mutation call. Shopify bills roughly 100 per variant. */
+  estimatedCostPerCall?: number;
+  /** Fraction of budget we allow ourselves, leaving headroom for other apps. */
+  headroom?: number;
+  /**
+   * How long a synchronous run may reasonably take before bulk is preferable
+   * regardless of row count. Default 60s.
+   */
+  maxSyncSeconds?: number;
+}
+
+export const DEFAULT_THRESHOLD = 1_000;
+const DEFAULT_COST_PER_CALL = 100;
+const DEFAULT_HEADROOM = 0.8;
+const DEFAULT_MAX_SYNC_SECONDS = 60;
+
+/**
+ * Picks a write path.
+ *
+ * Two independent reasons to choose bulk: too many rows, or a synchronous run that
+ * would not fit inside the shop's restore budget in reasonable time. The second
+ * matters because row count alone is a poor proxy — the same 800 rows are fine on a
+ * Plus store and painful on a throttled standard one.
+ */
+export function selectWritePath(
+  rowCount: number,
+  options: WritePathOptions = {},
+): WritePathDecision {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+
+  if (rowCount === 0) {
+    return { path: "sync", rowCount, reason: "Nothing to write." };
+  }
+
+  if (rowCount > threshold) {
+    return {
+      path: "bulk",
+      rowCount,
+      reason:
+        `${rowCount} rows exceeds the ${threshold}-row threshold; bulk operations ` +
+        `carry no rate-limit cost.`,
+    };
+  }
+
+  const restoreRate = options.restoreRatePerSecond;
+  if (restoreRate && restoreRate > 0) {
+    const costPerCall = options.estimatedCostPerCall ?? DEFAULT_COST_PER_CALL;
+    const headroom = options.headroom ?? DEFAULT_HEADROOM;
+    const maxSeconds = options.maxSyncSeconds ?? DEFAULT_MAX_SYNC_SECONDS;
+
+    const totalCost = rowCount * costPerCall;
+    const available = options.availablePoints ?? 0;
+    const usableRate = restoreRate * headroom;
+    const secondsNeeded = Math.max(0, totalCost - available) / usableRate;
+
+    if (secondsNeeded > maxSeconds) {
+      return {
+        path: "bulk",
+        rowCount,
+        reason:
+          `${rowCount} rows would need about ${Math.round(secondsNeeded)}s of ` +
+          `rate-limit budget at ${restoreRate} points/s, past the ${maxSeconds}s ` +
+          `ceiling for a synchronous run.`,
+      };
+    }
+  }
+
+  return {
+    path: "sync",
+    rowCount,
+    reason:
+      `${rowCount} rows is under the ${threshold}-row threshold and fits the ` +
+      `available rate-limit budget; sync avoids bulk queue latency.`,
+  };
+}
+
+/** Reads the threshold from the environment, falling back to the default. */
+export function thresholdFromEnv(env: Record<string, string | undefined>): number {
+  const raw = env.BULK_PATH_ROW_THRESHOLD;
+  if (!raw) return DEFAULT_THRESHOLD;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_THRESHOLD;
+}


### PR DESCRIPTION
Implements **P2.3** (#108) and subtasks #109–#113.

> Stacked on #184 (P2.2 resolver). Merge that first and this retargets to `main` — I'll retarget it manually this time rather than using `--delete-branch`, which is what auto-closed #181.

## What it does

For each enrolled variant × surface: resolve the intended state, diff against mirrored live values, emit a ledger row where they differ.

The core is **pure** — takes already-fetched inputs, returns rows, does no I/O — so the diffing and policy logic is property-testable without a database.

## Two behaviours carry most of the weight

**Write-ahead (invariant I4).** Rows are materialised *before* any Admin API call. If the worker dies between writing the row and calling the API, verification finds an unverified row and retries. The other order would change a merchant's storefront with no record that we did it.

**No-ops are skipped.** On the second run of a recurring campaign most rows are already correct; writing them anyway would multiply the API cost of every recurrence for nothing.

But a **missing** live value is deliberately *not* treated as a match — we have no record of what's live, so the safe assumption is that a write is needed. Wrongly skipping would leave a stale price up for an entire campaign.

## Write-path selection

Two independent reasons to choose bulk:

1. Row count above the threshold (default 1,000)
2. A sync run that wouldn't fit the shop's **observed** rate-limit budget within 60s

The second matters because row count alone is a poor proxy — the same 800 rows are fine on a Plus store and painful on a throttled standard one. Restore rate comes from `throttleStatus`, never hardcoded, since we don't know the merchant's plan in advance.

## A real gap the property tests found

Duplicate candidates for the same cell produced duplicate rows, which would violate `variant_changes(runId, variantGid, surfaceKind, priceListGid)` at INSERT — surfacing as an opaque constraint error deep inside the executor. Upstream queries shouldn't produce duplicates, but the planner now collapses them so the guarantee is explicit and the failure stays out of the write path.

## Two of my own test setups were wrong

Both now pinned as tests in their own right, since each is a tempting mistake:

- **A 0% change cannot create a strike-through.** Compare-at would equal the price, showing no saving, so it's cleared per E11 — and clearing an absent compare-at is a no-op. It looks like a way to "just add compare-at" and silently does nothing.
- **A store-wide never-below-cost rule skips variants with no cost at all**, rather than pricing them unguarded.

## Also

Removed a `campaignsTargeting` helper that took a candidate and ignored it — it implied surface filtering it didn't do. Callers pass pre-filtered campaigns per the resolver's contract, and that's now stated where it's relied upon.

## Verification

89 tests pass · typecheck · lint · build — all clean.

Closes #108, closes #109, closes #110, closes #111, closes #112, closes #113