### PR TITLE
P3.2 — Segments: CRUD, dynamic vs frozen, and lists that never guess

### DIFF
--- a/app/lib/segments/csv-import.test.ts
+++ b/app/lib/segments/csv-import.test.ts
@@ -1,0 +1,137 @@
+/**
+ * What the importer refuses to do.
+ *
+ * The matching itself is unremarkable. What matters is the four-way split: a merchant
+ * uploading 3,000 SKUs needs to know before anything is priced which rows could not be
+ * placed, and a row that could be placed two ways is a question rather than a match.
+ * Resolving a SKU collision on their behalf is how the wrong product ends up
+ * discounted, with nothing to indicate it until a customer notices.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMatchIndex,
+  firstCell,
+  identifierKindOf,
+  matchIdentifiers,
+  parseIdentifierCsv,
+} from "./csv-import";
+
+const variants = [
+  { variantGid: "gid://shopify/ProductVariant/1", productGid: "gid://shopify/Product/10", sku: "SHIRT-S", barcode: "5012345678900" },
+  { variantGid: "gid://shopify/ProductVariant/2", productGid: "gid://shopify/Product/10", sku: "SHIRT-M", barcode: null },
+  // A SKU reused across two products. Common in imported catalogues, and the reason
+  // the index maps to lists rather than single gids.
+  { variantGid: "gid://shopify/ProductVariant/3", productGid: "gid://shopify/Product/20", sku: "DUP", barcode: null },
+  { variantGid: "gid://shopify/ProductVariant/4", productGid: "gid://shopify/Product/30", sku: "dup", barcode: null },
+];
+
+const index = buildMatchIndex(variants);
+const match = (values: string[]) =>
+  matchIdentifiers(
+    values.map((value, i) => ({ line: i + 1, value })),
+    index,
+  );
+
+describe("parseIdentifierCsv", () => {
+  it("takes the first column and drops a header row", () => {
+    const { rows, skippedHeader } = parseIdentifierCsv("sku,title\nSHIRT-S,Blue shirt\nSHIRT-M,Blue shirt\n");
+    expect(skippedHeader).toBe("sku");
+    expect(rows).toEqual([
+      { line: 2, value: "SHIRT-S" },
+      { line: 3, value: "SHIRT-M" },
+    ]);
+  });
+
+  it("keeps a file that has no header", () => {
+    const { rows, skippedHeader } = parseIdentifierCsv("SHIRT-S\nSHIRT-M\n");
+    expect(skippedHeader).toBeNull();
+    expect(rows).toHaveLength(2);
+  });
+
+  it("reports the original line number, not the row index", () => {
+    // Blank lines are skipped but must not shift the numbers, or the error report
+    // points at the wrong row in the merchant's spreadsheet.
+    const { rows } = parseIdentifierCsv("SHIRT-S\n\n\nSHIRT-M\n");
+    expect(rows.map((r) => r.line)).toEqual([1, 4]);
+  });
+
+  it("honours quotes so a comma inside a cell does not split it", () => {
+    expect(firstCell('"Red, large",99')).toBe("Red, large");
+    expect(firstCell('"24"" monitor",1')).toBe('24" monitor');
+  });
+});
+
+describe("identifierKindOf", () => {
+  it("recognises gids by prefix and long digit strings as barcodes", () => {
+    expect(identifierKindOf("gid://shopify/ProductVariant/1")).toBe("variant-gid");
+    expect(identifierKindOf("gid://shopify/Product/10")).toBe("product-gid");
+    expect(identifierKindOf("5012345678900")).toBe("barcode");
+    expect(identifierKindOf("SHIRT-S")).toBe("sku");
+  });
+});
+
+describe("matchIdentifiers", () => {
+  it("matches SKUs case-insensitively", () => {
+    expect(match(["shirt-s"]).matched).toEqual(["gid://shopify/ProductVariant/1"]);
+  });
+
+  it("expands a product gid to all of its variants", () => {
+    // An instruction, not a collision: naming a product means its variants.
+    const out = match(["gid://shopify/Product/10"]);
+    expect(out.matched).toEqual([
+      "gid://shopify/ProductVariant/1",
+      "gid://shopify/ProductVariant/2",
+    ]);
+    expect(out.ambiguous).toHaveLength(0);
+  });
+
+  it("refuses to choose when a SKU matches more than one variant", () => {
+    // The one that matters. Picking either would discount a product the merchant
+    // never reviewed, and nothing downstream would reveal it.
+    const out = match(["DUP"]);
+    expect(out.matched).toEqual([]);
+    expect(out.ambiguous).toHaveLength(1);
+    expect(out.ambiguous[0].candidates).toEqual([
+      "gid://shopify/ProductVariant/3",
+      "gid://shopify/ProductVariant/4",
+    ]);
+  });
+
+  it("reports unmatched rows with the line they came from", () => {
+    const out = matchIdentifiers([{ line: 7, value: "NOPE" }], index);
+    expect(out.matched).toEqual([]);
+    expect(out.unmatched).toEqual([{ line: 7, value: "NOPE" }]);
+  });
+
+  it("falls back between SKU and barcode rather than failing", () => {
+    // A numeric SKU looks like a barcode. Telling the merchant their file is
+    // unmatched because of our guess about digits would be our bug, not their data.
+    expect(match(["5012345678900"]).matched).toEqual(["gid://shopify/ProductVariant/1"]);
+  });
+
+  it("counts a repeated identifier once and says it was repeated", () => {
+    const out = match(["SHIRT-S", "SHIRT-S"]);
+    expect(out.matched).toEqual(["gid://shopify/ProductVariant/1"]);
+    expect(out.repeated).toHaveLength(1);
+    expect(out.repeated[0].line).toBe(2);
+  });
+
+  it("never lists the same variant twice when two identifiers reach it", () => {
+    // The product gid and one of its variants, both named. The segment is a set.
+    const out = match(["gid://shopify/Product/10", "gid://shopify/ProductVariant/1"]);
+    expect(out.matched).toEqual([
+      "gid://shopify/ProductVariant/1",
+      "gid://shopify/ProductVariant/2",
+    ]);
+  });
+
+  it("keeps every bucket accounted for", () => {
+    const out = match(["SHIRT-S", "NOPE", "DUP", "SHIRT-S"]);
+    expect(out.matched).toHaveLength(1);
+    expect(out.unmatched).toHaveLength(1);
+    expect(out.ambiguous).toHaveLength(1);
+    expect(out.repeated).toHaveLength(1);
+  });
+});

--- a/app/lib/segments/csv-import.ts
+++ b/app/lib/segments/csv-import.ts
@@ -1,0 +1,228 @@
+/**
+ * Turning a pasted or uploaded list of identifiers into a frozen segment.
+ *
+ * The whole value of this feature is in what it refuses to do. A merchant uploading
+ * 3,000 SKUs to put on sale needs to know, before anything is priced, exactly which
+ * rows the app could not place — and a row it *could* place two ways is not a match,
+ * it is a question. Guessing between two variants that share a SKU is how the wrong
+ * product ends up discounted, and the merchant has no way to find out until a customer
+ * tells them.
+ *
+ * So the outcome has four buckets, not one list: matched, unmatched, ambiguous, and
+ * repeated. Only the first becomes the segment.
+ */
+
+/** What a value in the file was recognised as. */
+export type IdentifierKind = "variant-gid" | "product-gid" | "sku" | "barcode";
+
+export interface CsvRow {
+  /** 1-based line in the original file, so a report points at something findable. */
+  line: number;
+  value: string;
+}
+
+export interface AmbiguousRow {
+  row: CsvRow;
+  kind: IdentifierKind;
+  /** Every variant the value could mean. Never resolved for the merchant. */
+  candidates: string[];
+}
+
+export interface MatchOutcome {
+  /** Deduped variant gids, in first-seen order. */
+  matched: string[];
+  /** Values nothing in the catalogue answers to. */
+  unmatched: CsvRow[];
+  /** Values that match more than one variant. Deliberately not resolved. */
+  ambiguous: AmbiguousRow[];
+  /** Values listed more than once. Harmless, but worth saying so nobody miscounts. */
+  repeated: CsvRow[];
+}
+
+/**
+ * The catalogue, indexed for lookup.
+ *
+ * Values map to *lists* of variant gids rather than single ones, because SKUs and
+ * barcodes are not unique in practice — merchants reuse them across sizes, and
+ * imported catalogues are full of accidental collisions. A `Map<string, string>` here
+ * would silently keep whichever row happened to be inserted last, which is precisely
+ * the guess this module exists not to make.
+ */
+export interface MatchIndex {
+  byVariantGid: Set<string>;
+  byProductGid: Map<string, string[]>;
+  bySku: Map<string, string[]>;
+  byBarcode: Map<string, string[]>;
+}
+
+export function buildMatchIndex(
+  variants: ReadonlyArray<{
+    variantGid: string;
+    productGid: string;
+    sku?: string | null;
+    barcode?: string | null;
+  }>,
+): MatchIndex {
+  const index: MatchIndex = {
+    byVariantGid: new Set(),
+    byProductGid: new Map(),
+    bySku: new Map(),
+    byBarcode: new Map(),
+  };
+
+  const push = (map: Map<string, string[]>, key: string | null | undefined, gid: string) => {
+    const trimmed = key?.trim();
+    if (!trimmed) return;
+    const existing = map.get(trimmed.toLowerCase());
+    if (existing) existing.push(gid);
+    else map.set(trimmed.toLowerCase(), [gid]);
+  };
+
+  for (const variant of variants) {
+    index.byVariantGid.add(variant.variantGid);
+    push(index.byProductGid, variant.productGid, variant.variantGid);
+    push(index.bySku, variant.sku, variant.variantGid);
+    push(index.byBarcode, variant.barcode, variant.variantGid);
+  }
+
+  return index;
+}
+
+/**
+ * Extracts one identifier per line from CSV text.
+ *
+ * The first column only, and a header row dropped if it looks like one. Merchants
+ * export from a spreadsheet and the file arrives with whatever columns their theme or
+ * ERP produced; asking them to strip it down first is a good way to have them not use
+ * the feature.
+ */
+export function parseIdentifierCsv(text: string): { rows: CsvRow[]; skippedHeader: string | null } {
+  const lines = text.split(/\r?\n/);
+  const rows: CsvRow[] = [];
+  let skippedHeader: string | null = null;
+
+  for (const [i, raw] of lines.entries()) {
+    const value = firstCell(raw).trim();
+    if (!value) continue;
+
+    // A first row that names a column rather than being one. Checked by content, not
+    // position: plenty of files have no header, and dropping a real SKU called "sku"
+    // is a smaller sin than silently treating a header as a missing product.
+    if (rows.length === 0 && skippedHeader === null && isHeaderLabel(value)) {
+      skippedHeader = value;
+      continue;
+    }
+
+    rows.push({ line: i + 1, value });
+  }
+
+  return { rows, skippedHeader };
+}
+
+const HEADER_LABELS = new Set([
+  "sku",
+  "skus",
+  "variant",
+  "variant id",
+  "variant_id",
+  "variantid",
+  "variant gid",
+  "gid",
+  "id",
+  "barcode",
+  "handle",
+  "product",
+  "product id",
+]);
+
+function isHeaderLabel(value: string): boolean {
+  return HEADER_LABELS.has(value.toLowerCase());
+}
+
+/** First CSV cell of a line, honouring quotes so `"Red, large",99` yields one cell. */
+export function firstCell(line: string): string {
+  if (!line.startsWith('"')) return line.split(",")[0] ?? "";
+
+  let out = "";
+  for (let i = 1; i < line.length; i++) {
+    if (line[i] === '"') {
+      if (line[i + 1] === '"') {
+        out += '"';
+        i++;
+        continue;
+      }
+      break;
+    }
+    out += line[i];
+  }
+  return out;
+}
+
+/** Classifies a value without looking it up. */
+export function identifierKindOf(value: string): IdentifierKind {
+  if (value.startsWith("gid://shopify/ProductVariant/")) return "variant-gid";
+  if (value.startsWith("gid://shopify/Product/")) return "product-gid";
+  // Barcodes are all-digit and long; anything else is treated as a SKU. Wrong
+  // guesses here cost nothing, because both are looked up and a miss falls through.
+  return /^\d{8,14}$/.test(value) ? "barcode" : "sku";
+}
+
+export function matchIdentifiers(rows: readonly CsvRow[], index: MatchIndex): MatchOutcome {
+  const matched: string[] = [];
+  const seenGid = new Set<string>();
+  const seenValue = new Set<string>();
+
+  const unmatched: CsvRow[] = [];
+  const ambiguous: AmbiguousRow[] = [];
+  const repeated: CsvRow[] = [];
+
+  for (const row of rows) {
+    const key = row.value.toLowerCase();
+    if (seenValue.has(key)) {
+      repeated.push(row);
+      continue;
+    }
+    seenValue.add(key);
+
+    const kind = identifierKindOf(row.value);
+    const candidates = lookup(row.value, kind, index);
+
+    if (candidates.length === 0) {
+      unmatched.push(row);
+      continue;
+    }
+
+    // A product gid legitimately means all of its variants -- that is what the
+    // merchant asked for. A SKU or barcode matching several is a collision, and the
+    // difference matters: one is an instruction, the other is an unanswered question.
+    if (candidates.length > 1 && kind !== "product-gid") {
+      ambiguous.push({ row, kind, candidates });
+      continue;
+    }
+
+    for (const gid of candidates) {
+      if (seenGid.has(gid)) continue;
+      seenGid.add(gid);
+      matched.push(gid);
+    }
+  }
+
+  return { matched, unmatched, ambiguous, repeated };
+}
+
+function lookup(value: string, kind: IdentifierKind, index: MatchIndex): string[] {
+  const key = value.trim().toLowerCase();
+
+  switch (kind) {
+    case "variant-gid":
+      return index.byVariantGid.has(value.trim()) ? [value.trim()] : [];
+    case "product-gid":
+      return index.byProductGid.get(key) ?? [];
+    case "barcode":
+      // Falls through to SKU: a numeric string is only probably a barcode, and a
+      // merchant whose SKUs are numeric should not be told their file is unmatched.
+      return index.byBarcode.get(key) ?? index.bySku.get(key) ?? [];
+    case "sku":
+      return index.bySku.get(key) ?? index.byBarcode.get(key) ?? [];
+  }
+}

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -12,27 +12,56 @@ import { localInputToUtc, type Schedule } from "../lib/scheduling/window";
 import { FilterForm } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import prisma from "../db.server";
+import { segmentToAst } from "../services/segments.server";
 
 export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
   const url = new URL(request.url);
-  const ast = astFromParams(url.searchParams);
-  const [available, preview] = await Promise.all([
+  const segmentId = url.searchParams.get("segment") ?? "";
+
+  // A chosen segment replaces the inline filter rather than narrowing it. Combining
+  // the two would mean a campaign whose scope no longer matches the segment the
+  // merchant thinks it targets, which is exactly the confusion segments exist to end.
+  const segment = segmentId
+    ? await prisma.segment.findFirst({
+        where: { id: segmentId, shopId: shop.id },
+        select: { id: true, name: true, kind: true, filterAst: true, frozenVariantGids: true },
+      })
+    : null;
+
+  const ast = segment
+    ? segmentToAst({
+        kind: segment.kind as "DYNAMIC" | "FROZEN",
+        filterAst: segment.filterAst,
+        frozenVariantGids: segment.frozenVariantGids,
+      })
+    : astFromParams(url.searchParams);
+
+  const [available, preview, segments] = await Promise.all([
     facets(shop.id),
     previewMatches(shop.id, ast),
+    prisma.segment.findMany({
+      where: { shopId: shop.id },
+      select: { id: true, name: true, kind: true },
+      orderBy: { name: "asc" },
+    }),
   ]);
 
   return {
     timeZone: shop.timezone,
     facets: available,
     preview,
+    segments,
+    usingSegment: segment ? { id: segment.id, name: segment.name, kind: segment.kind } : null,
     selected: {
       collection: url.searchParams.get("collection") ?? "",
       tag: url.searchParams.get("tag") ?? "",
       vendor: url.searchParams.get("vendor") ?? "",
       title: url.searchParams.get("title") ?? "",
+      segment: segmentId,
     },
   };
 });
@@ -43,11 +72,14 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
  * Named once and shared with the form, so a field added to one and forgotten in the
  * other cannot silently stop being filterable.
  */
-export const SCOPE_FIELDS = ["collection", "tag", "vendor", "title"] as const;
+export const SCOPE_FIELDS = ["collection", "tag", "vendor", "title", "segment"] as const;
 
 /** Builds an AST from the simple scope form: all provided conditions ANDed. */
 function astFromParams(params: URLSearchParams): FilterAst {
-  const conditions = SCOPE_FIELDS.map((field) => [field, params.get(field)] as const)
+  // `segment` rides in the same form but is a reference, not a condition -- the
+  // loader resolves it into a whole AST rather than adding a clause to one.
+  const conditions = SCOPE_FIELDS.filter((field) => field !== "segment")
+    .map((field) => [field, params.get(field)] as const)
     .filter(([, value]) => value && value.trim().length > 0)
     .map(([field, value]) => ({ field, value: value!.trim() }));
 
@@ -101,9 +133,12 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
       }
     : undefined;
 
+  const segmentId = String(form.get("segment") ?? "").trim();
+
   const campaign = await createCampaign(shop.id, {
     name: String(form.get("name") ?? "Untitled campaign").trim() || "Untitled campaign",
     ast: astFromParams(params),
+    ...(segmentId ? { segmentId } : {}),
     rule,
     compareAtPolicy,
     rounding: String(form.get("rounding") ?? "none") === "charm99" ? "charm99" : "none",
@@ -117,7 +152,8 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
 });
 
 export default function NewCampaign() {
-  const { facets: available, preview, selected, timeZone } = useLoaderData<typeof loader>();
+  const { facets: available, preview, selected, segments, usingSegment, timeZone } =
+    useLoaderData<typeof loader>();
 
   return (
     <s-page heading="New campaign">
@@ -128,6 +164,28 @@ export default function NewCampaign() {
         </s-paragraph>
         <FilterForm fields={SCOPE_FIELDS}>
           <s-stack gap="base">
+            <label htmlFor="segment">Saved segment</label>
+            <select id="segment" name="segment" defaultValue={selected.segment}>
+              <option value="">Build a filter below instead</option>
+              {segments.map((segment) => (
+                <option key={segment.id} value={segment.id}>
+                  {segment.name} ({segment.kind === "DYNAMIC" ? "dynamic" : "frozen"})
+                </option>
+              ))}
+            </select>
+
+            {usingSegment ? (
+              <s-banner tone="info">
+                <s-paragraph>
+                  Targeting the segment <s-text>{usingSegment.name}</s-text>. The filter
+                  below is ignored.{" "}
+                  {usingSegment.kind === "DYNAMIC"
+                    ? "It re-checks its filter on every run, so products added later join this campaign."
+                    : "Its product list is pinned, so this campaign hits exactly those products and nothing added later."}
+                </s-paragraph>
+              </s-banner>
+            ) : null}
+
             <label htmlFor="collection">Collection</label>
             <select id="collection" name="collection" defaultValue={selected.collection}>
               <option value="">Any collection</option>
@@ -176,6 +234,9 @@ export default function NewCampaign() {
 
       <s-section heading="2 · Rule">
         <Form method="post">
+          {/* The scope form and the create form are separate elements, so the chosen
+              segment has to travel with the submission that actually creates. */}
+          <input type="hidden" name="segment" value={selected.segment} />
           <input type="hidden" name="collection" value={selected.collection} />
           <input type="hidden" name="tag" value={selected.tag} />
           <input type="hidden" name="vendor" value={selected.vendor} />

--- a/app/routes/app.segments.tsx
+++ b/app/routes/app.segments.tsx
@@ -1,0 +1,398 @@
+/**
+ * Saved targeting, and the choice that decides what a campaign actually hits.
+ *
+ * The dynamic/frozen distinction is explained here rather than hidden behind a tooltip
+ * because picking the wrong one does not fail — it quietly produces a different
+ * campaign. A merchant who wanted "everything in Summer" and got a frozen list watches
+ * new products miss the sale; one who wanted a reviewed list and got a dynamic filter
+ * watches products join it unreviewed.
+ */
+
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import {
+  createSegment,
+  deleteSegment,
+  listSegments,
+  matchCsv,
+} from "../services/segments-crud.server";
+import { facets } from "../services/segments.server";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+import { reportError } from "../services/error-report.server";
+
+export const loader = withGuard("/app/segments", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const [segments, available] = await Promise.all([listSegments(shop.id), facets(shop.id)]);
+  return { segments, facets: available };
+});
+
+type ActionData = {
+  ok: boolean;
+  message: string;
+  /** Rows the upload could not place. Shown, never guessed at. */
+  report?: {
+    total: number;
+    matched: number;
+    unmatched: Array<{ line: number; value: string }>;
+    ambiguous: Array<{ line: number; value: string; candidates: number }>;
+    repeated: number;
+  };
+  errorId?: string;
+};
+
+export const action = withGuard("/app/segments", async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+  const intent = String(form.get("intent"));
+
+  try {
+    if (intent === "delete") {
+      await deleteSegment(shop.id, String(form.get("segmentId")));
+      return { ok: true, message: "Segment deleted." };
+    }
+
+    const name = String(form.get("name") ?? "");
+    const kind = form.get("kind") === "FROZEN" ? "FROZEN" : "DYNAMIC";
+
+    if (intent === "create-from-csv") {
+      const csv = String(form.get("csv") ?? "");
+      const outcome = await matchCsv(shop.id, csv);
+
+      // The report comes back whether or not anything is created. A merchant who
+      // uploads 3,000 rows and gets a segment of 2,960 with no explanation has a
+      // campaign that quietly misses 40 products.
+      const report = {
+        total: outcome.total,
+        matched: outcome.matched.length,
+        unmatched: outcome.unmatched,
+        ambiguous: outcome.ambiguous.map((a) => ({
+          line: a.row.line,
+          value: a.row.value,
+          candidates: a.candidates.length,
+        })),
+        repeated: outcome.repeated.length,
+      };
+
+      if (outcome.matched.length === 0) {
+        return {
+          ok: false,
+          message:
+            "None of those rows matched a product in your catalogue. Check the file uses SKUs, barcodes or Shopify IDs.",
+          report,
+        };
+      }
+
+      await createSegment(shop.id, {
+        name,
+        kind: "FROZEN",
+        variantGids: outcome.matched,
+        createdBy: session.shop,
+      });
+
+      return {
+        ok: true,
+        message: `Created "${name}" with ${outcome.matched.length} of ${outcome.total} rows.`,
+        report,
+      };
+    }
+
+    const conditions = [
+      ["collection", form.get("collection")],
+      ["tag", form.get("tag")],
+      ["vendor", form.get("vendor")],
+    ] as const;
+
+    const ast = {
+      groups: [
+        {
+          conditions: conditions
+            .filter(([, value]) => value && String(value).trim())
+            .map(([field, value]) => ({ field, value: String(value).trim() })),
+        },
+      ].filter((group) => group.conditions.length > 0),
+    };
+
+    const segment = await createSegment(shop.id, {
+      name,
+      kind,
+      filterAst: ast,
+      createdBy: session.shop,
+    });
+
+    return {
+      ok: true,
+      message:
+        kind === "FROZEN"
+          ? `Created "${segment.name}" and pinned ${segment.frozenVariantGids.length} variants.`
+          : `Created "${segment.name}". It re-checks the filter every time a campaign uses it.`,
+    };
+  } catch (error) {
+    const reported = await reportError(error, {
+      shopId: shop.id,
+      shop: session.shop,
+      route: "/app/segments",
+      context: { intent },
+    });
+    return { ok: false, message: reported.userMessage, errorId: reported.errorId };
+  }
+});
+
+export default function Segments() {
+  const { segments, facets: available } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const result = fetcher.data;
+  const busy = fetcher.state !== "idle";
+
+  return (
+    <s-page heading="Segments">
+      {result ? (
+        <s-banner tone={result.ok ? "success" : "critical"}>
+          <s-paragraph>{result.message}</s-paragraph>
+          {result.errorId ? <s-paragraph>Reference {result.errorId}</s-paragraph> : null}
+        </s-banner>
+      ) : null}
+
+      {result?.report ? <ImportReport report={result.report} /> : null}
+
+      <s-section heading="Your segments">
+        {segments.length === 0 ? (
+          <s-paragraph>
+            No segments yet. A segment is a saved way of describing which products a
+            campaign covers, so you do not rebuild the same filter for every sale.
+          </s-paragraph>
+        ) : (
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Name</s-table-header>
+              <s-table-header>Kind</s-table-header>
+              <s-table-header>Products</s-table-header>
+              <s-table-header>Used by</s-table-header>
+              <s-table-header>Action</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {segments.map((segment) => (
+                <s-table-row key={segment.id}>
+                  <s-table-cell>{segment.name}</s-table-cell>
+                  <s-table-cell>
+                    <s-badge tone={segment.kind === "DYNAMIC" ? "info" : "neutral"}>
+                      {segment.kind === "DYNAMIC" ? "Dynamic" : "Frozen"}
+                    </s-badge>
+                  </s-table-cell>
+                  <s-table-cell>{segment.size}</s-table-cell>
+                  <s-table-cell>
+                    {segment.usedBy.length === 0
+                      ? "—"
+                      : segment.usedBy.map((c) => c.name).join(", ")}
+                  </s-table-cell>
+                  <s-table-cell>
+                    {segment.usedBy.length > 0 ? (
+                      // Not a disabled button: a control that does nothing invites
+                      // clicking it repeatedly. The reason is the answer.
+                      <s-text>In use — remove from campaigns first</s-text>
+                    ) : (
+                      <fetcher.Form method="post">
+                        <input type="hidden" name="intent" value="delete" />
+                        <input type="hidden" name="segmentId" value={segment.id} />
+                        <s-button type="submit" tone="critical" variant="tertiary" loading={busy || undefined}>
+                          Delete
+                        </s-button>
+                      </fetcher.Form>
+                    )}
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        )}
+      </s-section>
+
+      <s-section heading="New segment from a filter">
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="create-filter" />
+          <s-stack gap="base">
+            <s-text-field name="name" label="Name" placeholder="Summer collection" required />
+
+            <label htmlFor="collection">Collection</label>
+            <select id="collection" name="collection" defaultValue="">
+              <option value="">Any collection</option>
+              {available.collections.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="tag">Tag</label>
+            <select id="tag" name="tag" defaultValue="">
+              <option value="">Any tag</option>
+              {available.tags.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="vendor">Vendor</label>
+            <select id="vendor" name="vendor" defaultValue="">
+              <option value="">Any vendor</option>
+              {available.vendors.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="kind">How it should behave</label>
+            <select id="kind" name="kind" defaultValue="DYNAMIC">
+              <option value="DYNAMIC">Dynamic — re-check the filter every time</option>
+              <option value="FROZEN">Frozen — pin the products it matches right now</option>
+            </select>
+
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
+              Create segment
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      <s-section heading="New segment from a list">
+        <s-paragraph>
+          <s-text>
+            Paste SKUs, barcodes or Shopify IDs — one per line, or the first column of a
+            CSV. This always makes a frozen segment: you are naming specific products,
+            so the list is pinned to exactly those.
+          </s-text>
+        </s-paragraph>
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="create-from-csv" />
+          <s-stack gap="base">
+            <s-text-field name="name" label="Name" placeholder="Clearance list" required />
+            <s-text-area name="csv" label="SKUs, barcodes or IDs" rows={8} />
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
+              Match and create
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      <s-section slot="aside" heading="Dynamic or frozen">
+        <s-paragraph>
+          <s-text>
+            <s-badge tone="info">Dynamic</s-badge> re-checks its filter every time a
+            campaign uses it. A product you add to the collection tomorrow joins a sale
+            that is already running.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            <s-badge tone="neutral">Frozen</s-badge> pins the products it matches the
+            moment you save it. A campaign hits exactly the list you reviewed, and
+            nothing that appears later.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            Neither is safer than the other — they answer different questions. You
+            cannot switch a segment between the two afterwards, because doing so would
+            change what a running campaign prices without you asking it to. Make a new
+            one instead.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+function ImportReport({ report }: { report: NonNullable<ActionData["report"]> }) {
+  const clean =
+    report.unmatched.length === 0 && report.ambiguous.length === 0 && report.repeated === 0;
+
+  return (
+    <s-section heading="What the list matched">
+      <s-paragraph>
+        <s-text>
+          {report.matched} of {report.total} rows matched a product.
+          {clean ? " Every row was placed." : ""}
+        </s-text>
+      </s-paragraph>
+
+      {report.ambiguous.length > 0 ? (
+        <>
+          <s-banner tone="warning">
+            <s-paragraph>
+              {report.ambiguous.length} row{report.ambiguous.length === 1 ? "" : "s"} matched
+              more than one product, so {report.ambiguous.length === 1 ? "it was" : "they were"}{" "}
+              left out. Picking one for you could put the wrong product on sale.
+            </s-paragraph>
+          </s-banner>
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Line</s-table-header>
+              <s-table-header>Value</s-table-header>
+              <s-table-header>Matches</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {report.ambiguous.slice(0, 50).map((row) => (
+                <s-table-row key={`${row.line}-${row.value}`}>
+                  <s-table-cell>{row.line}</s-table-cell>
+                  <s-table-cell>{row.value}</s-table-cell>
+                  <s-table-cell>{row.candidates} products</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </>
+      ) : null}
+
+      {report.unmatched.length > 0 ? (
+        <>
+          <s-paragraph>
+            <s-text>
+              {report.unmatched.length} row{report.unmatched.length === 1 ? "" : "s"} matched
+              nothing in your catalogue:
+            </s-text>
+          </s-paragraph>
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Line</s-table-header>
+              <s-table-header>Value</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {report.unmatched.slice(0, 50).map((row) => (
+                <s-table-row key={`${row.line}-${row.value}`}>
+                  <s-table-cell>{row.line}</s-table-cell>
+                  <s-table-cell>{row.value}</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </>
+      ) : null}
+
+      {report.repeated > 0 ? (
+        <s-paragraph>
+          <s-text>
+            {report.repeated} row{report.repeated === 1 ? " was" : "s were"} listed more than
+            once and counted once.
+          </s-text>
+        </s-paragraph>
+      ) : null}
+    </s-section>
+  );
+}
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -23,6 +23,7 @@ export default function App() {
       <s-app-nav>
         <s-link href="/app">Dashboard</s-link>
         <s-link href="/app/campaigns">Campaigns</s-link>
+        <s-link href="/app/segments">Segments</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/settings">Settings</s-link>

--- a/app/services/auto-enroll.server.ts
+++ b/app/services/auto-enroll.server.ts
@@ -24,7 +24,7 @@
 import prisma from "../db.server";
 import { captureBaselines } from "./baselines.server";
 import { astToWhere } from "./segments.server";
-import { astOf, toResolvable } from "./campaigns/model.server";
+import { scopeOf, toResolvable } from "./campaigns/model.server";
 import { assignEnrollments, type CampaignMatch } from "../lib/enrollment/assign";
 
 export interface EnrollResult {
@@ -57,7 +57,12 @@ export async function enrollNewVariants(
     // Let the database apply the filter rather than re-implementing the AST here.
     const matched = await prisma.variantIndex.findMany({
       where: {
-        AND: [astToWhere(shopId, astOf(campaign)), { variantGid: { in: variantGids } }],
+        AND: [
+          // Resolved, so a campaign targeting a segment enrolls against the segment's
+          // current definition rather than a copy taken when it was created.
+          astToWhere(shopId, await scopeOf(shopId, campaign)),
+          { variantGid: { in: variantGids } },
+        ],
       },
       select: { variantGid: true },
     });

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -16,7 +16,7 @@ import type {
   Guardrails,
   ResolvableCampaign,
 } from "../../lib/pricing/types";
-import type { FilterAst } from "../segments.server";
+import { segmentToAst, type FilterAst } from "../segments.server";
 import type { CampaignInput } from "./types";
 
 export async function createCampaign(shopId: string, input: CampaignInput) {
@@ -39,7 +39,12 @@ export async function createCampaign(shopId: string, input: CampaignInput) {
         ...(input.schedule ?? { kind: "manual" }),
         rounding: input.rounding,
         ast: input.ast,
+        ...(input.segmentId ? { segmentId: input.segmentId } : {}),
       } as never,
+      // The declarative reference as well as the id in the blob. The rule engine reads
+      // the blob; the delete guard reads the relation, and a segment that could be
+      // deleted out from under a running campaign is the failure that matters.
+      ...(input.segmentId ? { segments: { connect: { id: input.segmentId } } } : {}),
       ...(input.schedule?.kind === "window"
         ? {
             startAt: new Date(input.schedule.startAt),
@@ -58,6 +63,45 @@ export function roundingFor(name: unknown): RoundingProfile {
 export function astOf(campaign: Pick<Campaign, "schedule">): FilterAst {
   const schedule = (campaign.schedule ?? {}) as { ast?: FilterAst };
   return schedule.ast ?? { groups: [] };
+}
+
+/** The segment a campaign targets, if it targets one rather than an inline filter. */
+export function segmentIdOf(campaign: Pick<Campaign, "schedule">): string | null {
+  const schedule = (campaign.schedule ?? {}) as { segmentId?: string };
+  return schedule.segmentId ?? null;
+}
+
+/**
+ * The scope a campaign actually runs against.
+ *
+ * Resolved rather than copied. A campaign that had its segment's filter written into
+ * it at creation would keep pricing the old products after the segment was edited,
+ * which would make "reusable" a lie -- the merchant fixes the segment once and expects
+ * every campaign using it to follow.
+ *
+ * A segment that has since been deleted falls back to the campaign's own stored
+ * filter. The reference guard makes that nearly unreachable, but "nearly" is not a
+ * basis for letting an empty AST through here: an empty AST matches the whole
+ * catalogue, so the failure mode would be repricing every product in the store.
+ */
+export async function scopeOf(
+  shopId: string,
+  campaign: Pick<Campaign, "schedule">,
+): Promise<FilterAst> {
+  const segmentId = segmentIdOf(campaign);
+  if (!segmentId) return astOf(campaign);
+
+  const segment = await prisma.segment.findFirst({
+    where: { id: segmentId, shopId },
+    select: { kind: true, filterAst: true, frozenVariantGids: true },
+  });
+  if (!segment) return astOf(campaign);
+
+  return segmentToAst({
+    kind: segment.kind as "DYNAMIC" | "FROZEN",
+    filterAst: segment.filterAst,
+    frozenVariantGids: segment.frozenVariantGids,
+  });
 }
 
 /** Rehydrates a stored campaign into the shape the pure resolver expects. */
@@ -115,6 +159,6 @@ export async function loadCampaignContext(shopId: string, campaignId: string) {
   return {
     campaign,
     resolvable: [toResolvable(campaign), ...others.map(toResolvable)],
-    ast: astOf(campaign),
+    ast: await scopeOf(shopId, campaign),
   };
 }

--- a/app/services/campaigns/types.ts
+++ b/app/services/campaigns/types.ts
@@ -26,6 +26,13 @@ export interface CampaignInput {
   autoEnroll?: boolean;
   /** Absent means the campaign only runs when applied by hand. */
   schedule?: Schedule;
+  /**
+   * Target a saved segment instead of an inline filter.
+   *
+   * Stored as a reference, not copied, so editing the segment updates every campaign
+   * using it -- which is what makes a segment reusable rather than a template.
+   */
+  segmentId?: string;
 }
 
 export interface PreviewRow {

--- a/app/services/segments-crud.server.ts
+++ b/app/services/segments-crud.server.ts
@@ -1,0 +1,274 @@
+/**
+ * Named, reusable targeting.
+ *
+ * The dynamic/frozen distinction is the point, and picking the wrong one silently
+ * produces the wrong campaign:
+ *
+ *   DYNAMIC re-evaluates whenever it is asked, so a product added to a collection
+ *   joins a sale that is already running. What a merchant wants for "everything in
+ *   Summer".
+ *
+ *   FROZEN pins the variant list at save time, so a campaign touches exactly the
+ *   variants that were reviewed and nothing else. What a merchant wants after
+ *   uploading a spreadsheet somebody signed off.
+ *
+ * Neither is a safe default, so the choice is made explicitly at creation and shown
+ * everywhere the segment appears.
+ */
+
+import prisma from "../db.server";
+import { AppError } from "../lib/errors/app-error";
+import {
+  buildMatchIndex,
+  matchIdentifiers,
+  parseIdentifierCsv,
+  type MatchOutcome,
+} from "../lib/segments/csv-import";
+import { resolveVariantGids, type FilterAst } from "./segments.server";
+
+export type SegmentKind = "DYNAMIC" | "FROZEN";
+
+export interface SegmentSummary {
+  id: string;
+  name: string;
+  kind: SegmentKind;
+  /** Variants it currently matches. For frozen segments, the pinned count. */
+  size: number;
+  usedBy: Array<{ id: string; name: string; status: string }>;
+  updatedAt: string;
+}
+
+/**
+ * Campaigns that would break if this segment went away.
+ *
+ * Checked in two places on purpose. The relation is the declarative reference, but a
+ * campaign's rule rows carry segment ids in JSON as well, and that is what the rule
+ * engine actually reads. A guard that consulted only the relation would happily delete
+ * a segment a running campaign was pricing from.
+ */
+export async function referencingCampaigns(shopId: string, segmentId: string) {
+  const [related, all] = await Promise.all([
+    prisma.campaign.findMany({
+      where: { shopId, segments: { some: { id: segmentId } } },
+      select: { id: true, name: true, status: true },
+    }),
+    prisma.campaign.findMany({
+      where: { shopId },
+      select: { id: true, name: true, status: true, ruleRows: true, schedule: true },
+    }),
+  ]);
+
+  const byId = new Map(related.map((c) => [c.id, { id: c.id, name: c.name, status: c.status }]));
+
+  for (const campaign of all) {
+    if (byId.has(campaign.id)) continue;
+    if (mentionsSegment(campaign.ruleRows, segmentId) || mentionsSegment(campaign.schedule, segmentId)) {
+      byId.set(campaign.id, { id: campaign.id, name: campaign.name, status: campaign.status });
+    }
+  }
+
+  return [...byId.values()];
+}
+
+/** True when this JSON blob names the segment anywhere inside it. */
+function mentionsSegment(blob: unknown, segmentId: string): boolean {
+  if (blob === null || blob === undefined) return false;
+  return JSON.stringify(blob).includes(segmentId);
+}
+
+export async function listSegments(shopId: string): Promise<SegmentSummary[]> {
+  const segments = await prisma.segment.findMany({
+    where: { shopId },
+    orderBy: { updatedAt: "desc" },
+    include: { campaigns: { select: { id: true, name: true, status: true } } },
+  });
+
+  return Promise.all(
+    segments.map(async (segment) => ({
+      id: segment.id,
+      name: segment.name,
+      kind: segment.kind as SegmentKind,
+      size:
+        segment.kind === "FROZEN"
+          ? segment.frozenVariantGids.length
+          : (await resolveVariantGids(shopId, astOfSegment(segment.filterAst))).length,
+      usedBy: await referencingCampaigns(shopId, segment.id),
+      updatedAt: segment.updatedAt.toISOString(),
+    })),
+  );
+}
+
+export async function getSegment(shopId: string, id: string) {
+  const segment = await prisma.segment.findFirst({ where: { id, shopId } });
+  if (!segment) {
+    throw new AppError({
+      code: "NOT_FOUND",
+      userMessage: "That segment no longer exists. It may have been deleted.",
+      context: { segmentId: id },
+    });
+  }
+  return segment;
+}
+
+export interface CreateSegmentInput {
+  name: string;
+  kind: SegmentKind;
+  /** For a dynamic segment, and for freezing a filter into a list. */
+  filterAst?: FilterAst;
+  /** For a frozen segment built from an upload. */
+  variantGids?: string[];
+  createdBy?: string;
+}
+
+export async function createSegment(shopId: string, input: CreateSegmentInput) {
+  const name = input.name.trim();
+  if (!name) {
+    throw new AppError({
+      code: "VALIDATION",
+      userMessage: "Give the segment a name so you can find it when building a campaign.",
+    });
+  }
+
+  // Frozen means pinned now. A frozen segment built from a filter resolves that filter
+  // once, here, and keeps the answer -- which is the entire difference from dynamic.
+  const frozen =
+    input.kind === "FROZEN"
+      ? (input.variantGids ?? (await resolveVariantGids(shopId, input.filterAst ?? { groups: [] })))
+      : [];
+
+  try {
+    return await prisma.segment.create({
+      data: {
+        shopId,
+        name,
+        kind: input.kind,
+        filterAst: (input.filterAst ?? { groups: [] }) as never,
+        frozenVariantGids: frozen,
+        createdBy: input.createdBy ?? null,
+      },
+    });
+  } catch (error) {
+    throw nameCollision(error, name);
+  }
+}
+
+export interface UpdateSegmentInput {
+  name?: string;
+  filterAst?: FilterAst;
+  variantGids?: string[];
+  /** Confirms the merchant saw the warning about campaigns using this segment. */
+  acknowledgedCampaigns?: boolean;
+}
+
+/**
+ * Edits a segment.
+ *
+ * Kind is deliberately not editable. Flipping dynamic to frozen would silently pin
+ * whatever the filter happens to match today; flipping frozen to dynamic would widen a
+ * reviewed list to whatever a filter returns. Both change what a running campaign
+ * prices without the merchant asking for it, and both are better expressed as making a
+ * new segment.
+ */
+export async function updateSegment(shopId: string, id: string, input: UpdateSegmentInput) {
+  const segment = await getSegment(shopId, id);
+  const users = await referencingCampaigns(shopId, id);
+  const live = users.filter((c) => c.status === "ACTIVE" || c.status === "APPLYING");
+
+  // A segment edit reaches straight into a running sale. Not blocked -- sometimes
+  // that is exactly the intent -- but never silent.
+  if (live.length > 0 && !input.acknowledgedCampaigns) {
+    throw new AppError({
+      code: "VALIDATION",
+      userMessage:
+        `${live.map((c) => `"${c.name}"`).join(", ")} ${live.length === 1 ? "is" : "are"} running and ` +
+        `using this segment. Saving changes which products ${live.length === 1 ? "it prices" : "they price"}. ` +
+        `Confirm to continue.`,
+      context: { segmentId: id, campaigns: live.map((c) => c.id) },
+    });
+  }
+
+  const name = input.name?.trim();
+
+  try {
+    return await prisma.segment.update({
+      where: { id: segment.id },
+      data: {
+        ...(name ? { name } : {}),
+        ...(input.filterAst ? { filterAst: input.filterAst as never } : {}),
+        // Frozen lists are re-pinned only when a new list is supplied; editing a
+        // frozen segment's name must not silently re-resolve what it contains.
+        ...(input.variantGids ? { frozenVariantGids: input.variantGids } : {}),
+      },
+    });
+  } catch (error) {
+    throw nameCollision(error, name ?? segment.name);
+  }
+}
+
+/**
+ * Deletes a segment, unless something is using it.
+ *
+ * Blocked rather than cascaded. A campaign whose targeting silently emptied would
+ * either price nothing or -- far worse, if an empty filter were treated as
+ * "everything" -- price the entire catalogue on its next run.
+ */
+export async function deleteSegment(shopId: string, id: string): Promise<void> {
+  const users = await referencingCampaigns(shopId, id);
+
+  if (users.length > 0) {
+    throw new AppError({
+      code: "VALIDATION",
+      userMessage:
+        `This segment is used by ${users.map((c) => `"${c.name}"`).join(", ")}. ` +
+        `Remove it from ${users.length === 1 ? "that campaign" : "those campaigns"} first, ` +
+        `or the campaign would lose its targeting.`,
+      context: { segmentId: id, campaigns: users.map((c) => c.id) },
+    });
+  }
+
+  await prisma.segment.deleteMany({ where: { id, shopId } });
+}
+
+export interface CsvImportResult extends MatchOutcome {
+  skippedHeader: string | null;
+  /** Rows read from the file, excluding a header. */
+  total: number;
+}
+
+/**
+ * Matches an uploaded list of identifiers against the catalogue.
+ *
+ * Returns the report without creating anything. The merchant sees what could not be
+ * placed *before* committing, because a segment quietly missing 40 of 3,000 rows is
+ * a campaign that quietly misses 40 products.
+ */
+export async function matchCsv(shopId: string, text: string): Promise<CsvImportResult> {
+  const { rows, skippedHeader } = parseIdentifierCsv(text);
+
+  const variants = await prisma.variantIndex.findMany({
+    where: { shopId, deletedAt: null },
+    select: { variantGid: true, productGid: true, sku: true, barcode: true },
+  });
+
+  return {
+    ...matchIdentifiers(rows, buildMatchIndex(variants)),
+    skippedHeader,
+    total: rows.length,
+  };
+}
+
+/** Prisma hands back JSON; the AST shape has to be asserted through `unknown`. */
+function astOfSegment(stored: unknown): FilterAst {
+  const ast = stored as FilterAst | null;
+  return ast && Array.isArray(ast.groups) ? ast : { groups: [] };
+}
+
+function nameCollision(error: unknown, name: string): unknown {
+  if (typeof error === "object" && error !== null && (error as { code?: string }).code === "P2002") {
+    return new AppError({
+      code: "VALIDATION",
+      userMessage: `You already have a segment called "${name}". Pick a different name.`,
+    });
+  }
+  return error;
+}

--- a/app/services/segments.server.ts
+++ b/app/services/segments.server.ts
@@ -25,11 +25,20 @@ export type ConditionField =
   | "inventoryMin"
   | "inventoryMax"
   | "hasCompareAt"
-  | "hasCost";
+  | "hasCost"
+  /**
+   * An explicit list of variants.
+   *
+   * What a frozen segment compiles to. Expressing it as an ordinary condition rather
+   * than as a special case means preview, planning, enrollment and the run path all
+   * handle a pinned variant list without knowing segments exist.
+   */
+  | "variantGid";
 
 export interface Condition {
   field: ConditionField;
-  value: string | number | boolean;
+  /** A list only for `variantGid`, which is inherently plural. */
+  value: string | number | boolean | string[];
 }
 
 /** AND of conditions. */
@@ -77,6 +86,13 @@ function conditionToWhere(condition: Condition): Prisma.VariantIndexWhereInput |
       return value ? { compareAt: { not: null } } : { compareAt: null };
     case "hasCost":
       return value ? { cost: { not: null } } : { cost: null };
+    case "variantGid": {
+      const gids = (Array.isArray(value) ? value : [text]).filter(Boolean);
+      // An empty pinned list matches nothing, which is not the same as matching
+      // everything. A frozen segment whose variants were all deleted must price zero
+      // variants, not the entire catalogue.
+      return { variantGid: { in: gids } };
+    }
     default:
       return null;
   }
@@ -177,4 +193,27 @@ export async function facets(shopId: string): Promise<{
     tags: sorted(tags),
     collections: sorted(collections),
   };
+}
+
+// ------------------------------------------------------------------ segments
+
+/**
+ * Compiles a segment to a filter.
+ *
+ * The dynamic/frozen distinction lives here and nowhere else. A dynamic segment is
+ * its filter, re-evaluated every time it is asked; a frozen one is the list of
+ * variants that filter matched when the merchant reviewed it. Both come out as an
+ * AST, so everything downstream stays unaware of the difference.
+ */
+export function segmentToAst(segment: {
+  kind: "DYNAMIC" | "FROZEN";
+  filterAst: unknown;
+  frozenVariantGids: string[];
+}): FilterAst {
+  if (segment.kind === "FROZEN") {
+    return { groups: [{ conditions: [{ field: "variantGid", value: segment.frozenVariantGids }] }] };
+  }
+  return ((segment.filterAst as FilterAst) ?? EMPTY_AST).groups
+    ? (segment.filterAst as FilterAst)
+    : EMPTY_AST;
 }

--- a/chaos/scenarios/segment-scope.chaos.ts
+++ b/chaos/scenarios/segment-scope.chaos.ts
@@ -1,0 +1,102 @@
+/**
+ * A campaign that targets a saved segment.
+ *
+ * Here because of the size of the failure. A segment-scoped campaign stores an empty
+ * inline filter — its scope lives in the segment — and an empty filter matches the
+ * *entire catalogue*. If segment resolution ever silently falls through, the campaign
+ * does not price nothing, it prices everything: every product in the store discounted
+ * by a campaign the merchant scoped to eleven items.
+ *
+ * That is not a failure a unit test on the resolver can catch, because the resolver is
+ * given whatever scope the caller worked out. The question is whether the caller works
+ * it out, against a real database, on the same path a run takes.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { createSegment } from "../../app/services/segments-crud.server";
+import { ledgerOf, withChaos } from "../harness/scenario";
+
+describe("chaos: a campaign scoped to a segment", () => {
+  it("prices the segment's variants and nothing else", async () => {
+    await withChaos(
+      "segment-scope",
+      { catalog: { products: 10, variantsPerProduct: 2 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids, baseline } = chaos.fixture;
+
+        // Three of twenty. If resolution falls through to the campaign's empty inline
+        // filter, all twenty get priced and the assertion below fails loudly.
+        const chosen = variantGids.slice(0, 3);
+        const segment = await createSegment(shopId, {
+          name: `chaos-segment-${chaos.seed}`,
+          kind: "FROZEN",
+          variantGids: chosen,
+        });
+
+        // Point the existing campaign at the segment, both ways a campaign can
+        // reference one: the id in its schedule blob, which the run path reads, and
+        // the relation, which the delete guard reads.
+        const campaign = await prisma.campaign.findUniqueOrThrow({ where: { id: campaignId } });
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: {
+            schedule: { ...(campaign.schedule as object), segmentId: segment.id } as never,
+            segments: { connect: { id: segment.id } },
+          },
+        });
+
+        const outcome = await chaos.apply();
+        await chaos.expectHonest(outcome.runId);
+
+        const rows = await ledgerOf(outcome.runId);
+        expect(rows).toHaveLength(chosen.length);
+        expect(rows.map((r) => r.variantGid).sort()).toEqual([...chosen].sort());
+
+        for (const gid of chosen) {
+          const expected = Math.round(baseline.get(gid)! * 0.8);
+          expect(chaos.fake.priceOf(gid)).toBe((expected / 100).toFixed(2));
+        }
+
+        // The other seventeen are untouched. This is the assertion the scenario
+        // exists for.
+        for (const gid of variantGids.slice(3)) {
+          expect(chaos.fake.priceOf(gid)).toBe((baseline.get(gid)! / 100).toFixed(2));
+        }
+      },
+    );
+  });
+
+  it("prices nothing when a frozen segment's list is empty", async () => {
+    await withChaos(
+      "segment-empty",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids, baseline } = chaos.fixture;
+
+        // The boundary that makes the whole mechanism safe. An empty pinned list means
+        // "no products", and it must not collapse into an empty filter, which means
+        // "every product".
+        const segment = await createSegment(shopId, {
+          name: `chaos-empty-${chaos.seed}`,
+          kind: "FROZEN",
+          variantGids: [],
+        });
+
+        const campaign = await prisma.campaign.findUniqueOrThrow({ where: { id: campaignId } });
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { schedule: { ...(campaign.schedule as object), segmentId: segment.id } as never },
+        });
+
+        const outcome = await chaos.apply();
+        expect(outcome.planned).toBe(0);
+
+        for (const gid of variantGids) {
+          expect(chaos.fake.priceOf(gid)).toBe((baseline.get(gid)! / 100).toFixed(2));
+        }
+      },
+    );
+  });
+});


### PR DESCRIPTION
Named, reusable targeting, so a merchant stops rebuilding the same filter for every
sale.

## The distinction is the feature

Dynamic vs frozen is load-bearing, and picking the wrong one **does not fail** — it
quietly produces a different campaign:

| | |
| --- | --- |
| **Dynamic** | re-checks its filter every time it is asked. A product added tomorrow joins a sale already running. |
| **Frozen** | pins the list at save time. A campaign hits exactly what was reviewed, and nothing that appears later. |

Neither is a safe default, so the choice is explicit at creation and explained beside
the form. It cannot be flipped afterwards: doing so would change what a running
campaign prices without anyone asking it to.

Segments are **referenced** by campaigns, not copied into them — editing a segment
updates every campaign using it, which is what makes it reusable rather than a
template. A frozen segment compiles to an ordinary AST through a new `variantGid`
condition, so preview, planning, enrollment and the run path handle a pinned list
without knowing segments exist.

## The import refuses to guess

A SKU matching two variants is not a match, it is a question. Resolving it would
discount a product nobody reviewed, with nothing to reveal it until a customer noticed.
So the outcome has four buckets — matched, unmatched, ambiguous, repeated — and only
the first becomes the segment. A product gid is treated as an *instruction* rather than
a collision, because naming a product means its variants.

## The guard reads two places

The relation is the declarative reference, but rule rows carry segment ids in JSON and
that is what the rule engine actually reads. A guard consulting only the relation would
happily delete a segment a running campaign was pricing from.

Editing a segment a live campaign uses **warns** before saving rather than blocking —
sometimes reaching into a running sale is the intent — but never silently.

## Two chaos scenarios for the failure that would be catastrophic

A segment-scoped campaign stores an **empty** inline filter, because its scope lives in
the segment. An empty filter matches the entire catalogue. So if resolution ever falls
through, the campaign does not price nothing — it prices *every product in the store*.

Reverting the resolution proves it:

```
× prices the segment's variants and nothing else
  → expected [...] to have a length of 3 but got 20
× prices nothing when a frozen segment's list is empty
  → expected 4 to be +0
```

## Verified against the dev store

Header detection, line numbers surviving blank rows, unmatched and repeated reporting,
frozen creation, a campaign scoped to 2 variants rather than 1,616, deletion blocked
while referenced, and the edit warning clearing once acknowledged.

- 289 unit tests (13 new), 10 chaos scenarios, typecheck/lint/build clean

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)