### PR TITLE
Error handling, loading states and a diagnostics path

### DIFF
--- a/app/components/AsyncState.tsx
+++ b/app/components/AsyncState.tsx
@@ -1,0 +1,66 @@
+/**
+ * The three states a data-bearing section can be in, in one place.
+ *
+ * Every table in this app previously rendered only one of them: the happy path. An
+ * empty catalogue and a catalogue that failed to load looked identical -- a blank
+ * area with a heading -- which is the single most confusing thing a merchant can be
+ * shown, because the two have opposite remedies.
+ */
+
+export interface EmptyStateProps {
+  /** What is missing, in the merchant's words. */
+  title: string;
+  /** Why it might be missing and what to do about it. */
+  description?: string;
+  action?: { label: string; href: string };
+}
+
+export function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <s-stack gap="base">
+      <s-heading>{title}</s-heading>
+      {description ? (
+        <s-paragraph>
+          <s-text>{description}</s-text>
+        </s-paragraph>
+      ) : null}
+      {action ? <s-button href={action.href}>{action.label}</s-button> : null}
+    </s-stack>
+  );
+}
+
+/**
+ * An inline failure, for a section that failed while the rest of the page is fine.
+ *
+ * Carries the error id for the same reason the full screen does: a merchant reporting
+ * "the drift panel is empty" is unanswerable, and "the drift panel says ANC-K3M2-P7QR"
+ * is a single query.
+ */
+export function InlineError({
+  message,
+  errorId,
+}: {
+  message: string;
+  errorId?: string;
+}) {
+  return (
+    <s-banner tone="critical">
+      <s-paragraph>{message}</s-paragraph>
+      {errorId ? (
+        <s-paragraph>
+          <s-text>Reference {errorId}</s-text>
+        </s-paragraph>
+      ) : null}
+    </s-banner>
+  );
+}
+
+/** A section waiting on a fetcher, as opposed to a whole-page navigation. */
+export function InlineBusy({ label = "Working…" }: { label?: string }) {
+  return (
+    <s-stack direction="inline" gap="base">
+      <s-spinner accessibilityLabel={label} size="base" />
+      <s-text>{label}</s-text>
+    </s-stack>
+  );
+}

--- a/app/components/ErrorScreen.tsx
+++ b/app/components/ErrorScreen.tsx
@@ -1,0 +1,80 @@
+/**
+ * What a merchant sees when something breaks.
+ *
+ * Three things, in this order, because that is the order the questions arrive in:
+ * what happened in plain language, whether their prices are safe, and what to do
+ * next. The error id comes last -- it matters enormously to support and not at all
+ * to someone who just wants their sale to run.
+ *
+ * The stack trace is shown only in development. In production it is in the log and
+ * the error_events table, reachable by the id, which is where it belongs: a stack on
+ * screen tells a merchant nothing and tells an attacker something.
+ */
+
+export interface ErrorScreenProps {
+  errorId: string;
+  userMessage: string;
+  code: string;
+  retryable: boolean;
+  /** Development only; omitted in production. */
+  stack?: string | null;
+  /** Where "try again" should go. Defaults to reloading. */
+  retryHref?: string;
+}
+
+export function ErrorScreen({
+  errorId,
+  userMessage,
+  code,
+  retryable,
+  stack,
+  retryHref,
+}: ErrorScreenProps) {
+  return (
+    <s-page heading="Something went wrong">
+      <s-section>
+        <s-banner tone={retryable ? "warning" : "critical"}>
+          <s-paragraph>{userMessage}</s-paragraph>
+        </s-banner>
+
+        <s-stack gap="base">
+          <s-paragraph>
+            <s-text>
+              No prices were changed by this error. If a run was in progress, open the
+              campaign — its ledger shows exactly which variants were written before
+              the failure, and resuming picks up from there.
+            </s-text>
+          </s-paragraph>
+
+          <s-stack direction="inline" gap="base">
+            <s-button href={retryHref ?? "."} variant="primary">
+              Try again
+            </s-button>
+            <s-button href="/app">Back to dashboard</s-button>
+          </s-stack>
+
+          <s-divider />
+
+          <s-paragraph>
+            <s-text>
+              Quote this reference if you contact support — it links straight to the
+              full technical detail.
+            </s-text>
+          </s-paragraph>
+          <s-paragraph>
+            <s-text><strong>{errorId}</strong> · {code}</s-text>
+          </s-paragraph>
+        </s-stack>
+
+        {stack ? (
+          <details>
+            <summary>Technical detail (development only)</summary>
+            <pre style={{ overflowX: "auto", whiteSpace: "pre-wrap", fontSize: "0.8rem" }}>
+              {stack}
+            </pre>
+          </details>
+        ) : null}
+      </s-section>
+    </s-page>
+  );
+}

--- a/app/components/RouteBoundary.tsx
+++ b/app/components/RouteBoundary.tsx
@@ -1,0 +1,83 @@
+/**
+ * The one ErrorBoundary every route uses.
+ *
+ * The split matters. Shopify's `boundary.error` is not a nicety -- an embedded app
+ * re-authenticates by *throwing a Response*, and that Response has to reach Shopify's
+ * handler with its headers intact or the app hangs on a blank frame instead of
+ * silently signing back in. So thrown Responses are delegated, always.
+ *
+ * Genuine exceptions are ours to present. Those get the error screen, with an id the
+ * merchant can quote, rather than a stack trace and a dead page.
+ */
+
+import { isRouteErrorResponse, useRouteError } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { ErrorScreen } from "./ErrorScreen";
+import {
+  ANCHOR_ERROR,
+  reportErrorSync,
+  type ReportedError,
+} from "../lib/errors/report";
+
+export function RouteBoundary() {
+  const error = useRouteError();
+
+  // Our own guard already classified, stored and titled this one on the server. The
+  // boundary just renders it -- crucially including an id that really is in the
+  // database, so looking it up on the Diagnostics page finds something.
+  const reportedOnServer = anchorPayload(error);
+  if (reportedOnServer) {
+    return (
+      <ErrorScreen
+        errorId={reportedOnServer.errorId}
+        userMessage={reportedOnServer.userMessage}
+        code={reportedOnServer.code}
+        retryable={reportedOnServer.retryable}
+      />
+    );
+  }
+
+  // Auth redirects and anything else thrown as a Response: Shopify's handler knows
+  // what to do with these, and intercepting them breaks the embedded flow.
+  if (isRouteErrorResponse(error) || error instanceof Response) {
+    return boundary.error(error);
+  }
+
+  // A render-time failure in the browser: never reached the server, so it is reported
+  // here. These are rarer and cannot be persisted from the client.
+  const reported = reportErrorSync(error, { route: currentRoute() });
+
+  return (
+    <ErrorScreen
+      errorId={reported.errorId}
+      userMessage={reported.userMessage}
+      code={reported.code}
+      retryable={reported.retryable}
+      stack={isDevelopment() && error instanceof Error ? error.stack : null}
+    />
+  );
+}
+
+/**
+ * Recognises a failure our server guard already handled.
+ *
+ * The tag matters: an untagged Response is Shopify's (auth, redirects) and must be
+ * delegated, so "is this ours" cannot be answered by status code alone.
+ */
+function anchorPayload(error: unknown): ReportedError | null {
+  if (!isRouteErrorResponse(error)) return null;
+  const payload = (error.data as Record<string, unknown> | null)?.[ANCHOR_ERROR];
+  return payload ? (payload as ReportedError) : null;
+}
+
+function currentRoute(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.location?.pathname;
+}
+
+function isDevelopment(): boolean {
+  // Same guard as the logger: this renders in the browser too.
+  if (typeof process === "undefined" || !process.env) return false;
+  return process.env.NODE_ENV !== "production";
+}

--- a/app/components/RouteProgress.tsx
+++ b/app/components/RouteProgress.tsx
@@ -1,0 +1,63 @@
+/**
+ * The "something is happening" bar for navigations.
+ *
+ * Loaders here are not always fast -- a catalogue preview walks thousands of variants
+ * -- and React Router keeps the *old* page on screen while the next one's loader runs.
+ * Without this, clicking a link looks like clicking a dead link, so people click again
+ * and queue a second run of the same work.
+ *
+ * The 150ms delay is done in CSS rather than with a timer and state. A quick
+ * navigation should never flash a progress bar, and expressing that as
+ * `animation-delay` keeps the component free of effects that fight React's rules
+ * about setting state during a render pass.
+ */
+
+import { useNavigation } from "react-router";
+
+export function RouteProgress() {
+  const navigation = useNavigation();
+  if (navigation.state === "idle") return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading"
+      style={{
+        position: "fixed",
+        insetInlineStart: 0,
+        insetBlockStart: 0,
+        inlineSize: "100%",
+        blockSize: "3px",
+        overflow: "hidden",
+        zIndex: 1000,
+        // Invisible until the delay elapses, so a fast navigation shows nothing.
+        opacity: 0,
+        animation: "anchor-progress-appear 1ms linear 150ms forwards",
+      }}
+    >
+      <div
+        style={{
+          blockSize: "100%",
+          inlineSize: "35%",
+          background: "currentColor",
+          opacity: 0.7,
+          borderRadius: "999px",
+          animation: "anchor-progress 1.1s ease-in-out infinite",
+        }}
+      />
+      {/* Scoped keyframes: this renders inside Shopify's frame, where a stylesheet of
+          our own is not guaranteed to have loaded. */}
+      <style>{`
+        @keyframes anchor-progress-appear { to { opacity: 1; } }
+        @keyframes anchor-progress {
+          0%   { transform: translateX(-100%); }
+          100% { transform: translateX(340%); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [role="status"] > div { animation: none; opacity: 0.45; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/app/lib/errors/app-error.test.ts
+++ b/app/lib/errors/app-error.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { AppError, toAppError, type ErrorCode } from "./app-error";
+import { isErrorId, newErrorId } from "./error-id";
+
+describe("toAppError", () => {
+  it("passes an AppError through untouched", () => {
+    const original = new AppError({ code: "VALIDATION", userMessage: "Fix the form." });
+    expect(toAppError(original)).toBe(original);
+  });
+
+  it("recognises a Shopify throttle as retryable", () => {
+    const result = toAppError(new Error("Throttled: too many requests"));
+    expect(result.code).toBe("SHOPIFY_THROTTLED");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("recognises the network failures that actually happen", () => {
+    // `fetch failed` is what Node throws when the connection drops mid-request, and
+    // it is the single most common transient failure in this app.
+    for (const message of [
+      "fetch failed",
+      "connect ECONNREFUSED 127.0.0.1:443",
+      "getaddrinfo ENOTFOUND admin.shopify.com",
+      "socket hang up",
+    ]) {
+      const result = toAppError(new Error(message));
+      expect(result.code, message).toBe("SHOPIFY_UNAVAILABLE");
+      expect(result.retryable, message).toBe(true);
+    }
+  });
+
+  it("never marks a guardrail block retryable", () => {
+    // Retrying a blocked run just blocks again. Getting this wrong would make the
+    // worker spin on a campaign that can never succeed.
+    const result = toAppError(
+      new Error("Campaign blocked by a guardrail on gid://x: below cost"),
+    );
+    expect(result.code).toBe("GUARDRAIL_BLOCKED");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("trusts Prisma's codes over its prose", () => {
+    const notFound = Object.assign(new Error("No Campaign found"), { code: "P2025" });
+    expect(toAppError(notFound).code).toBe("NOT_FOUND");
+
+    const down = Object.assign(new Error("Can't reach database server"), { code: "P1001" });
+    expect(toAppError(down).code).toBe("DB_UNAVAILABLE");
+    expect(toAppError(down).retryable).toBe(true);
+  });
+
+  it("treats a lost session as needing reinstall, not retry", () => {
+    const result = toAppError(new Error("No usable session for shop.myshopify.com"));
+    expect(result.code).toBe("NO_SESSION");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("falls back to UNKNOWN rather than guessing", () => {
+    const result = toAppError(new Error("something entirely novel"));
+    expect(result.code).toBe("UNKNOWN");
+    expect(result.status).toBe(500);
+  });
+
+  it("survives anything thrown, not just Errors", () => {
+    // People throw strings, objects and undefined. The error handler is the last
+    // place that should itself crash.
+    fc.assert(
+      fc.property(fc.anything(), (thrown) => {
+        const result = toAppError(thrown);
+        expect(result).toBeInstanceOf(AppError);
+        expect(typeof result.userMessage).toBe("string");
+        expect(result.userMessage.length).toBeGreaterThan(0);
+      }),
+    );
+  });
+
+  it("always produces a user message free of stack traces", () => {
+    const withStack = new Error("boom");
+    withStack.stack = "Error: boom\n    at /app/lib/secret-path.ts:42";
+    const result = toAppError(withStack);
+    expect(result.userMessage).not.toContain("at /app");
+    expect(result.userMessage).not.toContain("boom");
+  });
+
+  it("gives every code a status and a message", () => {
+    const codes: ErrorCode[] = [
+      "UNAUTHENTICATED",
+      "NO_SESSION",
+      "SHOPIFY_THROTTLED",
+      "SHOPIFY_UNAVAILABLE",
+      "SHOPIFY_REJECTED",
+      "GUARDRAIL_BLOCKED",
+      "NOT_FOUND",
+      "VALIDATION",
+      "DB_UNAVAILABLE",
+      "UNKNOWN",
+    ];
+    for (const code of codes) {
+      const error = new AppError({ code, userMessage: "x" });
+      expect(error.status, code).toBeGreaterThanOrEqual(400);
+    }
+  });
+});
+
+describe("error ids", () => {
+  it("produces ids that survive being read aloud", () => {
+    // No O/0, I/1/L or U: the whole point is a person transcribing it correctly.
+    for (let i = 0; i < 200; i++) {
+      const id = newErrorId();
+      expect(id).toMatch(/^ANC-[2-9A-HJ-NP-Z]{4}-[2-9A-HJ-NP-Z]{4}$/);
+      expect(id).not.toMatch(/[OIL01U]/);
+    }
+  });
+
+  it("round-trips through the validator, case-insensitively", () => {
+    const id = newErrorId();
+    expect(isErrorId(id)).toBe(true);
+    expect(isErrorId(id.toLowerCase())).toBe(true);
+    expect(isErrorId(`  ${id}  `)).toBe(true);
+  });
+
+  it("rejects things that are not ids", () => {
+    for (const value of ["", "ANC-", "hello", "ANC-OOOO-1111", "12345678"]) {
+      expect(isErrorId(value), value).toBe(false);
+    }
+  });
+
+  it("does not collide in practice", () => {
+    const ids = new Set(Array.from({ length: 5_000 }, newErrorId));
+    expect(ids.size).toBeGreaterThan(4_990);
+  });
+});

--- a/app/lib/errors/app-error.ts
+++ b/app/lib/errors/app-error.ts
@@ -1,0 +1,172 @@
+/**
+ * One error type, so every failure reaches the merchant as a sentence they can act
+ * on and reaches us with enough detail to debug.
+ *
+ * Raw errors are useless at both ends. `PrismaClientKnownRequestError: P2025` tells a
+ * merchant nothing, and "Something went wrong" tells us nothing. An AppError carries
+ * both: a `userMessage` written for the person looking at the screen, and a `code`
+ * plus `context` written for whoever reads the logs afterwards.
+ *
+ * `retryable` is the third audience: the worker. A throttle is worth retrying, a
+ * guardrail block never is, and code that has to guess by matching on message strings
+ * gets it wrong eventually.
+ */
+
+export type ErrorCode =
+  | "UNAUTHENTICATED"
+  | "NO_SESSION"
+  | "SHOPIFY_THROTTLED"
+  | "SHOPIFY_UNAVAILABLE"
+  | "SHOPIFY_REJECTED"
+  | "GUARDRAIL_BLOCKED"
+  | "NOT_FOUND"
+  | "VALIDATION"
+  | "DB_UNAVAILABLE"
+  | "UNKNOWN";
+
+export interface AppErrorOptions {
+  code: ErrorCode;
+  /** Written for the merchant: what happened, and what to do about it. */
+  userMessage: string;
+  /** Structured detail for the log. Must never contain tokens or secrets. */
+  context?: Record<string, unknown>;
+  cause?: unknown;
+  retryable?: boolean;
+  status?: number;
+}
+
+const RETRYABLE: ReadonlySet<ErrorCode> = new Set([
+  "SHOPIFY_THROTTLED",
+  "SHOPIFY_UNAVAILABLE",
+  "DB_UNAVAILABLE",
+]);
+
+const STATUS: Record<ErrorCode, number> = {
+  UNAUTHENTICATED: 401,
+  NO_SESSION: 401,
+  SHOPIFY_THROTTLED: 429,
+  SHOPIFY_UNAVAILABLE: 502,
+  SHOPIFY_REJECTED: 422,
+  GUARDRAIL_BLOCKED: 422,
+  NOT_FOUND: 404,
+  VALIDATION: 400,
+  DB_UNAVAILABLE: 503,
+  UNKNOWN: 500,
+};
+
+export class AppError extends Error {
+  readonly code: ErrorCode;
+  readonly userMessage: string;
+  readonly context: Record<string, unknown>;
+  readonly retryable: boolean;
+  readonly status: number;
+
+  constructor(options: AppErrorOptions) {
+    // The technical message stays on `message` for logs; `userMessage` is what the
+    // screen shows. Conflating them is how stack traces end up in front of merchants.
+    super(options.userMessage, { cause: options.cause });
+    this.name = "AppError";
+    this.code = options.code;
+    this.userMessage = options.userMessage;
+    this.context = options.context ?? {};
+    this.retryable = options.retryable ?? RETRYABLE.has(options.code);
+    this.status = options.status ?? STATUS[options.code];
+  }
+}
+
+/**
+ * Normalises anything thrown into an AppError.
+ *
+ * Matching on message text is unpleasant, but the alternative is worse: these errors
+ * come from Prisma, `fetch`, and Shopify's GraphQL layer, none of which share a type.
+ * Doing it in exactly one place means the guesswork is testable and the rest of the
+ * app can rely on the result.
+ */
+export function toAppError(error: unknown): AppError {
+  if (error instanceof AppError) return error;
+
+  const message = messageOf(error);
+  const code = classify(error, message);
+
+  return new AppError({
+    code,
+    userMessage: USER_MESSAGE[code],
+    cause: error,
+    context: { originalMessage: message.slice(0, 500) },
+  });
+}
+
+const USER_MESSAGE: Record<ErrorCode, string> = {
+  UNAUTHENTICATED:
+    "Your session expired. Reload the page to sign back in to Shopify.",
+  NO_SESSION:
+    "This store is no longer connected to the app. Reinstall it from the Shopify admin to continue.",
+  SHOPIFY_THROTTLED:
+    "Shopify is rate-limiting this store right now. The work is queued and will continue on its own — no prices were left half-written.",
+  SHOPIFY_UNAVAILABLE:
+    "Could not reach Shopify. This is usually brief; try again in a minute. Any run that had started is safe to resume.",
+  SHOPIFY_REJECTED:
+    "Shopify rejected part of this change. The ledger below shows exactly which variants were affected and why.",
+  GUARDRAIL_BLOCKED:
+    "A guardrail stopped this run before anything was written. Lower the floor in Settings, or exclude the variant, then try again.",
+  NOT_FOUND: "That campaign or record no longer exists. It may have been deleted.",
+  VALIDATION: "Some of the values on this form need fixing before it can be saved.",
+  DB_UNAVAILABLE:
+    "The app's own database is not responding. Nothing was changed in your store. Try again shortly.",
+  UNKNOWN:
+    "Something went wrong on our side. Nothing was changed in your store unless a run reported otherwise.",
+};
+
+function classify(error: unknown, message: string): ErrorCode {
+  const prismaCode = (error as { code?: unknown })?.code;
+
+  if (typeof prismaCode === "string") {
+    // Prisma's own codes are far more reliable than its messages.
+    if (prismaCode === "P2025") return "NOT_FOUND";
+    if (prismaCode === "P2002" || prismaCode.startsWith("P20")) return "VALIDATION";
+    if (prismaCode.startsWith("P1")) return "DB_UNAVAILABLE";
+    if (prismaCode === "ECONNREFUSED" || prismaCode === "ENOTFOUND") {
+      return "SHOPIFY_UNAVAILABLE";
+    }
+  }
+
+  const text = message.toLowerCase();
+
+  if (text.includes("throttled") || (text.includes("exceeded") && text.includes("rate"))) {
+    return "SHOPIFY_THROTTLED";
+  }
+  if (
+    text.includes("fetch failed") ||
+    text.includes("econnrefused") ||
+    text.includes("enotfound") ||
+    text.includes("socket hang up") ||
+    text.includes("etimedout")
+  ) {
+    return "SHOPIFY_UNAVAILABLE";
+  }
+  if (text.includes("blocked by a guardrail")) return "GUARDRAIL_BLOCKED";
+  if (text.includes("no usable session")) return "NO_SESSION";
+  if (text.includes("access denied") || text.includes("unauthorized")) {
+    return "UNAUTHENTICATED";
+  }
+  if (text.includes("usererrors") || text.includes("invalid value")) {
+    return "SHOPIFY_REJECTED";
+  }
+
+  return "UNKNOWN";
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const maybe = (error as { message?: unknown }).message;
+    if (typeof maybe === "string") return maybe;
+    try {
+      return JSON.stringify(error).slice(0, 500);
+    } catch {
+      return "Unserialisable error";
+    }
+  }
+  return String(error);
+}

--- a/app/lib/errors/error-id.ts
+++ b/app/lib/errors/error-id.ts
@@ -1,0 +1,41 @@
+/**
+ * Short ids a person can read out over the phone.
+ *
+ * The merchant sees this on the error screen and quotes it in a support message; we
+ * search the logs for the same string and land on the full stack. That handoff only
+ * works if the id survives being transcribed by hand, so the alphabet excludes the
+ * characters people confuse: no O/0, no I/1/L, no U (which turns into V in
+ * handwriting).
+ *
+ * Not a UUID, deliberately -- nobody reads a UUID out correctly, and this needs to be
+ * unique among the errors of one app, not among all objects in the universe.
+ */
+
+const ALPHABET = "23456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+export function newErrorId(): string {
+  const bytes = randomBytes(8);
+  let id = "";
+  for (const byte of bytes) id += ALPHABET[byte % ALPHABET.length];
+  return `ANC-${id.slice(0, 4)}-${id.slice(4)}`;
+}
+
+function randomBytes(count: number): Uint8Array {
+  const out = new Uint8Array(count);
+  const cryptoApi = globalThis.crypto;
+
+  if (cryptoApi?.getRandomValues) {
+    cryptoApi.getRandomValues(out);
+    return out;
+  }
+
+  // Only reachable on a runtime without WebCrypto. An id that repeats is a nuisance
+  // when searching logs, never a security problem -- these are not secrets.
+  for (let i = 0; i < count; i++) out[i] = Math.floor(Math.random() * 256);
+  return out;
+}
+
+/** True for something that looks like one of our ids, for the debug page's search. */
+export function isErrorId(value: string): boolean {
+  return /^ANC-[2-9A-HJ-NP-Z]{4}-[2-9A-HJ-NP-Z]{4}$/.test(value.trim().toUpperCase());
+}

--- a/app/lib/errors/guard.server.ts
+++ b/app/lib/errors/guard.server.ts
@@ -1,0 +1,71 @@
+/**
+ * Catching loader and action failures where the real error still exists.
+ *
+ * React Router sanitises errors before an ErrorBoundary sees them: the message
+ * survives, but the properties that make an error identifiable -- Prisma's `code`,
+ * the cause chain -- do not. A boundary trying to classify what it receives sees
+ * "No Campaign found" with no code attached and can only call it UNKNOWN.
+ *
+ * So classification, persistence and the id all happen here, on the server, at the
+ * moment of failure. The boundary is handed a finished result and only has to render
+ * it. That also fixes a subtler problem: an id minted in the boundary was never
+ * written to the database, so a merchant quoting it got "no error stored under that
+ * reference" -- the one answer a diagnostics page must never give.
+ */
+
+import { data } from "react-router";
+
+import { reportError, type ReportContext } from "../../services/error-report.server";
+import { ANCHOR_ERROR, type ReportedError } from "./report";
+
+export { ANCHOR_ERROR };
+
+export interface AnchorErrorPayload {
+  [ANCHOR_ERROR]: ReportedError;
+}
+
+/**
+ * Wraps a loader or action so its failures are reported and rendered properly.
+ *
+ * Thrown Responses pass straight through. That is not an optimisation: Shopify's
+ * `authenticate.admin` signals "redirect this embedded app to re-authenticate" by
+ * throwing a Response, and swallowing it would replace a silent sign-in with an
+ * error screen.
+ */
+export function withGuard<Args, Result>(
+  route: string,
+  handler: (args: Args) => Promise<Result>,
+): (args: Args) => Promise<Result> {
+  return async (args: Args) => {
+    try {
+      return await handler(args);
+    } catch (error) {
+      if (error instanceof Response) throw error;
+
+      const request = (args as { request?: Request })?.request;
+      const reported = await reportError(error, {
+        route,
+        method: request?.method,
+        ...shopContext(request),
+      } as ReportContext);
+
+      throw data({ [ANCHOR_ERROR]: reported }, { status: reported.status });
+    }
+  };
+}
+
+/**
+ * The shop domain, taken from the request rather than a session lookup.
+ *
+ * Deliberately best-effort: this runs while something is already failing, and a
+ * second database round trip to enrich a log line is exactly the sort of thing that
+ * turns one error into two.
+ */
+function shopContext(request?: Request): Record<string, unknown> {
+  if (!request) return {};
+  try {
+    return { shop: new URL(request.url).searchParams.get("shop") ?? undefined };
+  } catch {
+    return {};
+  }
+}

--- a/app/lib/errors/report.ts
+++ b/app/lib/errors/report.ts
@@ -1,0 +1,53 @@
+/**
+ * The isomorphic half of error reporting.
+ *
+ * Lives apart from `services/error-report.server.ts` for a concrete reason: the
+ * ErrorBoundary that uses it renders in the browser as well as on the server, and
+ * importing the server module there would pull Prisma into the client bundle.
+ *
+ * So this half normalises, mints an id and logs. Persisting to the database is the
+ * server module's job, and only ever called from a loader or action.
+ */
+
+import { toAppError } from "./app-error";
+import { newErrorId } from "./error-id";
+import { logger } from "../logging/logger";
+
+/**
+ * Marks a thrown Response as one our server guard produced, so the ErrorBoundary can
+ * tell it apart from Shopify's auth redirects. Lives here rather than in guard.server
+ * because the boundary runs in the browser and must not import Prisma.
+ */
+export const ANCHOR_ERROR = "__anchorError";
+
+export interface ReportedError {
+  errorId: string;
+  code: string;
+  userMessage: string;
+  retryable: boolean;
+  status: number;
+}
+
+export function reportErrorSync(
+  error: unknown,
+  context: Record<string, unknown> = {},
+): ReportedError {
+  const appError = toAppError(error);
+  const errorId = newErrorId();
+
+  logger.error(appError.message, {
+    errorId,
+    code: appError.code,
+    retryable: appError.retryable,
+    ...context,
+    error: appError.cause ?? appError,
+  });
+
+  return {
+    errorId,
+    code: appError.code,
+    userMessage: appError.userMessage,
+    retryable: appError.retryable,
+    status: appError.status,
+  };
+}

--- a/app/lib/logging/logger.ts
+++ b/app/lib/logging/logger.ts
@@ -1,0 +1,101 @@
+/**
+ * Structured logging.
+ *
+ * One line per event, JSON in production so it can be queried, and something a human
+ * can read at a glance in development. Every line carries the fields you actually
+ * search by when something has gone wrong at 2am: the error id the merchant quoted,
+ * the shop, the route, and the code.
+ *
+ * Everything routes through `redact` on the way out -- see that module for why.
+ */
+
+import { redact } from "./redact";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogFields {
+  /** The short id shown to the merchant; the join key between a report and a log. */
+  errorId?: string;
+  code?: string;
+  shop?: string;
+  route?: string;
+  campaignId?: string;
+  runId?: string;
+  durationMs?: number;
+  [key: string]: unknown;
+}
+
+const LEVELS: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+/**
+ * `process` does not exist in the browser, and this module is reachable from the
+ * ErrorBoundary, which renders on both sides. Reading env through a guard keeps the
+ * client bundle from throwing "process is not defined" at the exact moment it is
+ * trying to report a different error.
+ */
+function env(key: string): string | undefined {
+  if (typeof process === "undefined" || !process.env) return undefined;
+  return process.env[key];
+}
+
+function threshold(): number {
+  const configured = (env("LOG_LEVEL") ?? "").toLowerCase() as LogLevel;
+  if (configured in LEVELS) return LEVELS[configured];
+  return env("NODE_ENV") === "production" ? LEVELS.info : LEVELS.debug;
+}
+
+function isPretty(): boolean {
+  return env("NODE_ENV") !== "production" && env("LOG_FORMAT") !== "json";
+}
+
+function emit(level: LogLevel, message: string, fields: LogFields = {}): void {
+  if (LEVELS[level] < threshold()) return;
+
+  const safe = redact(fields) as LogFields;
+  const sink = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+
+  if (isPretty()) {
+    const tail = Object.entries(safe)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => `${k}=${typeof v === "string" ? v : JSON.stringify(v)}`)
+      .join(" ");
+    sink(`${level.toUpperCase().padEnd(5)} ${message}${tail ? ` ${tail}` : ""}`);
+    return;
+  }
+
+  sink(JSON.stringify({ level, time: new Date().toISOString(), message, ...safe }));
+}
+
+export const logger = {
+  debug: (message: string, fields?: LogFields) => emit("debug", message, fields),
+  info: (message: string, fields?: LogFields) => emit("info", message, fields),
+  warn: (message: string, fields?: LogFields) => emit("warn", message, fields),
+  error: (message: string, fields?: LogFields) => emit("error", message, fields),
+};
+
+/**
+ * Times an operation and logs how long it took.
+ *
+ * Slow is a failure mode of its own here: a preview that takes 30 seconds is broken
+ * even though nothing threw. Failures are logged with their duration too, because
+ * "it failed after 60s" and "it failed instantly" have completely different causes.
+ */
+export async function timed<T>(
+  message: string,
+  fields: LogFields,
+  work: () => Promise<T>,
+): Promise<T> {
+  const started = Date.now();
+  try {
+    const result = await work();
+    logger.debug(message, { ...fields, durationMs: Date.now() - started });
+    return result;
+  } catch (error) {
+    logger.warn(`${message} failed`, {
+      ...fields,
+      durationMs: Date.now() - started,
+      error,
+    });
+    throw error;
+  }
+}

--- a/app/lib/logging/redact.test.ts
+++ b/app/lib/logging/redact.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { redact, redactText } from "./redact";
+
+describe("redact", () => {
+  it("removes anything under a secret-looking key", () => {
+    const result = redact({
+      shop: "store.myshopify.com",
+      accessToken: "shpat_abc123",
+      apiKey: "k",
+      Authorization: "Bearer x",
+      password: "hunter2",
+      campaignId: "c1",
+    }) as Record<string, unknown>;
+
+    expect(result.accessToken).toBe("[redacted]");
+    expect(result.apiKey).toBe("[redacted]");
+    expect(result.Authorization).toBe("[redacted]");
+    expect(result.password).toBe("[redacted]");
+    // Non-secrets must survive, or the log stops being useful.
+    expect(result.shop).toBe("store.myshopify.com");
+    expect(result.campaignId).toBe("c1");
+  });
+
+  it("removes a token pasted into an ordinary string", () => {
+    // The dangerous case: a token inside an error message, under a harmless key.
+    const result = redact({
+      message: "POST failed with token shpat_0123456789abcdef",
+    }) as Record<string, string>;
+
+    expect(result.message).not.toContain("shpat_0123456789abcdef");
+    expect(result.message).toContain("shpat_[redacted]");
+  });
+
+  it("scrubs tokens out of a stack trace", () => {
+    const error = new Error("auth failed for shpca_deadbeef");
+    const result = redact(error) as { message: string };
+    expect(result.message).not.toContain("shpca_deadbeef");
+  });
+
+  it("survives a cycle instead of hanging", () => {
+    const node: Record<string, unknown> = { name: "a" };
+    node.self = node;
+    expect(() => redact(node)).not.toThrow();
+    expect((redact(node) as Record<string, unknown>).self).toBe("[circular]");
+  });
+
+  it("truncates rather than walking forever", () => {
+    let deep: Record<string, unknown> = { value: "bottom" };
+    for (let i = 0; i < 20; i++) deep = { nested: deep };
+    expect(JSON.stringify(redact(deep))).toContain("[truncated]");
+  });
+
+  it("summarises long arrays", () => {
+    const result = redact(Array.from({ length: 100 }, (_, i) => i)) as unknown[];
+    expect(result.length).toBe(21);
+    expect(result[20]).toBe("[+80 more]");
+  });
+
+  it("handles bigints, which JSON.stringify refuses to", () => {
+    // Prices are bigints throughout this app, so they turn up in error context
+    // constantly. An unhandled bigint makes the logger itself throw.
+    expect(redact({ price: 1999n })).toEqual({ price: "1999n" });
+  });
+
+  it("scrubs a bare string, for the columns that are not structured context", () => {
+    // The regression this guards: error_events stores `message` and `stack` as plain
+    // columns. They used to bypass redaction entirely, so the log line came out clean
+    // while the stored row still held the token -- and the Diagnostics page then
+    // displayed it.
+    expect(redactText("POST failed: token shpat_LEAKEDVALUE rejected")).toBe(
+      "POST failed: token shpat_[redacted] rejected",
+    );
+    expect(
+      redactText("Error: boom\n    at auth (/app/x.ts:1) shpca_INSTALLSECRET"),
+    ).not.toContain("INSTALLSECRET");
+  });
+
+  it("never throws, whatever it is handed", () => {
+    fc.assert(
+      fc.property(fc.anything(), (value) => {
+        expect(() => redact(value)).not.toThrow();
+      }),
+    );
+  });
+
+  it("leaves no shpat_ token anywhere in the output", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          note: fc.constant("prefix shpat_SECRETVALUE suffix"),
+          nested: fc.record({ deeper: fc.constant("shpat_ANOTHERONE") }),
+        }),
+        (input) => {
+          const serialised = JSON.stringify(redact(input));
+          expect(serialised).not.toContain("SECRETVALUE");
+          expect(serialised).not.toContain("ANOTHERONE");
+        },
+      ),
+    );
+  });
+});

--- a/app/lib/logging/redact.ts
+++ b/app/lib/logging/redact.ts
@@ -1,0 +1,78 @@
+/**
+ * Stripping secrets out of anything on its way to a log.
+ *
+ * Error context is genuinely useful for debugging, which is exactly why it is
+ * dangerous: the object nearest a failed Shopify call is often the one holding the
+ * access token. Redaction happens here, once, on the way out -- rather than relying
+ * on every call site to remember what is safe to attach.
+ *
+ * A leaked `shpat_` token is a full-catalogue write credential, and logs get shipped,
+ * pasted into issues and read by support. Treat this as a boundary, not a nicety.
+ */
+
+const SECRET_KEY = /token|secret|password|authorization|api[-_]?key|cookie|signature/i;
+
+/** Shopify access tokens and API secrets have recognisable prefixes. */
+const SECRET_VALUE = /\b(shpat|shpca|shpss|shppa|shhp)_[A-Za-z0-9]+/g;
+
+const REDACTED = "[redacted]";
+
+/**
+ * Returns a copy with secrets replaced.
+ *
+ * Depth-limited and cycle-safe: logging must never be the thing that hangs or blows
+ * the stack. Anything too deep is summarised rather than dropped, so the shape of the
+ * data is still visible.
+ */
+export function redact(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (depth > 6) return "[truncated]";
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === "string") return redactString(value);
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return `${value}n`;
+  if (typeof value === "function") return "[function]";
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactString(value.message),
+      stack: value.stack ? redactString(value.stack) : undefined,
+    };
+  }
+
+  if (typeof value === "object") {
+    if (seen.has(value)) return "[circular]";
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      // Long arrays are noise in a log line; the first few plus a count carry the
+      // same diagnostic weight.
+      const head = value.slice(0, 20).map((item) => redact(item, depth + 1, seen));
+      return value.length > 20 ? [...head, `[+${value.length - 20} more]`] : head;
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[key] = SECRET_KEY.test(key) ? REDACTED : redact(item, depth + 1, seen);
+    }
+    return out;
+  }
+
+  return String(value);
+}
+
+/**
+ * Scrubs a bare string.
+ *
+ * Exported because messages and stack traces are stored as plain columns, not inside
+ * the context object -- and a token in an error message is exactly as dangerous as
+ * one in a field. Anything writing free text to a log or a table goes through here.
+ */
+export function redactText(text: string): string {
+  return redactString(text);
+}
+
+function redactString(text: string): string {
+  return text.replace(SECRET_VALUE, (match) => `${match.split("_")[0]}_${REDACTED}`);
+}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData, useRouteError } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -7,8 +7,10 @@ import prisma from "../db.server";
 import { ensureShop, markSyncComplete } from "../services/shop.server";
 import { fetchShopBasics, syncCatalog } from "../services/catalog-sync.server";
 import { baselineHealth, captureBaselines } from "../services/baselines.server";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
@@ -26,9 +28,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     },
     campaigns,
   };
-};
+});
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = withGuard("/app", async ({ request }: ActionFunctionArgs) => {
   const { admin, session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const form = await request.formData();
@@ -74,7 +76,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   return { ok: false, message: `Unknown action: ${intent}`, errors: [] };
-};
+});
 
 type ActionData = { ok: boolean; message: string; errors: string[] };
 
@@ -194,7 +196,7 @@ export default function Dashboard() {
 }
 
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData, useRouteError } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -17,8 +17,11 @@ import { CountsRow } from "../components/CountsRow";
 import { LedgerTable } from "../components/LedgerTable";
 import { PreviewTable } from "../components/PreviewTable";
 import { RunHistoryTable } from "../components/RunHistoryTable";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { reportError } from "../services/error-report.server";
+import { withGuard } from "../lib/errors/guard.server";
 
-export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+export const loader = withGuard("/app/campaigns/$id", async ({ request, params }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const campaignId = String(params.id);
@@ -53,9 +56,9 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     autoEnroll: record.autoEnroll,
     enrollPendingAt: record.enrollPendingAt !== null,
   };
-};
+});
 
-export const action = async ({ request, params }: ActionFunctionArgs) => {
+export const action = withGuard("/app/campaigns/$id", async ({ request, params }: ActionFunctionArgs) => {
   const { admin, session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const intent = String((await request.formData()).get("intent"));
@@ -76,15 +79,32 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       details: result.messages,
     };
   } catch (error) {
+    // A failed run is the highest-stakes error in the app: the merchant needs to know
+    // their prices are intact, in words, plus a reference that leads us to the stack.
+    const reported = await reportError(error, {
+      shopId: shop.id,
+      shop: session.shop,
+      route: "/app/campaigns/$id",
+      method: "POST",
+      campaignId: String(params.id),
+      intent,
+    });
+
     return {
       ok: false,
-      message: error instanceof Error ? error.message : String(error),
-      details: [] as string[],
+      message: reported.userMessage,
+      details: [`Reference ${reported.errorId}`],
+      errorId: reported.errorId,
     };
   }
-};
+});
 
-type ActionData = { ok: boolean; message: string; details: string[] };
+type ActionData = {
+  ok: boolean;
+  message: string;
+  details: string[];
+  errorId?: string;
+};
 
 export default function CampaignDetail() {
   const {
@@ -235,7 +255,7 @@ export default function CampaignDetail() {
 }
 
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -1,12 +1,14 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useLoaderData, useRouteError } from "react-router";
+import { useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = withGuard("/app/campaigns", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
@@ -35,7 +37,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         : null,
     })),
   };
-};
+});
 
 type Tone = "info" | "success" | "critical" | "neutral" | "warning" | "caution" | "auto";
 
@@ -119,7 +121,7 @@ export default function CampaignList() {
 }
 
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { redirect, useLoaderData, useRouteError } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -9,8 +9,10 @@ import { createCampaign } from "../services/campaigns/index.server";
 import type { AdjustmentRule, CompareAtPolicy } from "../lib/pricing/types";
 import { money } from "../lib/money/money";
 import { localInputToUtc, type Schedule } from "../lib/scheduling/window";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
@@ -32,7 +34,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       title: url.searchParams.get("title") ?? "",
     },
   };
-};
+});
 
 /** Builds an AST from the simple scope form: all provided conditions ANDed. */
 function astFromParams(params: URLSearchParams): FilterAst {
@@ -50,7 +52,7 @@ function astFromParams(params: URLSearchParams): FilterAst {
   return conditions.length > 0 ? { groups: [{ conditions }] } : { groups: [] };
 }
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = withGuard("/app/campaigns/new", async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
@@ -110,7 +112,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   });
 
   return redirect(`/app/campaigns/${campaign.id}`);
-};
+});
 
 export default function NewCampaign() {
   const { facets: available, preview, selected, timeZone } = useLoaderData<typeof loader>();
@@ -269,7 +271,7 @@ export default function NewCampaign() {
 }
 
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/routes/app.catalog.tsx
+++ b/app/routes/app.catalog.tsx
@@ -1,15 +1,17 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useLoaderData, useRouteError, useSearchParams } from "react-router";
+import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { formatMoney, money } from "../lib/money/money";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
 
 const PAGE_SIZE = 50;
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = withGuard("/app/catalog", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
@@ -80,7 +82,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   });
 
   return { rows, total, page, query, pageSize: PAGE_SIZE };
-};
+});
 
 export default function Catalog() {
   const { rows, total, page, query, pageSize } = useLoaderData<typeof loader>();
@@ -197,7 +199,7 @@ export default function Catalog() {
 }
 
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/routes/app.debug.tsx
+++ b/app/routes/app.debug.tsx
@@ -1,0 +1,199 @@
+/**
+ * The page that turns "it crashed" into an answer.
+ *
+ * A merchant quotes an id; this looks it up and shows the stack, the route and the
+ * context that call site attached. Without the id, it lists what has failed recently
+ * grouped by code, which answers the other question worth asking fast: is this one
+ * merchant hitting one bug, or is everything on fire.
+ */
+
+import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { Form, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { errorByPublicId, recentErrors } from "../services/error-report.server";
+import { isErrorId } from "../lib/errors/error-id";
+import { EmptyState } from "../components/AsyncState";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+
+export const loader = withGuard("/app/debug", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const query = (new URL(request.url).searchParams.get("id") ?? "").trim();
+
+  // A quoted id is the common case and deserves an exact match, not a search over
+  // recent rows that may already have scrolled past the limit.
+  const match = query && isErrorId(query) ? await errorByPublicId(query) : null;
+  const recent = await recentErrors(shop.id, 50);
+
+  const counts = new Map<string, number>();
+  for (const row of recent) counts.set(row.code, (counts.get(row.code) ?? 0) + 1);
+
+  return {
+    query,
+    invalidQuery: query.length > 0 && !isErrorId(query),
+    match: match
+      ? {
+          ...match,
+          createdAt: match.createdAt.toISOString(),
+          context: JSON.stringify(match.context, null, 2),
+        }
+      : null,
+    recent: recent.map((row) => ({
+      errorId: row.errorId,
+      code: row.code,
+      message: row.message,
+      route: row.route,
+      retryable: row.retryable,
+      createdAt: row.createdAt.toISOString(),
+    })),
+    byCode: [...counts.entries()].sort((a, b) => b[1] - a[1]),
+  };
+});
+
+export default function Debug() {
+  const { query, invalidQuery, match, recent, byCode } = useLoaderData<typeof loader>();
+
+  return (
+    <s-page heading="Diagnostics">
+      <s-section heading="Look up an error">
+        <s-paragraph>
+          <s-text>
+            Paste the reference from an error screen, for example ANC-K3M2-P7QR.
+          </s-text>
+        </s-paragraph>
+
+        <Form method="get">
+          <s-stack direction="inline" gap="base">
+            <s-text-field name="id" label="Reference" defaultValue={query} />
+            <s-button type="submit" variant="primary">
+              Find
+            </s-button>
+          </s-stack>
+        </Form>
+
+        {invalidQuery ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              That does not look like a reference. They are in the form ANC-XXXX-XXXX.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        {query && !invalidQuery && !match ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              No error stored under {query}. Errors are recorded when they happen; if
+              the database itself was down, only the server log will have it.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        {match ? (
+          <s-stack gap="base">
+            <s-divider />
+            <s-heading>{match.errorId}</s-heading>
+            <s-paragraph>
+              <s-badge>{match.code}</s-badge>{" "}
+              {match.retryable ? <s-badge tone="warning">retryable</s-badge> : null}
+            </s-paragraph>
+            <s-paragraph>
+              <s-text>
+                {match.createdAt} · {match.method ?? "—"} {match.route ?? "—"}
+              </s-text>
+            </s-paragraph>
+
+            <s-heading>Shown to the merchant</s-heading>
+            <s-paragraph>{match.userMessage}</s-paragraph>
+
+            <s-heading>Technical message</s-heading>
+            <pre style={PRE}>{match.message}</pre>
+
+            {match.context && match.context !== "null" ? (
+              <>
+                <s-heading>Context</s-heading>
+                <pre style={PRE}>{match.context}</pre>
+              </>
+            ) : null}
+
+            {match.stack ? (
+              <>
+                <s-heading>Stack</s-heading>
+                <pre style={PRE}>{match.stack}</pre>
+              </>
+            ) : null}
+          </s-stack>
+        ) : null}
+      </s-section>
+
+      <s-section heading="Recent failures">
+        {recent.length === 0 ? (
+          <EmptyState
+            title="Nothing has failed recently"
+            description="Errors appear here as they happen, with the reference the merchant sees."
+          />
+        ) : (
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Reference</s-table-header>
+              <s-table-header>Code</s-table-header>
+              <s-table-header>Route</s-table-header>
+              <s-table-header>When</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {recent.map((row) => (
+                <s-table-row key={row.errorId}>
+                  <s-table-cell>
+                    <s-link href={`/app/debug?id=${row.errorId}`}>{row.errorId}</s-link>
+                  </s-table-cell>
+                  <s-table-cell>
+                    <s-badge tone={row.retryable ? "warning" : "critical"}>
+                      {row.code}
+                    </s-badge>
+                  </s-table-cell>
+                  <s-table-cell>{row.route ?? "—"}</s-table-cell>
+                  <s-table-cell>{row.createdAt}</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        )}
+      </s-section>
+
+      {byCode.length > 0 ? (
+        <s-section slot="aside" heading="By kind">
+          <s-paragraph>
+            <s-text>
+              One code dominating usually means one broken thing, not fifty.
+            </s-text>
+          </s-paragraph>
+          {byCode.map(([code, count]) => (
+            <s-paragraph key={code}>
+              <s-text>
+                {code} — {count}
+              </s-text>
+            </s-paragraph>
+          ))}
+        </s-section>
+      ) : null}
+    </s-page>
+  );
+}
+
+const PRE = {
+  overflowX: "auto" as const,
+  whiteSpace: "pre-wrap" as const,
+  fontSize: "0.8rem",
+};
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.drift.tsx
+++ b/app/routes/app.drift.tsx
@@ -1,18 +1,20 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData, useRouteError } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
 import { pendingDrift, resolveDrift, type DriftResolution } from "../services/drift.server";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = withGuard("/app/drift", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   return { events: await pendingDrift(shop.id) };
-};
+});
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = withGuard("/app/drift", async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
@@ -29,7 +31,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   };
 
   return { ok: true, message: wording[resolution] };
-};
+});
 
 type ActionData = { ok: boolean; message: string };
 
@@ -121,7 +123,7 @@ export default function DriftQueue() {
 }
 
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -1,13 +1,15 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData, useRouteError } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
@@ -19,9 +21,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   ]);
 
   return { settings, currency, withCost, variants };
-};
+});
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = withGuard("/app/settings", async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const form = await request.formData();
@@ -35,7 +37,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   });
 
   return { ok: true, message: "Guardrails saved. They apply to every campaign.", saved };
-};
+});
 
 function emptyToNull(value: FormDataEntryValue | null): number | null {
   const text = String(value ?? "").trim();
@@ -168,7 +170,7 @@ export default function Settings() {
 }
 
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,9 +1,11 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { Outlet, useLoaderData, useRouteError } from "react-router";
+import { Outlet, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 import { AppProvider } from "@shopify/shopify-app-react-router/react";
 
 import { authenticate } from "../shopify.server";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { RouteProgress } from "../components/RouteProgress";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
@@ -17,21 +19,25 @@ export default function App() {
 
   return (
     <AppProvider embedded apiKey={apiKey}>
+      <RouteProgress />
       <s-app-nav>
         <s-link href="/app">Dashboard</s-link>
         <s-link href="/app/campaigns">Campaigns</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/settings">Settings</s-link>
+        <s-link href="/app/debug">Diagnostics</s-link>
       </s-app-nav>
       <Outlet />
     </AppProvider>
   );
 }
 
-// Shopify needs React Router to catch some thrown responses, so that their headers are included in the response.
+// Thrown Responses still reach Shopify's handler with their headers intact — that is
+// how an embedded app re-authenticates. RouteBoundary delegates those and presents
+// everything else as a readable error screen.
 export function ErrorBoundary() {
-  return boundary.error(useRouteError());
+  return <RouteBoundary />;
 }
 
 export const headers: HeadersFunction = (headersArgs) => {

--- a/app/services/error-report.server.ts
+++ b/app/services/error-report.server.ts
@@ -1,0 +1,119 @@
+/**
+ * Recording a failure once, in a way both halves of the conversation can use.
+ *
+ * The merchant gets a short id and a sentence. We get the stack, the code, the route
+ * and whatever context the call site attached -- stored in a table, so the question
+ * "is this one merchant or all of them" is a query rather than a grep through logs
+ * that have already rolled over.
+ *
+ * Reporting must never throw. An error inside the error handler replaces a useful
+ * message with a useless one, and usually loses the original entirely.
+ */
+
+import prisma from "../db.server";
+import { AppError, toAppError } from "../lib/errors/app-error";
+import type { ReportedError } from "../lib/errors/report";
+import { newErrorId } from "../lib/errors/error-id";
+import { logger } from "../lib/logging/logger";
+import { redact, redactText } from "../lib/logging/redact";
+
+export interface ReportContext {
+  shopId?: string | null;
+  shop?: string | null;
+  route?: string;
+  method?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Normalises, logs and stores an error. Returns what the UI should show.
+ */
+export async function reportError(
+  error: unknown,
+  context: ReportContext = {},
+): Promise<ReportedError> {
+  const appError = toAppError(error);
+  const errorId = newErrorId();
+  const { shopId, shop, route, method, ...rest } = context;
+
+  const merged = { ...appError.context, ...rest };
+
+  // Log first. If the database is what is broken, the log line is all we will get,
+  // and losing it to a failed insert would be the worst possible trade.
+  logger.error(appError.message, {
+    errorId,
+    code: appError.code,
+    shop: shop ?? undefined,
+    route,
+    retryable: appError.retryable,
+    ...merged,
+    error: appError.cause ?? appError,
+  });
+
+  try {
+    await prisma.errorEvent.create({
+      data: {
+        errorId,
+        shopId: shopId ?? null,
+        code: appError.code,
+        message: technicalMessage(appError),
+        stack: stackOf(appError)?.slice(0, 8_000) ?? null,
+        userMessage: appError.userMessage,
+        route: route ?? null,
+        method: method ?? null,
+        context: redact(merged) as never,
+        retryable: appError.retryable,
+      },
+    });
+  } catch (storeFailure) {
+    // Deliberately swallowed. The merchant still gets their id and message, and the
+    // log line above already carries everything this row would have.
+    logger.warn("could not persist error event", {
+      errorId,
+      error: storeFailure instanceof Error ? storeFailure.message : String(storeFailure),
+    });
+  }
+
+  return {
+    errorId,
+    code: appError.code,
+    userMessage: appError.userMessage,
+    retryable: appError.retryable,
+    status: appError.status,
+  };
+}
+
+// The synchronous reporter lives in lib so the ErrorBoundary can use it without
+// pulling Prisma into the client bundle.
+export { reportErrorSync } from "../lib/errors/report";
+
+// Both of these go through redactText before they are stored. The message and the
+// stack are plain columns rather than part of the context object, so they miss the
+// redaction that `redact` applies to structured fields -- and a token pasted into an
+// error message is exactly as dangerous as one in a field. This was a real leak: the
+// log line was clean while the stored row still held the token.
+function technicalMessage(error: AppError): string {
+  const cause = error.cause;
+  const detail = cause instanceof Error ? cause.message : error.message;
+  return redactText(`${error.code}: ${detail}`);
+}
+
+function stackOf(error: AppError): string | undefined {
+  const cause = error.cause;
+  const stack = cause instanceof Error && cause.stack ? cause.stack : error.stack;
+  return stack ? redactText(stack) : undefined;
+}
+
+/** Recent failures for the debug page, newest first. */
+export async function recentErrors(shopId: string, limit = 50) {
+  return prisma.errorEvent.findMany({
+    where: { OR: [{ shopId }, { shopId: null }] },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+}
+
+/** One failure by the id a merchant quoted. */
+export async function errorByPublicId(errorId: string) {
+  return prisma.errorEvent.findUnique({ where: { errorId: errorId.trim().toUpperCase() } });
+}

--- a/prisma/migrations/20260816204555_error_events/migration.sql
+++ b/prisma/migrations/20260816204555_error_events/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "error_events" (
+    "id" TEXT NOT NULL,
+    "errorId" TEXT NOT NULL,
+    "shopId" TEXT,
+    "code" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "stack" TEXT,
+    "userMessage" TEXT NOT NULL,
+    "route" TEXT,
+    "method" TEXT,
+    "context" JSONB,
+    "retryable" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "error_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "error_events_errorId_key" ON "error_events"("errorId");
+
+-- CreateIndex
+CREATE INDEX "error_events_shopId_createdAt_idx" ON "error_events"("shopId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "error_events_code_createdAt_idx" ON "error_events"("code", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "error_events" ADD CONSTRAINT "error_events_shopId_fkey" FOREIGN KEY ("shopId") REFERENCES "shops"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,7 @@ model Shop {
   webhookEvents    WebhookEvent[]
   bulkOps          BulkOperationRecord[]
   auditEntries     AuditLogEntry[]
+  errorEvents      ErrorEvent[]
 
   @@index([uninstalledAt])
   @@map("shops")
@@ -622,6 +623,40 @@ model BulkOperationRecord {
 
 /// Append-only record of every state-changing action. Exportable, because agencies
 /// running pricing for clients need to prove exactly what changed and when.
+/// Every unhandled failure, kept so a merchant quoting an id gets a real answer.
+///
+/// Deliberately a table rather than only a log line: logs roll over, and the one
+/// question worth answering fast -- "is this happening to everyone or just them" --
+/// needs a query, not a grep.
+model ErrorEvent {
+  id String @id @default(cuid())
+
+  /// The short id shown on the error screen, e.g. ANC-K3M2-P7QR.
+  errorId String @unique
+
+  shopId String?
+  code   String
+  /// The technical message. Never shown to a merchant.
+  message String
+  stack   String?
+  /// What the merchant was shown, so support can see both halves of the story.
+  userMessage String
+
+  route     String?
+  method    String?
+  /// Redacted structured detail: ids, counts, durations. Never tokens.
+  context   Json?
+  retryable Boolean @default(false)
+
+  createdAt DateTime @default(now())
+
+  shop Shop? @relation(fields: [shopId], references: [id], onDelete: SetNull)
+
+  @@index([shopId, createdAt])
+  @@index([code, createdAt])
+  @@map("error_events")
+}
+
 model AuditLogEntry {
   id String @id @default(cuid())
 


### PR DESCRIPTION
Addresses #48 (structured logging) and the app-facing half of #45.

Every route used Shopify's default boundary, which renders the raw error. A merchant hitting a missing campaign saw a Prisma stack trace; we saw nothing, because nothing was recorded anywhere.

## One error type

`AppError` carries a `userMessage` written for the person looking at the screen and a `code` plus context written for whoever reads the logs. `toAppError` normalises Prisma codes, network failures and Shopify throttles in one tested place, rather than each call site guessing from message text. `retryable` is a third audience — the worker — so a guardrail block is never retried and a throttle always is.

## Where classification happens turned out to matter

React Router sanitises errors before an ErrorBoundary sees them: the message survives, Prisma's `code` does not. A boundary doing its own classification called a P2025 **UNKNOWN**, with a generic message. That was only caught by loading the page in the real embedded admin.

`withGuard` now wraps every loader and action, so classification, persistence and the id all happen server-side where the real error still exists. Thrown Responses pass through untouched — that is how Shopify's embedded auth re-authenticates, and swallowing one replaces a silent sign-in with an error screen.

Before and after, same URL:

| | code | shown to merchant |
|---|---|---|
| boundary-side | `UNKNOWN` | "Something went wrong on our side." |
| server-side | `NOT_FOUND` | "That campaign or record no longer exists. It may have been deleted." |

It fixed a second problem in the same stroke: an id minted in the boundary was never written to the database, so a merchant quoting it got *"no error stored under that reference"* — the one answer a diagnostics page must never give.

## The redaction test found a real leak

The log line came out clean while the stored `message` and `stack` columns still held an `shpat_` token — those are plain columns and missed the redaction applied to structured context. A full-catalogue write credential would have been written to the database and then **displayed on the Diagnostics page**. Both now go through `redactText`, with a regression test naming the failure.

## Loading states

React Router keeps the old page on screen while the next route's loader runs, so a slow preview looks like a dead link — and people click it again, queueing the same expensive run twice. `RouteProgress` shows a bar after 150ms, expressed as a CSS `animation-delay` rather than a timer and state, so a fast navigation never flashes and there is no effect setting state during render.

`AsyncState` gives empty and inline-error states a home: an empty catalogue and a catalogue that failed to load previously looked identical, which is the most confusing thing a merchant can be shown, because the two have opposite remedies.

## Debugging

`/app/debug` takes a quoted reference and returns the route, method, timestamp, the merchant-facing message, the real technical message and the stack, plus recent failures grouped by code — which answers the question worth asking fast: one merchant hitting one bug, or everything on fire.

Verified in the embedded admin: the error screen's reference resolved on the Diagnostics page and showed the genuine `prisma.campaign.findFirstOrThrow()` failure.

217 tests, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)