### PR TITLE
P2.6 — Retry policy, poison-row quarantine and run resumption

### DIFF
--- a/app/lib/execution/classify.ts
+++ b/app/lib/execution/classify.ts
@@ -1,0 +1,214 @@
+/**
+ * Deciding what a failure means, per RFC §11.
+ *
+ * Four classes, because they have four different remedies and conflating any two of
+ * them produces a specific, known failure:
+ *
+ *   RETRYABLE    Throttles, timeouts, 5xx. Back off and try again; these succeed.
+ *   TERMINAL_ROW This one variant will never succeed -- deleted, or rejected for a
+ *                reason specific to it. Quarantine it and *keep going*. One poison
+ *                row must never hold 149,999 others hostage.
+ *   TERMINAL_RUN Nothing will succeed: the token was revoked, the plan gate closed.
+ *                Retrying is a rate-limit-consuming way of failing 150,000 times.
+ *   USER_FIXABLE The merchant can resolve it -- a price below cost, an invalid
+ *                compare-at. Retrying identical input is pointless; say what to fix.
+ *
+ * The reason is machine-readable as well as human-readable, so the UI can group
+ * "these 40 rows failed for the same reason" rather than printing 40 sentences.
+ */
+
+export type FailureClass = "RETRYABLE" | "TERMINAL_ROW" | "TERMINAL_RUN" | "USER_FIXABLE";
+
+export type FailureReason =
+  | "throttled"
+  | "network"
+  | "shopify-internal"
+  | "variant-deleted"
+  | "variant-invalid"
+  | "price-rejected"
+  | "compare-at-invalid"
+  | "auth-revoked"
+  | "plan-gate"
+  | "below-cost"
+  | "unknown";
+
+export interface Classification {
+  class: FailureClass;
+  reason: FailureReason;
+  /** Shown per row in the ledger. Names the object, the cause and the next action. */
+  message: string;
+}
+
+export function isRetryable(classification: Classification): boolean {
+  return classification.class === "RETRYABLE";
+}
+
+/**
+ * Classifies whatever Shopify or the transport gave us.
+ *
+ * Takes the message text because that is genuinely all Shopify offers for
+ * `userErrors` -- there is no stable code on them. Doing the matching in one tested
+ * place keeps the guesswork auditable instead of scattering it through the executor.
+ */
+export function classifyFailure(error: unknown): Classification {
+  const text = messageOf(error).toLowerCase();
+
+  // A variant deleted while the run was in flight is not a failure -- the merchant
+  // deleted it, and reporting it as an error trains people to ignore errors (E4).
+  if (
+    text.includes("does not exist") ||
+    text.includes("was not found") ||
+    text.includes("not found") ||
+    text.includes("has been deleted")
+  ) {
+    return {
+      class: "TERMINAL_ROW",
+      reason: "variant-deleted",
+      message:
+        "This variant no longer exists in Shopify — it was deleted while the run was in progress. Nothing was written for it.",
+    };
+  }
+
+  if (text.includes("throttled") || (text.includes("rate") && text.includes("limit"))) {
+    return {
+      class: "RETRYABLE",
+      reason: "throttled",
+      message: "Shopify rate-limited this write. It will be retried automatically.",
+    };
+  }
+
+  if (
+    text.includes("fetch failed") ||
+    text.includes("econnreset") ||
+    text.includes("econnrefused") ||
+    text.includes("etimedout") ||
+    text.includes("socket hang up") ||
+    text.includes("timeout")
+  ) {
+    return {
+      class: "RETRYABLE",
+      reason: "network",
+      message: "The connection to Shopify failed. It will be retried automatically.",
+    };
+  }
+
+  if (
+    text.includes("internal error") ||
+    text.includes("service unavailable") ||
+    text.includes("502") ||
+    text.includes("503")
+  ) {
+    return {
+      class: "RETRYABLE",
+      reason: "shopify-internal",
+      message: "Shopify returned an internal error. It will be retried automatically.",
+    };
+  }
+
+  // Auth and plan gates fail every remaining row identically, so stopping the run is
+  // the kind thing to do -- it leaves the ledger honest instead of 150,000 identical
+  // failures.
+  if (
+    text.includes("access denied") ||
+    text.includes("unauthorized") ||
+    text.includes("invalid api key") ||
+    text.includes("access token")
+  ) {
+    return {
+      class: "TERMINAL_RUN",
+      reason: "auth-revoked",
+      message:
+        "The app's access to this store was revoked or expired. Reinstall the app, then resume this run — rows already written are untouched.",
+    };
+  }
+
+  if (text.includes("not available on your plan") || text.includes("plan does not")) {
+    return {
+      class: "TERMINAL_RUN",
+      reason: "plan-gate",
+      message:
+        "This store's Shopify plan does not allow this operation. The run stopped; nothing further was written.",
+    };
+  }
+
+  if (text.includes("compare at") || text.includes("compare_at")) {
+    return {
+      class: "USER_FIXABLE",
+      reason: "compare-at-invalid",
+      message:
+        "Shopify rejected the compare-at price for this variant — it must be above the selling price. Adjust the campaign's compare-at rule and run it again.",
+    };
+  }
+
+  if (text.includes("below cost") || text.includes("cost")) {
+    return {
+      class: "USER_FIXABLE",
+      reason: "below-cost",
+      message:
+        "This price would fall below the variant's cost. Change the guardrail in Settings or exclude the variant, then run it again.",
+    };
+  }
+
+  if (
+    text.includes("price") &&
+    (text.includes("invalid") || text.includes("must be") || text.includes("greater"))
+  ) {
+    return {
+      class: "USER_FIXABLE",
+      reason: "price-rejected",
+      message:
+        "Shopify rejected the price for this variant as invalid. Check the campaign's rule and rounding, then run it again.",
+    };
+  }
+
+  if (text.includes("invalid") || text.includes("cannot be")) {
+    return {
+      class: "TERMINAL_ROW",
+      reason: "variant-invalid",
+      message:
+        "Shopify rejected this variant for a reason specific to it. The rest of the run continued; see the message in the ledger.",
+    };
+  }
+
+  // Unknown failures are retried rather than quarantined. Retrying something terminal
+  // wastes a few attempts; quarantining something transient silently drops a price
+  // change the merchant asked for, which is far worse.
+  return {
+    class: "RETRYABLE",
+    reason: "unknown",
+    message: "This write failed for an unrecognised reason and will be retried.",
+  };
+}
+
+/** True when the whole run should stop rather than work through every remaining row. */
+export function stopsTheRun(classification: Classification): boolean {
+  return classification.class === "TERMINAL_RUN";
+}
+
+/**
+ * Whether a row that has failed this many times should be quarantined.
+ *
+ * Only RETRYABLE rows get attempts at all -- there is no point spending five on a
+ * variant that has been deleted.
+ */
+export function shouldQuarantine(
+  classification: Classification,
+  attempt: number,
+  maxAttempts = MAX_ATTEMPTS,
+): boolean {
+  if (classification.class === "TERMINAL_RUN") return false;
+  if (classification.class !== "RETRYABLE") return true;
+  return attempt >= maxAttempts;
+}
+
+export const MAX_ATTEMPTS = 5;
+
+function messageOf(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(error ?? "");
+}

--- a/app/lib/execution/interrupted-run.test.ts
+++ b/app/lib/execution/interrupted-run.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The resume-equivalence test the ticket asks for (E2), driven through the real
+ * executor rather than a model of it.
+ *
+ * A planner-level simulation can only prove the planner converges. This kills an
+ * actual `executeSync` partway through -- the client starts throwing after N writes,
+ * exactly as a deploy or a dropped connection would -- then resumes from the ledger
+ * that first pass produced and compares the final state, row by row and price by
+ * price, against a run that was never interrupted.
+ */
+
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { money } from "../money/money";
+import type { PlannedRow, SurfaceRef } from "../planning/types";
+import { RateLimitBudget } from "../shopify/budget";
+import { executeSync, type AdminClient, type ExecutedRow } from "./sync-executor";
+import { planResume, stateChecksum, type LedgerState, type PriorRow } from "./resume";
+
+const noSleep = async () => {};
+const budget = () => new RateLimitBudget({ now: () => 0, sleep: noSleep });
+
+const ref = (variantGid: string): SurfaceRef => ({
+  variantGid,
+  surfaceKind: "base",
+  priceListGid: "",
+  currency: "USD",
+});
+
+/** Ten variants per product, so a cut lands mid-product as it would in reality. */
+const productOf = (gid: string) => {
+  const index = Number(gid.split("/").pop());
+  return `gid://shopify/Product/${Math.floor(index / 10)}`;
+};
+
+function plannedRows(count: number): PlannedRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    ref: ref(`gid://shopify/ProductVariant/${i}`),
+    beforePrice: money(10_000, "USD"),
+    // A distinct price per row, so a checksum mismatch localises to a variant.
+    intendedPrice: money(9_000 - i, "USD"),
+    intendedCompareAtSet: false,
+    status: "pending" as const,
+  })) as unknown as PlannedRow[];
+}
+
+/**
+ * A client that serves `writesBeforeFailure` variant writes and then refuses.
+ *
+ * `written` persists across instances when shared, which is what lets the second pass
+ * read back prices the first pass actually wrote -- the whole point of the test.
+ */
+function interruptibleClient(
+  written: Map<string, string>,
+  writesBeforeFailure = Infinity,
+): AdminClient {
+  let writes = 0;
+
+  return {
+    async request<T>(query: string, variables: Record<string, unknown>) {
+      if (query.includes("productVariantsBulkUpdate")) {
+        const variants = variables.variants as Array<{ id: string; price?: string }>;
+
+        if (writes + variants.length > writesBeforeFailure) {
+          throw new Error("fetch failed");
+        }
+        writes += variants.length;
+
+        for (const v of variants) if (v.price) written.set(v.id, v.price);
+
+        return {
+          data: {
+            productVariantsBulkUpdate: {
+              productVariants: variants.map((v) => ({
+                id: v.id,
+                price: v.price ?? "0",
+                compareAtPrice: null,
+              })),
+              userErrors: [],
+            },
+          } as T,
+          extensions: {
+            cost: {
+              actualQueryCost: 100,
+              throttleStatus: {
+                maximumAvailable: 1_000,
+                currentlyAvailable: 900,
+                restoreRate: 50,
+              },
+            },
+          },
+        };
+      }
+
+      // Read-back reflects what was genuinely written, including nothing.
+      const ids = variables.ids as string[];
+      return {
+        data: {
+          nodes: ids.map((id) => ({
+            id,
+            price: written.get(id) ?? "0",
+            compareAtPrice: null,
+          })),
+        } as T,
+      };
+    },
+  };
+}
+
+function toPrior(rows: ExecutedRow[]): PriorRow[] {
+  return rows.map((executed) => ({
+    variantGid: executed.row.ref.variantGid,
+    status: (executed.status === "verified"
+      ? "VERIFIED"
+      : executed.status === "failed"
+        ? "FAILED"
+        : "APPLIED") as LedgerState,
+    attempt: 1,
+  }));
+}
+
+/** Fingerprints the live store, not the ledger: what a shopper would actually see. */
+function storeChecksum(written: Map<string, string>): string {
+  return stateChecksum(
+    [...written.entries()].map(([variantGid, price]) => ({
+      variantGid,
+      status: "VERIFIED" as LedgerState,
+      price: Number(price.replace(".", "")),
+    })),
+  );
+}
+
+async function run(rows: PlannedRow[], client: AdminClient) {
+  return executeSync(rows, {
+    client,
+    budget: budget(),
+    productOf,
+    // Verify everything: the test is about convergence, and sampling would make the
+    // comparison depend on which rows happened to be read back.
+    verifySampleRate: 1,
+    sleep: noSleep,
+    random: () => 0,
+  });
+}
+
+describe("a run killed partway resumes to the same state", () => {
+  it("reaches an identical store after being cut at 40%", async () => {
+    const planned = plannedRows(50);
+
+    const cleanStore = new Map<string, string>();
+    const clean = await run(planned, interruptibleClient(cleanStore));
+    expect(clean.verified).toBe(50);
+
+    // Interrupted at 40%, then resumed against the same store.
+    const resumedStore = new Map<string, string>();
+    const firstPass = await run(planned, interruptibleClient(resumedStore, 20));
+    expect(firstPass.verified).toBeGreaterThan(0);
+    expect(firstPass.verified).toBeLessThan(50);
+
+    const plan = planResume(planned, toPrior(firstPass.rows));
+    const secondPass = await run(plan.todo, interruptibleClient(resumedStore));
+
+    expect(secondPass.failed).toBe(0);
+    expect(storeChecksum(resumedStore)).toBe(storeChecksum(cleanStore));
+  });
+
+  it("converges from any cut point, including none and all", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.integer({ min: 0, max: 30 }), async (cut) => {
+        const planned = plannedRows(30);
+
+        const cleanStore = new Map<string, string>();
+        await run(planned, interruptibleClient(cleanStore));
+
+        const store = new Map<string, string>();
+        const first = await run(planned, interruptibleClient(store, cut));
+        const plan = planResume(planned, toPrior(first.rows));
+        await run(plan.todo, interruptibleClient(store));
+
+        expect(storeChecksum(store)).toBe(storeChecksum(cleanStore));
+      }),
+      { numRuns: 12 },
+    );
+  });
+
+  it("does not rewrite a row the first pass already verified", async () => {
+    const planned = plannedRows(20);
+    const store = new Map<string, string>();
+
+    const first = await run(planned, interruptibleClient(store, 10));
+    const verified = first.rows
+      .filter((r) => r.status === "verified")
+      .map((r) => r.row.ref.variantGid);
+
+    const plan = planResume(planned, toPrior(first.rows));
+    const retried = new Set(plan.todo.map((r) => r.ref.variantGid));
+
+    for (const gid of verified) {
+      expect(retried.has(gid), `${gid} was verified and must not be rewritten`).toBe(false);
+    }
+  });
+
+  it("is a no-op when re-delivered after finishing", async () => {
+    // BullMQ redelivery: the same job arriving twice must not write anything a second
+    // time. Nothing guards this at the queue level -- the row state machine is the
+    // guard, and this is what proves it.
+    const planned = plannedRows(15);
+    const store = new Map<string, string>();
+
+    const complete = await run(planned, interruptibleClient(store));
+    expect(complete.verified).toBe(15);
+
+    const redelivered = planResume(planned, toPrior(complete.rows));
+    expect(redelivered.todo).toHaveLength(0);
+    expect(redelivered.alreadyVerified).toBe(15);
+  });
+});

--- a/app/lib/execution/resume.test.ts
+++ b/app/lib/execution/resume.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import {
+  planResume,
+  runOutcome,
+  stateChecksum,
+  type LedgerState,
+  type PriorRow,
+} from "./resume";
+import {
+  classifyFailure,
+  shouldQuarantine,
+  stopsTheRun,
+  MAX_ATTEMPTS,
+} from "./classify";
+import type { PlannedRow } from "../planning/types";
+
+const row = (gid: string): PlannedRow =>
+  ({
+    ref: { variantGid: gid, surfaceKind: "BASE", priceListGid: "" },
+    status: "planned",
+    intendedPrice: { amount: 1000, currency: "USD" },
+  }) as unknown as PlannedRow;
+
+const prior = (gid: string, status: LedgerState, attempt = 0): PriorRow => ({
+  variantGid: gid,
+  status,
+  attempt,
+});
+
+describe("planResume", () => {
+  it("never touches a verified row", () => {
+    // The rule the whole guarantee rests on.
+    const plan = planResume([row("a"), row("b")], [prior("a", "VERIFIED")]);
+    expect(plan.todo.map((r) => r.ref.variantGid)).toEqual(["b"]);
+    expect(plan.alreadyVerified).toBe(1);
+  });
+
+  it("re-plans a row that was written but never read back", () => {
+    // APPLIED is the ambiguous state: it may or may not have landed. Rewriting an
+    // already-correct price is a no-op; skipping one that never landed leaves a wrong
+    // price live.
+    const plan = planResume([row("a")], [prior("a", "APPLIED")]);
+    expect(plan.todo).toHaveLength(1);
+  });
+
+  it("re-plans rows interrupted mid-write", () => {
+    for (const state of ["PENDING", "WRITING", "FAILED"] as LedgerState[]) {
+      expect(planResume([row("a")], [prior("a", state)]).todo, state).toHaveLength(1);
+    }
+  });
+
+  it("leaves settled decisions alone", () => {
+    // Skipped and clamped were decisions, not failures. Re-deciding them would reach
+    // the same answer and cost an API call to do it.
+    for (const state of ["SKIPPED", "CLAMPED", "REVERTED"] as LedgerState[]) {
+      expect(planResume([row("a")], [prior("a", state)]).todo, state).toHaveLength(0);
+    }
+  });
+
+  it("stops retrying a poison row once its attempts are spent", () => {
+    const plan = planResume([row("a"), row("b")], [prior("a", "FAILED", 5)]);
+    expect(plan.quarantined).toBe(1);
+    expect(plan.todo.map((r) => r.ref.variantGid)).toEqual(["b"]);
+  });
+
+  it("picks up rows that entered scope since the last attempt", () => {
+    const plan = planResume([row("a"), row("new")], [prior("a", "VERIFIED")]);
+    expect(plan.todo.map((r) => r.ref.variantGid)).toEqual(["new"]);
+  });
+
+  it("has nothing to do for a completed run — so re-delivery is harmless", () => {
+    // A duplicate job delivery re-plans only non-verified rows; on a finished run that
+    // set is empty, which is what makes double-apply structurally impossible.
+    const rows = [row("a"), row("b"), row("c")];
+    const allVerified = rows.map((r) => prior(r.ref.variantGid, "VERIFIED"));
+    expect(planResume(rows, allVerified).todo).toHaveLength(0);
+  });
+});
+
+describe("resume equivalence (E2)", () => {
+  it("a run killed at 40% resumes to an identical final state", () => {
+    // The acceptance criterion, as a simulation: execute a run to completion, then
+    // execute the same work interrupted at 40% and resumed, and compare fingerprints.
+    const gids = Array.from({ length: 50 }, (_, i) => `gid://v${i}`);
+    const planned = gids.map(row);
+
+    const clean = simulate(planned, planned.length);
+
+    const firstPass = simulate(planned, Math.floor(planned.length * 0.4));
+    const resumePlan = planResume(planned, firstPass);
+    const secondPass = simulate(resumePlan.todo, resumePlan.todo.length);
+
+    // The resumed run's state is the verified rows from pass one plus pass two.
+    const merged = [
+      ...firstPass.filter((r) => r.status === "VERIFIED"),
+      ...secondPass,
+    ];
+
+    expect(checksum(merged)).toBe(checksum(clean));
+    expect(runOutcome(merged).clean).toBe(true);
+  });
+
+  it("converges however many times it is interrupted", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.integer({ min: 1, max: 30 }), { minLength: 1, maxLength: 6 }),
+        (cutPoints) => {
+          const gids = Array.from({ length: 30 }, (_, i) => `gid://v${i}`);
+          const planned = gids.map(row);
+
+          let done: PriorRow[] = [];
+          for (const cut of cutPoints) {
+            const plan = planResume(planned, done);
+            const pass = simulate(plan.todo, Math.min(cut, plan.todo.length));
+            done = [...done.filter((r) => r.status === "VERIFIED"), ...pass];
+          }
+
+          // Finish whatever is left.
+          const finalPlan = planResume(planned, done);
+          const finalPass = simulate(finalPlan.todo, finalPlan.todo.length);
+          const merged = [...done.filter((r) => r.status === "VERIFIED"), ...finalPass];
+
+          expect(runOutcome(merged).verified).toBe(planned.length);
+          expect(checksum(merged)).toBe(checksum(simulate(planned, planned.length)));
+        },
+      ),
+    );
+  });
+});
+
+describe("runOutcome", () => {
+  it("reports partial when any row is outstanding", () => {
+    const rows = [prior("a", "VERIFIED"), prior("b", "FAILED")];
+    expect(runOutcome(rows)).toEqual({ clean: false, verified: 1, outstanding: 1 });
+  });
+
+  it("never calls a run clean with a written-but-unverified row", () => {
+    // The exact behaviour that earns competitors their one-star reviews.
+    expect(runOutcome([prior("a", "APPLIED")]).clean).toBe(false);
+  });
+
+  it("counts a skipped row as settled, not outstanding", () => {
+    expect(runOutcome([prior("a", "VERIFIED"), prior("b", "SKIPPED")]).clean).toBe(true);
+  });
+});
+
+describe("failure classification", () => {
+  it("treats a variant deleted mid-run as terminal for that row, not the run (E4)", () => {
+    const result = classifyFailure("Variant does not exist");
+    expect(result.class).toBe("TERMINAL_ROW");
+    expect(result.reason).toBe("variant-deleted");
+    expect(stopsTheRun(result)).toBe(false);
+  });
+
+  it("stops the run when the token is revoked", () => {
+    // Every remaining row would fail identically; retrying is a rate-limit-consuming
+    // way of failing 150,000 times.
+    const result = classifyFailure("Invalid API key or access token");
+    expect(result.class).toBe("TERMINAL_RUN");
+    expect(stopsTheRun(result)).toBe(true);
+  });
+
+  it("retries throttles and network failures", () => {
+    for (const message of ["Throttled", "fetch failed", "ETIMEDOUT", "503 Service Unavailable"]) {
+      expect(classifyFailure(message).class, message).toBe("RETRYABLE");
+    }
+  });
+
+  it("does not retry something the merchant has to fix", () => {
+    const result = classifyFailure("Compare at price must be greater than price");
+    expect(result.class).toBe("USER_FIXABLE");
+    expect(shouldQuarantine(result, 1)).toBe(true);
+  });
+
+  it("retries an unrecognised failure rather than dropping the row", () => {
+    // Wasting a few attempts on something terminal is cheap. Quarantining something
+    // transient silently drops a price change the merchant asked for.
+    expect(classifyFailure("something new from Shopify").class).toBe("RETRYABLE");
+  });
+
+  it("quarantines a retryable row only after its attempts are spent", () => {
+    const throttled = classifyFailure("Throttled");
+    expect(shouldQuarantine(throttled, 1)).toBe(false);
+    expect(shouldQuarantine(throttled, MAX_ATTEMPTS - 1)).toBe(false);
+    expect(shouldQuarantine(throttled, MAX_ATTEMPTS)).toBe(true);
+  });
+
+  it("never quarantines on a run-terminal failure", () => {
+    // Those rows are untouched, not poisoned: a resume after reinstalling should
+    // retry them normally.
+    const revoked = classifyFailure("access denied");
+    expect(shouldQuarantine(revoked, 99)).toBe(false);
+  });
+
+  it("always returns a message naming the next action", () => {
+    fc.assert(
+      fc.property(fc.string(), (message) => {
+        const result = classifyFailure(message);
+        expect(result.message.length).toBeGreaterThan(10);
+        expect(result.reason).toBeTruthy();
+      }),
+    );
+  });
+});
+
+/** Executes `count` of `rows`, leaving the rest untouched. */
+function simulate(rows: readonly PlannedRow[], count: number): PriorRow[] {
+  return rows
+    .slice(0, count)
+    .map((r) => prior(r.ref.variantGid, "VERIFIED", 1));
+}
+
+function checksum(rows: readonly PriorRow[]): string {
+  return stateChecksum(rows.map((r) => ({ ...r, price: 1000 })));
+}

--- a/app/lib/execution/resume.ts
+++ b/app/lib/execution/resume.ts
@@ -1,0 +1,146 @@
+/**
+ * Resuming an interrupted run.
+ *
+ * The guarantee (edge case E2): a run killed at any point and resumed converges to
+ * exactly the state a clean run would have produced. That is what makes deploying
+ * mid-run safe, and it rests on one rule -- **a verified row is never touched
+ * again**.
+ *
+ * Verified means read back from Shopify and confirmed, not merely written. The
+ * distinction matters: a row we wrote but could not read back may or may not have
+ * landed, so it is re-planned. Rewriting an already-correct price is a no-op; failing
+ * to rewrite one that never landed is a wrong price on a live storefront.
+ *
+ * This is also what makes job re-delivery harmless. A duplicate delivery re-plans
+ * only non-verified rows, and on a completed run that set is empty.
+ */
+
+import type { PlannedRow } from "../planning/types";
+
+/** The ledger states a row can be in when a run is picked back up. */
+export type LedgerState =
+  | "PENDING"
+  | "WRITING"
+  | "APPLIED"
+  | "VERIFIED"
+  | "FAILED"
+  | "SKIPPED"
+  | "CLAMPED"
+  | "REVERTED";
+
+export interface PriorRow {
+  variantGid: string;
+  status: LedgerState;
+  attempt: number;
+}
+
+export interface ResumePlan {
+  /** Rows to work on this time. */
+  todo: PlannedRow[];
+  /** Verified last time, deliberately left alone. */
+  alreadyVerified: number;
+  /** Quarantined: attempts exhausted, not retried again. */
+  quarantined: number;
+}
+
+/**
+ * States that count as settled -- a resumed run must not touch them.
+ *
+ * SKIPPED and CLAMPED are settled because they were decisions, not failures: the row
+ * was deliberately not written, and re-deciding it would produce the same answer.
+ */
+const SETTLED: ReadonlySet<LedgerState> = new Set<LedgerState>([
+  "VERIFIED",
+  "SKIPPED",
+  "CLAMPED",
+  "REVERTED",
+]);
+
+/**
+ * Works out what a resumed run should do.
+ *
+ * `maxAttempts` bounds retries per row so a poison row cannot make a run immortal --
+ * it is counted as quarantined and the run moves on.
+ */
+export function planResume(
+  planned: readonly PlannedRow[],
+  prior: readonly PriorRow[],
+  maxAttempts = 5,
+): ResumePlan {
+  const byGid = new Map(prior.map((row) => [row.variantGid, row]));
+
+  const todo: PlannedRow[] = [];
+  let alreadyVerified = 0;
+  let quarantined = 0;
+
+  for (const row of planned) {
+    const previous = byGid.get(row.ref.variantGid);
+
+    // Never seen before: a fresh row, or a row added to scope since the last attempt.
+    if (!previous) {
+      todo.push(row);
+      continue;
+    }
+
+    if (SETTLED.has(previous.status)) {
+      if (previous.status === "VERIFIED") alreadyVerified++;
+      continue;
+    }
+
+    // Attempts exhausted. Left as it is, with its reason, so the run can end and the
+    // merchant can see precisely which rows never made it.
+    if (previous.attempt >= maxAttempts) {
+      quarantined++;
+      continue;
+    }
+
+    // PENDING, WRITING, APPLIED or FAILED with attempts left. APPLIED is included on
+    // purpose: written but never read back is exactly the ambiguity a resume exists
+    // to settle.
+    todo.push(row);
+  }
+
+  return { todo, alreadyVerified, quarantined };
+}
+
+/**
+ * The run's outcome.
+ *
+ * `clean` requires every row to be settled -- anything else is `partial`. There is
+ * deliberately no way to report success with outstanding rows: that is precisely the
+ * behaviour this product exists not to have.
+ */
+export function runOutcome(rows: readonly PriorRow[]): {
+  clean: boolean;
+  verified: number;
+  outstanding: number;
+} {
+  let verified = 0;
+  let outstanding = 0;
+
+  for (const row of rows) {
+    if (row.status === "VERIFIED") verified++;
+    else if (!SETTLED.has(row.status)) outstanding++;
+  }
+
+  return { clean: outstanding === 0, verified, outstanding };
+}
+
+/**
+ * A stable fingerprint of a run's final state, for the resume-equivalence test.
+ *
+ * Sorted by variant so ordering differences -- which a resumed run will always have,
+ * since it processes a subset -- do not register as a difference in outcome.
+ */
+export function stateChecksum(
+  rows: ReadonlyArray<{
+    variantGid: string;
+    status: LedgerState;
+    price: bigint | number | null;
+  }>,
+): string {
+  return [...rows]
+    .map((row) => `${row.variantGid}:${row.status}:${row.price ?? "null"}`)
+    .sort()
+    .join("|");
+}

--- a/app/lib/execution/sync-executor.test.ts
+++ b/app/lib/execution/sync-executor.test.ts
@@ -292,7 +292,10 @@ describe("read-back verification", () => {
     });
     expect(result.rows[0].status).toBe("applied-unverified");
     expect(result.rows[0].failureReason).toContain("verification read failed");
-    expect(result.clean).toBe(true); // no write failed
+    // Not clean: the write did not fail, but nobody confirmed it landed either. A run
+    // is clean only when every row is read back and verified -- an unconfirmed row is
+    // a visible, resumable partial state, never silence.
+    expect(result.clean).toBe(false);
     expect(call).toBeGreaterThan(1);
   });
 });

--- a/app/lib/execution/sync-executor.ts
+++ b/app/lib/execution/sync-executor.ts
@@ -21,6 +21,12 @@
 import { formatMoney, money, type Money } from "../money/money";
 import type { PlannedRow } from "../planning/types";
 import { isThrottledError, RateLimitBudget, withRetry } from "../shopify/budget";
+import {
+  classifyFailure,
+  stopsTheRun,
+  type FailureClass,
+  type FailureReason,
+} from "./classify";
 import type { QueryCost } from "../shopify/budget";
 
 /** Minimal shape of the Admin GraphQL client, so tests can inject a fake. */
@@ -31,7 +37,12 @@ export interface AdminClient {
   ): Promise<{ data?: T; extensions?: { cost?: QueryCost } }>;
 }
 
-export type ExecutedStatus = "verified" | "failed" | "applied-unverified";
+export type ExecutedStatus =
+  | "verified"
+  | "failed"
+  | "applied-unverified"
+  /** Variant deleted in Shopify while the run was in flight -- not a failure (E4). */
+  | "skipped-deleted";
 
 export interface ExecutedRow {
   row: PlannedRow;
@@ -40,6 +51,12 @@ export interface ExecutedRow {
   failureReason?: string;
   /** What the read-back actually observed, when it disagreed. */
   observedPrice?: Money;
+  /** What the merchant should do about it, in plain words. */
+  guidance?: string;
+  /** Retryable, terminal for this row, terminal for the run, or the merchant's to fix. */
+  failureClass?: FailureClass;
+  /** Machine-readable, so the UI can group rows that failed for the same reason. */
+  failureCode?: FailureReason;
 }
 
 export interface ExecuteResult {
@@ -50,6 +67,8 @@ export interface ExecuteResult {
   unverified: number;
   /** True only when every row verified — the "verified clean" bar. */
   clean: boolean;
+  /** Set when the run stopped early because nothing further could succeed. */
+  stoppedEarly?: string;
 }
 
 export interface ExecuteOptions {
@@ -132,6 +151,9 @@ export async function executeSync(
   const writable = rows.filter((r) => r.status !== "skipped" && r.intendedPrice);
   const results = new Map<string, ExecutedRow>();
 
+  // Set when a failure means no further row can succeed; stops the loop.
+  let terminalRunFailure: string | undefined;
+
   // Skipped rows pass straight through: they were never going to be written, and
   // reporting them as failures would misrepresent a deliberate policy decision.
   for (const row of rows) {
@@ -182,17 +204,63 @@ export async function executeSync(
 
       group.forEach((row, index) => {
         const reason = errorsByIndex.get(index) ?? groupWideError;
-        results.set(
-          row.ref.variantGid,
-          reason
-            ? { row, status: "failed", failureReason: reason }
-            : { row, status: "applied-unverified" },
-        );
+
+        if (!reason) {
+          results.set(row.ref.variantGid, { row, status: "applied-unverified" });
+          return;
+        }
+
+        const classified = classifyFailure(reason);
+
+        // A variant deleted while the run was in flight is not a failure -- the
+        // merchant deleted it. Reporting it as one trains people to ignore failures,
+        // which is how a real failure goes unnoticed (E4).
+        if (classified.reason === "variant-deleted") {
+          results.set(row.ref.variantGid, {
+            row,
+            status: "skipped-deleted",
+            failureReason: reason,
+            guidance: classified.message,
+            failureCode: classified.reason,
+          });
+          return;
+        }
+
+        // Shopify's own words stay in failureReason. Replacing them with our
+        // paraphrase would leave support unable to see what Shopify actually said,
+        // which is the one thing worth having when a row fails for an unexpected
+        // reason. Our guidance rides alongside it.
+        results.set(row.ref.variantGid, {
+          row,
+          status: "failed",
+          failureReason: reason,
+          guidance: classified.message,
+          failureClass: classified.class,
+          failureCode: classified.reason,
+        });
       });
     } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error);
+      const classified = classifyFailure(error);
+
+      const original = error instanceof Error ? error.message : String(error);
       for (const row of group) {
-        results.set(row.ref.variantGid, { row, status: "failed", failureReason: reason });
+        results.set(row.ref.variantGid, {
+          row,
+          status: "failed",
+          failureReason: original,
+          guidance: classified.message,
+          failureClass: classified.class,
+          failureCode: classified.reason,
+        });
+      }
+
+      // Auth revoked or plan gate: every remaining product would fail identically.
+      // Working through them would burn the rate limit to produce 150,000 copies of
+      // the same message, and bury the one row that explains it. Rows not attempted
+      // stay PENDING, so a resume after the fix picks them up untouched.
+      if (stopsTheRun(classified)) {
+        terminalRunFailure = classified.message;
+        break;
       }
     }
   }
@@ -204,7 +272,18 @@ export async function executeSync(
   const failed = all.filter((r) => r.status === "failed").length;
   const unverified = all.filter((r) => r.status === "applied-unverified").length;
 
-  return { rows: all, verified, failed, unverified, clean: failed === 0 };
+  // Clean means every row was read back and confirmed -- not merely "nothing threw".
+  // A row we wrote but never verified may or may not have landed, and calling that
+  // success is exactly the reporting this product exists not to do. Deleted variants
+  // are settled decisions rather than outstanding work, so they do not block it.
+  return {
+    rows: all,
+    verified,
+    failed,
+    unverified,
+    clean: failed === 0 && unverified === 0 && terminalRunFailure === undefined,
+    stoppedEarly: terminalRunFailure,
+  };
 }
 
 /**

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -90,6 +90,7 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
     // implementation of the same thing, free to disagree with the first.
     const result = await runCampaign(shop.id, String(params.id), toAdminClient(admin), {
       revert: reverting,
+      resume: intent === "resume",
     });
 
     const verb = reverting ? "Reverted" : intent === "resume" ? "Resumed" : "Applied";

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -20,6 +20,7 @@ import { loadCampaignContext } from "./model.server";
 import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
 import { transitionCampaign } from "./lifecycle.server";
+import { planResume, type LedgerState } from "../../lib/execution/resume";
 
 export interface RunOptions {
   revert?: boolean;
@@ -29,6 +30,14 @@ export interface RunOptions {
    * confirmation from its result file instead.
    */
   verifySampleRate?: number;
+  /**
+   * Continue an interrupted run instead of starting fresh.
+   *
+   * Rows the previous attempt verified are left untouched, so a resumed run converges
+   * on the state a clean run would have produced (E2) without paying to rewrite work
+   * that already landed.
+   */
+  resume?: boolean;
 }
 
 export async function runCampaign(
@@ -58,7 +67,21 @@ export async function runCampaign(
   }
 
   const kind = options.revert ? "REVERT" : "APPLY";
-  const writable = outcome.rows.filter((row) => row.status !== "skipped");
+  let writable = outcome.rows.filter((row) => row.status !== "skipped");
+
+  // Resuming: drop rows a previous attempt already verified. The resolver would reach
+  // the same answer for them anyway, but re-sending costs rate limit and, worse, the
+  // mirror could be stale enough to make an already-correct row look like it needs
+  // rewriting.
+  let resumedFrom: { verified: number; quarantined: number } | null = null;
+  if (options.resume && !options.revert) {
+    const prior = await priorLedger(campaignId, kind);
+    if (prior.length > 0) {
+      const plan = planResume(writable, prior);
+      writable = plan.todo;
+      resumedFrom = { verified: plan.alreadyVerified, quarantined: plan.quarantined };
+    }
+  }
 
   const run = await prisma.campaignRun.create({
     data: {
@@ -97,7 +120,10 @@ export async function runCampaign(
   // Honour the planner's path choice. A 1,600-row campaign executed synchronously
   // would take roughly one variant every two seconds against a standard shop's
   // rate limit; the bulk path costs no rate-limit budget at all.
-  const result = await executeRows(outcome.rows, {
+  // `writable`, not `outcome.rows`: skipped rows were never going to be written, and
+  // on a resume this is the filtered set. Passing the unfiltered plan here would make
+  // the resume silently re-send every row it had just decided to leave alone.
+  const result = await executeRows(writable, {
     client,
     productOf: (gid) => products.get(gid) ?? gid,
     verifySampleRate: options.verifySampleRate ?? 1,
@@ -141,7 +167,26 @@ export async function runCampaign(
     failed: result.failed,
     unverified: result.unverified,
     clean: result.clean,
-    messages: messages.slice(0, 5),
+    messages: [
+      // Lead with what was skipped. "Applied 3 variants" after a 1,500-row campaign
+      // looks like a catastrophe until you know the other 1,497 were already correct
+      // and deliberately left alone.
+      //
+      // Two independent things skip work, and the merchant does not care which: the
+      // planner drops rows already showing the target price, and the resume drops rows
+      // the ledger says were verified. Reporting only the latter said "0 rows were
+      // already verified" straight after a run that had verified two of them.
+      ...(resumedFrom && resumedFrom.verified + outcome.counts.noop > 0
+        ? [
+            `Resumed: ${resumedFrom.verified + outcome.counts.noop} rows were already correct and left untouched` +
+              (resumedFrom.quarantined > 0
+                ? `, ${resumedFrom.quarantined} quarantined after repeated failures`
+                : "") +
+              ".",
+          ]
+        : []),
+      ...messages.slice(0, 5),
+    ],
   };
 }
 
@@ -177,27 +222,63 @@ async function writeLedgerRows(
 type ExecutedRows = Awaited<ReturnType<typeof executeRows>>["rows"];
 
 /** Folds execution results back into the ledger, grouped to avoid a query per row. */
+/**
+ * The most recent attempt's ledger for this campaign.
+ *
+ * Only the latest run matters: each run's rows are a complete picture of what that
+ * attempt achieved, and merging older ones would resurrect rows that a later attempt
+ * has since settled.
+ */
+async function priorLedger(campaignId: string, kind: "APPLY" | "REVERT") {
+  const previous = await prisma.campaignRun.findFirst({
+    where: { campaignId, kind },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  });
+  if (!previous) return [];
+
+  const changes = await prisma.variantChange.findMany({
+    where: { runId: previous.id },
+    select: { variantGid: true, status: true, attempt: true },
+  });
+
+  return changes.map((change) => ({
+    variantGid: change.variantGid,
+    status: change.status as LedgerState,
+    attempt: change.attempt,
+  }));
+}
+
 async function recordResults(
   runId: string,
   shopId: string,
   rows: ExecutedRows,
 ): Promise<string[]> {
-  const byStatus = new Map<"VERIFIED" | "APPLIED" | "FAILED", string[]>();
+  const byStatus = new Map<"VERIFIED" | "APPLIED" | "FAILED" | "SKIPPED", string[]>();
   const messages: string[] = [];
 
   for (const executed of rows) {
+    // A variant deleted mid-run is SKIPPED, not FAILED. Recording it as a failure
+    // would make an ordinary merchant action look like a defect, and a run full of
+    // "failures" nobody needs to act on is a run nobody reads (E4).
     const status =
       executed.status === "verified"
         ? "VERIFIED"
         : executed.status === "failed"
           ? "FAILED"
-          : "APPLIED";
+          : executed.status === "skipped-deleted"
+            ? "SKIPPED"
+            : "APPLIED";
 
     const bucket = byStatus.get(status) ?? [];
     bucket.push(executed.row.ref.variantGid);
     byStatus.set(status, bucket);
 
-    if (executed.failureReason) messages.push(executed.failureReason);
+    // Only genuine failures belong in the summary. A deleted variant has guidance
+    // attached but is not something the merchant has to fix.
+    if (executed.failureReason && executed.status === "failed") {
+      messages.push(executed.guidance ?? executed.failureReason);
+    }
   }
 
   const now = new Date();
@@ -218,7 +299,16 @@ async function recordResults(
     if (!executed.failureReason) continue;
     await prisma.variantChange.updateMany({
       where: { runId, shopId, variantGid: executed.row.ref.variantGid },
-      data: { failureReason: executed.failureReason },
+      data: {
+        // Shopify's own words, then ours. Support needs the former; the merchant
+        // needs the latter.
+        failureReason: executed.guidance
+          ? `${executed.guidance} (Shopify said: ${executed.failureReason})`
+          : executed.failureReason,
+        // Counts toward quarantine: a row that has burned its attempts is left alone
+        // by the next resume rather than retried forever.
+        attempt: { increment: 1 },
+      },
     });
   }
 

--- a/scripts/test-resume.ts
+++ b/scripts/test-resume.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env tsx
+/**
+ * Resume and poison-row behaviour against the real store.
+ *
+ * Two things a unit test cannot prove, because both depend on the ledger and on
+ * Shopify actually rejecting something:
+ *
+ *   A resume re-plans only non-verified rows -- so the second pass writes far fewer
+ *   rows than the first, and the prices already correct are left exactly as they are.
+ *
+ *   A poison row does not block the run. One variant deleted mid-run is recorded as
+ *   skipped, the rest still get their prices, and the run ends partial rather than
+ *   failed.
+ *
+ *   npx tsx scripts/test-resume.ts
+ */
+
+import prisma from "../app/db.server";
+import { adminClientForShop } from "../app/services/admin-client.server";
+import { createCampaign } from "../app/services/campaigns/model.server";
+import { runCampaign } from "../app/services/campaigns/run.server";
+import { transitionCampaign } from "../app/services/campaigns/lifecycle.server";
+import { captureBaselines } from "../app/services/baselines.server";
+
+const TAG = "anchor-resume-test";
+const PRODUCTS = 6;
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = actual === expected;
+  if (!ok) failures++;
+  console.log(`   ${ok ? "PASS" : "FAIL"}  ${label}: ${actual}${ok ? "" : ` (expected ${expected})`}`);
+}
+
+type Client = NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>;
+
+async function main() {
+  const shop = await prisma.shop.findFirstOrThrow({ where: { uninstalledAt: null } });
+  const client = await adminClientForShop(shop.domain);
+  if (!client) throw new Error("No usable session — open the app in the store first");
+
+  console.log(`shop: ${shop.domain}\ncreating ${PRODUCTS} probe products...`);
+  const products = [];
+  for (let i = 0; i < PRODUCTS; i++) products.push(await createProduct(client, i));
+
+  const variantGids = products.map((p) => p.variantGid);
+  await waitForMirror(shop.id, variantGids);
+  await captureBaselines(shop.id, { variantGids, source: "INSTALL_CAPTURE" });
+
+  const campaign = await createCampaign(shop.id, {
+    name: `Resume test ${Date.now()}`,
+    priority: 960,
+    rule: { kind: "percent-change", percent: -20 },
+    compareAtPolicy: { kind: "leave" },
+    rounding: "none",
+    ast: { groups: [{ conditions: [{ field: "tag", value: TAG }] }] },
+    schedule: { kind: "manual" },
+  });
+
+  // --------------------------------------- 1. clean apply, for reference
+  console.log("\n1. clean apply (the state a resumed run must converge on)");
+  await transitionCampaign(shop.id, campaign.id, "APPLYING", { reason: "test" });
+  const first = await runCampaign(shop.id, campaign.id, client, {});
+  check("all rows verified", first.verified, PRODUCTS);
+  check("run is clean", first.clean, true);
+
+  const reference = await livePrices(client, variantGids);
+  console.log(`      reference prices: ${[...reference.values()].join(", ")}`);
+
+  // Back to baseline so the next apply has real work to do.
+  await runCampaign(shop.id, campaign.id, client, { revert: true });
+
+  // ------------------------------- 2. an apply genuinely interrupted partway
+  console.log("2. apply interrupted after 2 products");
+  await transitionCampaign(shop.id, campaign.id, "APPLYING", { reason: "test: partial" });
+
+  const partial = await runCampaign(shop.id, campaign.id, failAfter(client, 2), {});
+  console.log(`      verified ${partial.verified}, failed ${partial.failed}`);
+  check("the run is not reported clean", partial.clean, false);
+  check("some rows landed", partial.verified > 0, true);
+  check("some rows did not", partial.verified < PRODUCTS, true);
+  check("campaign is PARTIAL, not ACTIVE", await stateOf(campaign.id), "PARTIAL");
+
+  // ------------------------------------------------- 3. resume the rest
+  console.log("3. resume");
+  await transitionCampaign(shop.id, campaign.id, "APPLYING", { reason: "test: resume" });
+  const resumed = await runCampaign(shop.id, campaign.id, client, { resume: true });
+  console.log(`      ${resumed.messages[0] ?? "(no resume message)"}`);
+  check(
+    "resume wrote only what was outstanding",
+    resumed.verified === PRODUCTS - partial.verified,
+    true,
+  );
+
+  const afterResume = await livePrices(client, variantGids);
+  const converged = variantGids.every((gid) => afterResume.get(gid) === reference.get(gid));
+  check("resumed store matches the clean run exactly", converged, true);
+  if (!converged) {
+    for (const gid of variantGids) {
+      console.log(`      ${gid}: ${afterResume.get(gid)} vs ${reference.get(gid)}`);
+    }
+  }
+
+  // ------------------------------- 4. a poison row does not block the rest
+  console.log("4. delete a variant, then apply — the poison row must not block");
+  await runCampaign(shop.id, campaign.id, client, { revert: true });
+
+  const victim = products[0];
+  // Deleted in Shopify but still in our mirror: exactly the mid-run deletion of E4,
+  // since the products/delete webhook has not arrived yet.
+  await deleteProduct(client, victim.productGid);
+
+  await transitionCampaign(shop.id, campaign.id, "APPLYING", { reason: "test: poison" });
+  const poisoned = await runCampaign(shop.id, campaign.id, client, {});
+  console.log(`      verified ${poisoned.verified}, failed ${poisoned.failed}`);
+  check("every surviving row still got written", poisoned.verified, PRODUCTS - 1);
+
+  const deletedRow = await prisma.variantChange.findFirst({
+    where: { runId: poisoned.runId, variantGid: victim.variantGid },
+    select: { status: true, failureReason: true },
+  });
+  console.log(`      deleted variant: ${deletedRow?.status} — ${deletedRow?.failureReason ?? ""}`);
+  check("deleted variant recorded as SKIPPED, not FAILED", deletedRow?.status, "SKIPPED");
+
+  // ------------------------------------------------------------ cleanup
+  await runCampaign(shop.id, campaign.id, client, { revert: true }).catch(() => {});
+  await prisma.campaign.delete({ where: { id: campaign.id } });
+  for (const product of products.slice(1)) {
+    await deleteProduct(client, product.productGid).catch(() => {});
+  }
+  console.log("\ncleaned up");
+
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+/**
+ * Wraps the real client so it refuses after `products` variant writes.
+ *
+ * A genuine interruption -- the writes before it really happened in Shopify, which is
+ * what makes the convergence check meaningful rather than a simulation.
+ */
+function failAfter(client: Client, products: number): Client {
+  let writes = 0;
+  return {
+    async request<T>(query: string, variables: Record<string, unknown>) {
+      if (query.includes("productVariantsBulkUpdate")) {
+        if (writes >= products) throw new Error("fetch failed");
+        writes++;
+      }
+      return client.request<T>(query, variables);
+    },
+  };
+}
+
+async function livePrices(client: Client, variantGids: string[]) {
+  const result = (await client.request(
+    `query($ids: [ID!]!) { nodes(ids: $ids) { ... on ProductVariant { id price } } }`,
+    { ids: variantGids },
+  )) as { data: { nodes: Array<{ id: string; price: string } | null> } };
+
+  const prices = new Map<string, string>();
+  for (const node of result.data.nodes) if (node) prices.set(node.id, node.price);
+  return prices;
+}
+
+async function stateOf(campaignId: string): Promise<string> {
+  const row = await prisma.campaign.findUniqueOrThrow({
+    where: { id: campaignId },
+    select: { status: true },
+  });
+  return row.status;
+}
+
+async function createProduct(client: Client, index: number) {
+  const result = (await client.request(
+    `mutation Create($input: ProductSetInput!) {
+       productSet(synchronous: true, input: $input) {
+         product { id variants(first: 1) { nodes { id } } }
+         userErrors { message }
+       }
+     }`,
+    {
+      input: {
+        title: `Resume probe ${Date.now()}-${index}`,
+        status: "ACTIVE",
+        tags: [TAG],
+        productOptions: [{ name: "Size", values: [{ name: "M" }] }],
+        variants: [
+          { optionValues: [{ optionName: "Size", name: "M" }], price: `${100 + index}.00` },
+        ],
+      },
+    },
+  )) as {
+    data: { productSet: { product: { id: string; variants: { nodes: Array<{ id: string }> } } } };
+  };
+
+  return {
+    productGid: result.data.productSet.product.id,
+    variantGid: result.data.productSet.product.variants.nodes[0].id,
+  };
+}
+
+async function deleteProduct(client: Client, productGid: string) {
+  await client.request(
+    `mutation D($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
+    { input: { id: productGid } },
+  );
+}
+
+async function waitForMirror(shopId: string, variantGids: string[]) {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const count = await prisma.variantIndex.count({
+      where: { shopId, variantGid: { in: variantGids }, deletedAt: null },
+    });
+    if (count === variantGids.length) return;
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  throw new Error("webhooks never mirrored every probe product");
+}
+
+main()
+  .catch((error) => {
+    console.error("\nERROR:", error);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
Closes #125, #126, #127, #128, #129.

Failure is now boring: retry what deserves it, quarantine what does not, and let an interrupted run resume to the state a clean run would have reached.

## Four failure classes, because there are four remedies

`lib/execution/classify.ts` sorts failures per RFC §11. The distinctions earn their keep:

| Class | Example | What happens |
|---|---|---|
| `RETRYABLE` | throttle, `fetch failed`, 503 | backoff with jitter, 5 attempts, then quarantine |
| `TERMINAL_ROW` | variant deleted mid-run | recorded **skipped**, run continues |
| `TERMINAL_RUN` | token revoked, plan gate | loop stops; untouched rows stay `PENDING` for a resume |
| `USER_FIXABLE` | compare-at below price | no retry — retrying identical input is pointless |

A variant deleted mid-run is *not* a failure (E4). It was an ordinary merchant action, and a run full of "failures" nobody needs to act on is a run nobody reads. A revoked token stops the loop because working through the rest would burn the rate limit producing 150,000 copies of one message and bury the row that explains it.

An **unrecognised** failure is retried, not quarantined. Wasting a few attempts on something terminal is cheap; quarantining something transient silently drops a price change the merchant asked for.

## Resume rests on one rule

`lib/execution/resume.ts`: **a verified row is never touched again.** Verified means read back and confirmed, not merely written — a row we wrote but could not read back is re-planned, because rewriting an already-correct price is a no-op while failing to rewrite one that never landed is a wrong price on a live storefront.

That is also what makes BullMQ re-delivery harmless: a duplicate re-plans only non-verified rows, and on a finished run that set is empty. No queue-level guard needed; the row state machine is the guard.

## `clean` now means what it says

It required only that nothing threw. It now requires every row to be read back. An existing test asserted the opposite — clean when the write succeeded but the read-back failed, commented *"no write failed"*. That contradicts the project rule that a run is clean only when every row is verified, and ticket #128, so the **test** was corrected rather than the behaviour.

## Three bugs found while testing

- **`executeRows` was passed the unfiltered plan**, so the resume worked out which rows to skip and then re-sent all of them anyway.
- **Classified messages replaced Shopify's own words**, leaving support unable to see what Shopify actually said. Both are kept now — our guidance, then theirs. The live test shows it: `"This variant no longer exists… (Shopify said: PRODUCT_DOES_NOT_EXIST: Product does not exist)"`.
- **The resume summary said "0 rows were already verified"** right after a run that verified two, because the planner had already dropped them as no-ops before the resume logic saw them.

## Verified against the live store, genuinely interrupted

A client that refuses after two products — so the earlier writes really happened in Shopify:

```
1. clean apply (reference): 6 verified, clean
   reference prices: 80.00, 80.80, 81.60, 82.40, 83.20, 84.00
2. apply interrupted after 2 products: 2 verified, 4 failed
   PASS  the run is not reported clean
   PASS  campaign is PARTIAL, not ACTIVE
3. resume: Resumed: 2 rows were already correct and left untouched.
   PASS  resume wrote only what was outstanding
   PASS  resumed store matches the clean run exactly
4. delete a variant, then apply: 5 verified, 0 failed
   PASS  deleted variant recorded as SKIPPED, not FAILED
```

The unit-level checksum test drives the **real** `executeSync` with a client that dies partway, rather than modelling it — and I verified it can fail: sabotaging `planResume` to treat `FAILED` as settled breaks 5 tests including both convergence tests.

256 tests, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)