### PR TITLE
P3.5 — Campaign lifecycle wiring and honest state display

### DIFF
--- a/app/lib/lifecycle/transitions.test.ts
+++ b/app/lib/lifecycle/transitions.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import {
+  ALL_STATES,
+  canTransition,
+  describeState,
+  isTerminal,
+  needsAttention,
+  pricesMayBeLive,
+  type CampaignState,
+} from "./transitions";
+
+const anyState = () => fc.constantFrom<CampaignState>(...ALL_STATES);
+
+describe("legal transitions", () => {
+  it("walks the documented happy path", () => {
+    const path: CampaignState[] = [
+      "DRAFT",
+      "SCHEDULED",
+      "APPLYING",
+      "ACTIVE",
+      "REVERTING",
+      "COMPLETED",
+    ];
+    for (let i = 0; i < path.length - 1; i++) {
+      expect(canTransition(path[i], path[i + 1]), `${path[i]} → ${path[i + 1]}`).toBe(true);
+    }
+  });
+
+  it("lets a partial run resume", () => {
+    // The acceptance criterion this whole state exists for: a partial must be
+    // recoverable, not a dead end.
+    expect(canTransition("PARTIAL", "APPLYING")).toBe(true);
+    expect(canTransition("PARTIAL", "REVERTING")).toBe(true);
+  });
+
+  it("lets a held campaign resolve either way", () => {
+    expect(canTransition("HELD", "APPLYING")).toBe(true);
+    expect(canTransition("HELD", "REVERTING")).toBe(true);
+  });
+
+  it("re-arms a completed campaign for the next occurrence", () => {
+    // Recurrence reuses the campaign rather than cloning it, so the run history stays
+    // in one place.
+    expect(canTransition("COMPLETED", "SCHEDULED")).toBe(true);
+  });
+
+  it("treats cancelled as the only dead end", () => {
+    expect(isTerminal("CANCELLED")).toBe(true);
+    for (const state of ALL_STATES.filter((s) => s !== "CANCELLED")) {
+      expect(isTerminal(state), state).toBe(false);
+    }
+  });
+
+  it("refuses to resurrect a cancelled campaign", () => {
+    for (const to of ALL_STATES.filter((s) => s !== "CANCELLED")) {
+      expect(canTransition("CANCELLED", to), to).toBe(false);
+    }
+  });
+
+  it("never skips straight from draft to active", () => {
+    // Going ACTIVE without passing through APPLYING would mean claiming prices are
+    // live and verified without ever having written any.
+    expect(canTransition("DRAFT", "ACTIVE")).toBe(false);
+    expect(canTransition("SCHEDULED", "ACTIVE")).toBe(false);
+  });
+
+  it("allows cancelling from anywhere that is still alive", () => {
+    for (const state of ALL_STATES.filter((s) => s !== "CANCELLED")) {
+      expect(canTransition(state, "CANCELLED"), state).toBe(true);
+    }
+  });
+
+  it("is idempotent: any state may transition to itself", () => {
+    // A redelivered tick asking for a state we already hold must be a no-op, not a
+    // failure. Without this, every duplicate webhook or double tick raises an error.
+    fc.assert(
+      fc.property(anyState(), (state) => {
+        expect(canTransition(state, state)).toBe(true);
+      }),
+    );
+  });
+
+  it("never throws, for any pair of states", () => {
+    fc.assert(
+      fc.property(anyState(), anyState(), (from, to) => {
+        expect(() => canTransition(from, to)).not.toThrow();
+        expect(typeof canTransition(from, to)).toBe("boolean");
+      }),
+    );
+  });
+});
+
+describe("what the merchant is told", () => {
+  it("describes every state without falling through", () => {
+    for (const state of ALL_STATES) {
+      const described = describeState(state);
+      expect(described.label, state).toBeTruthy();
+      expect(described.explanation.length, state).toBeGreaterThan(20);
+    }
+  });
+
+  it("gives the two attention states a way out", () => {
+    // A partial with no resume, or a held with no link to the drift queue, is a dead
+    // end dressed up as information.
+    expect(describeState("PARTIAL").nextAction?.intent).toBe("resume");
+    expect(describeState("HELD").nextAction?.intent).toBe("drift");
+  });
+
+  it("does not dress up partial or held as success", () => {
+    expect(describeState("PARTIAL").tone).toBe("critical");
+    expect(describeState("HELD").tone).toBe("warning");
+    expect(needsAttention("PARTIAL")).toBe(true);
+    expect(needsAttention("HELD")).toBe(true);
+  });
+
+  it("reserves success for the state where every row was verified", () => {
+    const successes = ALL_STATES.filter((s) => describeState(s).tone === "success");
+    expect(successes).toEqual(["ACTIVE"]);
+  });
+
+  it("knows where prices may still be live", () => {
+    // Drives the "your prices are safe" wording on the error screen and the warning
+    // before deleting a campaign.
+    expect(pricesMayBeLive("PARTIAL")).toBe(true);
+    expect(pricesMayBeLive("ACTIVE")).toBe(true);
+    expect(pricesMayBeLive("HELD")).toBe(true);
+    expect(pricesMayBeLive("DRAFT")).toBe(false);
+    expect(pricesMayBeLive("COMPLETED")).toBe(false);
+    expect(pricesMayBeLive("CANCELLED")).toBe(false);
+  });
+});

--- a/app/lib/lifecycle/transitions.ts
+++ b/app/lib/lifecycle/transitions.ts
@@ -1,0 +1,181 @@
+/**
+ * The campaign state machine.
+ *
+ *   draft → scheduled → applying → active → reverting → completed
+ *                          ↓                   ↓
+ *                       partial ←──────────── partial
+ *                          ↓
+ *                        held (drift)
+ *
+ * Two states carry the product's whole trust proposition, and both are ones
+ * competitors hide:
+ *
+ *   `partial` means some rows were written and some were not. It is not an
+ *   embarrassment to be styled away -- it is the honest answer, and it comes with
+ *   per-row reasons and a resume that works.
+ *
+ *   `held` means a merchant edited a price under a running campaign. Nothing is
+ *   overwritten while held, because silently reasserting our price would destroy
+ *   a deliberate human decision.
+ *
+ * Self-transitions are legal on purpose. A duplicate scheduler tick asking for
+ * APPLYING while already APPLYING must be a no-op rather than an error, or every
+ * redelivery becomes a spurious failure (acceptance: idempotent under duplicate
+ * delivery).
+ */
+
+export type CampaignState =
+  | "DRAFT"
+  | "SCHEDULED"
+  | "APPLYING"
+  | "ACTIVE"
+  | "HELD"
+  | "REVERTING"
+  | "COMPLETED"
+  | "PARTIAL"
+  | "CANCELLED";
+
+/**
+ * Where each state may legally go.
+ *
+ * COMPLETED → SCHEDULED exists for recurrence: a finished occurrence re-arms for the
+ * next one rather than creating a second campaign. CANCELLED is the only truly
+ * terminal state -- everything else can still be acted on.
+ */
+const LEGAL: Record<CampaignState, readonly CampaignState[]> = {
+  DRAFT: ["SCHEDULED", "APPLYING", "CANCELLED"],
+  SCHEDULED: ["APPLYING", "DRAFT", "CANCELLED"],
+  // A run that finishes with every row verified goes ACTIVE; one with failures goes
+  // PARTIAL. COMPLETED is reachable directly when a campaign's window closed while it
+  // was still applying and there is nothing live to revert.
+  APPLYING: ["ACTIVE", "PARTIAL", "HELD", "COMPLETED", "CANCELLED"],
+  ACTIVE: ["REVERTING", "HELD", "PARTIAL", "APPLYING", "COMPLETED", "CANCELLED"],
+  // Held resolves when the merchant decides: adopt their price, or re-apply ours.
+  HELD: ["ACTIVE", "APPLYING", "REVERTING", "PARTIAL", "CANCELLED"],
+  REVERTING: ["COMPLETED", "PARTIAL", "CANCELLED"],
+  // Resume re-enters APPLYING; reverting a partial is also allowed, because prices
+  // may well be live for the rows that did succeed.
+  PARTIAL: ["APPLYING", "REVERTING", "ACTIVE", "COMPLETED", "HELD", "CANCELLED"],
+  COMPLETED: ["SCHEDULED", "APPLYING", "CANCELLED"],
+  CANCELLED: [],
+};
+
+/** States where prices this campaign wrote may be live on the storefront. */
+const PRICES_MAY_BE_LIVE: ReadonlySet<CampaignState> = new Set<CampaignState>([
+  "APPLYING",
+  "ACTIVE",
+  "HELD",
+  "REVERTING",
+  "PARTIAL",
+]);
+
+export function canTransition(from: CampaignState, to: CampaignState): boolean {
+  // Idempotence: asking for the state you are already in always succeeds and changes
+  // nothing. See the note at the top about duplicate ticks.
+  if (from === to) return true;
+  return LEGAL[from].includes(to);
+}
+
+/** Only CANCELLED is final. Everything else can still be resumed, reverted or re-armed. */
+export function isTerminal(state: CampaignState): boolean {
+  return LEGAL[state].length === 0;
+}
+
+/**
+ * States the merchant has to do something about.
+ *
+ * Used to sort these to the top of the campaign list. A partial run that nobody
+ * notices is indistinguishable from a successful one, which is the failure this
+ * product exists to prevent.
+ */
+export function needsAttention(state: CampaignState): boolean {
+  return state === "PARTIAL" || state === "HELD";
+}
+
+export function pricesMayBeLive(state: CampaignState): boolean {
+  return PRICES_MAY_BE_LIVE.has(state);
+}
+
+export type StateTone = "info" | "success" | "critical" | "neutral" | "warning";
+
+export interface StateDescription {
+  label: string;
+  tone: StateTone;
+  /** What this state actually means for the merchant's storefront, in plain words. */
+  explanation: string;
+  /** The one thing worth doing next, if there is one. */
+  nextAction?: { label: string; intent: "resume" | "revert" | "apply" | "drift" };
+}
+
+export function describeState(state: CampaignState): StateDescription {
+  switch (state) {
+    case "DRAFT":
+      return {
+        label: "Draft",
+        tone: "neutral",
+        explanation:
+          "Not running. Nothing has been written to your storefront, and nothing will be until you apply it.",
+        nextAction: { label: "Apply to storefront", intent: "apply" },
+      };
+    case "SCHEDULED":
+      return {
+        label: "Scheduled",
+        tone: "info",
+        explanation:
+          "Waiting for its start time. Prices change automatically when the window opens.",
+      };
+    case "APPLYING":
+      return {
+        label: "Applying",
+        tone: "info",
+        explanation: "Writing prices now. The ledger fills in as each row is verified.",
+      };
+    case "ACTIVE":
+      return {
+        label: "Active",
+        tone: "success",
+        explanation:
+          "Running, and every row was read back and verified. Your storefront shows the campaign price.",
+        nextAction: { label: "Revert", intent: "revert" },
+      };
+    case "HELD":
+      return {
+        label: "Held — price edited outside Anchor",
+        tone: "warning",
+        explanation:
+          "Someone changed a price this campaign controls, so the campaign stopped writing rather than overwrite a deliberate decision. Nothing has been lost; choose what should win.",
+        nextAction: { label: "Review the drift queue", intent: "drift" },
+      };
+    case "REVERTING":
+      return {
+        label: "Reverting",
+        tone: "info",
+        explanation:
+          "Recomputing each price without this campaign. Variants another campaign still covers keep that campaign's price.",
+      };
+    case "PARTIAL":
+      return {
+        label: "Partial — some rows did not complete",
+        tone: "critical",
+        explanation:
+          "Some prices were written and verified; others were not. The ledger names every row and why it stopped. Resuming retries only what is outstanding — rows already correct are left alone.",
+        nextAction: { label: "Resume", intent: "resume" },
+      };
+    case "COMPLETED":
+      return {
+        label: "Completed",
+        tone: "info",
+        explanation:
+          "Finished and reverted. Prices are back to what they would be without this campaign.",
+      };
+    case "CANCELLED":
+      return {
+        label: "Cancelled",
+        tone: "neutral",
+        explanation: "Stopped and will not run again.",
+      };
+  }
+}
+
+/** Every state, for exhaustive iteration in tests and pickers. */
+export const ALL_STATES: readonly CampaignState[] = Object.keys(LEGAL) as CampaignState[];

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -20,6 +20,12 @@ import { RunHistoryTable } from "../components/RunHistoryTable";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { reportError } from "../services/error-report.server";
 import { withGuard } from "../lib/errors/guard.server";
+import {
+  describeState,
+  needsAttention,
+  type CampaignState,
+} from "../lib/lifecycle/transitions";
+import { transitionHistory } from "../services/campaigns/lifecycle.server";
 
 export const loader = withGuard("/app/campaigns/$id", async ({ request, params }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -31,9 +37,18 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     campaignRuns(shop.id, campaignId),
     prisma.campaign.findFirstOrThrow({
       where: { id: campaignId, shopId: shop.id },
-      select: { schedule: true, autoEnroll: true, enrollPendingAt: true },
+      select: {
+        schedule: true,
+        autoEnroll: true,
+        enrollPendingAt: true,
+        status: true,
+      },
     }),
   ]);
+
+  const state = record.status as CampaignState;
+  const lifecycle = describeState(state);
+  const history = await transitionHistory(shop.id, campaignId, 8);
 
   const schedule = parseSchedule(record.schedule);
   const scheduleText = describeSchedule(schedule, shop.timezone);
@@ -55,6 +70,10 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     warnings,
     autoEnroll: record.autoEnroll,
     enrollPendingAt: record.enrollPendingAt !== null,
+    state,
+    lifecycle,
+    needsAttention: needsAttention(state),
+    history,
   };
 });
 
@@ -65,11 +84,15 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
   const reverting = intent === "revert";
 
   try {
+    // Resume is an ordinary apply. The resolver is idempotent, so rows already at the
+    // campaign price are planned as "already correct" and cost nothing — only the ones
+    // that failed last time are written again. A separate retry path would be a second
+    // implementation of the same thing, free to disagree with the first.
     const result = await runCampaign(shop.id, String(params.id), toAdminClient(admin), {
       revert: reverting,
     });
 
-    const verb = reverting ? "Reverted" : "Applied";
+    const verb = reverting ? "Reverted" : intent === "resume" ? "Resumed" : "Applied";
     return {
       ok: result.clean,
       message: result.clean
@@ -116,6 +139,9 @@ export default function CampaignDetail() {
     warnings,
     autoEnroll,
     enrollPendingAt,
+    lifecycle,
+    needsAttention: attention,
+    history,
   } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
@@ -131,6 +157,16 @@ export default function CampaignDetail() {
           {result.details.map((detail) => (
             <s-paragraph key={detail}>{detail}</s-paragraph>
           ))}
+        </s-banner>
+      ) : null}
+
+      {attention ? (
+        <s-banner tone={lifecycle.tone === "critical" ? "critical" : "warning"}>
+          <s-paragraph>{lifecycle.label}</s-paragraph>
+          <s-paragraph>{lifecycle.explanation}</s-paragraph>
+          {lifecycle.nextAction?.intent === "drift" ? (
+            <s-button href="/app/drift">{lifecycle.nextAction.label}</s-button>
+          ) : null}
         </s-banner>
       ) : null}
 
@@ -204,6 +240,15 @@ export default function CampaignDetail() {
             </s-button>
           </fetcher.Form>
 
+          {lifecycle.nextAction?.intent === "resume" ? (
+            <fetcher.Form method="post">
+              <input type="hidden" name="intent" value="resume" />
+              <s-button type="submit" variant="primary" loading={busy || undefined}>
+                Resume — retry the rows that did not complete
+              </s-button>
+            </fetcher.Form>
+          ) : null}
+
           <fetcher.Form method="post">
             <input type="hidden" name="intent" value="revert" />
             <s-button type="submit" tone="critical" loading={busy || undefined}>
@@ -247,8 +292,27 @@ export default function CampaignDetail() {
 
       <s-section slot="aside" heading="Status">
         <s-paragraph>
-          <s-badge>{preview.status}</s-badge>
+          <s-badge tone={lifecycle.tone}>{lifecycle.label}</s-badge>
         </s-paragraph>
+        <s-paragraph>
+          <s-text>{lifecycle.explanation}</s-text>
+        </s-paragraph>
+
+        {history.length > 0 ? (
+          <>
+            <s-divider />
+            <s-paragraph>
+              <s-text>How it got here</s-text>
+            </s-paragraph>
+            {history.map((entry) => (
+              <s-paragraph key={`${entry.at}-${entry.to}`}>
+                <s-text>
+                  {entry.from} → {entry.to} · {entry.reason || entry.actor}
+                </s-text>
+              </s-paragraph>
+            ))}
+          </>
+        ) : null}
       </s-section>
     </s-page>
   );

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -7,6 +7,11 @@ import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import {
+  describeState,
+  needsAttention,
+  type CampaignState,
+} from "../lib/lifecycle/transitions";
 
 export const loader = withGuard("/app/campaigns", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -20,11 +25,14 @@ export const loader = withGuard("/app/campaigns", async ({ request }: LoaderFunc
     },
   });
 
-  return {
-    campaigns: campaigns.map((c) => ({
+  const rows = campaigns.map((c) => {
+    const state = c.status as CampaignState;
+    return {
       id: c.id,
       name: c.name,
-      status: c.status,
+      state,
+      lifecycle: describeState(state),
+      attention: needsAttention(state),
       priority: c.priority,
       createdAt: c.createdAt.toISOString(),
       lastRun: c.runs[0]
@@ -35,25 +43,35 @@ export const loader = withGuard("/app/campaigns", async ({ request }: LoaderFunc
             failed: c.runs[0].failedRows,
           }
         : null,
-    })),
-  };
+    };
+  });
+
+  // Anything needing a decision sorts to the top. A partial run buried on page two is
+  // functionally the same as not reporting it at all.
+  rows.sort((a, b) => Number(b.attention) - Number(a.attention));
+
+  return { campaigns: rows, attentionCount: rows.filter((r) => r.attention).length };
 });
 
-type Tone = "info" | "success" | "critical" | "neutral" | "warning" | "caution" | "auto";
-
-const STATUS_TONE: Record<string, Tone> = {
-  DRAFT: "neutral",
-  ACTIVE: "success",
-  PARTIAL: "warning",
-  COMPLETED: "info",
-  HELD: "warning",
-};
+// Tone and wording come from the state machine, so the list and the detail page can
+// never describe the same campaign differently. PARTIAL reads "critical" here for the
+// same reason it does there: a partial run that looks like a warning gets ignored.
 
 export default function CampaignList() {
-  const { campaigns } = useLoaderData<typeof loader>();
+  const { campaigns, attentionCount } = useLoaderData<typeof loader>();
 
   return (
     <s-page heading="Campaigns">
+      {attentionCount > 0 ? (
+        <s-banner tone="warning">
+          <s-paragraph>
+            {attentionCount === 1
+              ? "One campaign needs a decision — it is listed first below."
+              : `${attentionCount} campaigns need a decision — they are listed first below.`}
+          </s-paragraph>
+        </s-banner>
+      ) : null}
+
       <s-section>
         <s-stack direction="inline" gap="base">
           <s-link href="/app/campaigns/new">
@@ -81,8 +99,8 @@ export default function CampaignList() {
                 <s-table-row key={campaign.id}>
                   <s-table-cell>{campaign.name}</s-table-cell>
                   <s-table-cell>
-                    <s-badge tone={STATUS_TONE[campaign.status] ?? "neutral"}>
-                      {campaign.status}
+                    <s-badge tone={campaign.lifecycle.tone}>
+                      {campaign.lifecycle.label}
                     </s-badge>
                   </s-table-cell>
                   <s-table-cell>{campaign.priority}</s-table-cell>

--- a/app/services/admin-client.server.ts
+++ b/app/services/admin-client.server.ts
@@ -24,20 +24,52 @@ export function toAdminClient(admin: ShopifyAdminContext): AdminClient {
       const body = (await response.json()) as {
         data?: T;
         extensions?: { cost?: QueryCost };
-        errors?: Array<{ message: string }>;
+        errors?: unknown;
       };
 
       // Top-level GraphQL errors are transport-level failures, distinct from the
       // per-row `userErrors` the executors map back to individual variants.
-      if (body.errors?.length) {
-        throw new Error(body.errors.map((e) => e.message).join("; "));
-      }
+      const message = formatGraphQLErrors(body.errors);
+      if (message) throw new Error(message);
 
       return { data: body.data, extensions: body.extensions };
     },
   };
 }
 
+
+/**
+ * Renders whatever Shopify put in `errors` as a single message.
+ *
+ * The shape is not consistent. Field-level failures come back as the array the spec
+ * describes, but request-level ones -- a malformed query, a throttle -- arrive as a
+ * bare object such as `{"query": "Throttled"}`. Assuming an array turned every one of
+ * those into `body.errors.map is not a function`, which replaced the real cause with
+ * a TypeError from inside our own client at precisely the moment we needed to know
+ * what Shopify actually said.
+ */
+function formatGraphQLErrors(errors: unknown): string | null {
+  if (!errors) return null;
+
+  if (Array.isArray(errors)) {
+    if (errors.length === 0) return null;
+    return errors
+      .map((entry) => (entry as { message?: string })?.message ?? JSON.stringify(entry))
+      .join("; ");
+  }
+
+  if (typeof errors === "string") return errors;
+
+  if (typeof errors === "object") {
+    const entries = Object.entries(errors as Record<string, unknown>);
+    if (entries.length === 0) return null;
+    return entries
+      .map(([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`)
+      .join("; ");
+  }
+
+  return String(errors);
+}
 
 /**
  * Builds a client for a shop from its stored offline session.
@@ -49,8 +81,19 @@ export function toAdminClient(admin: ShopifyAdminContext): AdminClient {
 export async function adminClientForShop(shopDomain: string): Promise<AdminClient | null> {
   const { default: prisma } = await import("../db.server");
 
+  // Offline sessions first: they are the ones that outlive a browser tab, which is the
+  // whole point for a worker with no request to authenticate. An expired token is
+  // filtered out rather than used, because Shopify answers a dead token with
+  // "Invalid API key or access token" -- which reads like a misconfigured app and
+  // sends you looking in entirely the wrong place. Returning null instead surfaces as
+  // NO_SESSION: "reinstall the app", which is the actual remedy.
   const session = await prisma.session.findFirst({
-    where: { shop: shopDomain, accessToken: { not: "" } },
+    where: {
+      shop: shopDomain,
+      accessToken: { not: "" },
+      OR: [{ expires: null }, { expires: { gt: new Date() } }],
+    },
+    orderBy: [{ isOnline: "asc" }, { expires: "desc" }],
   });
   if (!session?.accessToken) return null;
 

--- a/app/services/campaigns/lifecycle.server.ts
+++ b/app/services/campaigns/lifecycle.server.ts
@@ -1,0 +1,177 @@
+/**
+ * The only place a campaign's status changes.
+ *
+ * Status was previously written inline wherever a run finished, which meant nothing
+ * enforced the state machine and nothing recorded who moved what. Two problems with
+ * that, both real:
+ *
+ *   A run finishing late could overwrite a newer state -- a revert that started while
+ *   an apply was still settling would flip ACTIVE back on after the revert completed.
+ *
+ *   When a campaign was found in a surprising state, there was no way to find out how
+ *   it got there.
+ *
+ * The update is conditional on the current state being one this transition is legal
+ * from, so it doubles as the claim: two workers racing on the same transition, one
+ * wins, and the loser sees `changed: false` rather than corrupting the sequence.
+ */
+
+import prisma from "../../db.server";
+import {
+  canTransition,
+  describeState,
+  type CampaignState,
+} from "../../lib/lifecycle/transitions";
+import { AppError } from "../../lib/errors/app-error";
+import { logger } from "../../lib/logging/logger";
+
+export interface TransitionResult {
+  changed: boolean;
+  from: CampaignState;
+  to: CampaignState;
+}
+
+export interface TransitionOptions {
+  /** Why, for the audit trail. "scheduler: window opened", "merchant clicked resume". */
+  reason: string;
+  actor?: string;
+  runId?: string;
+}
+
+/**
+ * Moves a campaign to `to`, if that is legal from where it currently is.
+ *
+ * Returns `changed: false` rather than throwing when the campaign has already moved
+ * on -- a duplicate tick is expected, not exceptional. Throws only when the requested
+ * transition is illegal from the *current* state, which is a bug worth surfacing.
+ */
+export async function transitionCampaign(
+  shopId: string,
+  campaignId: string,
+  to: CampaignState,
+  options: TransitionOptions,
+): Promise<TransitionResult> {
+  const campaign = await prisma.campaign.findFirstOrThrow({
+    where: { id: campaignId, shopId },
+    select: { status: true },
+  });
+
+  const from = campaign.status as CampaignState;
+
+  if (from === to) {
+    // Already there. Idempotent by design: see the note about duplicate ticks in
+    // lib/lifecycle/transitions.ts.
+    return { changed: false, from, to };
+  }
+
+  if (!canTransition(from, to)) {
+    throw new AppError({
+      code: "VALIDATION",
+      userMessage: `This campaign is ${describeState(from).label.toLowerCase()}, so that action does not apply to it. Reload the page to see its current state.`,
+      context: { campaignId, from, to, reason: options.reason },
+    });
+  }
+
+  // Conditional on `from`, so a concurrent transition cannot be clobbered: whoever
+  // reads the old state first wins, and the other sees changed: false.
+  const updated = await prisma.campaign.updateMany({
+    where: { id: campaignId, shopId, status: from },
+    data: { status: to },
+  });
+
+  if (updated.count === 0) return { changed: false, from, to };
+
+  await recordTransition(shopId, campaignId, from, to, options);
+
+  return { changed: true, from, to };
+}
+
+/**
+ * Records the move.
+ *
+ * Deliberately after the update and deliberately not fatal: losing the audit row is
+ * bad, but failing the transition because its bookkeeping failed would leave the
+ * campaign stuck mid-run, which is worse.
+ */
+async function recordTransition(
+  shopId: string,
+  campaignId: string,
+  from: CampaignState,
+  to: CampaignState,
+  options: TransitionOptions,
+): Promise<void> {
+  logger.info("campaign transition", {
+    campaignId,
+    from,
+    to,
+    reason: options.reason,
+    runId: options.runId,
+  });
+
+  try {
+    await prisma.auditLogEntry.create({
+      data: {
+        shopId,
+        actor: options.actor ?? "system",
+        action: "campaign.transition",
+        entity: "Campaign",
+        entityId: campaignId,
+        before: { status: from } as never,
+        after: { status: to, reason: options.reason, runId: options.runId } as never,
+      },
+    });
+  } catch (error) {
+    logger.warn("could not record campaign transition", {
+      campaignId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** The state history of one campaign, newest first, for the detail page. */
+export async function transitionHistory(shopId: string, campaignId: string, limit = 20) {
+  const entries = await prisma.auditLogEntry.findMany({
+    where: { shopId, action: "campaign.transition", entityId: campaignId },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+
+  return entries.map((entry) => {
+    const before = entry.before as { status?: string } | null;
+    const after = entry.after as { status?: string; reason?: string } | null;
+    return {
+      at: entry.createdAt.toISOString(),
+      from: (before?.status ?? "—") as string,
+      to: (after?.status ?? "—") as string,
+      reason: after?.reason ?? "",
+      actor: entry.actor ?? "system",
+    };
+  });
+}
+
+/**
+ * Puts a campaign on hold because a price it controls was edited elsewhere.
+ *
+ * Held rather than "keep writing": overwriting would undo a deliberate human
+ * decision, and the merchant is the one who should choose which price wins.
+ */
+export async function holdForDrift(
+  shopId: string,
+  campaignId: string,
+  variantGid: string,
+): Promise<TransitionResult | null> {
+  const campaign = await prisma.campaign.findFirst({
+    where: { id: campaignId, shopId },
+    select: { status: true },
+  });
+  if (!campaign) return null;
+
+  // Only a running campaign can be held. Holding one that already finished would
+  // raise an alarm about a price nobody is maintaining any more.
+  if (campaign.status !== "ACTIVE" && campaign.status !== "PARTIAL") return null;
+
+  return transitionCampaign(shopId, campaignId, "HELD", {
+    reason: `price edited outside Anchor on ${variantGid}`,
+    actor: "drift-detector",
+  });
+}

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -19,6 +19,7 @@ import { loadCandidates, productMapFor } from "./candidates.server";
 import { loadCampaignContext } from "./model.server";
 import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
+import { transitionCampaign } from "./lifecycle.server";
 
 export interface RunOptions {
   revert?: boolean;
@@ -115,9 +116,20 @@ export async function runCampaign(
     },
   });
 
-  await prisma.campaign.update({
-    where: { id: campaignId },
-    data: { status: options.revert ? "COMPLETED" : result.clean ? "ACTIVE" : "PARTIAL" },
+  // Through the state machine, not a direct write: it enforces which moves are legal
+  // and records how the campaign got here. A run that finishes late must not clobber a
+  // newer state, which a bare update would happily do.
+  const finalState = options.revert
+    ? result.clean
+      ? "COMPLETED"
+      : "PARTIAL"
+    : result.clean
+      ? "ACTIVE"
+      : "PARTIAL";
+
+  await transitionCampaign(shopId, campaignId, finalState, {
+    reason: `${options.revert ? "revert" : "apply"} finished: ${result.verified} verified, ${result.failed} failed`,
+    runId: run.id,
   });
 
   await refreshMirror(shopId, result.rows);

--- a/app/services/drift.server.ts
+++ b/app/services/drift.server.ts
@@ -21,6 +21,7 @@ import { createHash } from "node:crypto";
 
 import prisma from "../db.server";
 import { formatMinorUnits } from "../lib/money/format";
+import { holdForDrift } from "./campaigns/lifecycle.server";
 
 /** How long a write intent stays valid. Generous: webhook delivery is not instant. */
 const INTENT_TTL_MS = 15 * 60 * 1000;
@@ -129,6 +130,7 @@ export async function checkForDrift(
       where: { id: existing.id },
       data: { observedPrice: incomingPrice, detectedAt: new Date() },
     });
+    await holdForDrift(shopId, activeCampaign.id, variantGid);
     return true;
   }
 
@@ -145,6 +147,10 @@ export async function checkForDrift(
       resolution: "PENDING",
     },
   });
+
+  // Hold the campaign as well as recording the event. Recording alone would leave the
+  // campaign looking healthy while it quietly stopped controlling one of its prices.
+  await holdForDrift(shopId, activeCampaign.id, variantGid);
 
   return true;
 }

--- a/scripts/test-lifecycle.ts
+++ b/scripts/test-lifecycle.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env tsx
+/**
+ * End-to-end check of the campaign state machine, against the real store.
+ *
+ * Covers the three things the ticket says must be true and that a unit test cannot
+ * prove on its own: a real price edit outside Anchor holds the campaign, a partial
+ * run resumes to a clean state, and an illegal transition is refused rather than
+ * silently applied.
+ *
+ *   npx tsx scripts/test-lifecycle.ts
+ */
+
+import prisma from "../app/db.server";
+import { adminClientForShop } from "../app/services/admin-client.server";
+import { createCampaign } from "../app/services/campaigns/model.server";
+import { runCampaign } from "../app/services/campaigns/run.server";
+import {
+  transitionCampaign,
+  transitionHistory,
+} from "../app/services/campaigns/lifecycle.server";
+import { checkForDrift } from "../app/services/drift.server";
+import { captureBaselines } from "../app/services/baselines.server";
+
+const TAG = "anchor-lifecycle-test";
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = actual === expected;
+  if (!ok) failures++;
+  console.log(`   ${ok ? "PASS" : "FAIL"}  ${label}: ${actual}${ok ? "" : ` (expected ${expected})`}`);
+}
+
+async function main() {
+  const shop = await prisma.shop.findFirst({ where: { uninstalledAt: null } });
+  if (!shop) throw new Error("No installed shop");
+  const client = await adminClientForShop(shop.domain);
+  if (!client) throw new Error("No usable session");
+
+  const product = await createProduct(client);
+  console.log(`shop: ${shop.domain}\nprobe: ${product.productGid} at 200.00\n`);
+
+  // The webhook mirrors it; wait so a baseline exists to price from.
+  const mirrored = await waitFor(async () => {
+    const row = await prisma.variantIndex.findUnique({
+      where: { shopId_variantGid: { shopId: shop.id, variantGid: product.variantGid } },
+    });
+    return row ?? null;
+  }, 60_000);
+  if (!mirrored) throw new Error("webhook never mirrored the probe product");
+
+  // Without a baseline the campaign has nothing to compute from, so the run would
+  // plan zero rows and reach ACTIVE having written nothing -- which would make the
+  // resume check below pass vacuously.
+  await captureBaselines(shop.id, {
+    variantGids: [product.variantGid],
+    source: "INSTALL_CAPTURE",
+  });
+
+  const campaign = await createCampaign(shop.id, {
+    name: `Lifecycle test ${Date.now()}`,
+    priority: 950,
+    rule: { kind: "percent-change", percent: -25 },
+    compareAtPolicy: { kind: "leave" },
+    rounding: "none",
+    ast: { groups: [{ conditions: [{ field: "tag", value: TAG }] }] },
+    schedule: { kind: "manual" },
+  });
+
+  // ------------------------------------------------- 1. apply → ACTIVE
+  console.log("1. apply");
+  await transitionCampaign(shop.id, campaign.id, "APPLYING", { reason: "test: apply" });
+  await runCampaign(shop.id, campaign.id, client, {});
+  check("state after a clean run", await stateOf(campaign.id), "ACTIVE");
+  check("the run actually wrote a row", await verifiedRows(campaign.id) > 0, true);
+
+  // ------------------------------------------- 2. a real edit outside Anchor
+  console.log("2. merchant edits the price in Shopify");
+  await setPrice(client, product.variantGid, "111.11");
+  // checkForDrift is what the products webhook calls before overwriting the mirror.
+  const drifted = await checkForDrift(shop.id, product.variantGid, 11111n, null);
+  check("drift detected", drifted, true);
+  check("campaign held", await stateOf(campaign.id), "HELD");
+
+  // ------------------------------------------------ 3. illegal transition
+  console.log("3. illegal transition is refused");
+  await transitionCampaign(shop.id, campaign.id, "CANCELLED", { reason: "test" });
+  let refused = false;
+  try {
+    await transitionCampaign(shop.id, campaign.id, "ACTIVE", { reason: "test: illegal" });
+  } catch {
+    refused = true;
+  }
+  check("cancelled → active refused", refused, true);
+  check("still cancelled", await stateOf(campaign.id), "CANCELLED");
+
+  // ---------------------------------------------------- 4. resume a partial
+  console.log("4. resume from partial");
+  await prisma.campaign.update({ where: { id: campaign.id }, data: { status: "PARTIAL" } });
+  await transitionCampaign(shop.id, campaign.id, "APPLYING", { reason: "test: resume" });
+  await runCampaign(shop.id, campaign.id, client, {});
+  check("resume reaches a clean state", await stateOf(campaign.id), "ACTIVE");
+
+  // -------------------------------------------------------- 5. idempotence
+  console.log("5. duplicate transition is a no-op, not an error");
+  const again = await transitionCampaign(shop.id, campaign.id, "ACTIVE", {
+    reason: "test: duplicate tick",
+  });
+  check("second identical transition changed nothing", again.changed, false);
+
+  // ------------------------------------------------------- 6. audit trail
+  const history = await transitionHistory(shop.id, campaign.id, 20);
+  console.log(`6. audit trail has ${history.length} entries:`);
+  for (const entry of history.slice(0, 6)) {
+    console.log(`     ${entry.from} → ${entry.to} · ${entry.reason}`);
+  }
+  check("transitions were recorded", history.length > 0, true);
+
+  // ------------------------------------------------------------- cleanup
+  await runCampaign(shop.id, campaign.id, client, { revert: true }).catch(() => {});
+  await prisma.driftEvent.deleteMany({ where: { variantGid: product.variantGid } });
+  await prisma.campaign.delete({ where: { id: campaign.id } });
+  await client.request(
+    `mutation D($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
+    { input: { id: product.productGid } },
+  );
+  console.log("\ncleaned up");
+
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+async function verifiedRows(campaignId: string): Promise<number> {
+  const run = await prisma.campaignRun.findFirst({
+    where: { campaignId, kind: "APPLY" },
+    orderBy: { createdAt: "desc" },
+    select: { verifiedRows: true },
+  });
+  return run?.verifiedRows ?? 0;
+}
+
+async function stateOf(campaignId: string): Promise<string> {
+  const row = await prisma.campaign.findUniqueOrThrow({
+    where: { id: campaignId },
+    select: { status: true },
+  });
+  return row.status;
+}
+
+async function createProduct(client: NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>) {
+  const result = await client.request(
+    `mutation Create($input: ProductSetInput!) {
+       productSet(synchronous: true, input: $input) {
+         product { id variants(first: 1) { nodes { id } } }
+         userErrors { message }
+       }
+     }`,
+    {
+      input: {
+        title: `Lifecycle probe ${Date.now()}`,
+        status: "ACTIVE",
+        tags: [TAG],
+        productOptions: [{ name: "Size", values: [{ name: "M" }] }],
+        variants: [{ optionValues: [{ optionName: "Size", name: "M" }], price: "200.00" }],
+      },
+    },
+  );
+
+  const body = result as {
+    data: { productSet: { product: { id: string; variants: { nodes: Array<{ id: string }> } } } };
+  };
+  return {
+    productGid: body.data.productSet.product.id,
+    variantGid: body.data.productSet.product.variants.nodes[0].id,
+  };
+}
+
+async function setPrice(
+  client: NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>,
+  variantGid: string,
+  price: string,
+) {
+  const owner = await prisma.variantIndex.findFirstOrThrow({
+    where: { variantGid },
+    select: { productGid: true },
+  });
+
+  await client.request(
+    `mutation Update($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+       productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+         userErrors { message }
+       }
+     }`,
+    { productId: owner.productGid, variants: [{ id: variantGid, price }] },
+  );
+}
+
+async function waitFor<T>(probe: () => Promise<T | null>, timeoutMs: number): Promise<T | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await probe();
+    if (value) return value;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  return null;
+}
+
+main()
+  .catch((error) => {
+    console.error("\nERROR:", error);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
Closes #148.

Status was written inline wherever a run happened to finish, so nothing enforced the state machine and nothing recorded how a campaign reached the state it was in. A revert that started while an apply was still settling could flip `ACTIVE` back on after the revert completed.

## The graph, pure and tested

`app/lib/lifecycle/transitions.ts` holds the machine. Self-transitions are legal **on purpose** — a redelivered scheduler tick asking for a state we already hold must be a no-op, not a failure (the ticket's idempotency criterion). `CANCELLED` is the only terminal state; `COMPLETED → SCHEDULED` is what lets recurrence reuse one campaign instead of cloning it.

`transitionCampaign` is now the only writer, and its update is conditional on the current state — so it doubles as the claim. Two workers racing on the same transition: one wins, the loser gets `changed: false` rather than corrupting the sequence. Every move is audit-logged with a reason, so "how did it get here" has an answer.

## PARTIAL and HELD are not styled away

Both sort to the top of the campaign list behind a count, both get a banner naming what happened and what to do. `PARTIAL` gets a working **Resume**; `HELD` links to the drift queue. A test asserts `ACTIVE` is the *only* state rendered with a success tone.

Resume is deliberately an ordinary apply. The resolver is idempotent, so rows already at the campaign price are planned as "already correct" and cost nothing — only the outstanding ones are rewritten. A separate retry path would be a second implementation of the same thing, free to disagree with the first.

Drift now holds the campaign it belongs to. Recording the event alone left the campaign looking healthy while it had quietly stopped controlling one of its prices.

## Two production bugs fell out of testing this

**`admin-client` assumed GraphQL `errors` is always an array.** Shopify returns a bare object for request-level failures, so every one surfaced as `body.errors.map is not a function` — our own TypeError replacing whatever Shopify actually said. Fixing it immediately revealed the real message underneath.

**`adminClientForShop` never checked `expires`.** An expired offline session was used anyway, and Shopify answers a dead token with *"Invalid API key or access token"* — which reads like a misconfigured app and sends you looking in entirely the wrong place. Expired sessions are filtered out now, surfacing as `NO_SESSION`: reinstall the app.

## Verified against the live store

```
1. apply
   PASS  state after a clean run: ACTIVE
   PASS  the run actually wrote a row: true
2. merchant edits the price in Shopify
   PASS  drift detected: true
   PASS  campaign held: HELD
3. illegal transition is refused
   PASS  cancelled → active refused: true
   PASS  still cancelled: CANCELLED
4. resume from partial
   PASS  resume reaches a clean state: ACTIVE
5. duplicate transition is a no-op, not an error
   PASS  second identical transition changed nothing: false
6. audit trail has 6 entries:
     APPLYING → ACTIVE · apply finished: 1 verified, 0 failed
     PARTIAL → APPLYING · test: resume
     HELD → CANCELLED · test
     ACTIVE → HELD · price edited outside Anchor on gid://.../46173036445930
     APPLYING → ACTIVE · apply finished: 1 verified, 0 failed
     DRAFT → APPLYING · test: apply
```

The first run of that test passed with "0 verified" — the probe had no baseline, so the run wrote nothing and reached ACTIVE vacuously. The test now captures a baseline first and asserts a row was genuinely written, which is what makes the resume check mean anything.

## Not included

**Live progress with chunks done/total and an ETA** is the one acceptance criterion left open — it needs a progress channel from the executor to the page, which is a larger piece than the rest of this ticket. Everything else in the list is done.

232 tests, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)