### PR TITLE
P3.8 — Guardrail settings, wired into preview and run

### DIFF
--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -76,6 +76,9 @@ export default function Settings() {
               Only {costCoverage}% of your variants have a cost recorded. With
               &ldquo;never below cost&rdquo; on, the rest are skipped rather than
               priced unguarded — they will not be included in any campaign.
+              Variants added since the last catalogue sync have no cost yet, because
+              Shopify&rsquo;s product webhooks do not carry one; a re-sync from the
+              dashboard fills them in.
             </s-paragraph>
           </s-banner>
         ) : null}

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -1,0 +1,173 @@
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useFetcher, useLoaderData, useRouteError } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import prisma from "../db.server";
+import { ensureShop } from "../services/shop.server";
+import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const [settings, currency, withCost, variants] = await Promise.all([
+    readSettings(shop.id),
+    shopCurrency(shop.id),
+    prisma.variantIndex.count({ where: { shopId: shop.id, cost: { not: null } } }),
+    prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } }),
+  ]);
+
+  return { settings, currency, withCost, variants };
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  const saved = await writeSettings(shop.id, {
+    neverBelowCost: form.get("neverBelowCost") === "on",
+    minMarginPercent: emptyToNull(form.get("minMarginPercent")),
+    minPrice: emptyToNull(form.get("minPrice")),
+    violationPolicy: asPolicy(form.get("violationPolicy")),
+    missingCostPolicy: form.get("missingCostPolicy") === "error" ? "error" : "skip",
+  });
+
+  return { ok: true, message: "Guardrails saved. They apply to every campaign.", saved };
+};
+
+function emptyToNull(value: FormDataEntryValue | null): number | null {
+  const text = String(value ?? "").trim();
+  return text === "" ? null : Number(text);
+}
+
+function asPolicy(value: FormDataEntryValue | null): "clamp" | "skip" | "block" {
+  const text = String(value ?? "");
+  return text === "skip" || text === "block" ? text : "clamp";
+}
+
+type ActionData = { ok: boolean; message: string };
+
+export default function Settings() {
+  const { settings, currency, withCost, variants } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const busy = fetcher.state !== "idle";
+
+  const costCoverage = variants === 0 ? 0 : Math.round((withCost / variants) * 100);
+
+  return (
+    <s-page heading="Settings">
+      {fetcher.data ? (
+        <s-banner tone="success">
+          <s-paragraph>{fetcher.data.message}</s-paragraph>
+        </s-banner>
+      ) : null}
+
+      <s-section heading="Guardrails">
+        <s-paragraph>
+          Floors that no campaign may price below. They are checked after rounding,
+          so a rounding rule cannot push a price under them.
+        </s-paragraph>
+
+        {settings.neverBelowCost && costCoverage < 100 ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              Only {costCoverage}% of your variants have a cost recorded. With
+              &ldquo;never below cost&rdquo; on, the rest are skipped rather than
+              priced unguarded — they will not be included in any campaign.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <fetcher.Form method="post">
+          <s-stack gap="base">
+            <label>
+              <input
+                type="checkbox"
+                name="neverBelowCost"
+                defaultChecked={settings.neverBelowCost}
+              />{" "}
+              Never price at or below cost
+            </label>
+
+            <s-number-field
+              name="minMarginPercent"
+              label="Minimum margin (%)"
+              defaultValue={settings.minMarginPercent?.toString() ?? ""}
+              details="Share of the selling price. 25 means a price of at least cost ÷ 0.75. Leave blank for none."
+            />
+
+            <s-number-field
+              name="minPrice"
+              label={`Minimum price (${currency})`}
+              defaultValue={settings.minPrice?.toString() ?? ""}
+              details="An absolute floor, whatever the rule computes. Leave blank for none."
+            />
+
+            <label htmlFor="violationPolicy">When a price would breach a floor</label>
+            <select
+              id="violationPolicy"
+              name="violationPolicy"
+              defaultValue={settings.violationPolicy}
+            >
+              <option value="clamp">Clamp it to the floor and carry on</option>
+              <option value="skip">Skip that variant, price the rest</option>
+              <option value="block">Block the whole campaign</option>
+            </select>
+
+            <label htmlFor="missingCostPolicy">
+              When a cost-based floor meets a variant with no cost
+            </label>
+            <select
+              id="missingCostPolicy"
+              name="missingCostPolicy"
+              defaultValue={settings.missingCostPolicy}
+            >
+              <option value="skip">Skip that variant</option>
+              <option value="error">Fail the campaign</option>
+            </select>
+
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
+              Save guardrails
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      <s-section slot="aside" heading="Why floors are checked last">
+        <s-paragraph>
+          A campaign computes a price from the baseline, rounds it, and only then
+          checks the floor. Rounding down can push an otherwise-legal price under the
+          line, so checking earlier would let it through.
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            A price is never zero or negative regardless of these settings — that
+            floor is always on.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+
+      <s-section slot="aside" heading="Cost data">
+        <s-paragraph>
+          {withCost} of {variants} variants have a cost ({costCoverage}%).
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            Cost-based floors only constrain variants that have one. The policy above
+            decides what happens to the others.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -22,6 +22,7 @@ export default function App() {
         <s-link href="/app/campaigns">Campaigns</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/drift">Drift</s-link>
+        <s-link href="/app/settings">Settings</s-link>
       </s-app-nav>
       <Outlet />
     </AppProvider>

--- a/app/routes/webhooks.products.tsx
+++ b/app/routes/webhooks.products.tsx
@@ -11,6 +11,14 @@
  *   Out-of-order deliveries are ignored, not applied. Shopify does not guarantee
  *   ordering, so an older payload arriving after a newer one would otherwise
  *   overwrite current data with stale data. `remoteUpdatedAt` decides.
+ *
+ * One thing this path CANNOT supply: cost per item. Shopify's product webhook
+ * payload has no cost field -- cost lives on the inventory item, behind a separate
+ * lookup. So a variant that first appears via webhook has no cost until the next
+ * catalogue sync, and cost-based guardrails will skip it in the meantime. `cost` is
+ * deliberately absent from the update below rather than set to null, so a sync that
+ * already found a cost is not undone by a later webhook. The settings page reports
+ * cost coverage so the gap is visible rather than silent.
  */
 
 import type { ActionFunctionArgs } from "react-router";

--- a/app/services/campaigns/preview.server.ts
+++ b/app/services/campaigns/preview.server.ts
@@ -11,6 +11,7 @@ import { planRun } from "../../lib/planning/plan";
 import { selectWritePath } from "../../lib/planning/write-path";
 import { loadCandidates, titleMapFor } from "./candidates.server";
 import { loadCampaignContext } from "./model.server";
+import { guardrailsFor } from "../settings.server";
 import { BLAST_RADIUS_THRESHOLD, type CampaignPreview } from "./types";
 
 export interface PreviewOptions {
@@ -26,12 +27,15 @@ export async function previewCampaign(
   options: PreviewOptions = {},
 ): Promise<CampaignPreview> {
   const { campaign, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
-  const candidates = await loadCandidates(shopId, ast);
+  const [candidates, storeGuardrails] = await Promise.all([
+    loadCandidates(shopId, ast),
+    guardrailsFor(shopId),
+  ]);
 
   const outcome = planRun({
     campaigns: resolvable,
     candidates,
-    storeGuardrails: {},
+    storeGuardrails,
     excludeCampaignId: options.revert ? campaignId : undefined,
   });
 

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -17,6 +17,7 @@ import { planRun } from "../../lib/planning/plan";
 import { recordWriteIntents } from "../drift.server";
 import { loadCandidates, productMapFor } from "./candidates.server";
 import { loadCampaignContext } from "./model.server";
+import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
 
 export interface RunOptions {
@@ -36,12 +37,15 @@ export async function runCampaign(
   options: RunOptions = {},
 ): Promise<RunOutcome> {
   const { resolvable, ast } = await loadCampaignContext(shopId, campaignId);
-  const candidates = await loadCandidates(shopId, ast);
+  const [candidates, storeGuardrails] = await Promise.all([
+    loadCandidates(shopId, ast),
+    guardrailsFor(shopId),
+  ]);
 
   const outcome = planRun({
     campaigns: resolvable,
     candidates,
-    storeGuardrails: {},
+    storeGuardrails,
     excludeCampaignId: options.revert ? campaignId : undefined,
   });
 

--- a/app/services/settings.server.ts
+++ b/app/services/settings.server.ts
@@ -1,0 +1,141 @@
+/**
+ * Store settings, including the guardrails that bound every campaign.
+ *
+ * Stored as JSON on the shop row so the shape can evolve without a migration, but
+ * read back through a parser that validates and defaults, so the rest of the app
+ * never handles a half-populated settings object.
+ *
+ * Guardrails are the merchant-facing half of invariant I6: no campaign may price a
+ * variant below its floor. They were enforceable from the start but unreachable --
+ * preview and run both passed an empty object -- so this is what makes them real.
+ */
+
+import prisma from "../db.server";
+import { decimalsFor } from "../lib/money/format";
+import { money } from "../lib/money/money";
+import type { Guardrails } from "../lib/pricing/types";
+
+export interface StoreSettings {
+  /** Never price at or below cost. Requires cost data on the variant. */
+  neverBelowCost: boolean;
+  /** Minimum gross margin as a percentage of selling price. */
+  minMarginPercent: number | null;
+  /** Absolute minimum price, in major units as typed by the merchant. */
+  minPrice: number | null;
+  /** What to do when a computed price breaches a floor. */
+  violationPolicy: "clamp" | "skip" | "block";
+  /** What to do when a cost-dependent guardrail meets a variant with no cost. */
+  missingCostPolicy: "skip" | "error";
+}
+
+export const DEFAULT_SETTINGS: StoreSettings = {
+  // Off by default: switching it on when most variants have no cost would skip
+  // most of the catalogue, which looks like the app is broken. The dashboard
+  // prompts for it once cost data exists.
+  neverBelowCost: false,
+  minMarginPercent: null,
+  minPrice: null,
+  violationPolicy: "clamp",
+  missingCostPolicy: "skip",
+};
+
+/** Reads settings, filling anything absent or malformed with a default. */
+export async function readSettings(shopId: string): Promise<StoreSettings> {
+  const shop = await prisma.shop.findUnique({
+    where: { id: shopId },
+    select: { settings: true },
+  });
+
+  return parseSettings(shop?.settings);
+}
+
+export function parseSettings(raw: unknown): StoreSettings {
+  const value = (raw ?? {}) as Partial<Record<keyof StoreSettings, unknown>>;
+
+  return {
+    neverBelowCost: value.neverBelowCost === true,
+    minMarginPercent: finiteOrNull(value.minMarginPercent, 0, 99.9),
+    minPrice: finiteOrNull(value.minPrice, 0, Number.MAX_SAFE_INTEGER),
+    violationPolicy:
+      value.violationPolicy === "skip" || value.violationPolicy === "block"
+        ? value.violationPolicy
+        : "clamp",
+    missingCostPolicy: value.missingCostPolicy === "error" ? "error" : "skip",
+  };
+}
+
+function finiteOrNull(value: unknown, min: number, max: number): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  // Clamp rather than reject: a merchant typing 150 into a margin field means
+  // "as high as possible", and refusing the whole save would lose their other edits.
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export async function writeSettings(
+  shopId: string,
+  settings: StoreSettings,
+): Promise<StoreSettings> {
+  const parsed = parseSettings(settings);
+
+  await prisma.shop.update({
+    where: { id: shopId },
+    data: { settings: parsed as never },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      action: "settings.guardrails.update",
+      entity: "Shop",
+      entityId: shopId,
+      after: parsed as never,
+    },
+  });
+
+  return parsed;
+}
+
+/**
+ * Converts stored settings into the `Guardrails` the resolver expects.
+ *
+ * `minPrice` is typed by merchants in major units and stored that way, so it is
+ * converted to minor units here -- the single place that translation happens.
+ *
+ * The multiplier comes from the currency table rather than a literal 100. A
+ * hardcoded 100 would read a ¥1,000 floor as ¥100,000 and a 1.5 KWD floor as
+ * 0.15 KWD, which is the same mistake three service files were quietly making
+ * until recently.
+ */
+export function toGuardrails(settings: StoreSettings, currency: string): Guardrails {
+  const perMajor = 10 ** decimalsFor(currency);
+
+  return {
+    neverBelowCost: settings.neverBelowCost,
+    minMarginPercent: settings.minMarginPercent ?? undefined,
+    minPrice:
+      settings.minPrice === null
+        ? undefined
+        : money(Math.round(settings.minPrice * perMajor), currency),
+    missingCostPolicy: settings.missingCostPolicy,
+  };
+}
+
+/** The shop's primary currency, taken from the mirror. */
+export async function shopCurrency(shopId: string): Promise<string> {
+  const row = await prisma.variantIndex.findFirst({
+    where: { shopId, currency: { not: null } },
+    select: { currency: true },
+  });
+  return row?.currency ?? "USD";
+}
+
+/** Guardrails ready to hand to the planner, in one call. */
+export async function guardrailsFor(shopId: string): Promise<Guardrails> {
+  const [settings, currency] = await Promise.all([
+    readSettings(shopId),
+    shopCurrency(shopId),
+  ]);
+  return toGuardrails(settings, currency);
+}

--- a/app/services/settings.test.ts
+++ b/app/services/settings.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSettings, toGuardrails, DEFAULT_SETTINGS } from "./settings.server";
+
+describe("parseSettings", () => {
+  it("defaults everything when the stored value is empty or junk", () => {
+    expect(parseSettings(undefined)).toEqual(DEFAULT_SETTINGS);
+    expect(parseSettings(null)).toEqual(DEFAULT_SETTINGS);
+    expect(parseSettings({})).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("treats blank fields as 'no floor', not as zero", () => {
+    // Zero is a real floor; blank means the merchant did not set one. Conflating
+    // them would silently apply a floor nobody asked for.
+    const parsed = parseSettings({ minPrice: "", minMarginPercent: "" });
+    expect(parsed.minPrice).toBeNull();
+    expect(parsed.minMarginPercent).toBeNull();
+  });
+
+  it("clamps rather than rejecting an out-of-range margin", () => {
+    // Refusing the whole save would lose the merchant's other edits.
+    expect(parseSettings({ minMarginPercent: 150 }).minMarginPercent).toBe(99.9);
+    expect(parseSettings({ minMarginPercent: -20 }).minMarginPercent).toBe(0);
+  });
+
+  it("falls back to a safe policy for unrecognised values", () => {
+    expect(parseSettings({ violationPolicy: "nonsense" }).violationPolicy).toBe("clamp");
+    expect(parseSettings({ missingCostPolicy: "nonsense" }).missingCostPolicy).toBe("skip");
+  });
+
+  it("only treats an explicit true as enabling never-below-cost", () => {
+    expect(parseSettings({ neverBelowCost: "yes" }).neverBelowCost).toBe(false);
+    expect(parseSettings({ neverBelowCost: true }).neverBelowCost).toBe(true);
+  });
+});
+
+describe("toGuardrails", () => {
+  it("converts a minimum price using the currency's own precision", () => {
+    // A hardcoded x100 would read a 1000 yen floor as 100,000 yen.
+    const settings = { ...DEFAULT_SETTINGS, minPrice: 10 };
+    expect(toGuardrails(settings, "USD").minPrice).toEqual({ amount: 1000, currency: "USD" });
+    expect(toGuardrails(settings, "JPY").minPrice).toEqual({ amount: 10, currency: "JPY" });
+    expect(toGuardrails(settings, "KWD").minPrice).toEqual({ amount: 10000, currency: "KWD" });
+  });
+
+  it("omits floors the merchant did not set", () => {
+    const guardrails = toGuardrails(DEFAULT_SETTINGS, "USD");
+    expect(guardrails.minPrice).toBeUndefined();
+    expect(guardrails.minMarginPercent).toBeUndefined();
+  });
+
+  it("carries the policies through to the resolver", () => {
+    const guardrails = toGuardrails(
+      { ...DEFAULT_SETTINGS, neverBelowCost: true, missingCostPolicy: "error" },
+      "USD",
+    );
+    expect(guardrails.neverBelowCost).toBe(true);
+    expect(guardrails.missingCostPolicy).toBe("error");
+  });
+});


### PR DESCRIPTION
The engine enforced floors from day one, but nothing could configure them — preview and run both passed an empty guardrails object. Invariant I6 was technically upheld and **practically inert**. This makes it real.

## Verified on the 1,615-variant catalogue

| Setting | Result |
|---|---|
| Min price 100.00, −50% campaign | **1,377 clamped to exactly 100.00**; items already above priced normally (885.95 → 442.98) |
| Never-below-cost, −80% campaign | **1,159 clamped up to cost** (175.56 → 112.88, not the 35.11 the rule wanted); **456 skipped** as `missing-cost` |

Every variant lands in exactly one bucket — 1,159 + 456 = 1,615.

## Three parsing decisions worth naming

- **Blank is not zero.** Zero is a real floor; blank means none was set. Conflating them silently applies a floor nobody asked for.
- **Out-of-range clamps rather than rejects.** Typing 150 into a margin field means "as high as possible"; failing the save would lose the merchant's other edits.
- **never-below-cost defaults OFF.** Switching it on when most variants lack cost would skip most of the catalogue and look like the app is broken. The page shows cost coverage so the reason is visible.

## A bug of mine, caught before shipping

`toGuardrails` converted the minimum price with a hardcoded `× 100` — the *same* mistake three service files were making until the previous commit. It would read a ¥1,000 floor as ¥100,000 and a 1.5 KWD floor as 0.15 KWD. Now takes the multiplier from the currency table, with tests across USD/JPY/KWD.

## A gap the settings page exposed

It reported **0 of 1,615 variants with cost**. The mirror had been populated by `products/create` webhooks, and Shopify's product webhook payload carries **no cost** — it lives on the inventory item. A full sync populated 1,159 in 11.7s.

The webhook path therefore *cannot* supply cost, so `cost` is deliberately absent from its update (not set to null) — a sync that found one isn't undone by a later webhook. Both the handler and the settings banner now say so plainly.

156 tests · typecheck · lint · build clean. Guardrails reset to defaults afterwards, so no floor is left on the store.

Closes #151