### PR TITLE
P0.4 + P1.3 — Compliance and product webhooks

### DIFF
--- a/app/routes/webhooks.compliance.tsx
+++ b/app/routes/webhooks.compliance.tsx
@@ -1,0 +1,60 @@
+/**
+ * The three mandatory GDPR compliance webhooks, on one endpoint.
+ *
+ * One route switching on topic rather than three routes: fewer places to get HMAC
+ * verification wrong, and the three handlers share most of their reasoning.
+ *
+ * Anchor stores product and pricing data, plus staff attribution on audit entries.
+ * It holds **no customer PII at all**, which makes two of these three a documented
+ * acknowledgement rather than a data operation. Answering them correctly anyway is
+ * required for a public app, and saying "we hold none" is a real answer.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import { authenticate } from "../shopify.server";
+import prisma from "../db.server";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  // Shopify requires JSON; rejecting anything else before parsing keeps malformed
+  // or probing requests away from the HMAC check entirely.
+  const contentType = request.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    return new Response("Content-Type must be application/json", { status: 400 });
+  }
+
+  // authenticate.webhook verifies the HMAC over the raw body and throws on mismatch.
+  const { shop, topic } = await authenticate.webhook(request);
+
+  switch (topic) {
+    case "CUSTOMERS_DATA_REQUEST":
+      // We store no customer-specific data, so there is nothing to hand over.
+      // Acknowledging is the complete and honest response.
+      console.log(`[compliance] ${topic} for ${shop}: no customer data held`);
+      break;
+
+    case "CUSTOMERS_REDACT":
+      // Nothing to erase, for the same reason. Logged so the acknowledgement is
+      // auditable if a merchant ever asks what happened to a request.
+      console.log(`[compliance] ${topic} for ${shop}: no customer data to redact`);
+      break;
+
+    case "SHOP_REDACT": {
+      // This one is real. Everything we hold is keyed to the shop, and the cascade
+      // rules on Shop remove variants, baselines, campaigns, ledger rows and audit
+      // entries with it.
+      const deleted = await prisma.shop.deleteMany({ where: { domain: shop } });
+      await prisma.session.deleteMany({ where: { shop } });
+      console.log(`[compliance] ${topic} for ${shop}: purged ${deleted.count} shop record(s)`);
+      break;
+    }
+
+    default:
+      // An unexpected topic on this endpoint means the app config and this handler
+      // have drifted apart. Surface it rather than returning a silent 200.
+      console.error(`[compliance] Unhandled topic ${topic} for ${shop}`);
+      return new Response(`Unhandled topic ${topic}`, { status: 422 });
+  }
+
+  return new Response();
+};

--- a/app/routes/webhooks.products.tsx
+++ b/app/routes/webhooks.products.tsx
@@ -1,0 +1,178 @@
+/**
+ * Product create / update / delete, keeping the catalog mirror current between syncs.
+ *
+ * Two rules govern everything here:
+ *
+ *   Deletes tombstone, never hard-delete. Ledger rows may still reference a variant
+ *   that has since been deleted, and those rows must stay resolvable when a campaign
+ *   reverts (edge case E4). Hard deletion turns a graceful skip into a foreign-key
+ *   error mid-run.
+ *
+ *   Out-of-order deliveries are ignored, not applied. Shopify does not guarantee
+ *   ordering, so an older payload arriving after a newer one would otherwise
+ *   overwrite current data with stale data. `remoteUpdatedAt` decides.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import { authenticate } from "../shopify.server";
+import prisma from "../db.server";
+import { parseMoney } from "../lib/money/money";
+
+interface WebhookVariant {
+  id: number | string;
+  admin_graphql_api_id?: string;
+  title?: string | null;
+  sku?: string | null;
+  barcode?: string | null;
+  price?: string | null;
+  compare_at_price?: string | null;
+  inventory_quantity?: number | null;
+}
+
+interface WebhookProduct {
+  id: number | string;
+  admin_graphql_api_id?: string;
+  title?: string;
+  vendor?: string | null;
+  product_type?: string | null;
+  status?: string | null;
+  tags?: string | string[] | null;
+  updated_at?: string | null;
+  variants?: WebhookVariant[];
+}
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { shop: shopDomain, topic, payload } = await authenticate.webhook(request);
+
+  const shop = await prisma.shop.findUnique({ where: { domain: shopDomain } });
+  // A webhook for a shop we have never recorded is not an error: it can arrive
+  // between install and first load. Acknowledge so Shopify does not retry.
+  if (!shop) return new Response();
+
+  const product = payload as unknown as WebhookProduct;
+  const productGid =
+    product.admin_graphql_api_id ?? `gid://shopify/Product/${product.id}`;
+
+  if (topic === "PRODUCTS_DELETE") {
+    await prisma.variantIndex.updateMany({
+      where: { shopId: shop.id, productGid },
+      data: { deletedAt: new Date() },
+    });
+    return new Response();
+  }
+
+  const remoteUpdatedAt = product.updated_at ? new Date(product.updated_at) : null;
+  const currency = await currencyFor(shop.id);
+
+  const tags = Array.isArray(product.tags)
+    ? product.tags
+    : typeof product.tags === "string"
+      ? product.tags.split(",").map((t) => t.trim()).filter(Boolean)
+      : [];
+
+  for (const variant of product.variants ?? []) {
+    const variantGid =
+      variant.admin_graphql_api_id ?? `gid://shopify/ProductVariant/${variant.id}`;
+
+    const existing = await prisma.variantIndex.findUnique({
+      where: { shopId_variantGid: { shopId: shop.id, variantGid } },
+      select: { remoteUpdatedAt: true },
+    });
+
+    // Stale delivery: we already hold something newer.
+    if (
+      existing?.remoteUpdatedAt &&
+      remoteUpdatedAt &&
+      existing.remoteUpdatedAt > remoteUpdatedAt
+    ) {
+      continue;
+    }
+
+    const price = safeMinor(variant.price, currency);
+    const compareAt = safeMinor(variant.compare_at_price, currency);
+
+    const data = {
+      productGid,
+      sku: variant.sku ?? null,
+      barcode: variant.barcode ?? null,
+      title: [product.title, variant.title].filter(Boolean).join(" · "),
+      price,
+      compareAt,
+      currency,
+      inventoryQty: variant.inventory_quantity ?? null,
+      status: mapStatus(product.status),
+      vendor: product.vendor ?? null,
+      productType: product.product_type ?? null,
+      tags,
+      remoteUpdatedAt,
+      syncedAt: new Date(),
+      // A variant reappearing after deletion clears its tombstone.
+      deletedAt: null,
+    };
+
+    await prisma.variantIndex.upsert({
+      where: { shopId_variantGid: { shopId: shop.id, variantGid } },
+      create: { shopId: shop.id, variantGid, ...data },
+      update: data,
+    });
+
+    await prisma.priceSurfaceEntry.upsert({
+      where: {
+        shopId_variantGid_surfaceKind_priceListGid: {
+          shopId: shop.id,
+          variantGid,
+          surfaceKind: "BASE",
+          priceListGid: "",
+        },
+      },
+      create: {
+        shopId: shop.id,
+        variantGid,
+        surfaceKind: "BASE",
+        priceListGid: "",
+        currency,
+        livePrice: price,
+        liveCompareAt: compareAt,
+      },
+      update: { livePrice: price, liveCompareAt: compareAt, syncedAt: new Date() },
+    });
+  }
+
+  return new Response();
+};
+
+/**
+ * Parses a price to minor units, returning null rather than throwing.
+ *
+ * A webhook is not a good place to fail loudly on one odd value: rejecting the
+ * response makes Shopify retry the whole payload forever. Null means "unknown",
+ * which the planner already treats as a reason to write rather than to skip.
+ */
+function safeMinor(value: string | null | undefined, currency: string): bigint | null {
+  if (!value) return null;
+  try {
+    return BigInt(parseMoney(value, currency).amount);
+  } catch {
+    return null;
+  }
+}
+
+async function currencyFor(shopId: string): Promise<string> {
+  const row = await prisma.variantIndex.findFirst({
+    where: { shopId, currency: { not: null } },
+    select: { currency: true },
+  });
+  return row?.currency ?? "USD";
+}
+
+function mapStatus(status?: string | null): "ACTIVE" | "ARCHIVED" | "DRAFT" {
+  switch ((status ?? "").toUpperCase()) {
+    case "ARCHIVED":
+      return "ARCHIVED";
+    case "DRAFT":
+      return "DRAFT";
+    default:
+      return "ACTIVE";
+  }
+}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -20,6 +20,14 @@ api_version = "2026-07"
   topics = [ "app/uninstalled" ]
   uri = "/webhooks/app/uninstalled"
 
+  [[webhooks.subscriptions]]
+  topics = [ "products/create", "products/update", "products/delete" ]
+  uri = "/webhooks/products"
+
+  [[webhooks.subscriptions]]
+  uri = "/webhooks/compliance"
+  compliance_topics = [ "customers/data_request", "customers/redact", "shop/redact" ]
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_products"


### PR DESCRIPTION
Two mandatory pieces: the GDPR compliance trio, and product webhooks that keep the catalog mirror fresh between syncs.

## Compliance (P0.4)

All three topics on **one endpoint** switching on topic, rather than three routes — fewer places to get HMAC verification wrong.

Anchor holds product/pricing data and staff attribution, and **no customer PII at all**. So `customers/data_request` and `customers/redact` are honest acknowledgements rather than data operations; "we hold none" is a real answer. `shop/redact` is real work — every row is keyed to the shop and removed by cascade.

Two deliberate choices: non-JSON content types are rejected **before** parsing, keeping probes away from the HMAC check; and an unexpected topic returns **422 rather than a silent 200**, because that combination means the app config and this handler have drifted apart, which should be visible.

## Product sync (P1.3)

**Deletes tombstone, never hard-delete.** Ledger rows may still reference a deleted variant and must stay resolvable when a campaign reverts (**E4**) — hard deletion turns a graceful skip into a foreign-key error mid-run. A variant reappearing clears its tombstone.

**Out-of-order deliveries are ignored, not applied.** Shopify doesn't guarantee ordering, so an older payload arriving after a newer one would otherwise overwrite current data with stale data. `remoteUpdatedAt` decides.

**Price parsing returns null rather than throwing.** A webhook is a bad place to fail loudly on one odd value — rejecting the response makes Shopify retry the whole payload indefinitely. Null means "unknown", which the planner already treats as a reason to write rather than skip.

## Worth knowing

`shopify app deploy` **rewrites `shopify.app.toml` and strips all comments**, including the commented-out subscription blocks that documented what was still pending. The subscriptions are live config now so it no longer bites, but it's worth knowing before putting more documentation in that file.

Deployed and registered against the app. 136 tests · typecheck · lint clean.

Closes #32, closes #33, closes #34, closes #37, closes #38, closes #63