### PR TITLE
P3.6 — Run history and per-row ledger

### DIFF
--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -4,14 +4,28 @@ import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
-import { previewCampaign, runCampaign } from "../services/campaigns.server";
+import {
+  campaignRuns,
+  previewCampaign,
+  runCampaign,
+  runLedger,
+} from "../services/campaigns.server";
 import { toAdminClient } from "../services/admin-client.server";
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const preview = await previewCampaign(shop.id, String(params.id));
-  return { preview };
+  const runs = await campaignRuns(shop.id, String(params.id));
+
+  // Show the newest run's ledger inline: the first question after a run is always
+  // "what exactly did it do to each variant", and making that a second click loses
+  // the people who most need the answer.
+  const url = new URL(request.url);
+  const selectedRunId = url.searchParams.get("run") ?? runs[0]?.id ?? null;
+  const ledger = selectedRunId ? await runLedger(shop.id, selectedRunId) : [];
+
+  return { preview, runs, ledger, selectedRunId };
 };
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
@@ -45,6 +59,21 @@ type ActionData = { ok: boolean; message: string; details: string[] };
 
 type Tone = "info" | "success" | "critical" | "neutral" | "warning" | "caution" | "auto";
 
+const RUN_TONE: Record<string, Tone> = {
+  COMPLETED: "success",
+  PARTIAL: "warning",
+  FAILED: "critical",
+  EXECUTING: "info",
+};
+
+const LEDGER_TONE: Record<string, Tone> = {
+  VERIFIED: "success",
+  APPLIED: "info",
+  FAILED: "critical",
+  SKIPPED: "neutral",
+  PENDING: "info",
+};
+
 const STATUS_TONE: Record<string, Tone> = {
   pending: "info",
   clamped: "warning",
@@ -52,7 +81,7 @@ const STATUS_TONE: Record<string, Tone> = {
 };
 
 export default function CampaignDetail() {
-  const { preview } = useLoaderData<typeof loader>();
+  const { preview, runs, ledger, selectedRunId } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
   const result = fetcher.data;
@@ -148,6 +177,80 @@ export default function CampaignDetail() {
           </s-paragraph>
         )}
       </s-section>
+
+      {runs.length > 0 ? (
+        <s-section heading="Run history">
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Run</s-table-header>
+              <s-table-header>Status</s-table-header>
+              <s-table-header>Planned</s-table-header>
+              <s-table-header>Verified</s-table-header>
+              <s-table-header>Failed</s-table-header>
+              <s-table-header>Finished</s-table-header>
+              <s-table-header></s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {runs.map((run) => (
+                <s-table-row key={run.id}>
+                  <s-table-cell>{run.kind}</s-table-cell>
+                  <s-table-cell>
+                    <s-badge tone={RUN_TONE[run.status] ?? "neutral"}>{run.status}</s-badge>
+                  </s-table-cell>
+                  <s-table-cell>{run.planned}</s-table-cell>
+                  <s-table-cell>{run.verified}</s-table-cell>
+                  <s-table-cell>{run.failed}</s-table-cell>
+                  <s-table-cell>
+                    {run.finishedAt ? new Date(run.finishedAt).toLocaleString() : "—"}
+                  </s-table-cell>
+                  <s-table-cell>
+                    {run.id === selectedRunId ? (
+                      <s-text>Showing</s-text>
+                    ) : (
+                      <s-link href={`?run=${run.id}`}>View ledger</s-link>
+                    )}
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </s-section>
+      ) : null}
+
+      {ledger.length > 0 ? (
+        <s-section heading="Ledger">
+          <s-paragraph>
+            <s-text>
+              Every row we wrote, with what it was and what we intended. Retained
+              indefinitely on every plan.
+            </s-text>
+          </s-paragraph>
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Variant</s-table-header>
+              <s-table-header>Before</s-table-header>
+              <s-table-header>Intended</s-table-header>
+              <s-table-header>State</s-table-header>
+              <s-table-header>Reason</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {ledger.map((row) => (
+                <s-table-row key={row.variantGid}>
+                  <s-table-cell>{row.title}</s-table-cell>
+                  <s-table-cell>{row.before ?? "—"}</s-table-cell>
+                  <s-table-cell>{row.intended ?? "—"}</s-table-cell>
+                  <s-table-cell>
+                    <s-badge tone={LEDGER_TONE[row.status] ?? "neutral"}>
+                      {row.status}
+                    </s-badge>
+                  </s-table-cell>
+                  <s-table-cell>{row.failureReason ?? "—"}</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </s-section>
+      ) : null}
 
       <s-section slot="aside" heading="Actions">
         <s-stack gap="base">

--- a/app/services/campaigns.server.ts
+++ b/app/services/campaigns.server.ts
@@ -423,3 +423,85 @@ export async function runCampaign(
     messages: messages.slice(0, 5),
   };
 }
+
+
+export interface RunSummary {
+  id: string;
+  kind: string;
+  status: string;
+  planned: number;
+  verified: number;
+  failed: number;
+  skipped: number;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+export interface LedgerRow {
+  variantGid: string;
+  title: string;
+  before: string | null;
+  intended: string | null;
+  status: string;
+  failureReason: string | null;
+}
+
+/** Run history for a campaign, newest first. */
+export async function campaignRuns(shopId: string, campaignId: string): Promise<RunSummary[]> {
+  const runs = await prisma.campaignRun.findMany({
+    where: { shopId, campaignId },
+    orderBy: { createdAt: "desc" },
+    take: 20,
+  });
+
+  return runs.map((run) => ({
+    id: run.id,
+    kind: run.kind,
+    status: run.status,
+    planned: run.plannedRows,
+    verified: run.verifiedRows,
+    failed: run.failedRows,
+    skipped: run.skippedRows,
+    startedAt: run.startedAt?.toISOString() ?? null,
+    finishedAt: run.finishedAt?.toISOString() ?? null,
+  }));
+}
+
+/**
+ * The per-row ledger for one run.
+ *
+ * This is the forensic view: the success test is that support can trace any
+ * variant's complete price story without opening a database client. Retention is
+ * deliberately unlimited on every tier -- competitors sell 30/60/90-day history as
+ * a paid axis, and charging for the ability to explain what you did to someone's
+ * prices is the wrong trade.
+ */
+export async function runLedger(
+  shopId: string,
+  runId: string,
+  limit = 200,
+): Promise<LedgerRow[]> {
+  const changes = await prisma.variantChange.findMany({
+    where: { shopId, runId },
+    orderBy: { createdAt: "asc" },
+    take: limit,
+  });
+
+  const titles = await prisma.variantIndex.findMany({
+    where: { shopId, variantGid: { in: changes.map((c) => c.variantGid) } },
+    select: { variantGid: true, title: true },
+  });
+  const titleBy = new Map(titles.map((t) => [t.variantGid, t.title ?? t.variantGid]));
+
+  const fmt = (v: bigint | null, currency: string) =>
+    v === null ? null : formatMoneyLocal(money(Number(v), currency));
+
+  return changes.map((change) => ({
+    variantGid: change.variantGid,
+    title: titleBy.get(change.variantGid) ?? change.variantGid,
+    before: fmt(change.beforePrice, change.currency),
+    intended: fmt(change.intendedPrice, change.currency),
+    status: change.status,
+    failureReason: change.failureReason,
+  }));
+}


### PR DESCRIPTION
The forensic view for a campaign: every run, and every row within it.

**Success test:** support can trace any variant's complete price story without opening a database client. That question arrives constantly in competitors' reviews, and the answer there is usually a shrug.

## Two deliberate choices

**The newest run's ledger renders inline**, not behind a click. The first question after a run is always "what exactly did it do to each variant" — making that a second click loses the people who most need the answer. Older runs link to their own ledger via `?run=`.

**Retention is unlimited on every tier.** Competitors sell 30/60/90-day history as a paid axis. Charging for the ability to explain what you did to someone's prices is the wrong trade, and it's the cheapest possible way to be visibly different.

Verified live: the ledger shows all 42 rows from the applied campaign with before/intended values and VERIFIED state.

Closes #149