### PR TITLE
P3.9 + P0.5 — Scheduling and the worker process

### DIFF
--- a/app/lib/scheduling/window.test.ts
+++ b/app/lib/scheduling/window.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import {
+  DEFAULT_REVERT_BUFFER_MINUTES,
+  describeSchedule,
+  dueTransition,
+  effectiveBufferMs,
+  scheduleWarnings,
+  localInputToUtc,
+  parseSchedule,
+  utcToLocalInput,
+  windowClosed,
+  type Schedule,
+  type SchedulableStatus,
+} from "./window";
+
+const at = (iso: string) => new Date(iso);
+
+const window = (over: Partial<Extract<Schedule, { kind: "window" }>> = {}): Schedule => ({
+  kind: "window",
+  startAt: "2026-08-20T09:00:00.000Z",
+  endAt: "2026-08-22T09:00:00.000Z",
+  revertBufferMinutes: 5,
+  ...over,
+});
+
+describe("due transitions", () => {
+  it("applies a scheduled campaign once its start has passed", () => {
+    const state = { schedule: window(), status: "SCHEDULED" as SchedulableStatus };
+    expect(dueTransition(state, at("2026-08-20T08:59:00Z"))).toBeNull();
+    expect(dueTransition(state, at("2026-08-20T09:00:00Z"))).toBe("apply");
+    expect(dueTransition(state, at("2026-08-20T09:01:00Z"))).toBe("apply");
+  });
+
+  it("catches up after a missed tick rather than dropping the campaign", () => {
+    // The whole reason `due` is `at <= now` and not `at === now`: a deploy, restart
+    // or slow queue must not silently skip a campaign whose moment fell in the gap.
+    const state = { schedule: window(), status: "SCHEDULED" as SchedulableStatus };
+    expect(dueTransition(state, at("2026-08-20T09:47:00Z"))).toBe("apply");
+  });
+
+  it("reverts early by the buffer, so prices are back before the window closes", () => {
+    const state = { schedule: window(), status: "ACTIVE" as SchedulableStatus };
+    expect(dueTransition(state, at("2026-08-22T08:54:00Z"))).toBeNull();
+    expect(dueTransition(state, at("2026-08-22T08:55:00Z"))).toBe("revert");
+  });
+
+  it("reverts a partial run too — it may have left prices live", () => {
+    const state = { schedule: window(), status: "PARTIAL" as SchedulableStatus };
+    expect(dueTransition(state, at("2026-08-22T09:00:00Z"))).toBe("revert");
+  });
+
+  it("does not apply a campaign whose window has already closed", () => {
+    // Created late, or resumed after an outage. Applying here would put a finished
+    // sale live.
+    const state = { schedule: window(), status: "SCHEDULED" as SchedulableStatus };
+    expect(dueTransition(state, at("2026-09-01T00:00:00Z"))).toBeNull();
+  });
+
+  it("has nothing to revert for a campaign that never applied", () => {
+    for (const status of ["DRAFT", "COMPLETED", "CANCELLED"] as SchedulableStatus[]) {
+      expect(dueTransition({ schedule: window(), status }, at("2026-09-01T00:00:00Z")))
+        .toBeNull();
+    }
+  });
+
+  it("leaves an open-ended window running until reverted by hand", () => {
+    const schedule = window({ endAt: undefined });
+    expect(dueTransition({ schedule, status: "ACTIVE" }, at("2030-01-01T00:00:00Z")))
+      .toBeNull();
+    expect(windowClosed(schedule, at("2030-01-01T00:00:00Z"))).toBe(false);
+  });
+
+  it("never acts on a manual schedule", () => {
+    fc.assert(
+      fc.property(fc.date({ min: new Date(0), max: new Date(4102444800000) }), (now) => {
+        expect(dueTransition({ schedule: { kind: "manual" }, status: "SCHEDULED" }, now))
+          .toBeNull();
+      }),
+    );
+  });
+
+  it("returns at most one transition for any instant", () => {
+    fc.assert(
+      fc.property(
+        fc.date({ min: new Date("2026-08-19"), max: new Date("2026-08-23") }),
+        fc.constantFrom<SchedulableStatus>("SCHEDULED", "ACTIVE", "PARTIAL", "COMPLETED"),
+        (now, status) => {
+          const result = dueTransition({ schedule: window(), status }, now);
+          expect(result === null || result === "apply" || result === "revert").toBe(true);
+        },
+      ),
+    );
+  });
+});
+
+describe("parseSchedule", () => {
+  it("defaults to manual for anything it cannot act on", () => {
+    expect(parseSchedule(undefined)).toEqual({ kind: "manual" });
+    expect(parseSchedule({ kind: "window" })).toEqual({ kind: "manual" });
+    expect(parseSchedule({ kind: "window", startAt: "not a date" })).toEqual({ kind: "manual" });
+  });
+
+  it("drops an unparseable end rather than inventing one", () => {
+    const parsed = parseSchedule({
+      kind: "window",
+      startAt: "2026-08-20T09:00:00Z",
+      endAt: "rubbish",
+    });
+    expect(parsed).toMatchObject({ kind: "window", endAt: undefined });
+  });
+
+  it("falls back to the default buffer for a missing or negative value", () => {
+    const base = { kind: "window", startAt: "2026-08-20T09:00:00Z" };
+    expect(parseSchedule(base)).toMatchObject({
+      revertBufferMinutes: DEFAULT_REVERT_BUFFER_MINUTES,
+    });
+    expect(parseSchedule({ ...base, revertBufferMinutes: -5 })).toMatchObject({
+      revertBufferMinutes: DEFAULT_REVERT_BUFFER_MINUTES,
+    });
+    expect(parseSchedule({ ...base, revertBufferMinutes: 0 })).toMatchObject({
+      revertBufferMinutes: 0,
+    });
+  });
+});
+
+describe("timezone conversion", () => {
+  it("reads a local input as the store's zone, not the viewer's", () => {
+    // 09:00 in Toronto during EDT is 13:00 UTC.
+    expect(localInputToUtc("2026-08-20T09:00", "America/Toronto"))
+      .toBe("2026-08-20T13:00:00.000Z");
+    // The same wall-clock time in Tokyo is a different instant entirely.
+    expect(localInputToUtc("2026-08-20T09:00", "Asia/Tokyo"))
+      .toBe("2026-08-20T00:00:00.000Z");
+  });
+
+  it("uses the offset in force on that date, so DST is handled", () => {
+    // Toronto is UTC-5 in January and UTC-4 in August. A fixed offset would put one
+    // of these an hour wrong.
+    expect(localInputToUtc("2026-01-20T09:00", "America/Toronto"))
+      .toBe("2026-01-20T14:00:00.000Z");
+    expect(localInputToUtc("2026-08-20T09:00", "America/Toronto"))
+      .toBe("2026-08-20T13:00:00.000Z");
+  });
+
+  it("round-trips through the store's zone", () => {
+    for (const zone of ["America/Toronto", "Asia/Tokyo", "Europe/London", "UTC"]) {
+      const utc = localInputToUtc("2026-08-20T14:30", zone)!;
+      expect(utcToLocalInput(utc, zone)).toBe("2026-08-20T14:30");
+    }
+  });
+
+  it("rejects malformed input rather than guessing", () => {
+    expect(localInputToUtc("", "UTC")).toBeNull();
+    expect(localInputToUtc("20/08/2026 9am", "UTC")).toBeNull();
+  });
+
+  it("renders midnight as 00:00, not 24:00", () => {
+    const utc = localInputToUtc("2026-08-20T00:00", "Europe/London")!;
+    expect(utcToLocalInput(utc, "Europe/London")).toBe("2026-08-20T00:00");
+  });
+});
+
+describe("describeSchedule", () => {
+  it("always names the zone", () => {
+    const text = describeSchedule(window(), "America/Toronto");
+    expect(text).toContain("America/Toronto");
+    expect(text).toContain("Starts");
+    expect(text).toContain("reverts");
+  });
+
+  it("says so when there is no end", () => {
+    expect(describeSchedule(window({ endAt: undefined }), "UTC"))
+      .toContain("until you revert it");
+  });
+
+  it("explains manual scheduling plainly", () => {
+    expect(describeSchedule({ kind: "manual" }, "UTC")).toContain("by hand");
+  });
+});
+
+describe("revert buffer capping", () => {
+  it("caps a buffer longer than the window, so the campaign still applies", () => {
+    // The bug this guards: a 65-second window with a 1-minute buffer put the revert
+    // moment 5 seconds after the start. The campaign went straight from scheduled to
+    // nothing -- no error, no prices changed, no explanation.
+    const schedule = window({
+      startAt: "2026-08-20T09:00:00.000Z",
+      endAt: "2026-08-20T09:01:05.000Z",
+      revertBufferMinutes: 1,
+    });
+
+    // Capped to half the window, so there is a real apply period.
+    expect(effectiveBufferMs(schedule as never)).toBe(32_500);
+
+    const state = { schedule, status: "SCHEDULED" as SchedulableStatus };
+    expect(dueTransition(state, at("2026-08-20T09:00:10Z"))).toBe("apply");
+  });
+
+  it("leaves a sensible buffer untouched", () => {
+    const schedule = window({
+      startAt: "2026-08-20T09:00:00.000Z",
+      endAt: "2026-08-22T09:00:00.000Z",
+      revertBufferMinutes: 5,
+    });
+    expect(effectiveBufferMs(schedule as never)).toBe(5 * 60_000);
+  });
+
+  it("warns when the buffer had to be capped", () => {
+    const warnings = scheduleWarnings(
+      window({
+        startAt: "2026-08-20T09:00:00.000Z",
+        endAt: "2026-08-20T09:01:05.000Z",
+        revertBufferMinutes: 1,
+      }),
+    );
+    expect(warnings.join(" ")).toContain("longer than half the window");
+    expect(warnings.join(" ")).toContain("under five minutes");
+  });
+
+  it("warns when the end is not after the start", () => {
+    const warnings = scheduleWarnings(
+      window({ startAt: "2026-08-20T09:00:00.000Z", endAt: "2026-08-20T08:00:00.000Z" }),
+    );
+    expect(warnings.join(" ")).toContain("never apply");
+  });
+
+  it("has nothing to warn about for a manual schedule or a sane window", () => {
+    expect(scheduleWarnings({ kind: "manual" })).toEqual([]);
+    expect(scheduleWarnings(window())).toEqual([]);
+  });
+});

--- a/app/lib/scheduling/window.ts
+++ b/app/lib/scheduling/window.ts
@@ -1,0 +1,266 @@
+/**
+ * Deciding what a scheduled campaign owes right now.
+ *
+ * Pure: it takes a schedule, a status and a clock reading, and returns the
+ * transition due. No database, no `Date.now()` inside — so every timing rule below
+ * is testable without waiting for real time to pass.
+ *
+ * The rule that makes the whole thing self-healing: **due means `at <= now`, never
+ * `at === now`**. A tick that is missed — a deploy, a restart, a slow queue — is
+ * caught by the next one, because the campaign is still past its start time.
+ * Equality checks silently drop any campaign whose moment fell in the gap.
+ */
+
+export type Schedule =
+  | { kind: "manual" }
+  | {
+      kind: "window";
+      /** ISO 8601, always UTC. The UI renders it in the store's zone. */
+      startAt: string;
+      /** Absent means "runs until reverted by hand". */
+      endAt?: string;
+      /**
+       * Minutes before `endAt` to begin reverting. A deep bulk queue can take
+       * minutes, and starting exactly at the end leaves sale prices live past the
+       * window the merchant advertised.
+       */
+      revertBufferMinutes?: number;
+    };
+
+export const DEFAULT_REVERT_BUFFER_MINUTES = 5;
+
+export type Transition = "apply" | "revert";
+
+/** Campaign statuses this module reasons about. */
+export type SchedulableStatus =
+  | "DRAFT"
+  | "SCHEDULED"
+  | "APPLYING"
+  | "ACTIVE"
+  | "REVERTING"
+  | "COMPLETED"
+  | "PARTIAL"
+  | "HELD"
+  | "CANCELLED";
+
+export interface ScheduleState {
+  schedule: Schedule;
+  status: SchedulableStatus;
+}
+
+export function parseSchedule(raw: unknown): Schedule {
+  const value = (raw ?? {}) as Record<string, unknown>;
+  if (value.kind !== "window") return { kind: "manual" };
+
+  const startAt = typeof value.startAt === "string" ? value.startAt : null;
+  // A window with no valid start cannot be acted on; treating it as manual is
+  // safer than inventing a start time and applying prices unexpectedly.
+  if (!startAt || Number.isNaN(Date.parse(startAt))) return { kind: "manual" };
+
+  const endAt =
+    typeof value.endAt === "string" && !Number.isNaN(Date.parse(value.endAt))
+      ? value.endAt
+      : undefined;
+
+  const buffer = Number(value.revertBufferMinutes);
+
+  return {
+    kind: "window",
+    startAt,
+    endAt,
+    revertBufferMinutes: Number.isFinite(buffer) && buffer >= 0
+      ? buffer
+      : DEFAULT_REVERT_BUFFER_MINUTES,
+  };
+}
+
+/**
+ * The transition due for a campaign, or `null` if nothing is owed.
+ *
+ * Revert is checked before apply. A campaign whose whole window has already passed
+ * — created late, or resumed after a long outage — must revert rather than apply,
+ * or it would put a finished sale live.
+ */
+export function dueTransition(state: ScheduleState, now: Date): Transition | null {
+  const { schedule, status } = state;
+  if (schedule.kind !== "window") return null;
+
+  const start = Date.parse(schedule.startAt);
+  const end = schedule.endAt ? Date.parse(schedule.endAt) : null;
+  const revertAt = end === null ? null : end - effectiveBufferMs(schedule);
+  const millis = now.getTime();
+
+  const pastRevert = revertAt !== null && millis >= revertAt;
+
+  if (pastRevert) {
+    // Only something currently live needs reverting. A campaign that never applied
+    // has nothing to undo, and re-reverting a completed one would be a no-op run.
+    return status === "ACTIVE" || status === "PARTIAL" ? "revert" : null;
+  }
+
+  if (millis >= start) {
+    return status === "SCHEDULED" ? "apply" : null;
+  }
+
+  return null;
+}
+
+/**
+ * The revert buffer actually used, capped at half the window.
+ *
+ * A buffer longer than the window would put the revert moment before the start,
+ * so the campaign would never apply -- it would go straight from scheduled to
+ * nothing, with no error and no prices changed. Capping keeps a short window
+ * usable; `scheduleWarnings` tells the merchant when the cap kicked in.
+ */
+export function effectiveBufferMs(schedule: Extract<Schedule, { kind: "window" }>): number {
+  const requested = (schedule.revertBufferMinutes ?? DEFAULT_REVERT_BUFFER_MINUTES) * 60_000;
+  if (!schedule.endAt) return requested;
+
+  const duration = Date.parse(schedule.endAt) - Date.parse(schedule.startAt);
+  if (!Number.isFinite(duration) || duration <= 0) return 0;
+
+  return Math.min(requested, Math.floor(duration / 2));
+}
+
+/** Problems worth telling the merchant about before they schedule something. */
+export function scheduleWarnings(schedule: Schedule): string[] {
+  if (schedule.kind !== "window") return [];
+
+  const warnings: string[] = [];
+  const start = Date.parse(schedule.startAt);
+
+  if (schedule.endAt) {
+    const end = Date.parse(schedule.endAt);
+
+    if (end <= start) {
+      warnings.push("The end is not after the start, so this campaign will never apply.");
+    } else {
+      const requested =
+        (schedule.revertBufferMinutes ?? DEFAULT_REVERT_BUFFER_MINUTES) * 60_000;
+      const duration = end - start;
+
+      // Warn exactly when capping kicks in, which is when the buffer would eat more
+      // than half the window -- not only when it exceeds the whole window. A
+      // 60-second buffer on a 65-second window leaves five seconds to apply, which
+      // is just as broken and would otherwise pass silently.
+      if (requested > duration / 2) {
+        warnings.push(
+          `The revert buffer is longer than half the window, so there would be almost ` +
+            `no time to apply prices before reverting them. It has been capped at ` +
+            `${Math.max(1, Math.round(duration / 2 / 60_000))} minute(s).`,
+        );
+      }
+      if (duration < 5 * 60_000) {
+        warnings.push(
+          "This window is under five minutes. The scheduler checks every 30 seconds, " +
+            "and a busy bulk queue can take longer than that to apply prices.",
+        );
+      }
+    }
+  }
+
+  return warnings;
+}
+
+/** True when the window has closed, whether or not anything was applied. */
+export function windowClosed(schedule: Schedule, now: Date): boolean {
+  if (schedule.kind !== "window" || !schedule.endAt) return false;
+  return now.getTime() >= Date.parse(schedule.endAt);
+}
+
+/**
+ * Human summary of a schedule, rendered in the store's zone.
+ *
+ * The zone is always shown. A merchant reading "starts at 09:00" needs to know
+ * whose nine o'clock, and a campaign that goes live at the wrong hour is a real
+ * cost.
+ */
+export function describeSchedule(schedule: Schedule, timeZone: string): string {
+  if (schedule.kind !== "window") return "Runs when you apply it by hand.";
+
+  const format = (iso: string) =>
+    new Intl.DateTimeFormat("en", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone,
+    }).format(new Date(iso));
+
+  const start = `Starts ${format(schedule.startAt)}`;
+  if (!schedule.endAt) return `${start} (${timeZone}). Runs until you revert it.`;
+
+  const buffer = schedule.revertBufferMinutes ?? DEFAULT_REVERT_BUFFER_MINUTES;
+  return (
+    `${start}, reverts ${format(schedule.endAt)} (${timeZone}). ` +
+    `Reverting begins ${buffer} minutes early so prices are back before the window closes.`
+  );
+}
+
+/**
+ * Converts a datetime-local value, which carries no zone, into UTC for storage.
+ *
+ * The browser field gives "2026-08-20T09:00" meaning nine o'clock in the store's
+ * zone, not the viewer's and not UTC. Reading it with `new Date()` would silently
+ * use whatever zone the merchant's laptop happens to be in.
+ */
+export function localInputToUtc(value: string, timeZone: string): string | null {
+  if (!value) return null;
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value.trim());
+  if (!match) return null;
+
+  const [, y, mo, d, h, mi] = match.map(Number) as unknown as number[];
+
+  // Start from the naive UTC reading, then correct by the zone's offset at that
+  // instant. Doing it this way keeps DST correct: the offset is looked up for the
+  // date in question rather than assumed constant.
+  const naive = Date.UTC(y, mo - 1, d, h, mi);
+  const offset = zoneOffsetMs(new Date(naive), timeZone);
+  return new Date(naive - offset).toISOString();
+}
+
+/** A zone's UTC offset in milliseconds at a given instant. */
+function zoneOffsetMs(instant: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(instant);
+
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? 0);
+  const asUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour") % 24,
+    get("minute"),
+    get("second"),
+  );
+
+  return asUtc - instant.getTime();
+}
+
+/** Formats a UTC instant back into a datetime-local value in the store's zone. */
+export function utcToLocalInput(iso: string | undefined, timeZone: string): string {
+  if (!iso) return "";
+
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).formatToParts(new Date(iso));
+
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  // en-CA gives ISO-ish parts; hour can come back as "24" at midnight.
+  const hour = get("hour") === "24" ? "00" : get("hour");
+  return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}`;
+}

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -3,6 +3,7 @@ import { useFetcher, useLoaderData, useRouteError } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
+import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { toAdminClient } from "../services/admin-client.server";
 import {
@@ -11,6 +12,7 @@ import {
   runCampaign,
   runLedger,
 } from "../services/campaigns/index.server";
+import { describeSchedule, parseSchedule, scheduleWarnings } from "../lib/scheduling/window";
 import { CountsRow } from "../components/CountsRow";
 import { LedgerTable } from "../components/LedgerTable";
 import { PreviewTable } from "../components/PreviewTable";
@@ -21,10 +23,18 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const shop = await ensureShop(session.shop);
   const campaignId = String(params.id);
 
-  const [preview, runs] = await Promise.all([
+  const [preview, runs, record] = await Promise.all([
     previewCampaign(shop.id, campaignId),
     campaignRuns(shop.id, campaignId),
+    prisma.campaign.findFirstOrThrow({
+      where: { id: campaignId, shopId: shop.id },
+      select: { schedule: true },
+    }),
   ]);
+
+  const schedule = parseSchedule(record.schedule);
+  const scheduleText = describeSchedule(schedule, shop.timezone);
+  const warnings = scheduleWarnings(schedule);
 
   // Show the newest run's ledger inline. The first question after a run is always
   // "what exactly did it do to each variant", and making that a second click loses
@@ -33,7 +43,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const selectedRunId = requested ?? runs[0]?.id ?? null;
   const ledger = selectedRunId ? await runLedger(shop.id, selectedRunId) : [];
 
-  return { preview, runs, ledger, selectedRunId };
+  return { preview, runs, ledger, selectedRunId, scheduleText, warnings };
 };
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
@@ -68,7 +78,8 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 type ActionData = { ok: boolean; message: string; details: string[] };
 
 export default function CampaignDetail() {
-  const { preview, runs, ledger, selectedRunId } = useLoaderData<typeof loader>();
+  const { preview, runs, ledger, selectedRunId, scheduleText, warnings } =
+    useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
   const result = fetcher.data;
@@ -171,6 +182,15 @@ export default function CampaignDetail() {
             snap back to full price.
           </s-text>
         </s-paragraph>
+      </s-section>
+
+      <s-section slot="aside" heading="Schedule">
+        <s-paragraph>{scheduleText}</s-paragraph>
+        {warnings.map((warning) => (
+          <s-banner key={warning} tone="warning">
+            <s-paragraph>{warning}</s-paragraph>
+          </s-banner>
+        ))}
       </s-section>
 
       <s-section slot="aside" heading="Status">

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -8,6 +8,7 @@ import { facets, previewMatches, type FilterAst } from "../services/segments.ser
 import { createCampaign } from "../services/campaigns/index.server";
 import type { AdjustmentRule, CompareAtPolicy } from "../lib/pricing/types";
 import { money } from "../lib/money/money";
+import { localInputToUtc, type Schedule } from "../lib/scheduling/window";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -21,6 +22,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   ]);
 
   return {
+    timeZone: shop.timezone,
     facets: available,
     preview,
     selected: {
@@ -80,6 +82,21 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         ? { kind: "clear" }
         : { kind: "leave" };
 
+  const startLocal = String(form.get("startAt") ?? "").trim();
+  const endLocal = String(form.get("endAt") ?? "").trim();
+  const startUtc = startLocal ? localInputToUtc(startLocal, shop.timezone) : null;
+
+  // A schedule needs a valid start. Anything else stays manual rather than being
+  // half-scheduled, which would leave the merchant unsure whether it will fire.
+  const schedule: Schedule | undefined = startUtc
+    ? {
+        kind: "window",
+        startAt: startUtc,
+        endAt: endLocal ? localInputToUtc(endLocal, shop.timezone) ?? undefined : undefined,
+        revertBufferMinutes: Number(form.get("revertBuffer") ?? 5) || 5,
+      }
+    : undefined;
+
   const campaign = await createCampaign(shop.id, {
     name: String(form.get("name") ?? "Untitled campaign").trim() || "Untitled campaign",
     ast: astFromParams(params),
@@ -87,13 +104,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     compareAtPolicy,
     rounding: String(form.get("rounding") ?? "none") === "charm99" ? "charm99" : "none",
     priority: Number(form.get("priority") ?? 100) || 100,
+    schedule,
   });
 
   return redirect(`/app/campaigns/${campaign.id}`);
 };
 
 export default function NewCampaign() {
-  const { facets: available, preview, selected } = useLoaderData<typeof loader>();
+  const { facets: available, preview, selected, timeZone } = useLoaderData<typeof loader>();
 
   return (
     <s-page heading="New campaign">
@@ -194,6 +212,29 @@ export default function NewCampaign() {
               label="Priority"
               defaultValue="100"
               details="Higher wins when two campaigns cover the same variant. They never stack."
+            />
+
+            <s-divider />
+
+            <s-heading>Schedule (optional)</s-heading>
+            <s-paragraph>
+              <s-text>
+                Times are in your store&rsquo;s zone, {timeZone}. Leave the start
+                blank to run the campaign only when you apply it by hand.
+              </s-text>
+            </s-paragraph>
+
+            <label htmlFor="startAt">Start</label>
+            <input id="startAt" type="datetime-local" name="startAt" />
+
+            <label htmlFor="endAt">End (optional)</label>
+            <input id="endAt" type="datetime-local" name="endAt" />
+
+            <s-number-field
+              name="revertBuffer"
+              label="Revert this many minutes early"
+              defaultValue="5"
+              details="A busy bulk queue takes time; starting early means prices are back before the window closes."
             />
 
             <s-button type="submit" variant="primary">

--- a/app/services/admin-client.server.ts
+++ b/app/services/admin-client.server.ts
@@ -37,3 +37,37 @@ export function toAdminClient(admin: ShopifyAdminContext): AdminClient {
     },
   };
 }
+
+
+/**
+ * Builds a client for a shop from its stored offline session.
+ *
+ * The worker has no request to authenticate, so it reads the token directly. This
+ * returns null rather than throwing when there is no usable session -- an
+ * uninstalled shop is an expected state for a background tick, not an error.
+ */
+export async function adminClientForShop(shopDomain: string): Promise<AdminClient | null> {
+  const { default: prisma } = await import("../db.server");
+
+  const session = await prisma.session.findFirst({
+    where: { shop: shopDomain, accessToken: { not: "" } },
+  });
+  if (!session?.accessToken) return null;
+
+  const apiVersion = process.env.SHOPIFY_API_VERSION ?? "2026-07";
+  const endpoint = `https://${shopDomain}/admin/api/${apiVersion}/graphql.json`;
+
+  return toAdminClient({
+    async graphql(query, options) {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Shopify-Access-Token": session.accessToken,
+        },
+        body: JSON.stringify({ query, variables: options?.variables ?? {} }),
+      });
+      return { json: () => response.json() };
+    },
+  });
+}

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -24,7 +24,7 @@ export async function createCampaign(shopId: string, input: CampaignInput) {
     data: {
       shopId,
       name: input.name,
-      status: "DRAFT",
+      status: input.schedule?.kind === "window" ? "SCHEDULED" : "DRAFT",
       priority: input.priority ?? 100,
       ruleRows: [{ segmentIds: [], rule: input.rule }] as never,
       surfaces: { base: true } as never,
@@ -32,7 +32,19 @@ export async function createCampaign(shopId: string, input: CampaignInput) {
       compareAtViolationPolicy: "clear",
       guardrails: (input.guardrails ?? {}) as never,
       guardrailViolationPolicy: "clamp",
-      schedule: { kind: "manual", rounding: input.rounding, ast: input.ast } as never,
+      // Rounding and scope ride along in the schedule blob so the shape can evolve
+      // without a migration; parseSchedule ignores the extra keys.
+      schedule: {
+        ...(input.schedule ?? { kind: "manual" }),
+        rounding: input.rounding,
+        ast: input.ast,
+      } as never,
+      ...(input.schedule?.kind === "window"
+        ? {
+            startAt: new Date(input.schedule.startAt),
+            endAt: input.schedule.endAt ? new Date(input.schedule.endAt) : null,
+          }
+        : {}),
     },
   });
 }

--- a/app/services/campaigns/types.ts
+++ b/app/services/campaigns/types.ts
@@ -7,6 +7,7 @@
 
 import type { AdjustmentRule, CompareAtPolicy, Guardrails } from "../../lib/pricing/types";
 import type { PlannedRow } from "../../lib/planning/types";
+import type { Schedule } from "../../lib/scheduling/window";
 import type { FilterAst } from "../segments.server";
 
 export interface CampaignInput {
@@ -17,6 +18,8 @@ export interface CampaignInput {
   rounding: "none" | "charm99";
   guardrails?: Guardrails;
   priority?: number;
+  /** Absent means the campaign only runs when applied by hand. */
+  schedule?: Schedule;
 }
 
 export interface PreviewRow {

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -1,0 +1,107 @@
+/**
+ * The scheduler: finding campaigns that owe a transition, and running it.
+ *
+ * All the timing rules live in lib/scheduling/window.ts, which is pure and tested.
+ * This module only fetches candidates, asks that function what is due, and calls
+ * the existing run path — so scheduled and manual runs go through exactly the same
+ * code, ledger and verification.
+ */
+
+import prisma from "../db.server";
+import { dueTransition, parseSchedule, type Transition } from "../lib/scheduling/window";
+import { runCampaign } from "./campaigns/run.server";
+import { adminClientForShop } from "./admin-client.server";
+
+export interface TickResult {
+  examined: number;
+  applied: number;
+  reverted: number;
+  failures: Array<{ campaignId: string; error: string }>;
+}
+
+/**
+ * One scheduler pass.
+ *
+ * Statuses are filtered in the query, but the decision itself is left to
+ * `dueTransition` so there is one place that knows the rules.
+ */
+export async function tick(now: Date = new Date()): Promise<TickResult> {
+  const result: TickResult = { examined: 0, applied: 0, reverted: 0, failures: [] };
+
+  const candidates = await prisma.campaign.findMany({
+    where: { status: { in: ["SCHEDULED", "ACTIVE", "PARTIAL"] } },
+    include: { shop: { select: { id: true, domain: true, uninstalledAt: true } } },
+  });
+
+  for (const campaign of candidates) {
+    // An uninstalled shop has no usable token, and writing to it is impossible
+    // anyway. Skipping quietly is correct; the data is retained for reinstall.
+    if (campaign.shop.uninstalledAt) continue;
+
+    result.examined++;
+
+    const transition = dueTransition(
+      { schedule: parseSchedule(campaign.schedule), status: campaign.status },
+      now,
+    );
+    if (!transition) continue;
+
+    try {
+      await runTransition(campaign.shop.id, campaign.shop.domain, campaign.id, transition);
+      if (transition === "apply") result.applied++;
+      else result.reverted++;
+    } catch (error) {
+      // One campaign failing must not stop the tick: the others are still due, and
+      // a scheduler that gives up on the first error leaves sales unstarted.
+      result.failures.push({
+        campaignId: campaign.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return result;
+}
+
+async function runTransition(
+  shopId: string,
+  shopDomain: string,
+  campaignId: string,
+  transition: Transition,
+): Promise<void> {
+  const client = await adminClientForShop(shopDomain);
+  if (!client) throw new Error(`No usable session for ${shopDomain}`);
+
+  // Claim the campaign before running. Two ticks overlapping — a slow run, a second
+  // worker that briefly held the lock — would otherwise both start the same
+  // transition. The status change is the claim.
+  const claimed = await prisma.campaign.updateMany({
+    where: {
+      id: campaignId,
+      status: transition === "apply" ? "SCHEDULED" : { in: ["ACTIVE", "PARTIAL"] },
+    },
+    data: { status: transition === "apply" ? "APPLYING" : "REVERTING" },
+  });
+
+  if (claimed.count === 0) return; // someone else took it
+
+  await runCampaign(shopId, campaignId, client, { revert: transition === "revert" });
+}
+
+/** Campaigns with a schedule that has not yet fired, for the UI. */
+export async function upcomingTransitions(shopId: string, limit = 10) {
+  const campaigns = await prisma.campaign.findMany({
+    where: { shopId, status: { in: ["SCHEDULED", "ACTIVE", "PARTIAL"] } },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+
+  return campaigns
+    .map((campaign) => ({
+      id: campaign.id,
+      name: campaign.name,
+      status: campaign.status,
+      schedule: parseSchedule(campaign.schedule),
+    }))
+    .filter((entry) => entry.schedule.kind === "window");
+}

--- a/app/worker/leader-lock.test.ts
+++ b/app/worker/leader-lock.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { LeaderLock, type RedisLike } from "./leader-lock";
+
+/** In-memory stand-in with the SET NX PX and eval semantics the lock relies on. */
+function fakeRedis() {
+  const store = new Map<string, string>();
+  const redis: RedisLike = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async set(key, value, _mode, _ttl, _condition) {
+      if (store.has(key)) return null;      // NX: only if absent
+      store.set(key, value);
+      return "OK";
+    },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async eval(script, _numKeys, key, token) {
+      // Both scripts are guarded on "do we still hold it".
+      if (store.get(key) !== token) return 0;
+      if (script.includes("del")) store.delete(key);
+      return 1;
+    },
+    async quit() {},
+  };
+  return { redis, store };
+}
+
+describe("leader lock", () => {
+  it("lets exactly one of several workers lead", async () => {
+    const { redis } = fakeRedis();
+    const a = new LeaderLock(redis);
+    const b = new LeaderLock(redis);
+    const c = new LeaderLock(redis);
+
+    const results = await Promise.all([a.acquire(), b.acquire(), c.acquire()]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+
+  it("lets the holder renew but not anyone else", async () => {
+    const { redis } = fakeRedis();
+    const holder = new LeaderLock(redis);
+    const other = new LeaderLock(redis);
+
+    expect(await holder.acquire()).toBe(true);
+    expect(await holder.renew()).toBe(true);
+    expect(await other.renew()).toBe(false);
+  });
+
+  it("only releases its own hold, never someone else's", async () => {
+    // The reason release is a compare-and-delete script rather than a plain DEL: a
+    // slow worker waking up after its lock expired must not free the new leader's.
+    const { redis, store } = fakeRedis();
+    const holder = new LeaderLock(redis);
+    const other = new LeaderLock(redis);
+
+    await holder.acquire();
+    await other.release();
+    expect(store.size).toBe(1);
+
+    await holder.release();
+    expect(store.size).toBe(0);
+  });
+
+  it("hands leadership over after a release", async () => {
+    const { redis } = fakeRedis();
+    const first = new LeaderLock(redis);
+    const second = new LeaderLock(redis);
+
+    await first.acquire();
+    expect(await second.acquire()).toBe(false);
+    await first.release();
+    expect(await second.acquire()).toBe(true);
+  });
+});

--- a/app/worker/leader-lock.ts
+++ b/app/worker/leader-lock.ts
@@ -1,0 +1,70 @@
+/**
+ * Redis leader election for the scheduler tick.
+ *
+ * Running several worker replicas is normal. Two of them independently deciding a
+ * campaign is due would start the same transition twice, so exactly one may tick at
+ * a time.
+ *
+ * The lock's TTL is deliberately shorter than the interval between renewals plus a
+ * margin: a leader that dies mid-tick simply stops renewing, the key expires, and
+ * another worker takes over on its next attempt. No cleanup, no heartbeat table, no
+ * split brain lasting longer than one TTL.
+ */
+
+export interface RedisLike {
+  set(
+    key: string,
+    value: string,
+    mode: "PX",
+    ttl: number,
+    condition: "NX",
+  ): Promise<string | null>;
+  eval(script: string, numKeys: number, ...args: string[]): Promise<unknown>;
+  quit(): Promise<unknown>;
+}
+
+/** Releases only if we still hold it, so a slow worker cannot free someone else's lock. */
+const RELEASE = `
+  if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+  else
+    return 0
+  end
+`;
+
+/** Extends only our own hold, for the same reason. */
+const RENEW = `
+  if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("pexpire", KEYS[1], ARGV[2])
+  else
+    return 0
+  end
+`;
+
+export class LeaderLock {
+  private readonly token: string;
+
+  constructor(
+    private readonly redis: RedisLike,
+    private readonly key = "anchor:scheduler:leader",
+    private readonly ttlMs = 30_000,
+  ) {
+    // Unique per instance so a lock can only ever be released or renewed by the
+    // process that took it.
+    this.token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  async acquire(): Promise<boolean> {
+    const result = await this.redis.set(this.key, this.token, "PX", this.ttlMs, "NX");
+    return result === "OK";
+  }
+
+  async renew(): Promise<boolean> {
+    const result = await this.redis.eval(RENEW, 1, this.key, this.token, String(this.ttlMs));
+    return result === 1;
+  }
+
+  async release(): Promise<void> {
+    await this.redis.eval(RELEASE, 1, this.key, this.token);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@shopify/app-bridge-react": "^4.2.4",
         "@shopify/shopify-app-react-router": "^1.1.0",
         "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
+        "ioredis": "^6.0.0",
         "isbot": "^5.1.31",
         "prisma": "^6.16.3",
         "react": "^18.3.1",
@@ -39,6 +40,7 @@
         "fast-check": "^4.9.0",
         "graphql-config": "^5.1.1",
         "prettier": "^3.6.2",
+        "tsx": "^4.23.12",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
         "vitest": "^4.1.10"
@@ -2318,6 +2320,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+      "integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -5388,6 +5396,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5793,6 +5810,15 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -8001,6 +8027,27 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-6.0.0.tgz",
+      "integrity": "sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "2.0.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ipaddr.js": {
@@ -10351,6 +10398,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -11057,6 +11113,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -11504,6 +11566,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "vite": "vite",
     "typecheck": "react-router typegen && tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "worker": "tsx scripts/worker.ts"
   },
   "type": "module",
   "engines": {
@@ -34,6 +35,7 @@
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
+    "ioredis": "^6.0.0",
     "isbot": "^5.1.31",
     "prisma": "^6.16.3",
     "react": "^18.3.1",
@@ -59,6 +61,7 @@
     "fast-check": "^4.9.0",
     "graphql-config": "^5.1.1",
     "prettier": "^3.6.2",
+    "tsx": "^4.23.12",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vitest": "^4.1.10"

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * The worker process: the only thing that writes prices on a schedule.
+ *
+ * Deliberately separate from the web process. Web serves the admin UI and computes
+ * previews; it never writes. Giving the worker its own process means it can be
+ * restarted, scaled and rate-limited on its own, and a slow campaign cannot tie up
+ * a request thread.
+ *
+ *   npm run worker
+ */
+
+import Redis from "ioredis";
+
+import { tick } from "../app/services/scheduler.server";
+import { LeaderLock } from "../app/worker/leader-lock";
+import { pruneWriteIntents } from "../app/services/drift.server";
+import prisma from "../app/db.server";
+
+const TICK_INTERVAL_MS = Number(process.env.SCHEDULER_TICK_MS ?? 30_000);
+const LOCK_TTL_MS = Math.max(TICK_INTERVAL_MS * 2, 30_000);
+
+// Fail fast and loudly on missing configuration. A worker that starts without a
+// database and then fails silently per-tick is far harder to diagnose than one that
+// refuses to start at all.
+for (const key of ["DATABASE_URL"]) {
+  if (!process.env[key]) {
+    console.error(`[worker] Missing required environment variable ${key}`);
+    process.exit(1);
+  }
+}
+
+const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+  maxRetriesPerRequest: 3,
+  // Surface connection problems rather than hiding them: a lost Redis connection
+  // means the leader lock is gone, which is exactly when two workers could collide.
+  retryStrategy: (times) => Math.min(times * 500, 5_000),
+});
+
+redis.on("error", (error) => {
+  console.error("[worker] redis error:", error.message);
+});
+
+const lock = new LeaderLock(redis, "anchor:scheduler:leader", LOCK_TTL_MS);
+
+let running = true;
+let isLeader = false;
+let ticks = 0;
+
+async function runOnce(): Promise<void> {
+  // Renew if we already lead, otherwise try to take over. A failed renewal means we
+  // lost the lock -- fall back to acquiring rather than assuming we still lead.
+  isLeader = isLeader ? await lock.renew() : await lock.acquire();
+  if (!isLeader) return;
+
+  const started = Date.now();
+  const result = await tick();
+  ticks++;
+
+  if (result.applied > 0 || result.reverted > 0 || result.failures.length > 0) {
+    console.log(
+      `[worker] tick ${ticks}: examined ${result.examined}, applied ${result.applied}, ` +
+        `reverted ${result.reverted}, failed ${result.failures.length} ` +
+        `(${Date.now() - started}ms)`,
+    );
+    for (const failure of result.failures) {
+      console.error(`[worker]   campaign ${failure.campaignId}: ${failure.error}`);
+    }
+  }
+
+  // Cheap housekeeping, only while we hold the lock so it happens once per cluster.
+  if (ticks % 20 === 0) {
+    const pruned = await pruneWriteIntents();
+    if (pruned > 0) console.log(`[worker] pruned ${pruned} expired write intents`);
+  }
+}
+
+async function loop(): Promise<void> {
+  console.log(
+    `[worker] started, tick every ${TICK_INTERVAL_MS}ms, lock TTL ${LOCK_TTL_MS}ms`,
+  );
+
+  while (running) {
+    try {
+      await runOnce();
+    } catch (error) {
+      // Never let one bad tick kill the loop; the next one may well succeed.
+      console.error("[worker] tick failed:", error instanceof Error ? error.message : error);
+    }
+    await sleep(TICK_INTERVAL_MS);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Graceful shutdown.
+ *
+ * Releasing the lock explicitly means a deploy hands leadership over in seconds
+ * rather than leaving the cluster idle for a full TTL.
+ */
+async function shutdown(signal: string): Promise<void> {
+  if (!running) return;
+  running = false;
+  console.log(`[worker] ${signal} received, shutting down`);
+
+  try {
+    if (isLeader) await lock.release();
+  } catch {
+    // The lock expires on its own; a failure here must not block exit.
+  }
+
+  await Promise.allSettled([redis.quit(), prisma.$disconnect()]);
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));
+
+void loop();


### PR DESCRIPTION
Campaigns can now run in a window and revert themselves. **Verified unattended end to end:**

```
tick 2: examined 1, applied 1,  reverted 0, failed 0
tick 7: examined 1, applied 0,  reverted 1, failed 0
```

APPLY 152/152 verified → REVERT 152/152 verified → **COMPLETED**. No clicking.

## The timing rules are pure

`lib/scheduling/window.ts` takes a schedule, a status and a clock reading and returns the transition due. No database, no `Date.now()` inside — so DST and window edges are tested without waiting for real time.

**Due means `at <= now`, never `at === now`.** A tick missed to a deploy or a slow queue is caught by the next one. Equality silently drops any campaign whose moment fell in the gap.

**Revert is checked before apply.** A campaign whose window already closed — created late, or resumed after an outage — must not put a finished sale live.

**DST is handled by looking up the offset on the date in question.** A `datetime-local` field carries no zone; reading it with `new Date()` would use whatever zone the merchant's laptop is in. January and August 09:00 in Toronto both land correctly.

## The worker

Separate process, because it's the only thing writing prices on a schedule — restartable and scalable on its own, and a slow campaign can't tie up a request thread.

Leadership is a Redis lock whose TTL is shorter than the renewal interval, so a dead leader simply stops renewing and another takes over. Release and renew are **compare-and-delete scripts**, so a slow worker waking after its lock expired cannot free the *new* leader's lock.

## A real flaw my own bad test exposed

I scheduled a 65-second window with a 1-minute revert buffer. That put the revert moment **five seconds after the start** — the campaign went from scheduled to nothing, with no error, no prices changed, and no explanation.

The buffer is now capped at half the window so short windows stay usable, and `scheduleWarnings` reports when the cap applied, when the end isn't after the start, and when a window is short enough that the tick interval matters.

Worth noting: my first warning fired only when the buffer exceeded the *entire* window, which missed exactly the case that bit me. The threshold is now the same condition as the capping itself.

185 tests · typecheck · lint · build clean.

Closes #152, closes #39, closes #40, closes #42, closes #43, closes #44