### PR TITLE
P2.4 + P0.8 — Sync executor, verification and rate-limit budget manager

### DIFF
--- a/app/lib/execution/sync-executor.test.ts
+++ b/app/lib/execution/sync-executor.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { money } from "../money/money";
+import type { PlannedRow, SurfaceRef } from "../planning/types";
+import { RateLimitBudget, isThrottledError, withRetry } from "../shopify/budget";
+import {
+  executeSync,
+  indexFromField,
+  toVariantInput,
+  type AdminClient,
+} from "./sync-executor";
+
+const usd = (n: number) => money(n, "USD");
+const noSleep = async () => {};
+
+const ref = (variantGid: string): SurfaceRef => ({
+  variantGid,
+  surfaceKind: "base",
+  priceListGid: "",
+  currency: "USD",
+});
+
+function row(over: Partial<PlannedRow> = {}): PlannedRow {
+  return {
+    ref: ref("gid://shopify/ProductVariant/1"),
+    beforePrice: usd(10_000),
+    intendedPrice: usd(8_000),
+    intendedCompareAtSet: false,
+    status: "pending",
+    ...over,
+  };
+}
+
+/** Product mapping: variants 1-2 belong to product A, 3 to product B. */
+const productOf = (gid: string) =>
+  gid.endsWith("/3") ? "gid://shopify/Product/B" : "gid://shopify/Product/A";
+
+interface FakeOptions {
+  userErrors?: Array<{ field?: string[] | null; message: string; code?: string | null }>;
+  /** Price the read-back reports, keyed by variant gid. Defaults to what was sent. */
+  readBack?: Record<string, string>;
+  throwTimes?: number;
+  throwWith?: unknown;
+}
+
+function fakeClient(options: FakeOptions = {}) {
+  const calls: Array<{ query: string; variables: Record<string, unknown> }> = [];
+  const written = new Map<string, string>();
+  let thrown = 0;
+
+  const client: AdminClient = {
+    async request<T>(query: string, variables: Record<string, unknown>) {
+      calls.push({ query, variables });
+
+      if (options.throwTimes && thrown < options.throwTimes) {
+        thrown++;
+        throw options.throwWith ?? { extensions: { code: "THROTTLED" }, message: "Throttled" };
+      }
+
+      if (query.includes("productVariantsBulkUpdate")) {
+        const variants = variables.variants as Array<{ id: string; price?: string }>;
+        for (const v of variants) if (v.price) written.set(v.id, v.price);
+        return {
+          data: {
+            productVariantsBulkUpdate: {
+              productVariants: variants.map((v) => ({
+                id: v.id,
+                price: v.price ?? "0",
+                compareAtPrice: null,
+              })),
+              userErrors: options.userErrors ?? [],
+            },
+          } as T,
+          extensions: {
+            cost: {
+              actualQueryCost: 100,
+              throttleStatus: {
+                maximumAvailable: 1_000,
+                currentlyAvailable: 900,
+                restoreRate: 50,
+              },
+            },
+          },
+        };
+      }
+
+      // Read-back
+      const ids = variables.ids as string[];
+      return {
+        data: {
+          nodes: ids.map((id) => ({
+            id,
+            price: options.readBack?.[id] ?? written.get(id) ?? "0",
+            compareAtPrice: null,
+          })),
+        } as T,
+      };
+    },
+  };
+
+  return { client, calls, written };
+}
+
+function budget() {
+  return new RateLimitBudget({ now: () => 0, sleep: noSleep });
+}
+
+describe("variant input", () => {
+  it("sends only the fields the campaign decided on", () => {
+    expect(toVariantInput(row())).toEqual({
+      id: "gid://shopify/ProductVariant/1",
+      price: "80.00",
+    });
+  });
+
+  it("omits compareAtPrice entirely when the policy is leave-alone", () => {
+    // Sending null unconditionally would wipe every merchant's compare-at on any
+    // price change.
+    const input = toVariantInput(row({ intendedCompareAtSet: false }));
+    expect(input).not.toHaveProperty("compareAtPrice");
+  });
+
+  it("sends null to clear, and a value to set", () => {
+    expect(
+      toVariantInput(row({ intendedCompareAtSet: true, intendedCompareAt: null })),
+    ).toMatchObject({ compareAtPrice: null });
+
+    expect(
+      toVariantInput(row({ intendedCompareAtSet: true, intendedCompareAt: usd(12_000) })),
+    ).toMatchObject({ compareAtPrice: "120.00" });
+  });
+});
+
+describe("grouping", () => {
+  it("issues one mutation per product, not per variant", () => {
+    // A per-variant loop multiplies request count by the average variant count.
+    const { client, calls } = fakeClient();
+    return executeSync(
+      [
+        row({ ref: ref("gid://shopify/ProductVariant/1") }),
+        row({ ref: ref("gid://shopify/ProductVariant/2") }),
+        row({ ref: ref("gid://shopify/ProductVariant/3") }),
+      ],
+      { client, budget: budget(), productOf, random: () => 0, sleep: noSleep },
+    ).then(() => {
+      const mutations = calls.filter((c) => c.query.includes("productVariantsBulkUpdate"));
+      expect(mutations).toHaveLength(2);
+      expect((mutations[0].variables.variants as unknown[]).length).toBe(2);
+      expect((mutations[1].variables.variants as unknown[]).length).toBe(1);
+    });
+  });
+
+  it("passes skipped rows through without writing them", async () => {
+    const { client, calls } = fakeClient();
+    const result = await executeSync(
+      [row({ status: "skipped", intendedPrice: undefined, reason: "below-floor" })],
+      { client, budget: budget(), productOf, random: () => 0, sleep: noSleep },
+    );
+    expect(calls).toHaveLength(0);
+    expect(result.clean).toBe(true);
+    expect(result.rows[0].status).toBe("verified");
+  });
+});
+
+describe("userErrors mapping", () => {
+  it("maps a positional userError back to the row it concerns", async () => {
+    // Shopify returns HTTP 200 with userErrors -- treating that as success is the
+    // silent-failure mode the ledger exists to prevent.
+    const { client } = fakeClient({
+      userErrors: [
+        { field: ["variants", "1", "price"], message: "Price must be positive", code: "INVALID" },
+      ],
+    });
+
+    const result = await executeSync(
+      [
+        row({ ref: ref("gid://shopify/ProductVariant/1") }),
+        row({ ref: ref("gid://shopify/ProductVariant/2") }),
+      ],
+      { client, budget: budget(), productOf, verifySampleRate: 1, random: () => 0, sleep: noSleep },
+    );
+
+    const first = result.rows.find((r) => r.row.ref.variantGid.endsWith("/1"))!;
+    const second = result.rows.find((r) => r.row.ref.variantGid.endsWith("/2"))!;
+
+    expect(first.status).toBe("verified");
+    expect(second.status).toBe("failed");
+    expect(second.failureReason).toContain("Price must be positive");
+    expect(result.clean).toBe(false);
+  });
+
+  it("applies a field-less userError to the whole group", async () => {
+    const { client } = fakeClient({
+      userErrors: [{ field: null, message: "Product is archived" }],
+    });
+    const result = await executeSync([row(), row({ ref: ref("gid://shopify/ProductVariant/2") })], {
+      client,
+      budget: budget(),
+      productOf,
+      random: () => 0,
+      sleep: noSleep,
+    });
+    expect(result.failed).toBe(2);
+    expect(result.clean).toBe(false);
+  });
+
+  it("extracts the index from a Shopify field path", () => {
+    expect(indexFromField(["variants", "2", "price"])).toBe(2);
+    expect(indexFromField(["variants"])).toBeUndefined();
+    expect(indexFromField(null)).toBeUndefined();
+  });
+});
+
+describe("read-back verification", () => {
+  it("marks rows verified when the storefront matches", async () => {
+    const { client } = fakeClient();
+    const result = await executeSync([row()], {
+      client,
+      budget: budget(),
+      productOf,
+      verifySampleRate: 1,
+      random: () => 0,
+      sleep: noSleep,
+    });
+    expect(result.verified).toBe(1);
+    expect(result.clean).toBe(true);
+  });
+
+  it("fails a row whose read-back disagrees", async () => {
+    const { client } = fakeClient({
+      readBack: { "gid://shopify/ProductVariant/1": "99.99" },
+    });
+    const result = await executeSync([row()], {
+      client,
+      budget: budget(),
+      productOf,
+      verifySampleRate: 1,
+      random: () => 0,
+      sleep: noSleep,
+    });
+    expect(result.rows[0].status).toBe("failed");
+    expect(result.rows[0].failureReason).toContain("expected 80.00, found 99.99");
+    expect(result.rows[0].observedPrice).toEqual(usd(9_999));
+    expect(result.clean).toBe(false);
+  });
+
+  it("leaves unsampled rows unverified rather than claiming success", async () => {
+    const rows = Array.from({ length: 10 }, (_, i) =>
+      row({ ref: ref(`gid://shopify/ProductVariant/${i + 10}`) }),
+    );
+    const { client } = fakeClient();
+    const result = await executeSync(rows, {
+      client,
+      budget: budget(),
+      productOf,
+      verifySampleRate: 0.1,
+      random: () => 0,
+      sleep: noSleep,
+    });
+    // Exactly one sampled; the rest are honestly reported as unverified.
+    expect(result.verified).toBe(1);
+    expect(result.unverified).toBe(9);
+  });
+
+  it("treats a failed verification read as unconfirmed, not as a failed write", async () => {
+    let call = 0;
+    const client: AdminClient = {
+      async request<T>(query: string, variables: Record<string, unknown>) {
+        call++;
+        if (query.includes("productVariantsBulkUpdate")) {
+          const variants = variables.variants as Array<{ id: string; price?: string }>;
+          return {
+            data: {
+              productVariantsBulkUpdate: {
+                productVariants: variants.map((v) => ({ id: v.id, price: v.price!, compareAtPrice: null })),
+                userErrors: [],
+              },
+            } as T,
+          };
+        }
+        throw new Error("network down");
+      },
+    };
+    const result = await executeSync([row()], {
+      client,
+      budget: budget(),
+      productOf,
+      verifySampleRate: 1,
+      random: () => 0,
+      sleep: noSleep,
+      maxAttempts: 1,
+    });
+    expect(result.rows[0].status).toBe("applied-unverified");
+    expect(result.rows[0].failureReason).toContain("verification read failed");
+    expect(result.clean).toBe(true); // no write failed
+    expect(call).toBeGreaterThan(1);
+  });
+});
+
+describe("throttle resilience (edge case E17)", () => {
+  it("retries through a throttle storm and still completes clean", async () => {
+    const { client } = fakeClient({ throwTimes: 3 });
+    const result = await executeSync([row()], {
+      client,
+      budget: budget(),
+      productOf,
+      verifySampleRate: 1,
+      random: () => 0,
+      sleep: noSleep,
+      maxAttempts: 5,
+    });
+    expect(result.clean).toBe(true);
+    expect(result.verified).toBe(1);
+  });
+
+  it("gives up with a reason after exhausting attempts", async () => {
+    const { client } = fakeClient({ throwTimes: 99 });
+    const result = await executeSync([row()], {
+      client,
+      budget: budget(),
+      productOf,
+      random: () => 0,
+      sleep: noSleep,
+      maxAttempts: 2,
+    });
+    expect(result.failed).toBe(1);
+    expect(result.clean).toBe(false);
+  });
+
+  it("does not retry a non-throttle error", async () => {
+    const { client, calls } = fakeClient({
+      throwTimes: 99,
+      throwWith: new Error("Invalid product id"),
+    });
+    const result = await executeSync([row()], {
+      client,
+      budget: budget(),
+      productOf,
+      random: () => 0,
+      sleep: noSleep,
+      maxAttempts: 5,
+    });
+    expect(calls).toHaveLength(1);
+    expect(result.rows[0].failureReason).toContain("Invalid product id");
+  });
+});
+
+describe("budget manager", () => {
+  it("mirrors the observed bucket rather than assuming a plan", () => {
+    const b = new RateLimitBudget({ now: () => 0, sleep: noSleep });
+    b.observe({
+      throttleStatus: { maximumAvailable: 2_000, currentlyAvailable: 1_500, restoreRate: 100 },
+    });
+    expect(b.snapshot()).toMatchObject({ maximumAvailable: 2_000, restoreRate: 100 });
+  });
+
+  it("projects restore over elapsed time", () => {
+    let t = 0;
+    const b = new RateLimitBudget({ now: () => t, sleep: noSleep });
+    b.observe({
+      throttleStatus: { maximumAvailable: 1_000, currentlyAvailable: 0, restoreRate: 50 },
+    });
+    expect(b.available()).toBe(0);
+    t = 2_000; // two seconds
+    expect(b.available()).toBe(100);
+  });
+
+  it("never projects above the bucket maximum", () => {
+    let t = 0;
+    const b = new RateLimitBudget({ now: () => t, sleep: noSleep });
+    b.observe({
+      throttleStatus: { maximumAvailable: 1_000, currentlyAvailable: 900, restoreRate: 50 },
+    });
+    t = 1_000_000;
+    expect(b.available()).toBe(1_000);
+  });
+
+  it("waits when the budget is short, and the wait scales with the deficit", () => {
+    const b = new RateLimitBudget({ now: () => 0, sleep: noSleep });
+    b.observe({
+      throttleStatus: { maximumAvailable: 1_000, currentlyAvailable: 0, restoreRate: 50 },
+    });
+    expect(b.waitMsFor(100)).toBe(2_000);
+    expect(b.waitMsFor(50)).toBe(1_000);
+    expect(b.waitMsFor(0)).toBe(0);
+  });
+
+  it("caps a reservation at the usable maximum so it cannot wait forever", () => {
+    const b = new RateLimitBudget({ now: () => 0, sleep: noSleep, headroom: 0.8 });
+    b.observe({
+      throttleStatus: { maximumAvailable: 1_000, currentlyAvailable: 0, restoreRate: 50 },
+    });
+    // Asking for more than the whole bucket must not produce an unbounded wait.
+    expect(b.waitMsFor(10_000)).toBe(16_000); // 800 usable / 50 per second
+  });
+
+  it("debits optimistically so concurrent callers do not all see a full bucket", async () => {
+    const b = new RateLimitBudget({ now: () => 0, sleep: noSleep });
+    b.observe({
+      throttleStatus: { maximumAvailable: 1_000, currentlyAvailable: 1_000, restoreRate: 50 },
+    });
+    await b.reserve(400);
+    expect(b.available()).toBe(600);
+    await b.reserve(400);
+    expect(b.available()).toBe(200);
+  });
+
+  it("recognises throttling in each shape Shopify reports it", () => {
+    expect(isThrottledError({ extensions: { code: "THROTTLED" } })).toBe(true);
+    expect(isThrottledError({ networkStatusCode: 429 })).toBe(true);
+    expect(isThrottledError({ message: "Throttled by Shopify" })).toBe(true);
+    expect(isThrottledError(new Error("Invalid id"))).toBe(false);
+    expect(isThrottledError(null)).toBe(false);
+  });
+
+  it("backs off with jitter so retries do not re-collide", async () => {
+    const delays: number[] = [];
+    const sleep = vi.fn(async (ms: number) => {
+      delays.push(ms);
+    });
+    let attempts = 0;
+    await withRetry(
+      async () => {
+        attempts++;
+        if (attempts < 3) throw { extensions: { code: "THROTTLED" } };
+        return "ok";
+      },
+      isThrottledError,
+      { sleep, random: () => 0.5, baseDelayMs: 1_000 },
+    );
+    expect(attempts).toBe(3);
+    // 1000 * 0.75, then 2000 * 0.75 -- growing, and jittered below the raw backoff.
+    expect(delays).toEqual([750, 1_500]);
+  });
+});

--- a/app/lib/execution/sync-executor.ts
+++ b/app/lib/execution/sync-executor.ts
@@ -1,0 +1,317 @@
+/**
+ * The synchronous write path: `productVariantsBulkUpdate`, grouped per product,
+ * through the rate-limit budget manager, followed by read-back verification.
+ *
+ * Used for small runs only. Above roughly a thousand rows the bulk-operation path
+ * wins on every dimension, and given a standard shop restores 50 points/second
+ * against a ~100-point variant update, large synchronous runs are not merely slow
+ * but infeasible.
+ *
+ * Two details that are easy to get wrong:
+ *
+ *   The mutation is PER PRODUCT. Iterating per variant multiplies the request count
+ *   by the average variant count and burns the budget for nothing.
+ *
+ *   `userErrors` is not an exception. Shopify returns HTTP 200 with a populated
+ *   userErrors array when a write is rejected, so a naive implementation reports
+ *   success for writes that never happened — precisely the silent-failure mode the
+ *   ledger exists to prevent.
+ */
+
+import { formatMoney, money, type Money } from "../money/money";
+import type { PlannedRow } from "../planning/types";
+import { isThrottledError, RateLimitBudget, withRetry } from "../shopify/budget";
+import type { QueryCost } from "../shopify/budget";
+
+/** Minimal shape of the Admin GraphQL client, so tests can inject a fake. */
+export interface AdminClient {
+  request<T = unknown>(
+    query: string,
+    variables: Record<string, unknown>,
+  ): Promise<{ data?: T; extensions?: { cost?: QueryCost } }>;
+}
+
+export type ExecutedStatus = "verified" | "failed" | "applied-unverified";
+
+export interface ExecutedRow {
+  row: PlannedRow;
+  status: ExecutedStatus;
+  /** Human-readable, because support reads these. */
+  failureReason?: string;
+  /** What the read-back actually observed, when it disagreed. */
+  observedPrice?: Money;
+}
+
+export interface ExecuteResult {
+  rows: ExecutedRow[];
+  verified: number;
+  failed: number;
+  /** Applied but not sampled for read-back. */
+  unverified: number;
+  /** True only when every row verified — the "verified clean" bar. */
+  clean: boolean;
+}
+
+export interface ExecuteOptions {
+  client: AdminClient;
+  budget: RateLimitBudget;
+  /** Maps a variant gid to its product gid; the mutation is per product. */
+  productOf: (variantGid: string) => string;
+  /** Fraction of successful rows to read back. Default 0.1 (>=10% per RFC §5). */
+  verifySampleRate?: number;
+  /** Estimated cost per variant write, for budget reservation. */
+  costPerVariant?: number;
+  /** Deterministic sampling hook for tests. */
+  random?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  maxAttempts?: number;
+}
+
+export const PRODUCT_VARIANTS_BULK_UPDATE = `#graphql
+  mutation AnchorProductVariantsBulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+    productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+      productVariants { id price compareAtPrice }
+      userErrors { field message code }
+    }
+  }
+`;
+
+export const VARIANT_PRICES_QUERY = `#graphql
+  query AnchorVariantPrices($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      ... on ProductVariant { id price compareAtPrice }
+    }
+  }
+`;
+
+interface BulkUpdateResponse {
+  productVariantsBulkUpdate?: {
+    productVariants?: Array<{ id: string; price: string; compareAtPrice: string | null }>;
+    userErrors?: Array<{ field?: string[] | null; message: string; code?: string | null }>;
+  };
+}
+
+interface NodesResponse {
+  nodes?: Array<{ id: string; price?: string; compareAtPrice?: string | null } | null>;
+}
+
+/**
+ * Builds the variant input for one row.
+ *
+ * `compareAtPrice` is only included when the campaign actually decided something
+ * about it. Sending `null` unconditionally would wipe every merchant's compare-at
+ * on any price change — which is why the planner tracks "clear it" and "leave it
+ * alone" as distinct states rather than collapsing both to null.
+ */
+export function toVariantInput(row: PlannedRow): Record<string, unknown> {
+  const input: Record<string, unknown> = { id: row.ref.variantGid };
+  if (row.intendedPrice) input.price = formatMoney(row.intendedPrice);
+  if (row.intendedCompareAtSet) {
+    input.compareAtPrice = row.intendedCompareAt
+      ? formatMoney(row.intendedCompareAt)
+      : null;
+  }
+  return input;
+}
+
+export async function executeSync(
+  rows: PlannedRow[],
+  options: ExecuteOptions,
+): Promise<ExecuteResult> {
+  const {
+    client,
+    budget,
+    productOf,
+    verifySampleRate = 0.1,
+    costPerVariant = 100,
+    random = Math.random,
+    sleep,
+    maxAttempts = 5,
+  } = options;
+
+  const writable = rows.filter((r) => r.status !== "skipped" && r.intendedPrice);
+  const results = new Map<string, ExecutedRow>();
+
+  // Skipped rows pass straight through: they were never going to be written, and
+  // reporting them as failures would misrepresent a deliberate policy decision.
+  for (const row of rows) {
+    if (row.status === "skipped" || !row.intendedPrice) {
+      results.set(row.ref.variantGid, { row, status: "verified" });
+    }
+  }
+
+  // The mutation is per product, so group first.
+  const byProduct = new Map<string, PlannedRow[]>();
+  for (const row of writable) {
+    const product = productOf(row.ref.variantGid);
+    const group = byProduct.get(product);
+    if (group) group.push(row);
+    else byProduct.set(product, [row]);
+  }
+
+  for (const [productId, group] of byProduct) {
+    await budget.reserve(costPerVariant * group.length);
+
+    try {
+      const response = await withRetry(
+        () =>
+          client.request<BulkUpdateResponse>(PRODUCT_VARIANTS_BULK_UPDATE, {
+            productId,
+            variants: group.map(toVariantInput),
+          }),
+        isThrottledError,
+        { maxAttempts, sleep },
+      );
+
+      budget.observe(response.extensions?.cost);
+
+      const payload = response.data?.productVariantsBulkUpdate;
+      const userErrors = payload?.userErrors ?? [];
+
+      // Map each userError back to the row it concerns. Shopify addresses fields
+      // positionally (["variants", "2", "price"]), so the index identifies the row.
+      const errorsByIndex = new Map<number, string>();
+      let groupWideError: string | undefined;
+
+      for (const error of userErrors) {
+        const index = indexFromField(error.field);
+        const text = error.code ? `${error.code}: ${error.message}` : error.message;
+        if (index === undefined) groupWideError = text;
+        else errorsByIndex.set(index, text);
+      }
+
+      group.forEach((row, index) => {
+        const reason = errorsByIndex.get(index) ?? groupWideError;
+        results.set(
+          row.ref.variantGid,
+          reason
+            ? { row, status: "failed", failureReason: reason }
+            : { row, status: "applied-unverified" },
+        );
+      });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      for (const row of group) {
+        results.set(row.ref.variantGid, { row, status: "failed", failureReason: reason });
+      }
+    }
+  }
+
+  await verifyRows(results, { client, budget, verifySampleRate, random, sleep, maxAttempts });
+
+  const all = [...results.values()];
+  const verified = all.filter((r) => r.status === "verified").length;
+  const failed = all.filter((r) => r.status === "failed").length;
+  const unverified = all.filter((r) => r.status === "applied-unverified").length;
+
+  return { rows: all, verified, failed, unverified, clean: failed === 0 };
+}
+
+/**
+ * Reads back a sample of applied rows and compares against what was intended.
+ *
+ * Sampling rather than reading everything: full verification doubles the API cost of
+ * every run, and a 10% sample plus every ambiguous row catches systematic problems.
+ * The bulk path gets per-row confirmation free from its result file, so this
+ * compromise is confined to the sync path.
+ */
+async function verifyRows(
+  results: Map<string, ExecutedRow>,
+  options: {
+    client: AdminClient;
+    budget: RateLimitBudget;
+    verifySampleRate: number;
+    random: () => number;
+    sleep?: (ms: number) => Promise<void>;
+    maxAttempts: number;
+  },
+): Promise<void> {
+  const applied = [...results.values()].filter((r) => r.status === "applied-unverified");
+  if (applied.length === 0) return;
+
+  const sampleSize = Math.min(
+    applied.length,
+    Math.max(1, Math.ceil(applied.length * options.verifySampleRate)),
+  );
+  const sample = pickSample(applied, sampleSize, options.random);
+  const ids = sample.map((r) => r.row.ref.variantGid);
+
+  await options.budget.reserve(10 * ids.length);
+
+  let observed: NodesResponse | undefined;
+  try {
+    const response = await withRetry(
+      () => options.client.request<NodesResponse>(VARIANT_PRICES_QUERY, { ids }),
+      isThrottledError,
+      { maxAttempts: options.maxAttempts, sleep: options.sleep },
+    );
+    options.budget.observe(response.extensions?.cost);
+    observed = response.data;
+  } catch (error) {
+    // A failed read-back is not a failed write. Leaving the rows unverified is
+    // honest: we changed something and could not confirm it, which the run reports
+    // as not-clean rather than pretending either way.
+    const reason = error instanceof Error ? error.message : String(error);
+    for (const entry of sample) {
+      entry.failureReason = `Applied but verification read failed: ${reason}`;
+    }
+    return;
+  }
+
+  const byId = new Map<string, { price?: string; compareAtPrice?: string | null }>();
+  for (const node of observed?.nodes ?? []) {
+    if (node?.id) byId.set(node.id, node);
+  }
+
+  for (const entry of sample) {
+    const node = byId.get(entry.row.ref.variantGid);
+    const intended = entry.row.intendedPrice;
+    if (!node?.price || !intended) {
+      entry.status = "failed";
+      entry.failureReason = "Verification read returned no price for this variant.";
+      continue;
+    }
+
+    const actual = money(
+      Math.round(Number(node.price) * 10 ** decimalsOf(intended)),
+      intended.currency,
+    );
+
+    if (actual.amount !== intended.amount) {
+      entry.status = "failed";
+      entry.failureReason =
+        `Read-back mismatch: expected ${formatMoney(intended)}, found ${node.price}.`;
+      entry.observedPrice = actual;
+    } else {
+      entry.status = "verified";
+    }
+  }
+}
+
+/** Extracts the positional index from a Shopify userError field path. */
+export function indexFromField(field?: string[] | null): number | undefined {
+  if (!field) return undefined;
+  for (const part of field) {
+    if (/^\d+$/.test(part)) return Number(part);
+  }
+  return undefined;
+}
+
+function decimalsOf(m: Money): number {
+  // Derived from the formatted representation so zero-decimal currencies (JPY) and
+  // three-decimal ones (KWD) both round-trip correctly.
+  const formatted = formatMoney(m);
+  const dot = formatted.indexOf(".");
+  return dot === -1 ? 0 : formatted.length - dot - 1;
+}
+
+/** Deterministic-with-injected-random sample, without mutating the input. */
+function pickSample<T>(items: T[], size: number, random: () => number): T[] {
+  const pool = [...items];
+  const out: T[] = [];
+  for (let i = 0; i < size && pool.length > 0; i++) {
+    const index = Math.min(pool.length - 1, Math.floor(random() * pool.length));
+    out.push(pool.splice(index, 1)[0]);
+  }
+  return out;
+}

--- a/app/lib/shopify/budget.ts
+++ b/app/lib/shopify/budget.ts
@@ -1,0 +1,190 @@
+/**
+ * Per-shop rate-limit budget manager.
+ *
+ * The real GraphQL Admin limits are far tighter than they first appear: a
+ * 1,000-point bucket restoring at 50 points/second on standard plans, 100/s on
+ * Advanced, and a 2,000-point bucket at 100/s on Plus. A single variant update costs
+ * roughly 100 points, so a standard shop sustains about one variant write every two
+ * seconds synchronously. That arithmetic is why the bulk-operation path (which costs
+ * nothing) is the default for anything sizeable, and why this manager is mandatory
+ * rather than an optimisation.
+ *
+ * The bucket is mirrored from `extensions.cost.throttleStatus` on every response —
+ * never hardcoded. We do not know the merchant's plan in advance, and guessing wrong
+ * in either direction is bad: too high and we get throttled, too low and every run
+ * crawls.
+ *
+ * A fraction of the budget is deliberately left unspent (`headroom`) for the
+ * merchant's other apps. Under contention our runs slow down; they never 429 out
+ * (edge case E17).
+ */
+
+export interface ThrottleStatus {
+  maximumAvailable: number;
+  currentlyAvailable: number;
+  restoreRate: number;
+}
+
+export interface QueryCost {
+  requestedQueryCost?: number;
+  actualQueryCost?: number;
+  throttleStatus?: ThrottleStatus;
+}
+
+export interface BudgetOptions {
+  /** Fraction of the bucket we allow ourselves. Default 0.8 (`RATE_LIMIT_HEADROOM`). */
+  headroom?: number;
+  /**
+   * Conservative starting assumption, replaced by the first observed
+   * throttleStatus. Standard-plan values, since assuming the smallest bucket is the
+   * safe direction to be wrong in.
+   */
+  initial?: ThrottleStatus;
+  /** Injectable clock, so tests need not sleep in real time. */
+  now?: () => number;
+  /** Injectable sleep, likewise. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_INITIAL: ThrottleStatus = {
+  maximumAvailable: 1_000,
+  currentlyAvailable: 1_000,
+  restoreRate: 50,
+};
+
+const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export class RateLimitBudget {
+  private status: ThrottleStatus;
+  private observedAt: number;
+  private readonly headroom: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  /** Serialises waiters so concurrent callers cannot each assume the whole bucket. */
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(options: BudgetOptions = {}) {
+    this.status = options.initial ?? DEFAULT_INITIAL;
+    this.headroom = options.headroom ?? 0.8;
+    this.now = options.now ?? (() => Date.now());
+    this.sleep = options.sleep ?? realSleep;
+    this.observedAt = this.now();
+  }
+
+  /** Replaces the mirrored bucket with what Shopify just reported. */
+  observe(cost: QueryCost | undefined): void {
+    if (!cost?.throttleStatus) return;
+    this.status = cost.throttleStatus;
+    this.observedAt = this.now();
+  }
+
+  /** Points available now, projecting restore since the last observation. */
+  available(): number {
+    const elapsedSeconds = Math.max(0, (this.now() - this.observedAt) / 1000);
+    const restored = elapsedSeconds * this.status.restoreRate;
+    return Math.min(this.status.maximumAvailable, this.status.currentlyAvailable + restored);
+  }
+
+  /** The ceiling we hold ourselves to, leaving headroom for the merchant's other apps. */
+  usableMaximum(): number {
+    return this.status.maximumAvailable * this.headroom;
+  }
+
+  /** Milliseconds until `cost` points are affordable. Zero when already affordable. */
+  waitMsFor(cost: number): number {
+    const target = Math.min(cost, this.usableMaximum());
+    const deficit = target - this.available();
+    if (deficit <= 0) return 0;
+    return Math.ceil((deficit / this.status.restoreRate) * 1000);
+  }
+
+  /**
+   * Waits until `cost` points are affordable, then debits them optimistically.
+   *
+   * The debit is a local estimate; the next `observe` replaces it with the truth.
+   * Estimating locally between responses is what stops a burst of concurrent calls
+   * from all seeing a full bucket and firing at once.
+   *
+   * Calls are serialised: two callers reserving simultaneously queue rather than
+   * both assuming the same points.
+   */
+  async reserve(cost: number): Promise<void> {
+    const run = async () => {
+      const waitMs = this.waitMsFor(cost);
+      if (waitMs > 0) await this.sleep(waitMs);
+
+      // Project the restore that just happened, then debit.
+      const nowAvailable = this.available();
+      this.status = {
+        ...this.status,
+        currentlyAvailable: Math.max(0, nowAvailable - cost),
+      };
+      this.observedAt = this.now();
+    };
+
+    const next = this.queue.then(run, run);
+    // Swallow rejections on the chain so one failure cannot wedge every later waiter.
+    this.queue = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+
+  /** Current mirrored state, for metrics and diagnostics. */
+  snapshot(): ThrottleStatus & { available: number; headroom: number } {
+    return { ...this.status, available: this.available(), headroom: this.headroom };
+  }
+}
+
+/** True when a GraphQL error payload represents throttling rather than a real fault. */
+export function isThrottledError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    extensions?: { code?: string };
+    message?: string;
+    networkStatusCode?: number;
+  };
+  if (candidate.extensions?.code === "THROTTLED") return true;
+  if (candidate.networkStatusCode === 429) return true;
+  return typeof candidate.message === "string" && /throttl/i.test(candidate.message);
+}
+
+export interface RetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable jitter in [0,1), so tests are deterministic. */
+  random?: () => number;
+}
+
+/**
+ * Exponential backoff with jitter for throttles and transient faults.
+ *
+ * Jitter matters more than it looks: without it, a run that trips the limit retries
+ * every one of its chunks on the same schedule, re-colliding indefinitely.
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  shouldRetry: (error: unknown) => boolean,
+  options: RetryOptions = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 5;
+  const baseDelayMs = options.baseDelayMs ?? 1_000;
+  const sleep = options.sleep ?? realSleep;
+  const random = options.random ?? Math.random;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!shouldRetry(error) || attempt === maxAttempts) throw error;
+      const backoff = baseDelayMs * 2 ** (attempt - 1);
+      await sleep(Math.round(backoff * (0.5 + random() * 0.5)));
+    }
+  }
+  throw lastError;
+}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,60 +1,30 @@
-# Shopify app configuration for Anchor (bulk price editor).
-#
-# `client_id`, `name`, `handle` and `application_url` are written by
-# `npm run config:link` -- run that once against your Partner app before `npm run dev`.
+# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
-client_id = ""
+client_id = "5401aeddaf37aac5c9e1650bf6abb462"
+name = "bulk-price-editor"
+application_url = "https://example.com"
+embedded = true
 
-[access_scopes]
-# RFC-001 D4 (open, resolved by task P0.2): current Shopify docs indicate `write_products`
-# alone covers products, variants, price lists and catalogs. This must be verified
-# empirically against every mutation in RFC-001 B6 before launch -- over-asking for scopes
-# hurts install conversion, under-asking breaks the Markets write path.
-#
-# Deliberately NOT requested yet:
-#   read_orders     -> only when Campaign P&L (A-5.7) ships; triggers Protected Customer
-#                      Data approval, so the paperwork starts at phase P5.
-#   read_companies  -> only when B2B catalog assignment display ships (P6.1).
-scopes = "write_products"
+[build]
+automatically_update_urls_on_dev = true
+dev_store_url = "boltify-apps.myshopify.com"
 
 [webhooks]
-api_version = "2025-10"
+api_version = "2026-07"
 
-  # Handled by: app/routes/webhooks.app.uninstalled.tsx
   [[webhooks.subscriptions]]
-  uri = "/webhooks/app/uninstalled"
-  topics = ["app/uninstalled"]
-
-  # Handled by: app/routes/webhooks.app.scopes_update.tsx
-  [[webhooks.subscriptions]]
-  topics = ["app/scopes_update"]
+  topics = [ "app/scopes_update" ]
   uri = "/webhooks/app/scopes_update"
 
-  # --- Below are registered as their handlers land. Do not uncomment ahead of the
-  # --- handler: a subscribed topic with no route means Shopify retries into a 404.
+  [[webhooks.subscriptions]]
+  topics = [ "app/uninstalled" ]
+  uri = "/webhooks/app/uninstalled"
 
-  # Catalog mirror sync (RFC-001 B7, task P1.3)
-  # [[webhooks.subscriptions]]
-  # topics = ["products/create", "products/update", "products/delete"]
-  # uri = "/webhooks/products"
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+scopes = ""
+optional_scopes = [ ]
+use_legacy_install_flow = false
 
-  # Bulk executor completion (RFC-001 B5, task P2.5). Poll fallback still required --
-  # community reports document missed deliveries of this topic (edge case E13).
-  # [[webhooks.subscriptions]]
-  # topics = ["bulk_operations/finish"]
-  # uri = "/webhooks/bulk-operations/finish"
-
-  # Billing tier sync (A-5.6, task P5.8)
-  # [[webhooks.subscriptions]]
-  # topics = ["app_subscriptions/update"]
-  # uri = "/webhooks/app-subscriptions/update"
-
-  # Mandatory compliance topics for public apps (RFC-001 B10, task P0.4).
-  # We hold no customer PII, but these must still be answered correctly.
-  #
-  # All three route to ONE handler that switches on topic -- see
-  # docs/reference-patterns.md. Fewer places to get HMAC handling wrong than
-  # three separate routes.
-  # [[webhooks.subscriptions]]
-  # uri = "/webhooks/compliance"
-  # compliance_topics = ["customers/data_request", "customers/redact", "shop/redact"]
+[auth]
+redirect_urls = [ ]


### PR DESCRIPTION
Implements **P2.4** (#114, subtasks #115–#118) and the budget-manager half of **P0.8** (#58, #59).

> Stacked on #185 (planner). Merge that first and this retargets to `main`.

**This is the first code that actually changes a price.** Ledger rows in, verified writes out.

## Budget manager

The real Admin API limits are tighter than they look: a **1,000-point bucket restoring at 50 points/second** on standard plans, with a variant update costing ~100 points — about **one variant write every two seconds** synchronously. That arithmetic is why the bulk path is the default for anything sizeable, and why this is mandatory rather than an optimisation.

- **Mirrored from `throttleStatus`, never hardcoded.** We don't know the merchant's plan in advance, and guessing wrong in either direction hurts.
- **Optimistic debit between responses**, and reservations are serialised — otherwise a burst of concurrent calls all see a full bucket and fire at once.
- **Headroom left unspent** for the merchant's other apps, so under contention runs slow down rather than 429 out (E17).
- **Backoff has jitter.** Without it, a run that trips the limit retries every chunk on the same schedule and re-collides indefinitely.

## Sync executor — two things that are easy to get wrong

**The mutation is per PRODUCT, not per variant.** A per-variant loop multiplies request count by the average variant count and burns the budget for nothing. Tested: 3 variants across 2 products → exactly 2 mutations.

**`userErrors` is not an exception.** Shopify returns **HTTP 200** with a populated `userErrors` array when a write is rejected — so a naive implementation reports success for writes that never happened. That's precisely the silent-failure mode the ledger exists to prevent. Errors map back to individual rows via the positional index in Shopify's field path (`["variants","2","price"]`), with field-less errors applied to the whole group.

Also: **`compareAtPrice` is only sent when the campaign decided something about it.** Sending `null` unconditionally would wipe every merchant's compare-at on any price change — which is why the planner tracks "clear it" and "leave it alone" as distinct states rather than collapsing both to null.

## Verification is deliberately honest

Sampling rather than reading everything back — full verification doubles the API cost of every run, and a ≥10% sample plus every ambiguous row catches systematic problems. (The bulk path gets per-row confirmation free from its result file, so this compromise is confined here.)

Two distinctions the status model preserves:

- Unsampled rows report as **`applied-unverified`**, never as verified.
- A failed verification **read** leaves rows unconfirmed rather than marking the *write* failed. We changed something and couldn't confirm it — a different thing from failing, and the run reports not-clean either way.

## Verification

112 tests pass · typecheck · lint · build — all clean. The Admin client is injected behind a small interface, so every test runs against a fake without touching the real API.

Closes #114, closes #115, closes #116, closes #117, closes #118, closes #58, closes #59