### PR TITLE
P3 — Campaigns: scope, preview, apply, revert

### DIFF
--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -111,7 +111,7 @@ export default function Dashboard() {
           </s-paragraph>
           <fetcher.Form method="post">
             <input type="hidden" name="intent" value="sync" />
-            <s-button type="submit" variant="primary" loading={busy}>
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
               {busy ? "Syncing…" : "Sync catalogue and capture baselines"}
             </s-button>
           </fetcher.Form>
@@ -149,7 +149,7 @@ export default function Dashboard() {
           <s-stack direction="inline" gap="base">
             <fetcher.Form method="post">
               <input type="hidden" name="intent" value="sync" />
-              <s-button type="submit" loading={busy}>
+              <s-button type="submit" loading={busy || undefined}>
                 Re-sync catalogue
               </s-button>
             </fetcher.Form>
@@ -183,7 +183,7 @@ export default function Dashboard() {
           </s-paragraph>
           <fetcher.Form method="post">
             <input type="hidden" name="intent" value="recapture" />
-            <s-button type="submit" tone="critical" loading={busy}>
+            <s-button type="submit" tone="critical" loading={busy || undefined}>
               Recapture all baselines
             </s-button>
           </fetcher.Form>

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -1,0 +1,198 @@
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useFetcher, useLoaderData, useRouteError } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { previewCampaign, runCampaign } from "../services/campaigns.server";
+import { toAdminClient } from "../services/admin-client.server";
+
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const preview = await previewCampaign(shop.id, String(params.id));
+  return { preview };
+};
+
+export const action = async ({ request, params }: ActionFunctionArgs) => {
+  const { admin, session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+  const intent = String(form.get("intent"));
+
+  try {
+    const result = await runCampaign(shop.id, String(params.id), toAdminClient(admin), {
+      revert: intent === "revert",
+    });
+
+    return {
+      ok: result.clean,
+      message: result.clean
+        ? `${intent === "revert" ? "Reverted" : "Applied"} ${result.verified} variants, all verified.`
+        : `${intent === "revert" ? "Revert" : "Apply"} finished with ${result.failed} failures and ${result.unverified} unverified. Nothing is being hidden — resume to retry.`,
+      details: result.messages,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+      details: [],
+    };
+  }
+};
+
+type ActionData = { ok: boolean; message: string; details: string[] };
+
+type Tone = "info" | "success" | "critical" | "neutral" | "warning" | "caution" | "auto";
+
+const STATUS_TONE: Record<string, Tone> = {
+  pending: "info",
+  clamped: "warning",
+  skipped: "neutral",
+};
+
+export default function CampaignDetail() {
+  const { preview } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const busy = fetcher.state !== "idle";
+  const result = fetcher.data;
+
+  const canApply = preview.counts.planned > 0 && !preview.blocked;
+
+  return (
+    <s-page heading={preview.name}>
+      {result ? (
+        <s-banner tone={result.ok ? "success" : "critical"}>
+          <s-paragraph>{result.message}</s-paragraph>
+          {result.details.map((detail) => (
+            <s-paragraph key={detail}>{detail}</s-paragraph>
+          ))}
+        </s-banner>
+      ) : null}
+
+      {preview.blocked ? (
+        <s-banner tone="critical">
+          <s-paragraph>
+            Blocked by a guardrail on {preview.blocked.variantGid}: {preview.blocked.reason}.
+            No prices were changed — a blocking guardrail stops the whole run, not just
+            the offending variant.
+          </s-paragraph>
+        </s-banner>
+      ) : null}
+
+      <s-section heading="Preview">
+        <s-stack direction="inline" gap="large">
+          <s-box>
+            <s-text>Will change</s-text>
+            <s-heading>{preview.counts.planned}</s-heading>
+          </s-box>
+          <s-box>
+            <s-text>Already correct</s-text>
+            <s-heading>{preview.counts.noop}</s-heading>
+          </s-box>
+          <s-box>
+            <s-text>Skipped</s-text>
+            <s-heading>{preview.counts.skipped}</s-heading>
+          </s-box>
+          <s-box>
+            <s-text>Clamped</s-text>
+            <s-heading>{preview.counts.clamped}</s-heading>
+          </s-box>
+        </s-stack>
+
+        <s-paragraph>
+          <s-text>
+            Write path: {preview.writePath} — {preview.writePathReason}
+          </s-text>
+        </s-paragraph>
+
+        {preview.blastRadius ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              This campaign changes more than 1,000 variants. Re-read the preview
+              before applying.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        {preview.rows.length > 0 ? (
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Variant</s-table-header>
+              <s-table-header>Before</s-table-header>
+              <s-table-header>After</s-table-header>
+              <s-table-header>Compare at</s-table-header>
+              <s-table-header>State</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {preview.rows.map((row) => (
+                <s-table-row key={row.variantGid}>
+                  <s-table-cell>{row.title}</s-table-cell>
+                  <s-table-cell>{row.before ?? "—"}</s-table-cell>
+                  <s-table-cell>{row.after ?? "—"}</s-table-cell>
+                  <s-table-cell>{row.compareAt ?? "—"}</s-table-cell>
+                  <s-table-cell>
+                    <s-badge tone={STATUS_TONE[row.status] ?? "neutral"}>
+                      {row.status}
+                      {row.reason ? ` · ${row.reason}` : ""}
+                    </s-badge>
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        ) : (
+          <s-paragraph>
+            Nothing to change. Either every variant already shows the target price, or
+            the scope matched no variants with baselines.
+          </s-paragraph>
+        )}
+      </s-section>
+
+      <s-section slot="aside" heading="Actions">
+        <s-stack gap="base">
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="apply" />
+            <s-button
+              type="submit"
+              variant="primary"
+              loading={busy || undefined}
+              disabled={!canApply}
+            >
+              Apply to storefront
+            </s-button>
+          </fetcher.Form>
+
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="revert" />
+            <s-button type="submit" tone="critical" loading={busy || undefined}>
+              Revert
+            </s-button>
+          </fetcher.Form>
+        </s-stack>
+
+        <s-paragraph>
+          <s-text>
+            Reverting recomputes each price without this campaign. If another campaign
+            still covers a variant, that campaign&rsquo;s price stays — it does not
+            snap back to full price.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+
+      <s-section slot="aside" heading="Status">
+        <s-paragraph>
+          <s-badge>{preview.status}</s-badge>
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -1,0 +1,127 @@
+import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useLoaderData, useRouteError } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import prisma from "../db.server";
+import { ensureShop } from "../services/shop.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const campaigns = await prisma.campaign.findMany({
+    where: { shopId: shop.id },
+    orderBy: { createdAt: "desc" },
+    include: {
+      runs: { orderBy: { createdAt: "desc" }, take: 1 },
+    },
+  });
+
+  return {
+    campaigns: campaigns.map((c) => ({
+      id: c.id,
+      name: c.name,
+      status: c.status,
+      priority: c.priority,
+      createdAt: c.createdAt.toISOString(),
+      lastRun: c.runs[0]
+        ? {
+            kind: c.runs[0].kind,
+            status: c.runs[0].status,
+            verified: c.runs[0].verifiedRows,
+            failed: c.runs[0].failedRows,
+          }
+        : null,
+    })),
+  };
+};
+
+type Tone = "info" | "success" | "critical" | "neutral" | "warning" | "caution" | "auto";
+
+const STATUS_TONE: Record<string, Tone> = {
+  DRAFT: "neutral",
+  ACTIVE: "success",
+  PARTIAL: "warning",
+  COMPLETED: "info",
+  HELD: "warning",
+};
+
+export default function CampaignList() {
+  const { campaigns } = useLoaderData<typeof loader>();
+
+  return (
+    <s-page heading="Campaigns">
+      <s-section>
+        <s-stack direction="inline" gap="base">
+          <s-link href="/app/campaigns/new">
+            <s-button variant="primary">Create campaign</s-button>
+          </s-link>
+        </s-stack>
+
+        {campaigns.length === 0 ? (
+          <s-paragraph>
+            No campaigns yet. A campaign is a rule (&ldquo;20% off this collection&rdquo;)
+            plus the set of variants it applies to. Nothing is written to your
+            storefront until you apply it, and you can preview the exact result first.
+          </s-paragraph>
+        ) : (
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Campaign</s-table-header>
+              <s-table-header>Status</s-table-header>
+              <s-table-header>Priority</s-table-header>
+              <s-table-header>Last run</s-table-header>
+              <s-table-header></s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {campaigns.map((campaign) => (
+                <s-table-row key={campaign.id}>
+                  <s-table-cell>{campaign.name}</s-table-cell>
+                  <s-table-cell>
+                    <s-badge tone={STATUS_TONE[campaign.status] ?? "neutral"}>
+                      {campaign.status}
+                    </s-badge>
+                  </s-table-cell>
+                  <s-table-cell>{campaign.priority}</s-table-cell>
+                  <s-table-cell>
+                    {campaign.lastRun
+                      ? `${campaign.lastRun.kind} · ${campaign.lastRun.status} · ${campaign.lastRun.verified} verified${
+                          campaign.lastRun.failed > 0
+                            ? `, ${campaign.lastRun.failed} failed`
+                            : ""
+                        }`
+                      : "—"}
+                  </s-table-cell>
+                  <s-table-cell>
+                    <s-link href={`/app/campaigns/${campaign.id}`}>Open</s-link>
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        )}
+      </s-section>
+
+      <s-section slot="aside" heading="How campaigns resolve">
+        <s-paragraph>
+          When two campaigns cover the same variant, exactly one wins — the higher
+          priority, then the more recent. They never stack, so a variant cannot end
+          up discounted twice.
+        </s-paragraph>
+        <s-paragraph>
+          Reverting recomputes rather than restoring saved numbers. If another
+          campaign still covers a variant, that campaign&rsquo;s price stays in place.
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -1,0 +1,227 @@
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { redirect, useLoaderData, useRouteError } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { facets, previewMatches, type FilterAst } from "../services/segments.server";
+import { createCampaign } from "../services/campaigns.server";
+import type { AdjustmentRule, CompareAtPolicy } from "../lib/pricing/types";
+import { money } from "../lib/money/money";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const url = new URL(request.url);
+  const ast = astFromParams(url.searchParams);
+  const [available, preview] = await Promise.all([
+    facets(shop.id),
+    previewMatches(shop.id, ast),
+  ]);
+
+  return {
+    facets: available,
+    preview,
+    selected: {
+      collection: url.searchParams.get("collection") ?? "",
+      tag: url.searchParams.get("tag") ?? "",
+      vendor: url.searchParams.get("vendor") ?? "",
+      title: url.searchParams.get("title") ?? "",
+    },
+  };
+};
+
+/** Builds an AST from the simple scope form: all provided conditions ANDed. */
+function astFromParams(params: URLSearchParams): FilterAst {
+  const conditions = (
+    [
+      ["collection", params.get("collection")],
+      ["tag", params.get("tag")],
+      ["vendor", params.get("vendor")],
+      ["title", params.get("title")],
+    ] as const
+  )
+    .filter(([, value]) => value && value.trim().length > 0)
+    .map(([field, value]) => ({ field, value: value!.trim() }));
+
+  return conditions.length > 0 ? { groups: [{ conditions }] } : { groups: [] };
+}
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const form = await request.formData();
+  const params = new URLSearchParams();
+  for (const field of ["collection", "tag", "vendor", "title"]) {
+    const value = form.get(field);
+    if (typeof value === "string" && value.trim()) params.set(field, value.trim());
+  }
+
+  const kind = String(form.get("ruleKind") ?? "percent-change");
+  const amount = Number(form.get("ruleValue") ?? 0);
+  const currency = String(form.get("currency") ?? "USD");
+
+  let rule: AdjustmentRule;
+  if (kind === "fixed-change") {
+    rule = { kind: "fixed-change", amount: money(Math.round(amount * 100), currency) };
+  } else if (kind === "set-exact") {
+    rule = { kind: "set-exact", amount: money(Math.round(amount * 100), currency) };
+  } else {
+    rule = { kind: "percent-change", percent: amount };
+  }
+
+  const compareAt = String(form.get("compareAt") ?? "leave");
+  const compareAtPolicy: CompareAtPolicy =
+    compareAt === "set-to-baseline"
+      ? { kind: "set-to-baseline" }
+      : compareAt === "clear"
+        ? { kind: "clear" }
+        : { kind: "leave" };
+
+  const campaign = await createCampaign(shop.id, {
+    name: String(form.get("name") ?? "Untitled campaign").trim() || "Untitled campaign",
+    ast: astFromParams(params),
+    rule,
+    compareAtPolicy,
+    rounding: String(form.get("rounding") ?? "none") === "charm99" ? "charm99" : "none",
+    priority: Number(form.get("priority") ?? 100) || 100,
+  });
+
+  return redirect(`/app/campaigns/${campaign.id}`);
+};
+
+export default function NewCampaign() {
+  const { facets: available, preview, selected } = useLoaderData<typeof loader>();
+
+  return (
+    <s-page heading="New campaign">
+      <s-section heading="1 · Scope">
+        <s-paragraph>
+          Leave everything blank to target the whole catalogue. Conditions combine
+          with AND.
+        </s-paragraph>
+        <form method="get">
+          <s-stack gap="base">
+            <label htmlFor="collection">Collection</label>
+            <select id="collection" name="collection" defaultValue={selected.collection}>
+              <option value="">Any collection</option>
+              {available.collections.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <label htmlFor="vendor">Vendor</label>
+            <select id="vendor" name="vendor" defaultValue={selected.vendor}>
+              <option value="">Any vendor</option>
+              {available.vendors.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+            <label htmlFor="tag">Tag</label>
+            <select id="tag" name="tag" defaultValue={selected.tag}>
+              <option value="">Any tag</option>
+              {available.tags.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+            <s-text-field name="title" label="Title contains" defaultValue={selected.title} />
+            <s-button type="submit">Update match count</s-button>
+          </s-stack>
+        </form>
+
+        <s-paragraph>
+          <strong>{preview.count}</strong> variants match.
+        </s-paragraph>
+        {preview.sample.length > 0 ? (
+          <s-unordered-list>
+            {preview.sample.slice(0, 5).map((v) => (
+              <s-list-item key={v.variantGid}>
+                {v.title} {v.price ? `· ${v.price}` : ""}
+              </s-list-item>
+            ))}
+          </s-unordered-list>
+        ) : null}
+      </s-section>
+
+      <s-section heading="2 · Rule">
+        <form method="post">
+          <input type="hidden" name="collection" value={selected.collection} />
+          <input type="hidden" name="tag" value={selected.tag} />
+          <input type="hidden" name="vendor" value={selected.vendor} />
+          <input type="hidden" name="title" value={selected.title} />
+
+          <s-stack gap="base">
+            <s-text-field name="name" label="Campaign name" defaultValue="Sale" required />
+
+            <label htmlFor="ruleKind">Adjustment</label>
+            <select id="ruleKind" name="ruleKind" defaultValue="percent-change">
+              <option value="percent-change">Percent change from baseline</option>
+              <option value="fixed-change">Fixed change from baseline</option>
+              <option value="set-exact">Set an exact price</option>
+            </select>
+
+            <s-number-field
+              name="ruleValue"
+              label="Value"
+              defaultValue="-20"
+              details="Negative discounts. -20 means 20% off the baseline."
+            />
+
+            <label htmlFor="compareAt">Compare-at price</label>
+            <select id="compareAt" name="compareAt" defaultValue="set-to-baseline">
+              <option value="set-to-baseline">
+                Set to baseline (shows a strike-through)
+              </option>
+              <option value="leave">Leave unchanged</option>
+              <option value="clear">Clear it</option>
+            </select>
+
+            <label htmlFor="rounding">Rounding</label>
+            <select id="rounding" name="rounding" defaultValue="none">
+              <option value="none">None</option>
+              <option value="charm99">Charm endings (.99)</option>
+            </select>
+
+            <s-number-field
+              name="priority"
+              label="Priority"
+              defaultValue="100"
+              details="Higher wins when two campaigns cover the same variant. They never stack."
+            />
+
+            <s-button type="submit" variant="primary">
+              Create and preview
+            </s-button>
+          </s-stack>
+        </form>
+      </s-section>
+
+      <s-section slot="aside" heading="Nothing is written yet">
+        <s-paragraph>
+          Creating a campaign only records the rule. The next screen shows exactly
+          which prices would change, before anything touches your storefront.
+        </s-paragraph>
+        <s-paragraph>
+          Every change is computed from each variant&rsquo;s <strong>baseline</strong>,
+          not its current price — so applying twice gives the same result rather than
+          discounting the discount.
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -19,6 +19,7 @@ export default function App() {
     <AppProvider embedded apiKey={apiKey}>
       <s-app-nav>
         <s-link href="/app">Dashboard</s-link>
+        <s-link href="/app/campaigns">Campaigns</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
       </s-app-nav>
       <Outlet />

--- a/app/services/admin-client.server.ts
+++ b/app/services/admin-client.server.ts
@@ -1,0 +1,39 @@
+/**
+ * Adapts Shopify's authenticated admin context to the small `AdminClient`
+ * interface the executors depend on.
+ *
+ * The executors are written against a two-method interface so their tests can inject
+ * a fake and never touch the network. This is the one place that knows the real
+ * client returns a `Response` needing `.json()`, rather than a decoded body.
+ */
+
+import type { QueryCost } from "../lib/shopify/budget";
+import type { AdminClient } from "../lib/execution/sync-executor";
+
+export interface ShopifyAdminContext {
+  graphql(
+    query: string,
+    options?: { variables?: Record<string, unknown> },
+  ): Promise<{ json(): Promise<unknown> }>;
+}
+
+export function toAdminClient(admin: ShopifyAdminContext): AdminClient {
+  return {
+    async request<T>(query: string, variables: Record<string, unknown>) {
+      const response = await admin.graphql(query, { variables });
+      const body = (await response.json()) as {
+        data?: T;
+        extensions?: { cost?: QueryCost };
+        errors?: Array<{ message: string }>;
+      };
+
+      // Top-level GraphQL errors are transport-level failures, distinct from the
+      // per-row `userErrors` the executors map back to individual variants.
+      if (body.errors?.length) {
+        throw new Error(body.errors.map((e) => e.message).join("; "));
+      }
+
+      return { data: body.data, extensions: body.extensions };
+    },
+  };
+}

--- a/app/services/campaigns.server.ts
+++ b/app/services/campaigns.server.ts
@@ -1,0 +1,425 @@
+/**
+ * Campaigns: the bridge between the pure pricing engine and the store.
+ *
+ * Everything decision-making lives in app/lib (resolver, planner, executors) and is
+ * property-tested without a database. This module only loads inputs, calls those
+ * functions, and persists what came back — so the parts that can misprice a
+ * storefront stay testable, and the parts that touch I/O stay thin.
+ */
+
+import prisma from "../db.server";
+import { money, type Money } from "../lib/money/money";
+import { charm99, NO_ROUNDING, type RoundingProfile } from "../lib/money/rounding";
+import type {
+  AdjustmentRule,
+  Baseline,
+  CompareAtPolicy,
+  Guardrails,
+  ResolvableCampaign,
+} from "../lib/pricing/types";
+import { planRun } from "../lib/planning/plan";
+import type { PlanCandidate, PlannedRow } from "../lib/planning/types";
+import { selectWritePath } from "../lib/planning/write-path";
+import { executeSync, type AdminClient } from "../lib/execution/sync-executor";
+import { RateLimitBudget } from "../lib/shopify/budget";
+import { astToWhere, type FilterAst } from "./segments.server";
+
+export interface CampaignInput {
+  name: string;
+  ast: FilterAst;
+  rule: AdjustmentRule;
+  compareAtPolicy: CompareAtPolicy;
+  rounding: "none" | "charm99";
+  guardrails?: Guardrails;
+  priority?: number;
+}
+
+export async function createCampaign(shopId: string, input: CampaignInput) {
+  return prisma.campaign.create({
+    data: {
+      shopId,
+      name: input.name,
+      status: "DRAFT",
+      priority: input.priority ?? 100,
+      ruleRows: [{ segmentIds: [], rule: input.rule }] as never,
+      surfaces: { base: true } as never,
+      compareAtPolicy: input.compareAtPolicy as never,
+      compareAtViolationPolicy: "clear",
+      guardrails: (input.guardrails ?? {}) as never,
+      guardrailViolationPolicy: "clamp",
+      schedule: { kind: "manual", rounding: input.rounding, ast: input.ast } as never,
+    },
+  });
+}
+
+function roundingFor(name: unknown): RoundingProfile {
+  return name === "charm99" ? charm99 : NO_ROUNDING;
+}
+
+/** Rehydrates a stored campaign into the shape the pure resolver expects. */
+function toResolvable(campaign: {
+  id: string;
+  priority: number;
+  ruleRows: unknown;
+  compareAtPolicy: unknown;
+  guardrails: unknown;
+  schedule: unknown;
+  createdAt: Date;
+}): ResolvableCampaign {
+  const schedule = (campaign.schedule ?? {}) as { rounding?: string };
+  return {
+    id: campaign.id,
+    priority: campaign.priority,
+    startAt: campaign.createdAt.getTime(),
+    ruleRows: campaign.ruleRows as ResolvableCampaign["ruleRows"],
+    compareAtPolicy: campaign.compareAtPolicy as CompareAtPolicy,
+    compareAtViolationPolicy: "clear",
+    roundingProfile: roundingFor(schedule.rounding),
+    guardrails: (campaign.guardrails ?? undefined) as Guardrails | undefined,
+    guardrailViolationPolicy: "clamp",
+  };
+}
+
+/** Loads baselines and live values for the campaign's scope. */
+async function loadCandidates(shopId: string, ast: FilterAst): Promise<PlanCandidate[]> {
+  const variants = await prisma.variantIndex.findMany({
+    where: astToWhere(shopId, ast),
+    select: { variantGid: true, currency: true, cost: true, productGid: true },
+  });
+  if (variants.length === 0) return [];
+
+  const gids = variants.map((v) => v.variantGid);
+
+  const [baselines, entries] = await Promise.all([
+    prisma.baseline.findMany({
+      where: { shopId, supersededAt: null, surfaceKind: "BASE", variantGid: { in: gids } },
+    }),
+    prisma.priceSurfaceEntry.findMany({
+      where: { shopId, surfaceKind: "BASE", variantGid: { in: gids } },
+    }),
+  ]);
+
+  const baselineBy = new Map(baselines.map((b) => [b.variantGid, b]));
+  const entryBy = new Map(entries.map((e) => [e.variantGid, e]));
+
+  const candidates: PlanCandidate[] = [];
+
+  for (const variant of variants) {
+    const baseline = baselineBy.get(variant.variantGid);
+    // No baseline means nothing to compute from. Skipping is correct: pricing from
+    // the live value is the compounding bug this product exists to prevent.
+    if (!baseline) continue;
+
+    const currency = baseline.currency || variant.currency || "USD";
+    const entry = entryBy.get(variant.variantGid);
+
+    const asMoney = (v: bigint | null | undefined): Money | undefined =>
+      v === null || v === undefined ? undefined : money(Number(v), currency);
+
+    const base: Baseline = {
+      price: money(Number(baseline.basePrice), currency),
+      compareAtPrice: asMoney(baseline.baseCompareAt),
+      cost: asMoney(baseline.cost ?? variant.cost),
+    };
+
+    candidates.push({
+      ref: {
+        variantGid: variant.variantGid,
+        surfaceKind: "base",
+        priceListGid: "",
+        currency,
+      },
+      baseline: base,
+      livePrice: asMoney(entry?.livePrice),
+      liveCompareAt: asMoney(entry?.liveCompareAt),
+    });
+  }
+
+  return candidates;
+}
+
+export interface PreviewRow {
+  variantGid: string;
+  title: string;
+  before: string | null;
+  after: string | null;
+  compareAt: string | null;
+  status: PlannedRow["status"];
+  reason?: string;
+}
+
+export interface CampaignPreview {
+  campaignId: string;
+  name: string;
+  status: string;
+  counts: { planned: number; noop: number; skipped: number; clamped: number };
+  rows: PreviewRow[];
+  blocked?: { reason: string; variantGid: string };
+  writePath: string;
+  writePathReason: string;
+  /** Campaigns over this size need typed confirmation (A-3.11). */
+  blastRadius: boolean;
+}
+
+const BLAST_RADIUS_THRESHOLD = 1_000;
+
+/**
+ * Computes what a campaign would do, without writing anything.
+ *
+ * Preview and execution share this planning call, so a preview cannot disagree with
+ * what the run then does.
+ */
+export async function previewCampaign(
+  shopId: string,
+  campaignId: string,
+  options: { revert?: boolean; limit?: number } = {},
+): Promise<CampaignPreview> {
+  const campaign = await prisma.campaign.findFirstOrThrow({
+    where: { id: campaignId, shopId },
+  });
+  const schedule = (campaign.schedule ?? {}) as { ast?: FilterAst };
+  const ast = schedule.ast ?? { groups: [] };
+
+  const candidates = await loadCandidates(shopId, ast);
+
+  // Other active campaigns take part in resolution, so overlap resolves the same way
+  // it will at execution time rather than being previewed in isolation.
+  const others = await prisma.campaign.findMany({
+    where: { shopId, status: "ACTIVE", id: { not: campaignId } },
+  });
+
+  const resolvable = [toResolvable(campaign), ...others.map(toResolvable)];
+
+  const outcome = planRun({
+    campaigns: resolvable,
+    candidates,
+    storeGuardrails: {},
+    excludeCampaignId: options.revert ? campaignId : undefined,
+  });
+
+  const titles = await prisma.variantIndex.findMany({
+    where: { shopId, variantGid: { in: candidates.map((c) => c.ref.variantGid) } },
+    select: { variantGid: true, title: true },
+  });
+  const titleBy = new Map(titles.map((t) => [t.variantGid, t.title ?? t.variantGid]));
+
+  const fmt = (m?: Money | null) => (m ? formatMoneyLocal(m) : null);
+
+  if (outcome.kind === "blocked") {
+    return {
+      campaignId,
+      name: campaign.name,
+      status: campaign.status,
+      counts: outcome.counts,
+      rows: [],
+      blocked: { reason: outcome.reason, variantGid: outcome.ref.variantGid },
+      writePath: "none",
+      writePathReason: "Blocked before planning completed.",
+      blastRadius: false,
+    };
+  }
+
+  const decision = selectWritePath(outcome.rows.length);
+
+  return {
+    campaignId,
+    name: campaign.name,
+    status: campaign.status,
+    counts: outcome.counts,
+    rows: outcome.rows.slice(0, options.limit ?? 100).map((row) => ({
+      variantGid: row.ref.variantGid,
+      title: titleBy.get(row.ref.variantGid) ?? row.ref.variantGid,
+      before: fmt(row.beforePrice),
+      after: fmt(row.intendedPrice),
+      compareAt: row.intendedCompareAtSet ? fmt(row.intendedCompareAt) : null,
+      status: row.status,
+      reason: row.reason,
+    })),
+    writePath: decision.path,
+    writePathReason: decision.reason,
+    blastRadius: outcome.counts.planned > BLAST_RADIUS_THRESHOLD,
+  };
+}
+
+function formatMoneyLocal(m: Money): string {
+  const exponent = ["JPY", "KRW"].includes(m.currency) ? 0 : 2;
+  const digits = Math.abs(m.amount).toString().padStart(exponent + 1, "0");
+  const whole = digits.slice(0, digits.length - exponent) || "0";
+  const sign = m.amount < 0 ? "-" : "";
+  return exponent > 0
+    ? `${sign}${whole}.${digits.slice(digits.length - exponent)}`
+    : `${sign}${whole}`;
+}
+
+export interface RunOutcome {
+  runId: string;
+  planned: number;
+  verified: number;
+  failed: number;
+  unverified: number;
+  clean: boolean;
+  messages: string[];
+}
+
+/**
+ * Applies or reverts a campaign.
+ *
+ * Ledger rows are written **before** any API call (invariant I4). If this process
+ * dies between the two, verification finds an unverified row and retries; the other
+ * order would change a storefront with no record that we did it.
+ */
+export async function runCampaign(
+  shopId: string,
+  campaignId: string,
+  client: AdminClient,
+  options: { revert?: boolean } = {},
+): Promise<RunOutcome> {
+  const campaign = await prisma.campaign.findFirstOrThrow({
+    where: { id: campaignId, shopId },
+  });
+  const schedule = (campaign.schedule ?? {}) as { ast?: FilterAst };
+  const ast = schedule.ast ?? { groups: [] };
+
+  const candidates = await loadCandidates(shopId, ast);
+  const others = await prisma.campaign.findMany({
+    where: { shopId, status: "ACTIVE", id: { not: campaignId } },
+  });
+
+  const outcome = planRun({
+    campaigns: [toResolvable(campaign), ...others.map(toResolvable)],
+    candidates,
+    storeGuardrails: {},
+    excludeCampaignId: options.revert ? campaignId : undefined,
+  });
+
+  if (outcome.kind === "blocked") {
+    throw new Error(
+      `Campaign blocked by a guardrail on ${outcome.ref.variantGid}: ${outcome.reason}`,
+    );
+  }
+
+  const kind = options.revert ? "REVERT" : "APPLY";
+
+  const run = await prisma.campaignRun.create({
+    data: {
+      shopId,
+      campaignId,
+      kind,
+      status: "EXECUTING",
+      occurrenceKey: `${kind}-${Date.now()}`,
+      plannedRows: outcome.counts.planned,
+      startedAt: new Date(),
+    },
+  });
+
+  // Write-ahead: ledger first, API second.
+  const writable = outcome.rows.filter((r) => r.status !== "skipped");
+  if (writable.length > 0) {
+    await prisma.variantChange.createMany({
+      data: writable.map((row) => ({
+        runId: run.id,
+        shopId,
+        variantGid: row.ref.variantGid,
+        surfaceKind: "BASE" as const,
+        priceListGid: "",
+        currency: row.ref.currency,
+        beforePrice: row.beforePrice ? BigInt(row.beforePrice.amount) : null,
+        beforeCompareAt: row.beforeCompareAt ? BigInt(row.beforeCompareAt.amount) : null,
+        intendedPrice: row.intendedPrice ? BigInt(row.intendedPrice.amount) : null,
+        intendedCompareAt: row.intendedCompareAt
+          ? BigInt(row.intendedCompareAt.amount)
+          : null,
+        intendedCompareAtSet: row.intendedCompareAtSet,
+        status: "PENDING" as const,
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  const productOfMap = new Map(
+    (
+      await prisma.variantIndex.findMany({
+        where: { shopId, variantGid: { in: writable.map((r) => r.ref.variantGid) } },
+        select: { variantGid: true, productGid: true },
+      })
+    ).map((v) => [v.variantGid, v.productGid]),
+  );
+
+  const result = await executeSync(outcome.rows, {
+    client,
+    budget: new RateLimitBudget(),
+    productOf: (gid) => productOfMap.get(gid) ?? gid,
+    verifySampleRate: 1, // small dev catalogues: verify everything
+  });
+
+  const messages: string[] = [];
+  for (const executed of result.rows) {
+    const status =
+      executed.status === "verified"
+        ? "VERIFIED"
+        : executed.status === "failed"
+          ? "FAILED"
+          : "APPLIED";
+    await prisma.variantChange.updateMany({
+      where: { runId: run.id, variantGid: executed.row.ref.variantGid },
+      data: {
+        status,
+        failureReason: executed.failureReason ?? null,
+        appliedAt: status !== "FAILED" ? new Date() : null,
+        verifiedAt: status === "VERIFIED" ? new Date() : null,
+      },
+    });
+    if (executed.failureReason) messages.push(executed.failureReason);
+  }
+
+  await prisma.campaignRun.update({
+    where: { id: run.id },
+    data: {
+      status: result.clean ? "COMPLETED" : "PARTIAL",
+      verifiedRows: result.verified,
+      failedRows: result.failed,
+      skippedRows: outcome.counts.skipped,
+      finishedAt: new Date(),
+    },
+  });
+
+  await prisma.campaign.update({
+    where: { id: campaignId },
+    data: { status: options.revert ? "COMPLETED" : result.clean ? "ACTIVE" : "PARTIAL" },
+  });
+
+  // Refresh the mirror for what we just changed, so the dashboard's "not at
+  // baseline" counts are immediately truthful rather than waiting for a re-sync.
+  for (const executed of result.rows) {
+    if (executed.status === "failed" || !executed.row.intendedPrice) continue;
+    await prisma.priceSurfaceEntry.updateMany({
+      where: {
+        shopId,
+        variantGid: executed.row.ref.variantGid,
+        surfaceKind: "BASE",
+        priceListGid: "",
+      },
+      data: {
+        livePrice: BigInt(executed.row.intendedPrice.amount),
+        ...(executed.row.intendedCompareAtSet
+          ? {
+              liveCompareAt: executed.row.intendedCompareAt
+                ? BigInt(executed.row.intendedCompareAt.amount)
+                : null,
+            }
+          : {}),
+        syncedAt: new Date(),
+      },
+    });
+  }
+
+  return {
+    runId: run.id,
+    planned: outcome.counts.planned,
+    verified: result.verified,
+    failed: result.failed,
+    unverified: result.unverified,
+    clean: result.clean,
+    messages: messages.slice(0, 5),
+  };
+}

--- a/app/services/segments.server.ts
+++ b/app/services/segments.server.ts
@@ -1,0 +1,186 @@
+/**
+ * Targeting: turning a filter into a concrete set of variants.
+ *
+ * The filter AST is `(group OR group)` where each group is an AND of conditions.
+ * Stored as JSON so segments stay versionable and previewable, and translated to a
+ * Prisma `where` here rather than to raw SQL — the mirror's indexes (GIN on tags and
+ * collections, btree on sku and price) do the work.
+ */
+
+import type { Prisma } from "@prisma/client";
+import prisma from "../db.server";
+
+export type ConditionField =
+  | "collection"
+  | "tag"
+  | "vendor"
+  | "productType"
+  | "status"
+  | "title"
+  | "sku"
+  | "barcode"
+  | "priceMin"
+  | "priceMax"
+  | "inventoryMin"
+  | "inventoryMax"
+  | "hasCompareAt"
+  | "hasCost";
+
+export interface Condition {
+  field: ConditionField;
+  value: string | number | boolean;
+}
+
+/** AND of conditions. */
+export interface ConditionGroup {
+  conditions: Condition[];
+}
+
+/** OR of groups. An empty AST matches the whole catalogue. */
+export interface FilterAst {
+  groups: ConditionGroup[];
+}
+
+export const EMPTY_AST: FilterAst = { groups: [] };
+
+function conditionToWhere(condition: Condition): Prisma.VariantIndexWhereInput | null {
+  const { field, value } = condition;
+  const text = String(value).trim();
+
+  switch (field) {
+    case "collection":
+      return text ? { collections: { has: text } } : null;
+    case "tag":
+      return text ? { tags: { has: text } } : null;
+    case "vendor":
+      return text ? { vendor: { equals: text, mode: "insensitive" } } : null;
+    case "productType":
+      return text ? { productType: { equals: text, mode: "insensitive" } } : null;
+    case "status":
+      return text ? { status: text.toUpperCase() as "ACTIVE" | "ARCHIVED" | "DRAFT" } : null;
+    case "title":
+      return text ? { title: { contains: text, mode: "insensitive" } } : null;
+    case "sku":
+      return text ? { sku: { contains: text, mode: "insensitive" } } : null;
+    case "barcode":
+      return text ? { barcode: { contains: text, mode: "insensitive" } } : null;
+    case "priceMin":
+      return { price: { gte: BigInt(Math.round(Number(value))) } };
+    case "priceMax":
+      return { price: { lte: BigInt(Math.round(Number(value))) } };
+    case "inventoryMin":
+      return { inventoryQty: { gte: Number(value) } };
+    case "inventoryMax":
+      return { inventoryQty: { lte: Number(value) } };
+    case "hasCompareAt":
+      return value ? { compareAt: { not: null } } : { compareAt: null };
+    case "hasCost":
+      return value ? { cost: { not: null } } : { cost: null };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Compiles an AST to a Prisma filter.
+ *
+ * Tombstoned variants are always excluded: a deleted variant must never be enrolled
+ * in a campaign, but its ledger rows still have to resolve on revert (edge case E4).
+ */
+export function astToWhere(shopId: string, ast: FilterAst): Prisma.VariantIndexWhereInput {
+  const base: Prisma.VariantIndexWhereInput = { shopId, deletedAt: null };
+
+  const groups = (ast.groups ?? [])
+    .map((group) => {
+      const clauses = (group.conditions ?? [])
+        .map(conditionToWhere)
+        .filter((c): c is Prisma.VariantIndexWhereInput => c !== null);
+      return clauses.length > 0 ? { AND: clauses } : null;
+    })
+    .filter((g): g is { AND: Prisma.VariantIndexWhereInput[] } => g !== null);
+
+  if (groups.length === 0) return base;
+  return { ...base, OR: groups };
+}
+
+export interface MatchPreview {
+  count: number;
+  sample: Array<{ variantGid: string; title: string; sku: string | null; price: string | null }>;
+}
+
+/** Live count plus a small sample, for the scope step of the wizard. */
+export async function previewMatches(
+  shopId: string,
+  ast: FilterAst,
+  sampleSize = 10,
+): Promise<MatchPreview> {
+  const where = astToWhere(shopId, ast);
+  const [count, sample] = await Promise.all([
+    prisma.variantIndex.count({ where }),
+    prisma.variantIndex.findMany({
+      where,
+      take: sampleSize,
+      orderBy: { title: "asc" },
+      select: { variantGid: true, title: true, sku: true, price: true, currency: true },
+    }),
+  ]);
+
+  return {
+    count,
+    sample: sample.map((v) => ({
+      variantGid: v.variantGid,
+      title: v.title ?? v.variantGid,
+      sku: v.sku,
+      price: v.price === null ? null : formatMinor(v.price, v.currency ?? "USD"),
+    })),
+  };
+}
+
+function formatMinor(amount: bigint, currency: string): string {
+  const exponent = ["JPY", "KRW"].includes(currency) ? 0 : 2;
+  const digits = amount.toString().padStart(exponent + 1, "0");
+  const whole = digits.slice(0, digits.length - exponent) || "0";
+  return exponent > 0 ? `${whole}.${digits.slice(digits.length - exponent)}` : whole;
+}
+
+/** Every variant gid matching the AST, for enrollment. */
+export async function resolveVariantGids(shopId: string, ast: FilterAst): Promise<string[]> {
+  const rows = await prisma.variantIndex.findMany({
+    where: astToWhere(shopId, ast),
+    select: { variantGid: true },
+  });
+  return rows.map((r) => r.variantGid);
+}
+
+/** Distinct values available for the picker, so the UI offers real options. */
+export async function facets(shopId: string): Promise<{
+  vendors: string[];
+  productTypes: string[];
+  tags: string[];
+  collections: string[];
+}> {
+  const rows = await prisma.variantIndex.findMany({
+    where: { shopId, deletedAt: null },
+    select: { vendor: true, productType: true, tags: true, collections: true },
+  });
+
+  const vendors = new Set<string>();
+  const productTypes = new Set<string>();
+  const tags = new Set<string>();
+  const collections = new Set<string>();
+
+  for (const row of rows) {
+    if (row.vendor) vendors.add(row.vendor);
+    if (row.productType) productTypes.add(row.productType);
+    for (const tag of row.tags) tags.add(tag);
+    for (const collection of row.collections) collections.add(collection);
+  }
+
+  const sorted = (set: Set<string>) => [...set].sort().slice(0, 100);
+  return {
+    vendors: sorted(vendors),
+    productTypes: sorted(productTypes),
+    tags: sorted(tags),
+    collections: sorted(collections),
+  };
+}


### PR DESCRIPTION
**The app can now run a sale.** Verified live against `dartmode-labs`: a −20% campaign across 42 variants applied and verified, **0 failures**.

## The thesis, demonstrated

After applying, re-previewing the same campaign shows **Will change: 0, Already correct: 42**.

That is **invariant I2 on a real storefront** — applying twice does nothing the second time. It is exactly the compounding bug competitors ship (and the 1★ review about discounts not measured against MSRP), eliminated because the resolver reads the baseline and never the live price.

## Structure

`campaigns.server.ts` is deliberately thin. Every decision lives in `app/lib` — resolver, planner, executors — where it is property-tested without a database. This module only loads inputs, calls those functions, and persists results. The parts that can misprice a storefront stay testable; the parts that touch I/O stay dumb.

- **Ledger rows are written before any API call** (invariant I4).
- **Preview and apply share the same planning call**, so a preview cannot disagree with the run.
- **Variants with no baseline are skipped**, never priced from their live value.
- The mirror refreshes for what was just written, so "not at baseline" is immediately truthful.

## Three defects found by *running* it

1. **Every action button showed a permanent spinner.** Web components read attribute *presence*, so `loading={false}` still emits `loading="false"` and stays loading forever. `undefined` omits it. This made the buttons unclickable — invisible to typecheck and to tests.
2. **Polaris `Select` extends `Omit<FieldProps, 'defaultValue'>`**, so scope selects couldn't take initial values. Swapped for native selects, which submit identically. Worth revisiting when the typing settles.
3. **The admin context exposes `graphql()` returning a `Response`**, not the executors' `request()` interface. `admin-client.server.ts` adapts between them — keeping executors testable against a fake, with the real-client knowledge in one place.

Also fixed six a11y failures (labels not associated with controls), since WCAG AA is a stated NFR.

## Verification

136 tests · typecheck · lint · build clean — plus a live apply against a real store with all 42 rows read-back verified.

Closes #144, closes #146, closes #147