### PR TITLE
P2.9.2 + P2.9.3 — Variant-level revert and the drift-aware rollback report

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__claude-in-chrome__tabs_context_mcp",
+      "mcp__claude-in-chrome__find",
+      "mcp__claude-in-chrome__get_page_text",
+      "mcp__claude-in-chrome__read_page",
+      "mcp__claude-in-chrome__read_console_messages",
+      "mcp__claude-in-chrome__read_network_requests",
+      "mcp__claude-in-chrome__list_connected_browsers",
+      "mcp__chrome-devtools__list_pages",
+      "mcp__chrome-devtools__take_screenshot",
+      "mcp__chrome-devtools__take_snapshot",
+      "mcp__chrome-devtools__list_console_messages",
+      "mcp__chrome-devtools__list_network_requests",
+      "mcp__chrome-devtools__get_network_request"
+    ]
+  }
+}

--- a/app/components/LedgerTable.tsx
+++ b/app/components/LedgerTable.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { LedgerRow } from "../services/campaigns/index.server";
 import { LEDGER_TONE, toneFor } from "./tone";
 
@@ -7,7 +9,20 @@ import { LEDGER_TONE, toneFor } from "./tone";
  * Retained indefinitely on every plan -- charging to explain what you did to
  * someone's prices is the wrong trade.
  */
-export function LedgerTable({ rows }: { rows: LedgerRow[] }) {
+export function LedgerTable({
+  rows,
+  /**
+   * Optional per-row control, rendered in a trailing column.
+   *
+   * A render prop rather than a flag, because the action needs a fetcher and this
+   * component has no business knowing about one. Passing the markup in keeps the
+   * table a table.
+   */
+  renderAction,
+}: {
+  rows: LedgerRow[];
+  renderAction?: (row: LedgerRow) => ReactNode;
+}) {
   return (
     <s-table>
       <s-table-header-row>
@@ -16,6 +31,7 @@ export function LedgerTable({ rows }: { rows: LedgerRow[] }) {
         <s-table-header>Intended</s-table-header>
         <s-table-header>State</s-table-header>
         <s-table-header>Reason</s-table-header>
+        {renderAction ? <s-table-header>Action</s-table-header> : null}
       </s-table-header-row>
       <s-table-body>
         {rows.map((row) => (
@@ -27,6 +43,7 @@ export function LedgerTable({ rows }: { rows: LedgerRow[] }) {
               <s-badge tone={toneFor(LEDGER_TONE, row.status)}>{row.status}</s-badge>
             </s-table-cell>
             <s-table-cell>{row.failureReason ?? "—"}</s-table-cell>
+            {renderAction ? <s-table-cell>{renderAction(row)}</s-table-cell> : null}
           </s-table-row>
         ))}
       </s-table-body>

--- a/app/components/RollbackReportTable.tsx
+++ b/app/components/RollbackReportTable.tsx
@@ -1,0 +1,58 @@
+import type { RollbackRow } from "../services/campaigns/index.server";
+
+/**
+ * What reverting would do, row by row, with the drifted ones first.
+ *
+ * The checkbox is the whole point. A row somebody edited by hand while the sale ran
+ * is a decision, and reverting it silently overwrites that decision — so the merchant
+ * gets to keep it, per row, rather than choosing between "revert everything" and
+ * "revert nothing".
+ *
+ * Clean rows are shown too, greyed of choice. Seeing that 3,412 rows will revert
+ * without argument is what makes the eleven that need attention legible as eleven
+ * rather than as an unbounded worry.
+ */
+
+const STATE: Record<RollbackRow["kind"], { label: string; tone: "info" | "warning" | "neutral" }> = {
+  drifted: { label: "Changed since", tone: "warning" },
+  deleted: { label: "Deleted", tone: "neutral" },
+  clean: { label: "Unchanged", tone: "info" },
+};
+
+export function RollbackReportTable({ rows }: { rows: RollbackRow[] }) {
+  return (
+    <s-table>
+      <s-table-header-row>
+        <s-table-header>Variant</s-table-header>
+        <s-table-header>State</s-table-header>
+        <s-table-header>We applied</s-table-header>
+        <s-table-header>Live now</s-table-header>
+        <s-table-header>Reverts to</s-table-header>
+        <s-table-header>Keep the edit</s-table-header>
+      </s-table-header-row>
+      <s-table-body>
+        {rows.map((row) => (
+          <s-table-row key={row.variantGid}>
+            <s-table-cell>{row.title}</s-table-cell>
+            <s-table-cell>
+              <s-badge tone={STATE[row.kind].tone}>{STATE[row.kind].label}</s-badge>
+            </s-table-cell>
+            <s-table-cell>{row.applied ?? "—"}</s-table-cell>
+            <s-table-cell>{row.live ?? "—"}</s-table-cell>
+            <s-table-cell>{row.revertsTo ?? "—"}</s-table-cell>
+            <s-table-cell>
+              {row.kind === "drifted" ? (
+                // Named `keep`, and read as a list by the revert action. Unchecked by
+                // default: reverting is what the merchant asked for, and the checkbox
+                // is them making an exception, not confirming the obvious.
+                <s-checkbox name="keep" value={row.variantGid} label="Leave as it is" />
+              ) : (
+                <s-text>—</s-text>
+              )}
+            </s-table-cell>
+          </s-table-row>
+        ))}
+      </s-table-body>
+    </s-table>
+  );
+}

--- a/app/lib/planning/exclusions.test.ts
+++ b/app/lib/planning/exclusions.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Variant-level exclusion: pulling one variant out of a running campaign.
+ *
+ * The interesting case is not "the campaign stops pricing it" — it is *what price it
+ * lands on*. Excluding a variant is resolution with that campaign removed for that
+ * variant, so it falls through to whatever else still controls it. A variant pulled
+ * out of a 30% sale that also sits inside a 10% one belongs at 10%, not at full
+ * price, and an implementation that filtered the candidate out upstream would
+ * silently produce the latter — quietly ending a sale the merchant never ended.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { money } from "../money/money";
+import { NO_ROUNDING } from "../money/rounding";
+import type { ResolvableCampaign } from "../pricing/types";
+import { planRun } from "./plan";
+import type { PlanCandidate, SurfaceRef } from "./types";
+
+const usd = (n: number) => money(n, "USD");
+
+const ref = (variantGid: string): SurfaceRef => ({
+  variantGid,
+  surfaceKind: "base",
+  priceListGid: "",
+  currency: "USD",
+});
+
+function candidate(variantGid: string, live = 10_000): PlanCandidate {
+  return { ref: ref(variantGid), baseline: { price: usd(10_000) }, livePrice: usd(live) };
+}
+
+function campaign(over: Partial<ResolvableCampaign> = {}): ResolvableCampaign {
+  return {
+    id: "c1",
+    priority: 100,
+    startAt: 1_000,
+    ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -30 } }],
+    compareAtPolicy: { kind: "leave" },
+    compareAtViolationPolicy: "clear",
+    roundingProfile: NO_ROUNDING,
+    guardrailViolationPolicy: "clamp",
+    ...over,
+  };
+}
+
+const rowFor = (out: ReturnType<typeof planRun>, variantGid: string) => {
+  if (out.kind !== "ok") throw new Error(`plan was ${out.kind}`);
+  return out.rows.find((row) => row.ref.variantGid === variantGid);
+};
+
+describe("variant-level exclusion", () => {
+  it("returns an excluded variant to baseline when nothing else controls it", () => {
+    const out = planRun({
+      campaigns: [campaign({ excludedVariantGids: ["gid://Variant/1"] })],
+      // Currently sitting at the campaign price, so the revert has real work to do.
+      candidates: [candidate("gid://Variant/1", 7_000)],
+    });
+
+    expect(rowFor(out, "gid://Variant/1")?.intendedPrice).toEqual(usd(10_000));
+  });
+
+  it("leaves other variants in the campaign untouched", () => {
+    const out = planRun({
+      campaigns: [campaign({ excludedVariantGids: ["gid://Variant/1"] })],
+      candidates: [candidate("gid://Variant/1", 7_000), candidate("gid://Variant/2")],
+    });
+
+    expect(rowFor(out, "gid://Variant/1")?.intendedPrice).toEqual(usd(10_000));
+    expect(rowFor(out, "gid://Variant/2")?.intendedPrice).toEqual(usd(7_000));
+  });
+
+  it("falls through to the next campaign rather than to full price", () => {
+    // The claim this whole mechanism rests on. Excluding the winner must re-resolve,
+    // not skip: the variant is still in a 10% sale and must land there.
+    const out = planRun({
+      campaigns: [
+        campaign({ id: "sale-30", priority: 200, excludedVariantGids: ["gid://Variant/1"] }),
+        campaign({
+          id: "sale-10",
+          priority: 100,
+          ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -10 } }],
+        }),
+      ],
+      candidates: [candidate("gid://Variant/1", 7_000)],
+    });
+
+    expect(rowFor(out, "gid://Variant/1")?.intendedPrice).toEqual(usd(9_000));
+  });
+
+  it("only excludes for the campaign that names the variant", () => {
+    // Exclusions are per campaign, not per variant. A variant pulled out of one sale
+    // is still fully enrolled in every other.
+    const out = planRun({
+      campaigns: [
+        campaign({ id: "sale-30", priority: 200, excludedVariantGids: ["gid://Variant/2"] }),
+        campaign({
+          id: "sale-10",
+          priority: 100,
+          ruleRows: [{ segmentIds: [], rule: { kind: "percent-change", percent: -10 } }],
+          excludedVariantGids: ["gid://Variant/1"],
+        }),
+      ],
+      candidates: [candidate("gid://Variant/1", 10_000), candidate("gid://Variant/2", 10_000)],
+    });
+
+    // Variant 1 is excluded from the 10% sale, but the 30% sale still wins outright.
+    expect(rowFor(out, "gid://Variant/1")?.intendedPrice).toEqual(usd(7_000));
+    // Variant 2 is excluded from the 30% sale, so the 10% one takes over.
+    expect(rowFor(out, "gid://Variant/2")?.intendedPrice).toEqual(usd(9_000));
+  });
+
+  it("plans nothing when the excluded variant is already at the right price", () => {
+    // Exclusion is not a reason to write. If the variant already sits where
+    // resolve-without-the-campaign puts it, there is nothing to do, and writing
+    // anyway would spend rate limit to change nothing.
+    const out = planRun({
+      campaigns: [campaign({ excludedVariantGids: ["gid://Variant/1"] })],
+      candidates: [candidate("gid://Variant/1", 10_000)],
+    });
+
+    if (out.kind !== "ok") throw new Error("plan was blocked");
+    expect(out.rows).toHaveLength(0);
+    expect(out.counts.noop).toBe(1);
+  });
+
+  it("costs nothing when no campaign excludes anything", () => {
+    // The common case. Guarded so the per-candidate filter is skipped entirely
+    // rather than rebuilt for every variant in a 100K-variant catalogue.
+    const out = planRun({
+      campaigns: [campaign()],
+      candidates: [candidate("gid://Variant/1")],
+    });
+
+    expect(rowFor(out, "gid://Variant/1")?.intendedPrice).toEqual(usd(7_000));
+  });
+});

--- a/app/lib/planning/plan.ts
+++ b/app/lib/planning/plan.ts
@@ -47,6 +47,16 @@ export function planRun(input: PlanInput): PlanOutcome {
     ? input.campaigns.filter((c) => c.id !== excludeCampaignId)
     : input.campaigns;
 
+  // Variant-level exclusions, resolved per candidate below. Built once as sets: the
+  // alternative is an array scan per campaign per variant, which on a 100K-variant
+  // catalogue is the difference between a plan and a hang.
+  const exclusions = new Map<string, Set<string>>();
+  for (const campaign of campaigns) {
+    if (campaign.excludedVariantGids?.length) {
+      exclusions.set(campaign.id, new Set(campaign.excludedVariantGids));
+    }
+  }
+
   const rows: PlannedRow[] = [];
   const counts: PlanCounts = { planned: 0, noop: 0, skipped: 0, clamped: 0 };
 
@@ -63,6 +73,16 @@ export function planRun(input: PlanInput): PlanOutcome {
     if (seen.has(key)) continue;
     seen.add(key);
 
+    // A variant reverted out of a campaign individually. Dropping the campaign for
+    // this candidate and re-resolving is what makes the variant fall through to
+    // whatever else still controls it, rather than to full price.
+    const applicable =
+      exclusions.size === 0
+        ? campaigns
+        : campaigns.filter(
+            (campaign) => !exclusions.get(campaign.id)?.has(candidate.ref.variantGid),
+          );
+
     const resolution = resolve({
       baseline: candidate.baseline,
       surface: {
@@ -76,7 +96,7 @@ export function planRun(input: PlanInput): PlanOutcome {
       // tagged mid-campaign is not priced by a run that never planned for it, and
       // one untagged mid-campaign is still reverted (edge cases E5, E6). Those
       // decisions need the clock and the database, so they live in the caller.
-      campaigns,
+      campaigns: applicable,
       storeGuardrails,
       variantSegmentIds: candidate.segmentIds,
     });

--- a/app/lib/pricing/types.ts
+++ b/app/lib/pricing/types.ts
@@ -127,6 +127,21 @@ export interface ResolvableCampaign {
   /** Tightens the store guardrails for this campaign only. */
   guardrails?: Guardrails;
   guardrailViolationPolicy: GuardrailViolationPolicy;
+  /**
+   * Variants this campaign no longer prices, because someone reverted them out of it
+   * individually.
+   *
+   * Not a filter applied before resolution -- an input to it. Removing the campaign
+   * for one variant lets the next campaign in priority order take over, which is the
+   * whole point: a variant pulled out of a 30% sale that also sits in a 10% one
+   * should land on 10%, not on full price. Filtering the candidate out upstream would
+   * silently produce the latter.
+   *
+   * The resolver itself never sees this, because it has no variant identity by
+   * design. The planner applies it per candidate, in the same place it applies a
+   * campaign-level revert, so preview and execution cannot disagree.
+   */
+  excludedVariantGids?: string[];
 }
 
 // ------------------------------------------------------------------ results

--- a/app/routes/app.campaigns.$id.rollback.tsx
+++ b/app/routes/app.campaigns.$id.rollback.tsx
@@ -1,0 +1,31 @@
+/**
+ * The rollback report as a CSV download.
+ *
+ * Exportable because this is the artefact somebody forwards to whoever made the
+ * edits, or keeps as the record of a decision about a few thousand prices. A report
+ * you can only look at is not a record of anything.
+ */
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { rollbackReport, rollbackReportCsv } from "../services/campaigns/index.server";
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const report = await rollbackReport(shop.id, String(params.id));
+
+  // The campaign name, not the id: this file lands in somebody's downloads folder
+  // next to eleven others, and `rollback-cmt8ro02a000q.csv` tells them nothing.
+  const slug = report.campaignName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+  return new Response(rollbackReportCsv(report), {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="rollback-${slug || "campaign"}.csv"`,
+    },
+  });
+}

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -9,12 +9,16 @@ import { toAdminClient } from "../services/admin-client.server";
 import {
   campaignRuns,
   previewCampaign,
+  reinstateVariant,
+  revertVariant,
+  rollbackReport,
   runCampaign,
   runLedger,
 } from "../services/campaigns/index.server";
 import { describeSchedule, parseSchedule, scheduleWarnings } from "../lib/scheduling/window";
 import { CountsRow } from "../components/CountsRow";
 import { LedgerTable } from "../components/LedgerTable";
+import { RollbackReportTable } from "../components/RollbackReportTable";
 import { PreviewTable } from "../components/PreviewTable";
 import { RunHistoryTable } from "../components/RunHistoryTable";
 import { RouteBoundary } from "../components/RouteBoundary";
@@ -61,7 +65,17 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
   const selectedRunId = requested ?? runs[0]?.id ?? null;
   const ledger = selectedRunId ? await runLedger(shop.id, selectedRunId) : [];
 
+  // Only for a campaign that has actually written something and could still be
+  // reverted. It costs a full plan, and on a draft it would be a report about
+  // nothing -- the honest answer there is that there is nothing to roll back.
+  const revertable = state === "ACTIVE" || state === "PARTIAL" || state === "HELD";
+  const rollback =
+    revertable && runs.some((run) => run.kind === "APPLY")
+      ? await rollbackReport(shop.id, campaignId)
+      : null;
+
   return {
+    rollback,
     preview,
     runs,
     ledger,
@@ -80,10 +94,32 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
 export const action = withGuard("/app/campaigns/$id", async ({ request, params }: ActionFunctionArgs) => {
   const { admin, session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
-  const intent = String((await request.formData()).get("intent"));
+  const form = await request.formData();
+  const intent = String(form.get("intent"));
   const reverting = intent === "revert";
 
   try {
+    // Reverting one variant out of a running campaign, rather than ending the whole
+    // thing. The exclusion is durable, so tonight's scheduled run leaves it alone too.
+    if (intent === "revert-variant" || intent === "reinstate-variant") {
+      const variantGid = String(form.get("variantGid"));
+      const result =
+        intent === "revert-variant"
+          ? await revertVariant(shop.id, String(params.id), variantGid, toAdminClient(admin), {
+              actor: session.shop,
+              excludeOnly: form.get("excludeOnly") === "1",
+            })
+          : await reinstateVariant(shop.id, String(params.id), variantGid, toAdminClient(admin), {
+              actor: session.shop,
+            });
+
+      return {
+        ok: result.outcome ? result.outcome.clean : true,
+        message: result.message,
+        details: result.outcome?.messages ?? [],
+      };
+    }
+
     // Resume is an ordinary apply. The resolver is idempotent, so rows already at the
     // campaign price are planned as "already correct" and cost nothing — only the ones
     // that failed last time are written again. A separate retry path would be a second
@@ -91,6 +127,9 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
     const result = await runCampaign(shop.id, String(params.id), toAdminClient(admin), {
       revert: reverting,
       resume: intent === "resume",
+      // Rows the merchant ticked "leave as it is" in the rollback report. Only
+      // meaningful on a revert; an apply has no drifted-row conversation to honour.
+      skipVariantGids: reverting ? form.getAll("keep").map(String) : undefined,
     });
 
     const verb = reverting ? "Reverted" : intent === "resume" ? "Resumed" : "Applied";
@@ -141,6 +180,7 @@ type ActionData = {
 
 export default function CampaignDetail() {
   const {
+    rollback,
     preview,
     runs,
     ledger,
@@ -224,15 +264,70 @@ export default function CampaignDetail() {
         </s-section>
       ) : null}
 
+      {rollback && rollback.counts.total > 0 ? (
+        <s-section heading="If you revert this campaign">
+          <s-paragraph>
+            <s-text>
+              {rollback.straightforward
+                ? `All ${rollback.counts.total} variants are still at the price this campaign set. Reverting recomputes each one without it.`
+                : `${rollback.counts.drifted} of ${rollback.counts.total} variants have been changed since this campaign set them. Someone edited those on purpose — tick any you want left alone, then revert.`}
+            </s-text>
+          </s-paragraph>
+
+          {rollback.counts.deleted > 0 ? (
+            <s-paragraph>
+              <s-text>
+                {rollback.counts.deleted} variant
+                {rollback.counts.deleted === 1 ? " was" : "s were"} deleted in Shopify.
+                Nothing is written for {rollback.counts.deleted === 1 ? "it" : "them"}.
+              </s-text>
+            </s-paragraph>
+          ) : null}
+
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="revert" />
+            <RollbackReportTable rows={rollback.rows} />
+            <s-stack direction="inline" gap="base">
+              <s-button type="submit" tone="critical" loading={busy || undefined}>
+                Revert, keeping the ticked edits
+              </s-button>
+              <s-link href={`/app/campaigns/${rollback.campaignId}/rollback`}>
+                Export this report (CSV)
+              </s-link>
+            </s-stack>
+          </fetcher.Form>
+        </s-section>
+      ) : null}
+
       {ledger.length > 0 ? (
         <s-section heading="Ledger">
           <s-paragraph>
             <s-text>
               Every row we wrote, with what it was and what we intended. Retained
-              indefinitely on every plan.
+              indefinitely on every plan. Reverting a single variant takes it out of
+              this campaign for good — including future scheduled runs — and recomputes
+              its price without it.
             </s-text>
           </s-paragraph>
-          <LedgerTable rows={ledger} />
+          <LedgerTable
+            rows={ledger}
+            renderAction={(row) =>
+              // Only rows this campaign actually wrote. Offering to revert a row that
+              // failed or was skipped would promise to undo something that never
+              // happened.
+              row.status === "VERIFIED" || row.status === "APPLIED" ? (
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="revert-variant" />
+                  <input type="hidden" name="variantGid" value={row.variantGid} />
+                  <s-button type="submit" variant="tertiary" loading={busy || undefined}>
+                    Revert this variant
+                  </s-button>
+                </fetcher.Form>
+              ) : (
+                <s-text>—</s-text>
+              )
+            }
+          />
         </s-section>
       ) : null}
 
@@ -259,12 +354,27 @@ export default function CampaignDetail() {
             </fetcher.Form>
           ) : null}
 
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="revert" />
-            <s-button type="submit" tone="critical" loading={busy || undefined}>
-              Revert
-            </s-button>
-          </fetcher.Form>
+          {rollback && !rollback.straightforward ? (
+            // Deliberately not a button. There are edits to decide about, and a
+            // one-click revert here would silently overwrite them -- the decision
+            // belongs in the report, where the merchant can see what they are
+            // choosing between.
+            <s-paragraph>
+              <s-text>
+                {rollback.counts.drifted} variant
+                {rollback.counts.drifted === 1 ? " has" : "s have"} been changed since
+                this campaign set {rollback.counts.drifted === 1 ? "it" : "them"}.
+                Review them above before reverting.
+              </s-text>
+            </s-paragraph>
+          ) : (
+            <fetcher.Form method="post">
+              <input type="hidden" name="intent" value="revert" />
+              <s-button type="submit" tone="critical" loading={busy || undefined}>
+                Revert
+              </s-button>
+            </fetcher.Form>
+          )}
         </s-stack>
 
         <s-paragraph>

--- a/app/services/campaigns/candidates.server.ts
+++ b/app/services/campaigns/candidates.server.ts
@@ -53,9 +53,21 @@ export async function titleMapFor(
 export async function loadCandidates(
   shopId: string,
   ast: FilterAst,
+  /**
+   * Restricts the scope to these variants, for a run that concerns only some of them.
+   *
+   * Intersected with the campaign's filter rather than replacing it: a variant outside
+   * the campaign's scope must not be pulled into a run just because a caller named it.
+   */
+  onlyVariantGids?: string[],
 ): Promise<PlanCandidate[]> {
+  if (onlyVariantGids?.length === 0) return [];
+
   const variants = await prisma.variantIndex.findMany({
-    where: astToWhere(shopId, ast),
+    where: {
+      ...astToWhere(shopId, ast),
+      ...(onlyVariantGids ? { variantGid: { in: onlyVariantGids } } : {}),
+    },
     select: { variantGid: true, currency: true, cost: true },
   });
   if (variants.length === 0) return [];

--- a/app/services/campaigns/index.server.ts
+++ b/app/services/campaigns/index.server.ts
@@ -10,6 +10,15 @@ export { loadCandidates, productMapFor, titleMapFor } from "./candidates.server"
 export { previewCampaign, type PreviewOptions } from "./preview.server";
 export { runCampaign, type RunOptions } from "./run.server";
 export { campaignRuns, runLedger } from "./history.server";
+export { revertVariant, reinstateVariant } from "./variant-revert.server";
+export {
+  rollbackReport,
+  rollbackReportCsv,
+  classifyRollbackRow,
+  type RollbackReport,
+  type RollbackRow,
+  type RollbackRowKind,
+} from "./rollback-report.server";
 export type {
   CampaignInput,
   CampaignPreview,

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -64,7 +64,14 @@ export function astOf(campaign: Pick<Campaign, "schedule">): FilterAst {
 export function toResolvable(
   campaign: Pick<
     Campaign,
-    "id" | "priority" | "ruleRows" | "compareAtPolicy" | "guardrails" | "schedule" | "createdAt"
+    | "id"
+    | "priority"
+    | "ruleRows"
+    | "compareAtPolicy"
+    | "guardrails"
+    | "schedule"
+    | "createdAt"
+    | "excludedVariantGids"
   >,
 ): ResolvableCampaign {
   const schedule = (campaign.schedule ?? {}) as { rounding?: string };
@@ -83,6 +90,10 @@ export function toResolvable(
     roundingProfile: roundingFor(schedule.rounding),
     guardrails: (campaign.guardrails ?? undefined) as unknown as Guardrails | undefined,
     guardrailViolationPolicy: "clamp",
+    // Variants reverted out of this campaign individually. Carried into resolution
+    // rather than filtered out beforehand, so an excluded variant falls through to
+    // whatever else still controls it instead of jumping to full price.
+    excludedVariantGids: campaign.excludedVariantGids,
   };
 }
 

--- a/app/services/campaigns/rollback-report.server.ts
+++ b/app/services/campaigns/rollback-report.server.ts
@@ -1,0 +1,277 @@
+/**
+ * What reverting this campaign would actually do — and which rows somebody has
+ * touched since.
+ *
+ * Revert is `resolve(without C)`, which is the right computation but says nothing
+ * about whether it is the right *action* for every row. If a variant's live price no
+ * longer matches what the campaign wrote, a person changed it on purpose while the
+ * sale was running. Reverting it silently overwrites that decision, and a merchant
+ * who watches the app undo their manual correction has learned not to trust it with
+ * their prices.
+ *
+ * So a revert with drift in it is a conversation, not a command. This builds the two
+ * lists that conversation needs: rows that will revert cleanly, and rows where
+ * somebody else got there first.
+ *
+ * Deleted variants are their own category rather than an error. A merchant removing a
+ * product mid-sale is ordinary; reporting it as a problem to resolve trains people to
+ * click past the list, which is how the rows that do matter get missed (E4).
+ */
+
+import prisma from "../../db.server";
+import { format } from "../../lib/money/format";
+import { money } from "../../lib/money/money";
+import { planRun } from "../../lib/planning/plan";
+import { loadCandidates, titleMapFor } from "./candidates.server";
+import { loadCampaignContext } from "./model.server";
+import { guardrailsFor } from "../settings.server";
+
+export type RollbackRowKind =
+  /** Live value matches what we applied. Reverting is uncontroversial. */
+  | "clean"
+  /** Live value differs from what we applied — somebody edited it. */
+  | "drifted"
+  /** Variant no longer exists in Shopify. Nothing to revert. */
+  | "deleted";
+
+export interface RollbackRow {
+  variantGid: string;
+  title: string;
+  kind: RollbackRowKind;
+  /** What this campaign last wrote, from the ledger. */
+  applied: string | null;
+  /** What the storefront shows now, from the mirror. */
+  live: string | null;
+  /** What `resolve(without this campaign)` would write. */
+  revertsTo: string | null;
+}
+
+export interface RollbackReport {
+  campaignId: string;
+  campaignName: string;
+  rows: RollbackRow[];
+  counts: { total: number; clean: number; drifted: number; deleted: number };
+  /** True when nothing needs a decision and the revert can just run. */
+  straightforward: boolean;
+}
+
+/**
+ * Which of the three states a row is in.
+ *
+ * Pure, so the boundaries are testable without a database — and they need to be,
+ * because the default matters. An unknown comparison resolves to `clean`, meaning the
+ * revert proceeds. That is the right way round: `drifted` asks a person a question,
+ * and a report that invents questions about rows nobody touched is a report people
+ * learn to click through, which is how the real ones get missed.
+ */
+export function classifyRollbackRow(input: {
+  deleted: boolean;
+  /** What the campaign wrote, in minor units. */
+  applied: number | null;
+  /** What the mirror says is live, in minor units. */
+  live: number | null;
+}): RollbackRowKind {
+  if (input.deleted) return "deleted";
+  if (input.applied === null || input.live === null) return "clean";
+  return input.live === input.applied ? "clean" : "drifted";
+}
+
+export async function rollbackReport(
+  shopId: string,
+  campaignId: string,
+): Promise<RollbackReport> {
+  const { campaign, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
+
+  const [candidates, storeGuardrails, applied] = await Promise.all([
+    loadCandidates(shopId, ast),
+    guardrailsFor(shopId),
+    appliedValues(campaignId),
+  ]);
+
+  // The report is a list of what this campaign wrote, so the ledger defines the rows
+  // -- not the campaign's current filter. Those are different sets, and the
+  // difference is exactly where the interesting rows live: `loadCandidates` drops
+  // tombstoned variants by design, so a product deleted mid-sale would vanish from a
+  // filter-driven report rather than being reported as deleted (E4).
+  const appliedGids = [...applied.keys()];
+
+  // The same planner the revert itself will use, so the "reverts to" column cannot
+  // disagree with what happens when the merchant clicks the button.
+  const outcome = planRun({
+    campaigns: resolvable,
+    candidates,
+    storeGuardrails,
+    excludeCampaignId: campaignId,
+  });
+
+  const [titles, mirror] = await Promise.all([
+    titleMapFor(shopId, appliedGids),
+    mirrorState(shopId, appliedGids),
+  ]);
+
+  const revertsTo = new Map(
+    outcome.kind === "ok"
+      ? outcome.rows.map((row) => [
+          row.ref.variantGid,
+          row.intendedPrice ? format(row.intendedPrice) : null,
+        ])
+      : [],
+  );
+
+  // Where the planner found no row, the variant is already where the revert would put
+  // it -- so it reverts to what it currently shows, not to nothing.
+  const inScope = new Map(candidates.map((c) => [c.ref.variantGid, c]));
+
+  const rows: RollbackRow[] = [];
+
+  for (const [gid, wrote] of applied) {
+    const state = mirror.get(gid);
+    const currency = state?.currency ?? inScope.get(gid)?.ref.currency ?? "USD";
+    const live = state?.livePrice ?? null;
+
+    const kind = classifyRollbackRow({
+      // Absent from the mirror entirely counts as gone, not as unchanged: we have no
+      // basis to claim anything about a variant we can no longer see.
+      deleted: state === undefined || state.deleted,
+      applied: wrote === null ? null : Number(wrote),
+      live: live === null ? null : Number(live),
+    });
+
+    rows.push({
+      variantGid: gid,
+      title: titles.get(gid) ?? gid,
+      kind,
+      applied: wrote === null ? null : format(money(Number(wrote), currency)),
+      live: live === null ? null : format(money(Number(live), currency)),
+      // A deleted variant has nowhere to revert to, and claiming otherwise implies a
+      // write that cannot happen.
+      revertsTo:
+        kind === "deleted"
+          ? null
+          : (revertsTo.get(gid) ??
+            (live === null ? null : format(money(Number(live), currency)))),
+    });
+  }
+
+  // Rows needing a decision first: this is a list people skim, and the ones that
+  // matter must not be below the fold.
+  const order: Record<RollbackRowKind, number> = { drifted: 0, deleted: 1, clean: 2 };
+  rows.sort((a, b) => order[a.kind] - order[b.kind] || a.title.localeCompare(b.title));
+
+  const counts = {
+    total: rows.length,
+    clean: rows.filter((r) => r.kind === "clean").length,
+    drifted: rows.filter((r) => r.kind === "drifted").length,
+    deleted: rows.filter((r) => r.kind === "deleted").length,
+  };
+
+  return {
+    campaignId,
+    campaignName: campaign.name,
+    rows,
+    counts,
+    straightforward: counts.drifted === 0,
+  };
+}
+
+/** Live value, currency and tombstone state for the variants a campaign wrote. */
+async function mirrorState(
+  shopId: string,
+  variantGids: string[],
+): Promise<Map<string, { livePrice: bigint | null; currency: string; deleted: boolean }>> {
+  if (variantGids.length === 0) return new Map();
+
+  const [entries, index] = await Promise.all([
+    prisma.priceSurfaceEntry.findMany({
+      where: { shopId, variantGid: { in: variantGids }, surfaceKind: "BASE", priceListGid: "" },
+      select: { variantGid: true, livePrice: true, currency: true },
+    }),
+    prisma.variantIndex.findMany({
+      where: { shopId, variantGid: { in: variantGids } },
+      select: { variantGid: true, deletedAt: true, currency: true },
+    }),
+  ]);
+
+  const tombstones = new Map(index.map((row) => [row.variantGid, row.deletedAt !== null]));
+  const state = new Map<
+    string,
+    { livePrice: bigint | null; currency: string; deleted: boolean }
+  >();
+
+  for (const entry of entries) {
+    state.set(entry.variantGid, {
+      livePrice: entry.livePrice,
+      currency: entry.currency,
+      // Absent from variant_index at all is treated as gone, for the same reason as
+      // an explicit tombstone: we cannot say anything about a variant we cannot see.
+      deleted: tombstones.get(entry.variantGid) ?? true,
+    });
+  }
+
+  return state;
+}
+
+/**
+ * What this campaign last wrote for each variant, from the ledger.
+ *
+ * The ledger, not the mirror: the mirror holds what is live, which is precisely the
+ * value being compared against. Reading both from the same place would compare a
+ * number to itself and report that nothing ever drifts.
+ *
+ * Only settled rows count. A row that failed was never written, so a live value
+ * differing from its intent is not drift — it is the failure, and the run already
+ * reports that.
+ */
+async function appliedValues(campaignId: string): Promise<Map<string, bigint | null>> {
+  const runs = await prisma.campaignRun.findMany({
+    where: { campaignId, kind: "APPLY" },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+    take: 20,
+  });
+  if (runs.length === 0) return new Map();
+
+  const changes = await prisma.variantChange.findMany({
+    where: {
+      runId: { in: runs.map((r) => r.id) },
+      status: { in: ["VERIFIED", "APPLIED"] },
+    },
+    orderBy: { id: "desc" },
+    select: { variantGid: true, intendedPrice: true },
+  });
+
+  // Newest wins. A recurring campaign writes the same variant on every occurrence,
+  // and only the most recent value is the one drift is measured against.
+  const latest = new Map<string, bigint | null>();
+  for (const change of changes) {
+    if (!latest.has(change.variantGid)) latest.set(change.variantGid, change.intendedPrice);
+  }
+  return latest;
+}
+
+/**
+ * The report as CSV.
+ *
+ * Exportable because this is the artefact somebody forwards to whoever made the edit,
+ * or keeps as the record of a decision about a few thousand prices. Values are
+ * quoted and internal quotes doubled: product titles contain commas and inches
+ * routinely, and a report that corrupts itself on a 24" monitor is not a record.
+ */
+export function rollbackReportCsv(report: RollbackReport): string {
+  const header = ["variant_gid", "title", "state", "applied", "live_now", "reverts_to"];
+  const lines = [header.join(",")];
+
+  for (const row of report.rows) {
+    lines.push(
+      [row.variantGid, row.title, row.kind, row.applied ?? "", row.live ?? "", row.revertsTo ?? ""]
+        .map(csvCell)
+        .join(","),
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function csvCell(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}

--- a/app/services/campaigns/rollback-report.test.ts
+++ b/app/services/campaigns/rollback-report.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Row classification and the export.
+ *
+ * The classification decides whether a revert asks a person a question. Getting it
+ * wrong in one direction silently overwrites a deliberate edit; in the other it fills
+ * the report with questions about rows nobody touched, which trains people to click
+ * through it — and then the rows that mattered go with them.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { classifyRollbackRow, rollbackReportCsv, type RollbackReport } from "./rollback-report.server";
+
+describe("classifyRollbackRow", () => {
+  it("calls a row clean when live matches what we applied", () => {
+    expect(classifyRollbackRow({ deleted: false, applied: 8_000, live: 8_000 })).toBe("clean");
+  });
+
+  it("calls a row drifted when somebody changed it since", () => {
+    expect(classifyRollbackRow({ deleted: false, applied: 8_000, live: 7_500 })).toBe("drifted");
+  });
+
+  it("reports a deleted variant as deleted rather than drifted", () => {
+    // A merchant removing a product mid-sale is ordinary. Surfacing it as a conflict
+    // needing resolution would be asking a question with no answer (E4).
+    expect(classifyRollbackRow({ deleted: true, applied: 8_000, live: null })).toBe("deleted");
+  });
+
+  it("prefers deleted over drifted when both look true", () => {
+    expect(classifyRollbackRow({ deleted: true, applied: 8_000, live: 7_500 })).toBe("deleted");
+  });
+
+  it("treats an unknown comparison as clean, not as a question", () => {
+    // No mirrored live value, or nothing recorded as applied. There is no evidence of
+    // an edit, and inventing one costs the merchant attention they will stop paying.
+    expect(classifyRollbackRow({ deleted: false, applied: null, live: 8_000 })).toBe("clean");
+    expect(classifyRollbackRow({ deleted: false, applied: 8_000, live: null })).toBe("clean");
+  });
+});
+
+describe("rollbackReportCsv", () => {
+  const report = (rows: RollbackReport["rows"]): RollbackReport => ({
+    campaignId: "c1",
+    campaignName: "Summer sale",
+    rows,
+    counts: { total: rows.length, clean: 0, drifted: 0, deleted: 0 },
+    straightforward: false,
+  });
+
+  it("writes a header and one row per variant", () => {
+    const csv = rollbackReportCsv(
+      report([
+        {
+          variantGid: "gid://Variant/1",
+          title: "Blue shirt",
+          kind: "drifted",
+          applied: "$80.00",
+          live: "$75.00",
+          revertsTo: "$100.00",
+        },
+      ]),
+    );
+
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe("variant_gid,title,state,applied,live_now,reverts_to");
+    expect(lines[1]).toBe(
+      '"gid://Variant/1","Blue shirt","drifted","$80.00","$75.00","$100.00"',
+    );
+  });
+
+  it("survives titles containing commas and quotes", () => {
+    // Product titles carry both routinely — a 24" monitor, "Red, large". A report that
+    // corrupts itself on ordinary catalogue data is not a record of anything.
+    const csv = rollbackReportCsv(
+      report([
+        {
+          variantGid: "gid://Variant/2",
+          title: 'Monitor, 24" — "Pro"',
+          kind: "clean",
+          applied: "$80.00",
+          live: "$80.00",
+          revertsTo: "$100.00",
+        },
+      ]),
+    );
+
+    expect(csv).toContain('"Monitor, 24"" — ""Pro"""');
+    expect(csv.trim().split("\n")).toHaveLength(2);
+  });
+
+  it("writes empty cells rather than the word null", () => {
+    const csv = rollbackReportCsv(
+      report([
+        {
+          variantGid: "gid://Variant/3",
+          title: "Gone",
+          kind: "deleted",
+          applied: "$80.00",
+          live: null,
+          revertsTo: null,
+        },
+      ]),
+    );
+
+    expect(csv).toContain('"gid://Variant/3","Gone","deleted","$80.00","",""');
+    expect(csv).not.toContain("null");
+  });
+});

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -43,6 +43,26 @@ export interface RunOptions {
    * second one. Defaults to the current instant, which is right for a manual apply.
    */
   occurrenceKey?: string;
+  /**
+   * Restricts the run to these variants.
+   *
+   * A variant-level revert would otherwise replan the entire campaign to fix one row,
+   * which on a large catalogue costs more than the operation it is performing. The
+   * planner still resolves against every campaign, so the row lands where full
+   * resolution would have put it -- the scope narrows what is examined, never how it
+   * is decided.
+   */
+  variantGids?: string[];
+  /**
+   * Variants to leave exactly as they are, recorded rather than silently dropped.
+   *
+   * This is the rollback report's "keep the merchant's edit". Somebody changed the
+   * price by hand while the campaign was running, and reverting would overwrite a
+   * deliberate decision. The rows still land in the ledger as SKIPPED with the reason
+   * attached, because "we chose not to touch these" is exactly the kind of thing that
+   * has to be explainable six weeks later.
+   */
+  skipVariantGids?: string[];
 }
 
 export async function runCampaign(
@@ -53,7 +73,7 @@ export async function runCampaign(
 ): Promise<RunOutcome> {
   const { resolvable, ast } = await loadCampaignContext(shopId, campaignId);
   const [candidates, storeGuardrails] = await Promise.all([
-    loadCandidates(shopId, ast),
+    loadCandidates(shopId, ast, options.variantGids),
     guardrailsFor(shopId),
   ]);
 
@@ -72,7 +92,20 @@ export async function runCampaign(
   }
 
   const kind = options.revert ? "REVERT" : "APPLY";
-  let writable = outcome.rows.filter((row) => row.status !== "skipped");
+  const leaveAlone = new Set(options.skipVariantGids ?? []);
+
+  let writable = outcome.rows.filter(
+    (row) => row.status !== "skipped" && !leaveAlone.has(row.ref.variantGid),
+  );
+
+  // Planned, then deliberately not written. Kept separate from `writable` so nothing
+  // downstream can accidentally execute them, and still ledgered below.
+  const spared =
+    leaveAlone.size === 0
+      ? []
+      : outcome.rows.filter(
+          (row) => row.status !== "skipped" && leaveAlone.has(row.ref.variantGid),
+        );
 
   // Resuming: drop rows a previous attempt already verified. The resolver would reach
   // the same answer for them anyway, but re-sending costs rate limit and, worse, the
@@ -136,6 +169,7 @@ export async function runCampaign(
   }
 
   await writeLedgerRows(run.id, shopId, writable);
+  await writeSparedRows(run.id, shopId, spared);
 
   // Record intents before writing: every price we write produces a products/update
   // webhook moments later, and without this the drift detector would flag our own
@@ -182,6 +216,15 @@ export async function runCampaign(
       finishedAt: new Date(),
     },
   });
+
+  // A run over a named handful of variants says nothing about the campaign as a
+  // whole. Reverting one variant out of a four-thousand-variant sale must not mark
+  // the sale COMPLETED -- it is still running, for everything else. The ledger records
+  // what happened to those rows; the campaign's own state is left alone.
+  if (options.variantGids) {
+    await refreshMirror(shopId, result.rows);
+    return scopedOutcome(run.id, outcome.counts.planned, result, messages);
+  }
 
   // Through the state machine, not a direct write: it enforces which moves are legal
   // and records how the campaign got here. A run that finishes late must not clobber a
@@ -269,6 +312,61 @@ function heartbeat(runId: string, everyMs = 5_000) {
       // Liveness is a hint, never a reason to fail a run that is otherwise working.
     }
   };
+}
+
+/** The outcome shape for a scoped run, which reports rows without judging the campaign. */
+function scopedOutcome(
+  runId: string,
+  planned: number,
+  result: Awaited<ReturnType<typeof executeRows>>,
+  messages: string[],
+): RunOutcome {
+  return {
+    runId,
+    planned,
+    verified: result.verified,
+    failed: result.failed,
+    unverified: result.unverified,
+    clean: result.clean,
+    messages: messages.slice(0, 5),
+  };
+}
+
+/**
+ * Ledgers the rows a person chose not to touch.
+ *
+ * Written as SKIPPED and already settled, so they never look like outstanding work to
+ * a resume, and never count against a clean run. The reason is stored on the row
+ * because the run view is where somebody asks why a variant they expected to change
+ * did not.
+ */
+async function writeSparedRows(
+  runId: string,
+  shopId: string,
+  rows: PlannedRow[],
+): Promise<void> {
+  if (rows.length === 0) return;
+
+  await prisma.variantChange.createMany({
+    data: rows.map((row) => ({
+      runId,
+      shopId,
+      variantGid: row.ref.variantGid,
+      surfaceKind: "BASE" as const,
+      priceListGid: "",
+      currency: row.ref.currency,
+      beforePrice: row.beforePrice ? BigInt(row.beforePrice.amount) : null,
+      beforeCompareAt: row.beforeCompareAt ? BigInt(row.beforeCompareAt.amount) : null,
+      intendedPrice: row.intendedPrice ? BigInt(row.intendedPrice.amount) : null,
+      intendedCompareAt: row.intendedCompareAt ? BigInt(row.intendedCompareAt.amount) : null,
+      intendedCompareAtSet: row.intendedCompareAtSet,
+      status: "SKIPPED" as const,
+      failureReason:
+        "Left as it is: this price was changed outside the app and you chose to keep that edit.",
+      appliedAt: new Date(),
+    })),
+    skipDuplicates: true,
+  });
 }
 
 /** Write-ahead ledger. Chunked so a large plan does not build one giant statement. */

--- a/app/services/campaigns/variant-revert.server.ts
+++ b/app/services/campaigns/variant-revert.server.ts
@@ -1,0 +1,220 @@
+/**
+ * Reverting one variant out of a running campaign.
+ *
+ * The case this exists for: a merchant puts 4,000 products on sale, then notices that
+ * three of them should not have been. The alternatives without this are all bad --
+ * revert the whole campaign and reapply it with a narrower filter, or edit the price
+ * by hand in Shopify and have the next run overwrite it. Both are how a merchant ends
+ * up not trusting the app to leave their prices alone.
+ *
+ * Two halves, and both are needed:
+ *
+ *   The exclusion is durable. Written to the campaign before anything is priced, so
+ *   the next scheduled run, the next auto-enroll and the next recurrence all leave
+ *   the variant alone. A revert that only fixed today's price would be undone by
+ *   tonight's tick, which is worse than not offering it.
+ *
+ *   The price is recomputed, not restored. `resolve(without this campaign, for this
+ *   variant)` -- so a variant pulled out of a 30% sale that also sits in a 10% one
+ *   lands on 10%. Restoring a saved number would quietly end a sale the merchant
+ *   never ended.
+ *
+ * It runs through the ordinary planner, executor and verifier. A separate write path
+ * for "just one variant" would be a second implementation of the ledger, free to
+ * disagree with the first about what happened.
+ */
+
+import prisma from "../../db.server";
+import { AppError } from "../../lib/errors/app-error";
+import type { AdminClient } from "../../lib/execution/sync-executor";
+import { runCampaign } from "./run.server";
+import type { RunOutcome } from "./types";
+
+export interface VariantRevertOptions {
+  actor?: string;
+  /**
+   * Record the exclusion but write nothing.
+   *
+   * For the rollback report's "leave the merchant's edit": the campaign should stop
+   * touching the variant, and the value currently on the storefront is the one the
+   * merchant wants kept.
+   */
+  excludeOnly?: boolean;
+}
+
+export interface VariantRevertResult {
+  /** Null when the variant was already excluded, or when nothing needed writing. */
+  outcome: RunOutcome | null;
+  /** False when this variant was already excluded from the campaign. */
+  changed: boolean;
+  message: string;
+}
+
+export async function revertVariant(
+  shopId: string,
+  campaignId: string,
+  variantGid: string,
+  client: AdminClient,
+  options: VariantRevertOptions = {},
+): Promise<VariantRevertResult> {
+  const campaign = await prisma.campaign.findFirst({
+    where: { id: campaignId, shopId },
+    select: { id: true, name: true, excludedVariantGids: true },
+  });
+
+  if (!campaign) {
+    throw new AppError({
+      code: "NOT_FOUND",
+      userMessage:
+        "That campaign no longer exists, so there is nothing to revert this variant out of. Reload the page.",
+      context: { campaignId, variantGid },
+    });
+  }
+
+  const already = campaign.excludedVariantGids.includes(variantGid);
+
+  if (!already) {
+    // Before the write, always. If the exclusion failed to persist but the price was
+    // already recomputed, the next run would put the campaign price straight back and
+    // the merchant would watch their fix undo itself.
+    await prisma.campaign.update({
+      where: { id: campaignId },
+      data: { excludedVariantGids: { push: variantGid } },
+    });
+
+    await prisma.auditLogEntry.create({
+      data: {
+        shopId,
+        actor: options.actor ?? null,
+        action: "campaign.variant.excluded",
+        entity: "campaign",
+        entityId: campaignId,
+        after: { variantGid, excludeOnly: options.excludeOnly ?? false },
+      },
+    });
+  }
+
+  if (options.excludeOnly) {
+    return {
+      changed: !already,
+      outcome: null,
+      message: already
+        ? `This variant was already excluded from "${campaign.name}". Its price is unchanged.`
+        : `"${campaign.name}" will no longer price this variant. Its current price was left as it is.`,
+    };
+  }
+
+  // Scoped to the one variant, but resolved against every campaign — so it lands
+  // where full resolution would put it, including under a lower-priority campaign
+  // that still covers it.
+  // `revert: true` so the run is ledgered as a REVERT rather than an APPLY -- what
+  // happened here is an undo, and a run history that calls it an apply is a run
+  // history that misleads whoever reads it later. The campaign's own state is
+  // untouched, because a scoped run says nothing about the other 3,999 variants.
+  const outcome = await runCampaign(shopId, campaignId, client, {
+    revert: true,
+    variantGids: [variantGid],
+    verifySampleRate: 1,
+    occurrenceKey: `VARIANT-REVERT-${variantGid}-${Date.now()}`,
+  });
+
+  return {
+    changed: !already,
+    outcome,
+    message: describe(campaign.name, outcome, already),
+  };
+}
+
+function describe(campaignName: string, outcome: RunOutcome, already: boolean): string {
+  const prefix = already
+    ? `This variant was already excluded from "${campaignName}".`
+    : `"${campaignName}" will no longer price this variant.`;
+
+  if (outcome.planned === 0) {
+    // Nothing to write: the storefront already shows what resolution says it should.
+    // Saying "0 variants updated" without this reads like a failure.
+    return `${prefix} Its price was already correct, so nothing was written.`;
+  }
+
+  if (!outcome.clean) {
+    return (
+      `${prefix} The price change did not complete — ${outcome.failed} failed, ` +
+      `${outcome.unverified} unverified. The exclusion is saved; resume the campaign to retry.`
+    );
+  }
+
+  return `${prefix} Its price has been recomputed without it and verified.`;
+}
+
+/**
+ * Puts a variant back into a campaign.
+ *
+ * The undo. Removing the exclusion is not enough on its own — the variant is now
+ * sitting at a price the campaign disagrees with, so it is repriced in the same
+ * scoped way it was let out.
+ */
+export async function reinstateVariant(
+  shopId: string,
+  campaignId: string,
+  variantGid: string,
+  client: AdminClient,
+  options: { actor?: string } = {},
+): Promise<VariantRevertResult> {
+  const campaign = await prisma.campaign.findFirst({
+    where: { id: campaignId, shopId },
+    select: { name: true, excludedVariantGids: true },
+  });
+
+  if (!campaign) {
+    throw new AppError({
+      code: "NOT_FOUND",
+      userMessage: "That campaign no longer exists. Reload the page.",
+      context: { campaignId, variantGid },
+    });
+  }
+
+  if (!campaign.excludedVariantGids.includes(variantGid)) {
+    return {
+      changed: false,
+      outcome: null,
+      message: `This variant is already part of "${campaign.name}".`,
+    };
+  }
+
+  // `set`, not a pull: Prisma has no array-remove primitive, and read-modify-write on
+  // the list we already hold is exact.
+  await prisma.campaign.update({
+    where: { id: campaignId },
+    data: {
+      excludedVariantGids: {
+        set: campaign.excludedVariantGids.filter((gid) => gid !== variantGid),
+      },
+    },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor: options.actor ?? null,
+      action: "campaign.variant.reinstated",
+      entity: "campaign",
+      entityId: campaignId,
+      after: { variantGid },
+    },
+  });
+
+  const outcome = await runCampaign(shopId, campaignId, client, {
+    variantGids: [variantGid],
+    verifySampleRate: 1,
+    occurrenceKey: `VARIANT-REINSTATE-${variantGid}-${Date.now()}`,
+  });
+
+  return {
+    changed: true,
+    outcome,
+    message:
+      outcome.planned === 0
+        ? `This variant is back in "${campaign.name}". Its price was already correct.`
+        : `This variant is back in "${campaign.name}" and has been repriced.`,
+  };
+}

--- a/chaos/harness/scenario.ts
+++ b/chaos/harness/scenario.ts
@@ -39,7 +39,7 @@ export interface ChaosContext {
   /** Applies the campaign in-process, through the real run path. */
   apply(options?: RunOptions): Promise<RunOutcome>;
   /** Reverts it, likewise -- `resolve(without C)`, not a restore. */
-  revert(): Promise<RunOutcome>;
+  revert(options?: RunOptions): Promise<RunOutcome>;
 
   /** What the store says right now, per variant. */
   livePrices(): Map<string, string | undefined>;
@@ -109,13 +109,14 @@ export async function withChaos(
       });
     },
 
-    revert: async () => {
+    revert: async (options = {}) => {
       await transitionCampaign(fixture.shopId, fixture.campaignId, "REVERTING", {
         reason: `chaos/${scenario}: reset`,
       });
       return runCampaign(fixture.shopId, fixture.campaignId, client, {
         revert: true,
         verifySampleRate: 1,
+        ...options,
       });
     },
 

--- a/chaos/harness/verdict.ts
+++ b/chaos/harness/verdict.ts
@@ -47,6 +47,21 @@ export async function judge(
   });
   const rows = await prisma.variantChange.findMany({ where: { runId } });
 
+  // Every ledger row on the shop, not just this run's. I4 says no price is written
+  // without a row committed first -- it says nothing about which run owns it, and a
+  // scenario that applies then reverts then reverts one variant has writes spread
+  // across several runs. Checking one run's rows against every write ever made
+  // reported the earlier runs' perfectly-ledgered writes as violations.
+  const everLedgered = new Set(
+    (
+      await prisma.variantChange.findMany({
+        where: { shopId: fixture.shopId },
+        select: { variantGid: true },
+        distinct: ["variantGid"],
+      })
+    ).map((row) => row.variantGid),
+  );
+
   const counts: Record<string, number> = {};
   for (const row of rows) counts[row.status] = (counts[row.status] ?? 0) + 1;
 
@@ -83,9 +98,8 @@ export async function judge(
   //
   // Every price the store accepted must have had a row committed first. A write with
   // no ledger row is a storefront change we cannot explain, attribute or revert.
-  const ledgered = new Set(rows.map((row) => row.variantGid));
   for (const write of fake.writeLog) {
-    if (!ledgered.has(write.variantGid)) {
+    if (!everLedgered.has(write.variantGid)) {
       violations.push(
         `${write.variantGid} was written to the store with no ledger row behind it (I4).`,
       );

--- a/chaos/scenarios/variant-revert.chaos.ts
+++ b/chaos/scenarios/variant-revert.chaos.ts
@@ -1,0 +1,174 @@
+/**
+ * Pulling one variant out of a running campaign, and a revert that respects an edit
+ * somebody made by hand.
+ *
+ * Here rather than in the unit suite because the claims are about durability, and
+ * durability is not something a pure test can check. "Excluded from subsequent runs"
+ * means a row in Postgres that a later run reads; "the ledger records the partial
+ * revert" means a run somebody can open in six weeks. Both need the real engine
+ * against a real database, which is the rig this directory already provides.
+ *
+ * It earns its place among the chaos scenarios on the second half. The rollback
+ * report exists because a merchant edits a price while a sale is running, so the test
+ * does exactly that -- reaches past the app and changes the store behind its back --
+ * and then asserts the revert notices, asks, and honours the answer instead of
+ * silently overwriting a deliberate decision.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import {
+  reinstateVariant,
+  revertVariant,
+  rollbackReport,
+  rollbackReportCsv,
+} from "../../app/services/campaigns/index.server";
+import { chaosAdminClient } from "../harness/http-client";
+import { ledgerOf, withChaos } from "../harness/scenario";
+
+describe("chaos: one variant reverted out of a running campaign", () => {
+  it("recomputes it, ledgers the revert, and keeps it out of later runs", async () => {
+    await withChaos(
+      "variant-revert",
+      { catalog: { products: 8, variantsPerProduct: 2 }, percent: -25 },
+      async (chaos) => {
+        const client = chaosAdminClient(chaos.server.endpoint());
+        const { shopId, campaignId, baseline } = chaos.fixture;
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const victim = chaos.fixture.variantGids[0];
+        const base = baseline.get(victim)!;
+        expect(chaos.fake.priceOf(victim)).toBe(((base * 0.75) / 100).toFixed(2));
+
+        // ---------------------------------------------------- the single revert
+        const result = await revertVariant(shopId, campaignId, victim, client);
+        expect(result.changed).toBe(true);
+        expect(result.outcome?.clean).toBe(true);
+
+        // Back to its own baseline, because nothing else covers it.
+        expect(chaos.fake.priceOf(victim)).toBe((base / 100).toFixed(2));
+
+        // Every other variant is untouched. A single-variant revert that quietly
+        // ended the sale for everyone would be far worse than not offering one.
+        for (const gid of chaos.fixture.variantGids.slice(1)) {
+          const expected = Math.round(baseline.get(gid)! * 0.75);
+          expect(chaos.fake.priceOf(gid)).toBe((expected / 100).toFixed(2));
+        }
+
+        // -------------------------------------------------- durably excluded
+        const record = await prisma.campaign.findUniqueOrThrow({
+          where: { id: campaignId },
+          select: { excludedVariantGids: true, status: true },
+        });
+        expect(record.excludedVariantGids).toContain(victim);
+
+        // The campaign is still running. A scoped run must not decide the fate of
+        // the variants it never looked at.
+        expect(record.status).toBe("ACTIVE");
+
+        // Ledgered as a revert, not as an apply.
+        const scopedRun = await prisma.campaignRun.findFirstOrThrow({
+          where: { campaignId, kind: "REVERT" },
+          orderBy: { createdAt: "desc" },
+        });
+        const scopedRows = await ledgerOf(scopedRun.id);
+        expect(scopedRows).toHaveLength(1);
+        expect(scopedRows[0].variantGid).toBe(victim);
+        expect(scopedRows[0].status).toBe("VERIFIED");
+        expect(Number(scopedRows[0].intendedPrice)).toBe(base);
+
+        // ------------------------------------- and it stays out on the next run
+        // The claim that makes this worth offering. A revert undone by tonight's
+        // scheduled run is worse than no revert at all.
+        const rerun = await chaos.apply();
+        await chaos.expectHonest(rerun.runId);
+        expect(chaos.fake.priceOf(victim)).toBe((base / 100).toFixed(2));
+
+        const rerunRows = await ledgerOf(rerun.runId);
+        expect(rerunRows.some((row) => row.variantGid === victim)).toBe(false);
+
+        // ------------------------------------------------------- and back in
+        const back = await reinstateVariant(shopId, campaignId, victim, client);
+        expect(back.changed).toBe(true);
+        expect(chaos.fake.priceOf(victim)).toBe(((base * 0.75) / 100).toFixed(2));
+      },
+    );
+  });
+});
+
+describe("chaos: a revert that respects a merchant's edit", () => {
+  it("reports the drifted row, leaves it when asked, and ledgers the decision", async () => {
+    await withChaos(
+      "rollback-report",
+      { catalog: { products: 6, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, baseline } = chaos.fixture;
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // A person changes a price in Shopify while the sale is running -- the whole
+        // reason this report exists. Written straight into the store and the mirror,
+        // never through the app, because a drift the app made is not drift.
+        const edited = chaos.fixture.variantGids[0];
+        const deleted = chaos.fixture.variantGids[1];
+        const handPrice = 4_242;
+
+        chaos.fake.variants.get(edited)!.price = (handPrice / 100).toFixed(2);
+        await prisma.priceSurfaceEntry.updateMany({
+          where: { shopId, variantGid: edited, surfaceKind: "BASE", priceListGid: "" },
+          data: { livePrice: BigInt(handPrice) },
+        });
+
+        // And one deleted mid-sale, which must be reported as deleted rather than as
+        // a conflict somebody has to resolve (E4).
+        chaos.fake.deleteVariant(deleted);
+        await prisma.variantIndex.updateMany({
+          where: { shopId, variantGid: deleted },
+          data: { deletedAt: new Date() },
+        });
+
+        // ------------------------------------------------------- the report
+        const report = await rollbackReport(shopId, campaignId);
+        expect(report.straightforward).toBe(false);
+        expect(report.counts.drifted).toBe(1);
+        expect(report.counts.deleted).toBe(1);
+
+        const drifted = report.rows.find((row) => row.variantGid === edited);
+        expect(drifted?.kind).toBe("drifted");
+        expect(drifted?.live).toContain("42.42");
+        expect(drifted?.revertsTo).toContain((baseline.get(edited)! / 100).toFixed(2));
+
+        // Rows needing a decision come first, so they are not below the fold.
+        expect(report.rows[0].kind).toBe("drifted");
+
+        // Exportable, and intact.
+        const csv = rollbackReportCsv(report);
+        expect(csv.split("\n")[0]).toBe("variant_gid,title,state,applied,live_now,reverts_to");
+        expect(csv).toContain(edited);
+
+        // -------------------------------------------- revert, keeping the edit
+        const reverted = await chaos.revert({ skipVariantGids: [edited] });
+        await chaos.expectHonest(reverted.runId);
+
+        // The merchant's price survived.
+        expect(chaos.fake.priceOf(edited)).toBe((handPrice / 100).toFixed(2));
+
+        // Everything else went back to baseline.
+        for (const gid of chaos.fixture.variantGids.slice(2)) {
+          expect(chaos.fake.priceOf(gid)).toBe((baseline.get(gid)! / 100).toFixed(2));
+        }
+
+        // The decision is in the ledger, not merely in somebody's memory of clicking
+        // a checkbox.
+        const rows = await ledgerOf(reverted.runId);
+        const spared = rows.find((row) => row.variantGid === edited);
+        expect(spared?.status).toBe("SKIPPED");
+        expect(spared?.failureReason).toMatch(/keep that edit/i);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Closes out P2. The two remaining subtasks turn out to be the same mechanism seen from
two sides: taking one variant out of a campaign, and choosing not to overwrite an edit
somebody made by hand.

## Variant-level revert (#141)

For the merchant who puts 4,000 products on sale and then notices three that should
not have been. Without it the options are revert-and-reapply-with-a-narrower-filter,
or edit the price in Shopify and watch the next run overwrite it — both of which teach
people not to trust the app with their prices.

`excludedVariantGids` was a **dead column**: declared in the schema, never read or
written anywhere. It is now an *input to* resolution rather than a filter applied
*before* it, and that distinction is the whole design:

> A variant pulled out of a 30% sale that also sits inside a 10% one belongs at 10%.

Filtering the candidate out upstream would put it at full price — quietly ending a
sale the merchant never ended. So the planner drops the campaign for that candidate
and re-resolves, which lets the next campaign in priority order take over.

The exclusion is written **before** anything is priced, so tonight's scheduled run,
the next auto-enroll and the next recurrence all leave it alone. A revert undone by
the next tick is worse than no revert at all.

**Scoped runs also had to stop judging the campaign.** Reverting one variant out of a
4,000-variant sale was marking the whole sale `COMPLETED`. A run over a named handful
now ledgers what it did and leaves the campaign's state alone. It is recorded as
`REVERT`, not `APPLY` — a run history that calls an undo an apply misleads whoever
reads it later.

## Drift-aware rollback report (#142)

Revert is `resolve(without C)`, which is the right computation but says nothing about
whether it is the right *action* for every row. If a variant's live price no longer
matches what the campaign wrote, a person changed it on purpose while the sale was
running.

So a revert with drift in it is a conversation, not a command. Drifted rows are listed
first with a per-row choice, and the aside's one-click Revert button is replaced by a
pointer to the report whenever there is anything to decide. "Leave as it is" lands in
the ledger as `SKIPPED` with the reason attached — "we chose not to touch these" is
exactly the kind of thing that has to be explainable six weeks later. Exportable as
CSV, quoted properly, because product titles contain commas and inches routinely.

## Two things the new integration scenario found

**The report cannot be built from the campaign's filter.** `loadCandidates` drops
tombstoned variants by design, so a product deleted mid-sale vanished from the report
entirely instead of being reported as deleted (E4). It is built from the ledger now —
what the campaign actually wrote — which is the right definition anyway, and also
catches variants that have since fallen out of the filter.

**The chaos verdict's I4 check was scope-wrong.** It compared every write the store
had ever accepted against a *single run's* ledger rows, so a scenario that applies,
then reverts, then reverts one variant reported its earlier, perfectly-ledgered writes
as violations. I4 is "no price written without a row committed first" and says nothing
about which run owns it. This is the first scenario with enough runs in it to expose
that, and it would have produced false failures for any future multi-run scenario.

## Verification

- 276 unit tests (14 new), 8 chaos scenarios green in 36s, typecheck/lint/build clean
- Both new claims shown to fail against a mutated engine:
  - dropping the exclusion → the variant is back on sale after the next run
    (`expected '72.75' to be '97.00'`)
  - ignoring the keep list → the revert overwrites the merchant's price
    (`expected '97.00' to be '42.42'`)

The new scenario lives in `chaos/` because its claims are about durability, which a
pure test cannot check — "excluded from subsequent runs" means a row in Postgres that
a later run reads. It earns its place among the chaos scenarios on the second half,
where it reaches past the app and changes the store behind its back.

Closes #141, #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)