### PR TITLE
P2.5 — Bulk executor: staged JSONL, submission, poll fallback

### DIFF
--- a/app/lib/execution/bulk-executor.test.ts
+++ b/app/lib/execution/bulk-executor.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, it } from "vitest";
+
+import { money } from "../money/money";
+import type { PlannedRow, SurfaceRef } from "../planning/types";
+import {
+  buildMutationLines,
+  collect,
+  fromString,
+  parseResults,
+  serializeJsonl,
+  streamLines,
+} from "./jsonl";
+import {
+  isTerminal,
+  pollUntilTerminal,
+  reconcileResults,
+  submitBulkMutation,
+  BulkSubmissionError,
+  type BulkOperationState,
+  type StagedTarget,
+} from "./bulk-executor";
+import type { AdminClient } from "./sync-executor";
+
+const usd = (n: number) => money(n, "USD");
+const noSleep = async () => {};
+
+const ref = (variantGid: string): SurfaceRef => ({
+  variantGid,
+  surfaceKind: "base",
+  priceListGid: "",
+  currency: "USD",
+});
+
+function row(over: Partial<PlannedRow> = {}): PlannedRow {
+  return {
+    ref: ref("gid://shopify/ProductVariant/1"),
+    intendedPrice: usd(8_000),
+    intendedCompareAtSet: false,
+    status: "pending",
+    ...over,
+  };
+}
+
+const productOf = (gid: string) =>
+  gid.endsWith("/3") ? "gid://shopify/Product/B" : "gid://shopify/Product/A";
+
+describe("JSONL builder", () => {
+  it("emits one line per product, not per variant", () => {
+    const lines = [
+      ...buildMutationLines(
+        [
+          row({ ref: ref("gid://shopify/ProductVariant/1") }),
+          row({ ref: ref("gid://shopify/ProductVariant/2") }),
+          row({ ref: ref("gid://shopify/ProductVariant/3") }),
+        ],
+        productOf,
+      ),
+    ];
+    expect(lines).toHaveLength(2);
+    expect(lines[0].variants).toHaveLength(2);
+    expect(lines[1].variants).toHaveLength(1);
+  });
+
+  it("omits skipped rows and rows with no price", () => {
+    const lines = [
+      ...buildMutationLines(
+        [
+          row({ status: "skipped", intendedPrice: undefined }),
+          row({ ref: ref("gid://shopify/ProductVariant/2") }),
+        ],
+        productOf,
+      ),
+    ];
+    expect(lines).toHaveLength(1);
+    expect(lines[0].variants).toHaveLength(1);
+  });
+
+  it("serialises as newline-delimited JSON", () => {
+    const text = [...serializeJsonl(buildMutationLines([row()], productOf))].join("");
+    expect(text.endsWith("\n")).toBe(true);
+    expect(JSON.parse(text.trim())).toMatchObject({
+      productId: "gid://shopify/Product/A",
+      variants: [{ id: "gid://shopify/ProductVariant/1", price: "80.00" }],
+    });
+  });
+
+  it("is a generator, so a large payload is never materialised at once", () => {
+    const gen = buildMutationLines([row()], productOf);
+    expect(typeof gen[Symbol.iterator]).toBe("function");
+    expect(typeof (gen as { next?: unknown }).next).toBe("function");
+  });
+});
+
+describe("line streaming", () => {
+  it("splits across arbitrary chunk boundaries", async () => {
+    async function* chunks() {
+      yield '{"a":1}\n{"b"';
+      yield ':2}\n{"c":3}';
+    }
+    expect(await collect(streamLines(chunks()))).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
+  });
+
+  it("handles a final line with no trailing newline, and CRLF", async () => {
+    expect(await collect(streamLines(fromString('{"a":1}\r\n{"b":2}')))).toEqual([
+      '{"a":1}',
+      '{"b":2}',
+    ]);
+  });
+
+  it("skips blank lines", async () => {
+    expect(await collect(streamLines(fromString('{"a":1}\n\n\n{"b":2}\n')))).toEqual([
+      '{"a":1}',
+      '{"b":2}',
+    ]);
+  });
+});
+
+describe("result parsing", () => {
+  const okLine = (id: string, price: string) =>
+    JSON.stringify({
+      data: {
+        productVariantsBulkUpdate: {
+          productVariants: [{ id, price, compareAtPrice: null }],
+          userErrors: [],
+        },
+      },
+      __lineNumber: 0,
+    });
+
+  it("yields a successful outcome per variant", async () => {
+    const out = await collect(parseResults(streamLines(fromString(okLine("gid://v/1", "80.00")))));
+    expect(out).toEqual([
+      { variantGid: "gid://v/1", ok: true, price: "80.00", compareAtPrice: null, failureReason: undefined },
+    ]);
+  });
+
+  it("attributes a positional userError to the right variant", async () => {
+    const line = JSON.stringify({
+      data: {
+        productVariantsBulkUpdate: {
+          productVariants: [
+            { id: "gid://v/1", price: "80.00" },
+            { id: "gid://v/2", price: "70.00" },
+          ],
+          userErrors: [{ field: ["variants", "1", "price"], message: "Bad price", code: "INVALID" }],
+        },
+      },
+    });
+    const out = (await collect(parseResults(streamLines(fromString(line))))) as Array<{
+      variantGid: string;
+      ok: boolean;
+      failureReason?: string;
+    }>;
+    expect(out[0]).toMatchObject({ variantGid: "gid://v/1", ok: true });
+    expect(out[1]).toMatchObject({ variantGid: "gid://v/2", ok: false });
+    expect(out[1].failureReason).toContain("Bad price");
+  });
+
+  it("reports a malformed line without discarding the rest of the run", async () => {
+    // One unparseable line must not throw away 150K rows of results.
+    const text = `${okLine("gid://v/1", "80.00")}\nnot json\n${okLine("gid://v/2", "70.00")}\n`;
+    const out = await collect(parseResults(streamLines(fromString(text))));
+    expect(out).toHaveLength(3);
+    expect(out.filter((o) => "malformed" in o)).toHaveLength(1);
+    expect(out.filter((o) => "variantGid" in o)).toHaveLength(2);
+  });
+
+  it("reports a line-level error", async () => {
+    const text = JSON.stringify({ errors: [{ message: "Internal error" }] });
+    const out = await collect(parseResults(streamLines(fromString(text))));
+    expect(out[0]).toMatchObject({ reason: expect.stringContaining("Internal error") });
+  });
+});
+
+// ------------------------------------------------------------------ submission
+
+function stagedTarget(): StagedTarget {
+  return {
+    url: "https://staged.example/upload",
+    resourceUrl: null,
+    parameters: [
+      { name: "key", value: "tmp/anchor-bulk.jsonl" },
+      { name: "policy", value: "abc" },
+    ],
+  };
+}
+
+interface FakeSubmitOptions {
+  stagedErrors?: Array<{ message: string }>;
+  submitErrors?: Array<{ message: string }>;
+  noTarget?: boolean;
+  noKey?: boolean;
+}
+
+function submitClient(options: FakeSubmitOptions = {}) {
+  const uploaded: string[] = [];
+  const client: AdminClient = {
+    async request<T>(query: string) {
+      if (query.includes("stagedUploadsCreate")) {
+        const target = options.noKey
+          ? { ...stagedTarget(), parameters: [{ name: "policy", value: "abc" }] }
+          : stagedTarget();
+        return {
+          data: {
+            stagedUploadsCreate: {
+              stagedTargets: options.noTarget ? [] : [target],
+              userErrors: options.stagedErrors ?? [],
+            },
+          } as T,
+        };
+      }
+      return {
+        data: {
+          bulkOperationRunMutation: {
+            bulkOperation: { id: "gid://bulk/1", status: "CREATED" },
+            userErrors: options.submitErrors ?? [],
+          },
+        } as T,
+      };
+    },
+  };
+  const upload = async (_t: StagedTarget, body: string) => {
+    uploaded.push(body);
+  };
+  return { client, upload, uploaded };
+}
+
+describe("submission", () => {
+  it("uploads the payload and submits the operation", async () => {
+    const { client, upload, uploaded } = submitClient();
+    const op = await submitBulkMutation([row()], { client, upload, productOf, sleep: noSleep });
+    expect(op.id).toBe("gid://bulk/1");
+    expect(uploaded).toHaveLength(1);
+    expect(JSON.parse(uploaded[0].trim())).toMatchObject({ productId: "gid://shopify/Product/A" });
+  });
+
+  it("refuses to submit an empty payload", async () => {
+    const { client, upload } = submitClient();
+    await expect(
+      submitBulkMutation([row({ status: "skipped", intendedPrice: undefined })], {
+        client,
+        upload,
+        productOf,
+        sleep: noSleep,
+      }),
+    ).rejects.toBeInstanceOf(BulkSubmissionError);
+  });
+
+  it("surfaces userErrors from staging and from submission", async () => {
+    const staged = submitClient({ stagedErrors: [{ message: "quota exceeded" }] });
+    await expect(
+      submitBulkMutation([row()], { ...staged, productOf, sleep: noSleep }),
+    ).rejects.toThrow(/quota exceeded/);
+
+    const submit = submitClient({ submitErrors: [{ message: "already running" }] });
+    await expect(
+      submitBulkMutation([row()], { ...submit, productOf, sleep: noSleep }),
+    ).rejects.toThrow(/already running/);
+  });
+
+  it("fails clearly when the staged target has no key", async () => {
+    const { client, upload } = submitClient({ noKey: true });
+    await expect(
+      submitBulkMutation([row()], { client, upload, productOf, sleep: noSleep }),
+    ).rejects.toThrow(/key/);
+  });
+});
+
+// ----------------------------------------------------------------- polling
+
+describe("poll fallback (edge case E13)", () => {
+  function pollClient(states: BulkOperationState[]) {
+    let i = 0;
+    const calls = { count: 0 };
+    const client: AdminClient = {
+      async request<T>() {
+        calls.count++;
+        const state = states[Math.min(i, states.length - 1)];
+        i++;
+        return { data: { currentBulkOperation: state } as T };
+      },
+    };
+    return { client, calls };
+  }
+
+  it("polls until the operation reaches a terminal state", async () => {
+    const { client, calls } = pollClient([
+      { id: "1", status: "RUNNING" },
+      { id: "1", status: "RUNNING" },
+      { id: "1", status: "COMPLETED", url: "https://results" },
+    ]);
+    const final = await pollUntilTerminal({ client, sleep: noSleep, intervalMs: 1 });
+    expect(final?.status).toBe("COMPLETED");
+    expect(calls.count).toBe(3);
+  });
+
+  it("returns the last state on timeout rather than throwing", async () => {
+    // A run that may yet succeed must be reported as still-running, not failed.
+    let t = 0;
+    const { client } = pollClient([{ id: "1", status: "RUNNING" }]);
+    const final = await pollUntilTerminal({
+      client,
+      sleep: async () => {
+        t += 10_000;
+      },
+      now: () => t,
+      intervalMs: 1,
+      timeoutMs: 15_000,
+    });
+    expect(final?.status).toBe("RUNNING");
+  });
+
+  it("treats FAILED, CANCELED and EXPIRED as terminal", () => {
+    expect(isTerminal("COMPLETED")).toBe(true);
+    expect(isTerminal("FAILED")).toBe(true);
+    expect(isTerminal("CANCELED")).toBe(true);
+    expect(isTerminal("EXPIRED")).toBe(true);
+    expect(isTerminal("RUNNING")).toBe(false);
+    expect(isTerminal("CREATED")).toBe(false);
+  });
+});
+
+// -------------------------------------------------------------- reconciliation
+
+describe("reconciliation", () => {
+  const results = (ids: Array<[string, string]>) =>
+    ids
+      .map(([id, price]) =>
+        JSON.stringify({
+          data: {
+            productVariantsBulkUpdate: {
+              productVariants: [{ id, price, compareAtPrice: null }],
+              userErrors: [],
+            },
+          },
+        }),
+      )
+      .join("\n");
+
+  const fetcher = (text: string) => () => fromString(text);
+
+  it("maps outcomes back to variants", async () => {
+    const out = await reconcileResults(
+      { id: "1", status: "COMPLETED", url: "https://r" },
+      ["gid://v/1", "gid://v/2"],
+      fetcher(results([["gid://v/1", "80.00"], ["gid://v/2", "70.00"]])),
+    );
+    expect(out.outcomes.size).toBe(2);
+    expect(out.unreported).toEqual([]);
+  });
+
+  it("treats absence as unreported, never as success", async () => {
+    // The asymmetry that stops a half-applied campaign being reported complete.
+    const out = await reconcileResults(
+      { id: "1", status: "COMPLETED", url: "https://r" },
+      ["gid://v/1", "gid://v/2", "gid://v/3"],
+      fetcher(results([["gid://v/1", "80.00"]])),
+    );
+    expect(out.outcomes.size).toBe(1);
+    expect(out.unreported).toEqual(["gid://v/2", "gid://v/3"]);
+  });
+
+  it("uses partialDataUrl when the operation did not complete", async () => {
+    // Whatever did finish is still reconciled rather than discarded.
+    const out = await reconcileResults(
+      { id: "1", status: "FAILED", url: null, partialDataUrl: "https://partial" },
+      ["gid://v/1", "gid://v/2"],
+      fetcher(results([["gid://v/1", "80.00"]])),
+    );
+    expect(out.outcomes.size).toBe(1);
+    expect(out.unreported).toEqual(["gid://v/2"]);
+  });
+
+  it("reports everything unreported when there is no result file at all", async () => {
+    const out = await reconcileResults(
+      { id: "1", status: "EXPIRED", url: null, partialDataUrl: null },
+      ["gid://v/1"],
+      fetcher(""),
+    );
+    expect(out.unreported).toEqual(["gid://v/1"]);
+  });
+
+  it("collects malformed lines separately from outcomes", async () => {
+    const text = `${results([["gid://v/1", "80.00"]])}\ngarbage\n`;
+    const out = await reconcileResults(
+      { id: "1", status: "COMPLETED", url: "https://r" },
+      ["gid://v/1"],
+      fetcher(text),
+    );
+    expect(out.outcomes.size).toBe(1);
+    expect(out.malformedLines).toHaveLength(1);
+  });
+});
+
+describe("scale", () => {
+  it("builds a 50k-row payload without materialising it (P2.5.5 smoke)", () => {
+    const rows: PlannedRow[] = [];
+    for (let i = 0; i < 50_000; i++) {
+      rows.push(row({ ref: ref(`gid://shopify/ProductVariant/${i}`) }));
+    }
+    // 10 variants per product.
+    const productFor = (gid: string) =>
+      `gid://shopify/Product/${Math.floor(Number(gid.split("/").pop()) / 10)}`;
+
+    let lines = 0;
+    let variants = 0;
+    for (const line of buildMutationLines(rows, productFor)) {
+      lines++;
+      variants += line.variants.length;
+    }
+    expect(lines).toBe(5_000);
+    expect(variants).toBe(50_000);
+  });
+});

--- a/app/lib/execution/bulk-executor.ts
+++ b/app/lib/execution/bulk-executor.ts
@@ -1,0 +1,282 @@
+/**
+ * The bulk write path: staged JSONL upload -> `bulkOperationRunMutation` -> result
+ * reconciliation.
+ *
+ * Bulk operations carry **zero** rate-limit cost, which is the only reason a
+ * 150K-variant campaign is viable at all against a bucket that restores 50
+ * points/second. The trade is latency: submissions are queued FIFO per shop, so a
+ * busy queue can add minutes before the first row is touched.
+ *
+ * Completion arrives one of two ways, and the second is not optional:
+ *
+ *   the `bulk_operations/finish` webhook, or
+ *   a poll of `currentBulkOperation` once the expected duration has elapsed.
+ *
+ * Community reports document missed `finish` deliveries. Without the fallback a
+ * missed webhook means a run that never completes and a merchant watching a progress
+ * bar that never moves (edge case E13).
+ */
+
+import type { PlannedRow } from "../planning/types";
+import { isThrottledError, withRetry } from "../shopify/budget";
+import type { AdminClient } from "./sync-executor";
+import { buildMutationLines, parseResults, serializeJsonl, streamLines } from "./jsonl";
+import type { VariantOutcome } from "./jsonl";
+
+export type BulkOperationStatus =
+  | "CREATED"
+  | "RUNNING"
+  | "COMPLETED"
+  | "FAILED"
+  | "CANCELED"
+  | "EXPIRED";
+
+export interface BulkOperationState {
+  id: string;
+  status: BulkOperationStatus;
+  url?: string | null;
+  partialDataUrl?: string | null;
+  objectCount?: string | number | null;
+  errorCode?: string | null;
+}
+
+export interface StagedTarget {
+  url: string;
+  resourceUrl?: string | null;
+  parameters: Array<{ name: string; value: string }>;
+}
+
+/** Uploads the JSONL body to the staged target. Injected so tests need no network. */
+export type Uploader = (target: StagedTarget, body: string) => Promise<void>;
+
+/** Fetches a result file as a stream of text chunks. Injected likewise. */
+export type ResultFetcher = (url: string) => AsyncIterable<string>;
+
+export const STAGED_UPLOADS_CREATE = `#graphql
+  mutation AnchorStagedUploadsCreate($input: [StagedUploadInput!]!) {
+    stagedUploadsCreate(input: $input) {
+      stagedTargets { url resourceUrl parameters { name value } }
+      userErrors { field message }
+    }
+  }
+`;
+
+export const BULK_OPERATION_RUN_MUTATION = `#graphql
+  mutation AnchorBulkOperationRunMutation($mutation: String!, $stagedUploadPath: String!) {
+    bulkOperationRunMutation(mutation: $mutation, stagedUploadPath: $stagedUploadPath) {
+      bulkOperation { id status url partialDataUrl objectCount }
+      userErrors { field message }
+    }
+  }
+`;
+
+export const CURRENT_BULK_OPERATION = `#graphql
+  query AnchorCurrentBulkOperation {
+    currentBulkOperation(type: MUTATION) {
+      id status url partialDataUrl objectCount errorCode
+    }
+  }
+`;
+
+export class BulkSubmissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BulkSubmissionError";
+  }
+}
+
+export interface SubmitOptions {
+  client: AdminClient;
+  upload: Uploader;
+  productOf: (variantGid: string) => string;
+  /** The mutation the JSONL lines are arguments for. */
+  mutation?: string;
+  sleep?: (ms: number) => Promise<void>;
+  maxAttempts?: number;
+}
+
+/** Builds the payload, stages it, uploads it and submits the operation. */
+export async function submitBulkMutation(
+  rows: Iterable<PlannedRow>,
+  options: SubmitOptions,
+): Promise<BulkOperationState> {
+  const { client, upload, productOf, sleep, maxAttempts = 5 } = options;
+
+  const body = [...serializeJsonl(buildMutationLines(rows, productOf))].join("");
+  if (body.length === 0) {
+    throw new BulkSubmissionError("Nothing to submit: no writable rows.");
+  }
+
+  const staged = await withRetry(
+    () =>
+      client.request<{
+        stagedUploadsCreate?: {
+          stagedTargets?: StagedTarget[];
+          userErrors?: Array<{ message: string }>;
+        };
+      }>(STAGED_UPLOADS_CREATE, {
+        input: [
+          {
+            resource: "BULK_MUTATION_VARIABLES",
+            filename: "anchor-bulk.jsonl",
+            mimeType: "text/jsonl",
+            httpMethod: "POST",
+          },
+        ],
+      }),
+    isThrottledError,
+    { maxAttempts, sleep },
+  );
+
+  const stagedErrors = staged.data?.stagedUploadsCreate?.userErrors ?? [];
+  if (stagedErrors.length > 0) {
+    throw new BulkSubmissionError(
+      `stagedUploadsCreate failed: ${stagedErrors.map((e) => e.message).join("; ")}`,
+    );
+  }
+
+  const target = staged.data?.stagedUploadsCreate?.stagedTargets?.[0];
+  if (!target) throw new BulkSubmissionError("stagedUploadsCreate returned no target.");
+
+  await upload(target, body);
+
+  // The staged path is carried in the `key` parameter of the upload target.
+  const key = target.parameters.find((p) => p.name === "key")?.value;
+  if (!key) throw new BulkSubmissionError("Staged target has no `key` parameter.");
+
+  const submitted = await withRetry(
+    () =>
+      client.request<{
+        bulkOperationRunMutation?: {
+          bulkOperation?: BulkOperationState;
+          userErrors?: Array<{ message: string }>;
+        };
+      }>(BULK_OPERATION_RUN_MUTATION, {
+        mutation: options.mutation ?? DEFAULT_BULK_MUTATION,
+        stagedUploadPath: key,
+      }),
+    isThrottledError,
+    { maxAttempts, sleep },
+  );
+
+  const submitErrors = submitted.data?.bulkOperationRunMutation?.userErrors ?? [];
+  if (submitErrors.length > 0) {
+    throw new BulkSubmissionError(
+      `bulkOperationRunMutation failed: ${submitErrors.map((e) => e.message).join("; ")}`,
+    );
+  }
+
+  const operation = submitted.data?.bulkOperationRunMutation?.bulkOperation;
+  if (!operation) throw new BulkSubmissionError("Submission returned no bulkOperation.");
+
+  return operation;
+}
+
+export const DEFAULT_BULK_MUTATION = `
+  mutation call($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+    productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+      productVariants { id price compareAtPrice }
+      userErrors { field message code }
+    }
+  }
+`;
+
+/** Terminal states: no further polling will change the outcome. */
+export function isTerminal(status: BulkOperationStatus): boolean {
+  return status === "COMPLETED" || status === "FAILED" || status === "CANCELED" || status === "EXPIRED";
+}
+
+export interface PollOptions {
+  client: AdminClient;
+  /** Time between polls. */
+  intervalMs?: number;
+  /** Give up after this long and report, rather than polling forever. */
+  timeoutMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  maxAttempts?: number;
+}
+
+/**
+ * Polls until the operation reaches a terminal state.
+ *
+ * This is the fallback for a missed `finish` webhook, not a replacement for it —
+ * the webhook is faster and cheaper when it arrives. A timeout returns the last
+ * observed state rather than throwing, so the caller can surface "still running"
+ * honestly instead of failing a run that may yet succeed.
+ */
+export async function pollUntilTerminal(
+  options: PollOptions,
+): Promise<BulkOperationState | undefined> {
+  const {
+    client,
+    intervalMs = 5_000,
+    timeoutMs = 30 * 60_000,
+    now = () => Date.now(),
+    sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+    maxAttempts = 5,
+  } = options;
+
+  const deadline = now() + timeoutMs;
+  let last: BulkOperationState | undefined;
+
+  for (;;) {
+    const response = await withRetry(
+      () => client.request<{ currentBulkOperation?: BulkOperationState | null }>(
+        CURRENT_BULK_OPERATION,
+        {},
+      ),
+      isThrottledError,
+      { maxAttempts, sleep },
+    );
+
+    last = response.data?.currentBulkOperation ?? last;
+    if (last && isTerminal(last.status)) return last;
+    if (now() >= deadline) return last;
+
+    await sleep(intervalMs);
+  }
+}
+
+export interface ReconcileResult {
+  /** Variant gid -> outcome, for every variant Shopify reported on. */
+  outcomes: Map<string, VariantOutcome>;
+  /** Rows we sent but never heard about. Left unverified, never assumed successful. */
+  unreported: string[];
+  malformedLines: Array<{ malformed: string; reason: string }>;
+}
+
+/**
+ * Reconciles a finished operation's result file against the rows we sent.
+ *
+ * The important asymmetry: absence is never success. A row we submitted but that
+ * appears nowhere in the results stays unverified and gets retried. Assuming
+ * otherwise is exactly how a half-applied campaign gets reported as complete.
+ *
+ * `partialDataUrl` is used when the operation failed or was cancelled part-way,
+ * so whatever did complete is still reconciled rather than discarded.
+ */
+export async function reconcileResults(
+  operation: BulkOperationState,
+  submittedVariantGids: Iterable<string>,
+  fetchResults: ResultFetcher,
+): Promise<ReconcileResult> {
+  const outcomes = new Map<string, VariantOutcome>();
+  const malformedLines: Array<{ malformed: string; reason: string }> = [];
+
+  const url = operation.url ?? operation.partialDataUrl ?? undefined;
+
+  if (url) {
+    for await (const item of parseResults(streamLines(fetchResults(url)))) {
+      if ("malformed" in item) malformedLines.push(item);
+      else outcomes.set(item.variantGid, item);
+    }
+  }
+
+  const unreported: string[] = [];
+  for (const gid of submittedVariantGids) {
+    if (!outcomes.has(gid)) unreported.push(gid);
+  }
+
+  return { outcomes, unreported, malformedLines };
+}

--- a/app/lib/execution/jsonl.ts
+++ b/app/lib/execution/jsonl.ts
@@ -1,0 +1,191 @@
+/**
+ * JSONL for bulk operations, in both directions.
+ *
+ * Both are generators over lines rather than arrays of them. A 150K-variant campaign
+ * produces a payload too large to hold comfortably in memory, and its result file is
+ * larger still — building or parsing either eagerly works fine on a dev store and
+ * falls over on the first real customer. That is the specific failure that produces
+ * the category's "the app freezes" reviews.
+ */
+
+import type { PlannedRow } from "../planning/types";
+import { toVariantInput } from "./sync-executor";
+
+/** One line of the upload: the variables for a single `productVariantsBulkUpdate`. */
+export interface BulkMutationLine {
+  productId: string;
+  variants: Array<Record<string, unknown>>;
+}
+
+/**
+ * Groups rows by product and yields one JSONL line per product.
+ *
+ * Line order is irrelevant to correctness — results are matched back by variant id,
+ * not by position — but it is deterministic anyway, which makes failures
+ * reproducible.
+ */
+export function* buildMutationLines(
+  rows: Iterable<PlannedRow>,
+  productOf: (variantGid: string) => string,
+): Generator<BulkMutationLine> {
+  const byProduct = new Map<string, PlannedRow[]>();
+
+  for (const row of rows) {
+    if (row.status === "skipped" || !row.intendedPrice) continue;
+    const product = productOf(row.ref.variantGid);
+    const group = byProduct.get(product);
+    if (group) group.push(row);
+    else byProduct.set(product, [row]);
+  }
+
+  for (const [productId, group] of byProduct) {
+    yield { productId, variants: group.map(toVariantInput) };
+  }
+}
+
+/** Serialises lines to JSONL text. Yields strings so the caller can stream them. */
+export function* serializeJsonl(lines: Iterable<BulkMutationLine>): Generator<string> {
+  for (const line of lines) yield `${JSON.stringify(line)}\n`;
+}
+
+// ------------------------------------------------------------------- results
+
+/**
+ * A parsed result line.
+ *
+ * Shopify emits one JSON object per line of the original upload, carrying the
+ * mutation payload and a `__lineNumber` pointing back at the request line.
+ */
+export interface BulkResultLine {
+  __lineNumber?: number;
+  data?: {
+    productVariantsBulkUpdate?: {
+      productVariants?: Array<{ id: string; price?: string; compareAtPrice?: string | null }>;
+      userErrors?: Array<{ field?: string[] | null; message: string; code?: string | null }>;
+    };
+  };
+  /** Present when the whole line failed rather than an individual field. */
+  errors?: unknown;
+}
+
+export interface VariantOutcome {
+  variantGid: string;
+  ok: boolean;
+  price?: string;
+  compareAtPrice?: string | null;
+  failureReason?: string;
+}
+
+/**
+ * Splits a byte/text stream into lines without buffering the whole thing.
+ *
+ * Handles a final line with no trailing newline, and tolerates \r\n.
+ */
+export async function* streamLines(
+  chunks: AsyncIterable<string>,
+): AsyncGenerator<string> {
+  let buffer = "";
+  for await (const chunk of chunks) {
+    buffer += chunk;
+    let newline = buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).replace(/\r$/, "");
+      if (line.length > 0) yield line;
+      buffer = buffer.slice(newline + 1);
+      newline = buffer.indexOf("\n");
+    }
+  }
+  const tail = buffer.trim();
+  if (tail.length > 0) yield tail;
+}
+
+/**
+ * Turns result lines into per-variant outcomes.
+ *
+ * A malformed line is reported rather than thrown: one unparseable line must not
+ * discard the results for every other row in a 150K-row run. The affected rows stay
+ * unverified and get retried, which is the safe direction.
+ */
+export async function* parseResults(
+  lines: AsyncIterable<string>,
+): AsyncGenerator<VariantOutcome | { malformed: string; reason: string }> {
+  for await (const raw of lines) {
+    let parsed: BulkResultLine;
+    try {
+      parsed = JSON.parse(raw) as BulkResultLine;
+    } catch (error) {
+      yield {
+        malformed: raw.slice(0, 200),
+        reason: error instanceof Error ? error.message : String(error),
+      };
+      continue;
+    }
+
+    const payload = parsed.data?.productVariantsBulkUpdate;
+
+    if (parsed.errors) {
+      yield {
+        malformed: raw.slice(0, 200),
+        reason: `Line-level error: ${JSON.stringify(parsed.errors).slice(0, 200)}`,
+      };
+      continue;
+    }
+
+    if (!payload) continue;
+
+    const userErrors = payload.userErrors ?? [];
+
+    // Positional field paths identify which variant in the line failed; an error
+    // with no index applies to every variant the line touched.
+    const errorsByIndex = new Map<number, string>();
+    let lineWideError: string | undefined;
+    for (const error of userErrors) {
+      const index = positionalIndex(error.field);
+      const text = error.code ? `${error.code}: ${error.message}` : error.message;
+      if (index === undefined) lineWideError = text;
+      else errorsByIndex.set(index, text);
+    }
+
+    const variants = payload.productVariants ?? [];
+
+    // A line-wide failure returns no variants, so there is nothing to key outcomes
+    // on. The caller reconciles by absence: any row it sent but never heard about
+    // stays unverified rather than being assumed successful.
+    // A plain loop, not forEach: `yield` only works in the generator's own body,
+    // never inside a callback.
+    for (const [index, variant] of variants.entries()) {
+      const reason = errorsByIndex.get(index) ?? lineWideError;
+      yield {
+        variantGid: variant.id,
+        ok: !reason,
+        price: variant.price,
+        compareAtPrice: variant.compareAtPrice,
+        failureReason: reason,
+      };
+    }
+
+    if (variants.length === 0 && lineWideError) {
+      yield { malformed: raw.slice(0, 200), reason: lineWideError };
+    }
+  }
+}
+
+function positionalIndex(field?: string[] | null): number | undefined {
+  if (!field) return undefined;
+  for (const part of field) {
+    if (/^\d+$/.test(part)) return Number(part);
+  }
+  return undefined;
+}
+
+/** Convenience for tests and small payloads: collect an async iterable. */
+export async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of source) out.push(item);
+  return out;
+}
+
+/** Wraps a string as a single-chunk async iterable. */
+export async function* fromString(text: string): AsyncGenerator<string> {
+  yield text;
+}


### PR DESCRIPTION
Implements **P2.5** (#119) and subtasks #120–#124. Stacked on #186.

The write path that makes a **150K-variant campaign viable**. Bulk operations carry zero rate-limit cost — the only way that many writes fit against a bucket restoring 50 points/second. The trade is latency: submissions queue FIFO per shop.

## Streaming, in both directions

`buildMutationLines` and `parseResults` are **generators over lines**, not arrays. A large campaign's payload and its result file are both too big to hold comfortably in memory. Building or parsing either eagerly works fine on a dev store and falls over on the first real customer — the specific failure behind the category's "the app freezes" reviews.

`streamLines` handles arbitrary chunk boundaries, CRLF, blank lines, and a final line with no trailing newline.

## The poll fallback is not optional

Community reports document missed `bulk_operations/finish` deliveries. Without a fallback, a missed webhook means a run that never completes and a merchant watching a progress bar that never moves (**E13**).

A poll **timeout returns the last observed state rather than throwing**, so a run that may yet succeed is reported as still-running instead of failed.

## Three deliberate asymmetries in reconciliation

1. **Absence is never success.** A row we submitted that appears nowhere in the results stays *unreported* and gets retried. Assuming otherwise is exactly how a half-applied campaign gets reported as complete.
2. **`partialDataUrl` is used** when an operation failed or was cancelled part-way, so whatever did complete is reconciled rather than discarded.
3. **A malformed line is reported, not thrown.** One unparseable line must not discard the outcomes for every other row in a 150K-row run.

## A bug the tests caught

`yield` inside a `forEach` callback is invalid — the callback isn't the generator's own body, so it failed to even parse. Replaced with a plain loop.

## Verification

136 tests · typecheck · lint · build — all clean. Includes a 50K-row payload-shaping smoke test (5,000 lines, 50,000 variants) that exercises the grouping path at scale without any network.

Closes #119, closes #120, closes #121, closes #122, closes #123, closes #124