### PR TITLE
P3.11 — Campaign tag kit, ledgered so revert can prove it

### DIFF
--- a/app/lib/notifications/templates.test.ts
+++ b/app/lib/notifications/templates.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The rule this module exists to keep: no price value ever reaches an email body.
+ *
+ * Email is unencrypted in transit, lands in a mailbox the app does not control, gets
+ * forwarded, indexed by mail providers and read on shared screens. A merchant's
+ * pricing is commercially sensitive and none of it belongs there — counts carry
+ * everything an email needs to, and the app is one click away for the specifics.
+ *
+ * A rule kept by care is a rule that lapses the first time somebody adds a field to a
+ * template in a hurry, so it is asserted with a property test over generated counts
+ * rather than checked by eye.
+ */
+
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { compose, type RunCounts } from "./templates";
+
+const counts = (over: Partial<RunCounts> = {}): RunCounts => ({
+  verified: 12,
+  skipped: 0,
+  clamped: 0,
+  failed: 0,
+  unverified: 0,
+  ...over,
+});
+
+describe("compose", () => {
+  it("leads with the outcome, not the campaign name, in the subject", () => {
+    // A merchant scanning an inbox needs the verdict before the label.
+    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    expect(email.subject).toContain("finished");
+    expect(email.subject).toContain("12 variants updated");
+  });
+
+  it("says a partial run is partial, and how to finish it", () => {
+    const email = compose({
+      kind: "run-partial",
+      campaignName: "Summer",
+      counts: counts({ verified: 8, failed: 4 }),
+      reasons: ["Shopify rate-limited this write. It will be retried automatically."],
+    });
+
+    expect(email.subject).toContain("partially");
+    expect(email.text).toContain("Failed: 4");
+    expect(email.text).toContain("Resuming");
+    expect(email.text).toContain("rate-limited");
+  });
+
+  it("omits zero counts rather than listing them", () => {
+    // "0 failed, 0 skipped, 0 clamped" is noise that hides the number that matters.
+    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    expect(email.text).not.toContain("Failed: 0");
+    expect(email.text).not.toContain("Skipped: 0");
+  });
+
+  it("explains that a revert recomputes rather than restores", () => {
+    // The single most misunderstood thing the app does. A merchant expecting prices
+    // to snap back to full will read a correct revert as a bug without this.
+    const email = compose({
+      kind: "revert-completed",
+      campaignName: "Summer",
+      counts: counts(),
+    });
+    expect(email.text).toContain("recomputes");
+    expect(email.text).toContain("another campaign still covers");
+  });
+
+  it("tells a drift email that the edits were deliberate and untouched", () => {
+    const email = compose({ kind: "drift-hold", campaignName: "Summer", driftedCount: 3 });
+    expect(email.subject).toContain("changed outside the app");
+    expect(email.text).toContain("has not overwritten them");
+  });
+
+  it("says plainly when a digest needs nothing from the merchant", () => {
+    const quiet = compose({
+      kind: "weekly-digest",
+      shopName: "DartMode",
+      campaignsRun: 2,
+      variantsChanged: 40,
+      driftOpen: 0,
+      partialRuns: 0,
+    });
+    expect(quiet.text).toContain("Nothing is waiting for you.");
+  });
+});
+
+describe("no price values in any email body", () => {
+  /**
+   * Anything that reads as money. Deliberately broad — a decimal, a currency symbol,
+   * or a currency code all count as a leak, and being over-strict here costs nothing
+   * because legitimate content is counts and prose.
+   */
+  const MONEY = /[$£€¥]|\b\d+\.\d{2}\b|\b(USD|EUR|GBP|JPY|CAD|AUD)\b/;
+
+  it("holds for every run notification, whatever the counts", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          verified: fc.nat({ max: 1_000_000 }),
+          skipped: fc.nat({ max: 1_000_000 }),
+          clamped: fc.nat({ max: 1_000_000 }),
+          failed: fc.nat({ max: 1_000_000 }),
+          unverified: fc.nat({ max: 1_000_000 }),
+        }),
+        fc.constantFrom("run-completed", "run-partial", "run-failed", "revert-completed" as const),
+        (generated, kind) => {
+          const email = compose({
+            kind: kind as "run-completed",
+            campaignName: "Summer sale",
+            counts: generated,
+          });
+          expect(email.subject).not.toMatch(MONEY);
+          expect(email.text).not.toMatch(MONEY);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it("holds when a campaign is named after a price", () => {
+    // The merchant chose the name; the app still must not be the thing that puts a
+    // price in a subject line. Names are echoed, so this documents the one place a
+    // money-shaped string can legitimately appear.
+    const email = compose({
+      kind: "run-completed",
+      campaignName: "$5 off everything",
+      counts: counts(),
+    });
+    expect(email.subject).toContain("$5 off everything");
+    // Everything the app itself generated is still clean.
+    expect(email.text.replace("$5 off everything", "")).not.toMatch(MONEY);
+  });
+
+  it("holds for a digest", () => {
+    const email = compose({
+      kind: "weekly-digest",
+      shopName: "DartMode",
+      campaignsRun: 9,
+      variantsChanged: 123_456,
+      driftOpen: 2,
+      partialRuns: 1,
+    });
+    expect(email.text).not.toMatch(MONEY);
+  });
+});

--- a/app/lib/notifications/templates.ts
+++ b/app/lib/notifications/templates.ts
@@ -1,0 +1,217 @@
+/**
+ * What the app tells a merchant by email, and what it deliberately does not.
+ *
+ * Campaigns run for hours. The merchant has to be able to close the tab and still find
+ * out what happened, which is the entire reason these exist.
+ *
+ * The hard constraint is that **no price value ever appears in an email body**. Not
+ * the old price, not the new one, not a single variant's. Email is unencrypted in
+ * transit to a mailbox the app does not control, forwarded, indexed by mail providers
+ * and read on shared screens; a merchant's pricing is commercially sensitive and none
+ * of it belongs there. Aggregate counts carry everything an email needs to carry, and
+ * the app itself is one click away for anything specific.
+ *
+ * That is a rule about this module, so it is enforced by a test rather than by care —
+ * these functions take counts and names, and are never handed a Money.
+ */
+
+export type NotificationKind =
+  | "run-completed"
+  | "run-partial"
+  | "run-failed"
+  | "revert-completed"
+  | "drift-hold"
+  | "weekly-digest";
+
+export interface RunCounts {
+  verified: number;
+  skipped: number;
+  clamped: number;
+  failed: number;
+  unverified: number;
+}
+
+export interface RunNotification {
+  kind: Exclude<NotificationKind, "weekly-digest" | "drift-hold">;
+  campaignName: string;
+  counts: RunCounts;
+  /** Merchant-facing reasons, already through the error taxonomy. Never raw errors. */
+  reasons?: string[];
+  /** Deep link back into the app, where the specifics live. */
+  campaignUrl?: string;
+}
+
+export interface DriftNotification {
+  kind: "drift-hold";
+  campaignName: string;
+  driftedCount: number;
+  campaignUrl?: string;
+}
+
+export interface DigestNotification {
+  kind: "weekly-digest";
+  shopName: string;
+  campaignsRun: number;
+  variantsChanged: number;
+  driftOpen: number;
+  partialRuns: number;
+}
+
+export type Notification = RunNotification | DriftNotification | DigestNotification;
+
+export interface Email {
+  subject: string;
+  /** Plain text. Deliverability is better and there is nothing here worth styling. */
+  text: string;
+}
+
+export function compose(notification: Notification): Email {
+  switch (notification.kind) {
+    case "run-completed":
+      return runCompleted(notification);
+    case "run-partial":
+      return runPartial(notification);
+    case "run-failed":
+      return runFailed(notification);
+    case "revert-completed":
+      return revertCompleted(notification);
+    case "drift-hold":
+      return driftHold(notification);
+    case "weekly-digest":
+      return digest(notification);
+  }
+}
+
+function runCompleted(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" finished — ${n.counts.verified} variants updated`,
+    text: [
+      `"${n.campaignName}" has finished and every row was read back and confirmed.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      "Your storefront now shows the campaign price for these products.",
+      link(n.campaignUrl),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function runPartial(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" finished partially — ${n.counts.failed} rows need attention`,
+    text: [
+      `"${n.campaignName}" has finished, but not every row landed.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      // Named plainly, because the alternative reading of a partial run is that the
+      // app does not know what it did. It does, per row.
+      "Nothing is hidden: every row that did not complete has a reason recorded against",
+      "it, and the prices that did apply are live. Resuming retries only the rows that",
+      "are outstanding.",
+      ...reasonLines(n.reasons),
+      link(n.campaignUrl, "Open the campaign to review and resume"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function runFailed(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" could not run`,
+    text: [
+      `"${n.campaignName}" stopped before it could finish.`,
+      "",
+      ...countLines(n.counts),
+      ...reasonLines(n.reasons),
+      "",
+      "Prices already written are unchanged and recorded. Fixing the cause and resuming",
+      "picks up exactly where this run stopped.",
+      link(n.campaignUrl, "Open the campaign"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function revertCompleted(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" has been reverted`,
+    text: [
+      `"${n.campaignName}" is over and its prices have been recomputed without it.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      // Worth saying every time: this is the single most misunderstood thing the app
+      // does, and a merchant expecting a snap-back to full price will otherwise read
+      // a correct revert as a bug.
+      "Reverting recomputes each price rather than restoring a saved number. Where",
+      "another campaign still covers a product, that campaign's price stays in place.",
+      link(n.campaignUrl),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function driftHold(n: DriftNotification): Email {
+  return {
+    subject: `"${n.campaignName}" — ${n.driftedCount} prices changed outside the app`,
+    text: [
+      `${n.driftedCount} product${n.driftedCount === 1 ? "" : "s"} covered by`,
+      `"${n.campaignName}" ${n.driftedCount === 1 ? "has" : "have"} been repriced somewhere other than this app.`,
+      "",
+      "Those edits were made on purpose by someone, so the app has not overwritten them.",
+      "Each one is waiting for a decision: keep the new price as the new normal, put the",
+      "campaign price back, or leave it alone this time.",
+      link(n.campaignUrl, "Review the drift queue"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function digest(n: DigestNotification): Email {
+  return {
+    subject: `${n.shopName}: ${n.campaignsRun} campaign${n.campaignsRun === 1 ? "" : "s"} this week`,
+    text: [
+      `A week of pricing on ${n.shopName}.`,
+      "",
+      `Campaigns run: ${n.campaignsRun}`,
+      `Variants changed: ${n.variantsChanged}`,
+      `Runs finished partially: ${n.partialRuns}`,
+      `Drift waiting on a decision: ${n.driftOpen}`,
+      "",
+      n.partialRuns > 0 || n.driftOpen > 0
+        ? "Anything above zero on the last two lines is waiting for you."
+        : "Nothing is waiting for you.",
+    ].join("\n"),
+  };
+}
+
+/**
+ * The counts, and only the counts.
+ *
+ * Zeroes are omitted rather than listed. "0 failed, 0 skipped, 0 clamped" is three
+ * lines of noise that makes the one number that matters harder to find.
+ */
+function countLines(counts: RunCounts): string[] {
+  const lines = [`Variants updated and verified: ${counts.verified}`];
+  if (counts.failed > 0) lines.push(`Failed: ${counts.failed}`);
+  if (counts.unverified > 0) lines.push(`Applied but not confirmed: ${counts.unverified}`);
+  if (counts.skipped > 0) lines.push(`Skipped: ${counts.skipped}`);
+  if (counts.clamped > 0) lines.push(`Adjusted to stay within your guardrails: ${counts.clamped}`);
+  return lines;
+}
+
+function reasonLines(reasons?: string[]): string[] {
+  if (!reasons?.length) return [];
+  return ["", "What went wrong:", ...reasons.slice(0, 5).map((reason) => `  - ${reason}`)];
+}
+
+function link(url?: string, label = "Open the campaign"): string {
+  return url ? `\n${label}: ${url}` : "";
+}

--- a/app/lib/tags/plan.test.ts
+++ b/app/lib/tags/plan.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tag ownership.
+ *
+ * Adding a tag is harmless. Removing one is not: a merchant who already had "SALE" on
+ * a product for their own reasons, and watched a campaign's revert delete it, has lost
+ * merchandising the app never created and has nothing explaining where it went.
+ *
+ * So every test here is really the same question asked from a different angle — is
+ * this tag ours to take back?
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { planTagRemoval, planTagsFor } from "./plan";
+
+describe("planTagsFor", () => {
+  it("adds tags the product does not have", () => {
+    const plan = planTagsFor("p1", ["SALE", "SUMMER"], ["NEW"]);
+    expect(plan.toAdd).toEqual(["SALE", "SUMMER"]);
+    expect(plan.alreadyPresent).toEqual([]);
+  });
+
+  it("never claims a tag the product already carried", () => {
+    // The one that matters. `tagsAdd` is a no-op here, so removing it later would
+    // delete the merchant's own tag.
+    const plan = planTagsFor("p1", ["SALE"], ["SALE", "NEW"]);
+    expect(plan.toAdd).toEqual([]);
+    expect(plan.alreadyPresent).toEqual(["SALE"]);
+  });
+
+  it("compares case-insensitively, as Shopify does", () => {
+    // Shopify treats "Sale" and "sale" as one tag. A case-sensitive comparison would
+    // record "Sale" as ours and strip the merchant's "sale" on revert.
+    const plan = planTagsFor("p1", ["Sale"], ["sale"]);
+    expect(plan.toAdd).toEqual([]);
+    expect(plan.alreadyPresent).toEqual(["Sale"]);
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(planTagsFor("p1", ["  SALE  "], ["SALE"]).toAdd).toEqual([]);
+  });
+
+  it("drops empty entries rather than adding a blank tag", () => {
+    expect(planTagsFor("p1", ["", "   ", "SALE"], []).toAdd).toEqual(["SALE"]);
+  });
+
+  it("counts a tag listed twice in the kit only once", () => {
+    // Otherwise the ledger claims ownership of two copies of something that exists
+    // once, and the second removal would be removing nothing -- or worse, a merchant's.
+    const plan = planTagsFor("p1", ["SALE", "sale"], []);
+    expect(plan.toAdd).toEqual(["SALE"]);
+  });
+});
+
+describe("planTagRemoval", () => {
+  it("removes what the ledger says was added", () => {
+    expect(planTagRemoval([{ productGid: "p1", addedTags: ["SALE"] }])).toEqual([
+      { productGid: "p1", toRemove: ["SALE"] },
+    ]);
+  });
+
+  it("unions across every run of the campaign", () => {
+    // A recurring sale, or one resumed after a failure, adds tags over several runs.
+    // Taking only the newest run's row strands the earlier ones on the storefront --
+    // the "SALE badge on a full-price product weeks later" this exists to prevent.
+    const out = planTagRemoval([
+      { productGid: "p1", addedTags: ["SALE"] },
+      { productGid: "p1", addedTags: ["SUMMER"] },
+      { productGid: "p2", addedTags: ["SALE"] },
+    ]);
+
+    expect(out).toHaveLength(2);
+    expect(out.find((r) => r.productGid === "p1")?.toRemove.sort()).toEqual(["SALE", "SUMMER"]);
+  });
+
+  it("leaves a tag another running campaign still owes", () => {
+    // Two overlapping sales both tagging "SALE" is ordinary. Ending one must not
+    // strip the badge from the other.
+    const out = planTagRemoval(
+      [{ productGid: "p1", addedTags: ["SALE", "CLEARANCE"] }],
+      new Map([["p1", new Set(["sale"])]]),
+    );
+
+    expect(out).toEqual([{ productGid: "p1", toRemove: ["CLEARANCE"] }]);
+  });
+
+  it("emits no work for a product whose every tag is still owed", () => {
+    const out = planTagRemoval(
+      [{ productGid: "p1", addedTags: ["SALE"] }],
+      new Map([["p1", new Set(["sale"])]]),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("returns nothing when the campaign never tagged anything", () => {
+    expect(planTagRemoval([])).toEqual([]);
+  });
+});

--- a/app/lib/tags/plan.ts
+++ b/app/lib/tags/plan.ts
@@ -1,0 +1,102 @@
+/**
+ * Deciding which tags a campaign may add, and — far more importantly — which it is
+ * allowed to take away again.
+ *
+ * The tag kit is the deliberate alternative to shipping theme code: a theme keys its
+ * sale badge off a tag, and the app never touches the storefront. That only works if
+ * the app is scrupulous about ownership.
+ *
+ * The danger is not adding a tag, it is removing one. If a merchant already had "SALE"
+ * on a product for their own reasons and a campaign also asks for "SALE", then
+ * `tagsAdd` is a no-op — and a revert that removed it would delete something the app
+ * never added. The merchant loses their own merchandising, with no record of why.
+ *
+ * So the unit of truth is the *delta*: the tags that were genuinely absent before this
+ * campaign touched the product. Those are ledgered, and those are the only ones a
+ * revert removes. Tags the product already had are recorded too, explicitly, so the
+ * ledger can show that the app knew about them and deliberately left them alone.
+ */
+
+export interface TagPlan {
+  productGid: string;
+  /** Absent before, so ours to add — and ours to remove later. */
+  toAdd: string[];
+  /** Asked for but already present. Never removed, recorded so the choice is visible. */
+  alreadyPresent: string[];
+}
+
+/** Normalises for comparison. Shopify tags are case-insensitive and space-trimmed. */
+export function normaliseTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+/**
+ * Splits a campaign's tag kit against what a product already carries.
+ *
+ * Comparison is case-insensitive because Shopify treats "Sale" and "sale" as the same
+ * tag. Adding "Sale" to a product tagged "sale" changes nothing, and a case-sensitive
+ * comparison would record it as ours and remove the merchant's tag on revert.
+ */
+export function planTagsFor(
+  productGid: string,
+  tagKit: readonly string[],
+  currentTags: readonly string[],
+): TagPlan {
+  const current = new Set(currentTags.map(normaliseTag));
+  const toAdd: string[] = [];
+  const alreadyPresent: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of tagKit) {
+    const tag = raw.trim();
+    if (!tag) continue;
+
+    const key = normaliseTag(tag);
+    // A kit listing the same tag twice must not add it twice, or the ledger would
+    // claim ownership of one copy of something that only exists once.
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    if (current.has(key)) alreadyPresent.push(tag);
+    else toAdd.push(tag);
+  }
+
+  return { productGid, toAdd, alreadyPresent };
+}
+
+/**
+ * What a revert should remove, given what the apply runs recorded.
+ *
+ * Union across every run of the campaign: a recurring sale, or one resumed after a
+ * failure, adds tags over several runs and all of them are the campaign's. Taking only
+ * the newest run's row would strand tags from earlier ones on the storefront forever —
+ * which is the "SALE badge on a full-price product weeks later" this ticket exists to
+ * prevent.
+ *
+ * Tags another still-active campaign also applied are excluded. Two overlapping sales
+ * both tagging "SALE" is ordinary, and ending one must not strip the badge from the
+ * other.
+ */
+export function planTagRemoval(
+  ledgered: ReadonlyArray<{ productGid: string; addedTags: string[] }>,
+  /** Tags still owed by other campaigns, per product. */
+  stillOwed: ReadonlyMap<string, ReadonlySet<string>> = new Map(),
+): Array<{ productGid: string; toRemove: string[] }> {
+  const byProduct = new Map<string, Set<string>>();
+
+  for (const row of ledgered) {
+    const existing = byProduct.get(row.productGid) ?? new Set<string>();
+    for (const tag of row.addedTags) existing.add(tag);
+    byProduct.set(row.productGid, existing);
+  }
+
+  const out: Array<{ productGid: string; toRemove: string[] }> = [];
+
+  for (const [productGid, tags] of byProduct) {
+    const owed = stillOwed.get(productGid);
+    const toRemove = [...tags].filter((tag) => !owed?.has(normaliseTag(tag)));
+    if (toRemove.length > 0) out.push({ productGid, toRemove });
+  }
+
+  return out;
+}

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -145,6 +145,10 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
     priority: Number(form.get("priority") ?? 100) || 100,
     // An unchecked checkbox is simply absent from the form, so presence is the value.
     autoEnroll: form.get("autoEnroll") !== null,
+    tagKit: String(form.get("tagKit") ?? "")
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean),
     schedule,
   });
 
@@ -279,6 +283,13 @@ export default function NewCampaign() {
               label="Priority"
               defaultValue="100"
               details="Higher wins when two campaigns cover the same variant. They never stack."
+            />
+
+            <s-text-field
+              name="tagKit"
+              label="Storefront tags (optional)"
+              placeholder="SALE, SUMMER"
+              details="Comma separated. Added to each product while the campaign runs and removed when it ends, so your theme can badge sale items. Tags a product already has are never removed."
             />
 
             <s-checkbox

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -6,6 +6,7 @@ import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
+import { readPreferences, writePreferences } from "../services/notifications.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 
@@ -13,20 +14,42 @@ export const loader = withGuard("/app/settings", async ({ request }: LoaderFunct
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
-  const [settings, currency, withCost, variants] = await Promise.all([
+  const [settings, currency, withCost, variants, notifications] = await Promise.all([
     readSettings(shop.id),
     shopCurrency(shop.id),
     prisma.variantIndex.count({ where: { shopId: shop.id, cost: { not: null } } }),
     prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } }),
+    readPreferences(shop.id),
   ]);
 
-  return { settings, currency, withCost, variants };
+  return {
+    settings,
+    currency,
+    withCost,
+    variants,
+    notifications,
+    // Whether the deployment can actually send. Shown rather than hidden: a merchant
+    // ticking boxes that silently do nothing is worse than being told why.
+    mailConfigured: Boolean(process.env.RESEND_API_KEY && process.env.NOTIFICATION_FROM_EMAIL),
+  };
 });
 
 export const action = withGuard("/app/settings", async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const form = await request.formData();
+
+  if (String(form.get("intent")) === "notifications") {
+    await writePreferences(shop.id, {
+      email: String(form.get("email") ?? ""),
+      onCompletion: form.get("onCompletion") === "on",
+      onPartialOrFailure: form.get("onPartialOrFailure") === "on",
+      onDrift: form.get("onDrift") === "on",
+      onRevert: form.get("onRevert") === "on",
+      weeklyDigest: form.get("weeklyDigest") === "on",
+    });
+    return { ok: true, message: "Notification preferences saved." };
+  }
 
   const saved = await writeSettings(shop.id, {
     neverBelowCost: form.get("neverBelowCost") === "on",
@@ -52,7 +75,8 @@ function asPolicy(value: FormDataEntryValue | null): "clamp" | "skip" | "block" 
 type ActionData = { ok: boolean; message: string };
 
 export default function Settings() {
-  const { settings, currency, withCost, variants } = useLoaderData<typeof loader>();
+  const { settings, currency, withCost, variants, notifications, mailConfigured } =
+    useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
 
@@ -138,6 +162,78 @@ export default function Settings() {
             </s-button>
           </s-stack>
         </fetcher.Form>
+      </s-section>
+
+      <s-section heading="Notifications">
+        <s-paragraph>
+          <s-text>
+            A campaign over a large catalogue runs for a while. These let you close the
+            tab and still find out what happened.
+          </s-text>
+        </s-paragraph>
+
+        {!mailConfigured ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              Email is not configured on this deployment, so nothing is sent yet. Your
+              preferences are saved and take effect once it is.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="notifications" />
+          <s-stack gap="base">
+            <s-text-field
+              name="email"
+              label="Send to"
+              placeholder="ops@yourshop.com"
+              defaultValue={notifications.email ?? ""}
+              details="Leave blank to turn notifications off entirely."
+            />
+
+            <s-checkbox
+              name="onPartialOrFailure"
+              label="A run did not finish cleanly"
+              details="Something needs you: rows failed, or the run stopped early."
+              defaultChecked={notifications.onPartialOrFailure || undefined}
+            />
+            <s-checkbox
+              name="onDrift"
+              label="Someone changed a price outside the app"
+              details="Those edits are held for your decision rather than overwritten."
+              defaultChecked={notifications.onDrift || undefined}
+            />
+            <s-checkbox
+              name="onRevert"
+              label="A campaign was reverted"
+              defaultChecked={notifications.onRevert || undefined}
+            />
+            <s-checkbox
+              name="onCompletion"
+              label="A run finished cleanly"
+              details="Off by default. Being emailed about every success is how the one email that mattered gets skimmed past."
+              defaultChecked={notifications.onCompletion || undefined}
+            />
+            <s-checkbox
+              name="weeklyDigest"
+              label="Weekly summary"
+              defaultChecked={notifications.weeklyDigest || undefined}
+            />
+
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
+              Save notification preferences
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+
+        <s-paragraph>
+          <s-text>
+            Emails carry counts only — how many variants changed, failed or were
+            skipped. No prices are ever included, because email is not a place your
+            pricing should end up.
+          </s-text>
+        </s-paragraph>
       </s-section>
 
       <s-section slot="aside" heading="Why floors are checked last">

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -27,6 +27,7 @@ export async function createCampaign(shopId: string, input: CampaignInput) {
       status: input.schedule?.kind === "window" ? "SCHEDULED" : "DRAFT",
       priority: input.priority ?? 100,
       autoEnroll: input.autoEnroll ?? true,
+      tagKit: input.tagKit ?? [],
       ruleRows: [{ segmentIds: [], rule: input.rule }] as never,
       surfaces: { base: true } as never,
       compareAtPolicy: input.compareAtPolicy as never,

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -21,6 +21,7 @@ import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
 import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
+import { applyCampaignTags, removeCampaignTags } from "./tags.server";
 
 export interface RunOptions {
   revert?: boolean;
@@ -230,6 +231,12 @@ export async function runCampaign(
 
   const messages = await recordResults(run.id, shopId, result.rows);
 
+  // Tags after prices, deliberately. A badge on a product still showing full price is
+  // worse than a price change nobody has badged yet, so the storefront never claims a
+  // sale that has not landed.
+  const tagOutcome = await syncTags(shopId, campaignId, run.id, writable, products, client, options);
+  if (tagOutcome) messages.push(...tagOutcome.messages);
+
   await prisma.campaignRun.update({
     where: { id: run.id },
     data: {
@@ -296,6 +303,79 @@ export async function runCampaign(
       ...messages.slice(0, 5),
     ],
   };
+}
+
+/**
+ * Adds or removes the campaign's tag kit alongside the price write.
+ *
+ * Failures are reported but never fail the run. A price that landed and a badge that
+ * did not is a visibly incomplete campaign the merchant can retry; throwing here would
+ * discard a successful price write over a cosmetic one, and the ledger already records
+ * exactly which products are missing their tags.
+ */
+async function syncTags(
+  shopId: string,
+  campaignId: string,
+  runId: string,
+  rows: PlannedRow[],
+  products: Map<string, string>,
+  client: AdminClient,
+  options: RunOptions,
+): Promise<{ messages: string[] } | null> {
+  const campaign = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: { tagKit: true },
+  });
+  if (!campaign?.tagKit.length) return null;
+
+  try {
+    if (options.revert) {
+      // Scoped reverts leave tags alone: one variant coming out of a sale does not
+      // un-badge the product, whose other variants are still in it.
+      if (options.variantGids) return null;
+      const outcome = await removeCampaignTags(shopId, campaignId, client);
+      return {
+        messages:
+          outcome.failed > 0
+            ? [`${outcome.failed} product(s) kept their campaign tags — see the run for why.`]
+            : [],
+      };
+    }
+
+    const productGids = [
+      ...new Set(rows.map((row) => products.get(row.ref.variantGid)).filter((gid): gid is string => !!gid)),
+    ];
+
+    const outcome = await applyCampaignTags(
+      shopId,
+      campaignId,
+      runId,
+      productGids,
+      campaign.tagKit,
+      client,
+    );
+
+    const notes: string[] = [];
+    if (outcome.failed > 0) {
+      notes.push(`${outcome.failed} product(s) could not be tagged — prices were still applied.`);
+    }
+    if (outcome.leftAlone > 0) {
+      // Said out loud, because the alternative reading is that the app failed to tag
+      // them. It did not: they were already tagged, and they are the merchant's.
+      notes.push(
+        `${outcome.leftAlone} tag(s) were already on their products and were left as they are.`,
+      );
+    }
+    return { messages: notes };
+  } catch (error) {
+    return {
+      messages: [
+        `Prices were applied, but tagging did not finish: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ],
+    };
+  }
 }
 
 /** Prisma's unique-constraint violation, which here means somebody else got there first. */

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -22,6 +22,7 @@ import type { RunOutcome } from "./types";
 import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
+import { notify } from "../notifications.server";
 
 export interface RunOptions {
   revert?: boolean;
@@ -96,7 +97,8 @@ export async function runCampaign(
     });
   }
 
-  const { resolvable, ast } = await loadCampaignContext(shopId, campaignId);
+  const { campaign: campaignRecord, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
+  const campaignName = campaignRecord.name;
   const [candidates, storeGuardrails] = await Promise.all([
     loadCandidates(shopId, ast, options.variantGids),
     guardrailsFor(shopId),
@@ -274,6 +276,27 @@ export async function runCampaign(
   });
 
   await refreshMirror(shopId, result.rows);
+
+  // Best-effort, and deliberately last. A campaign runs for hours; the merchant has to
+  // be able to close the tab and still learn the outcome. Nothing about a mail
+  // provider is allowed to change what happened to their prices, so this never throws
+  // and never blocks the outcome being returned.
+  void notify(shopId, {
+    kind: options.revert
+      ? "revert-completed"
+      : result.clean
+        ? "run-completed"
+        : "run-partial",
+    campaignName: campaignName ?? "Your campaign",
+    counts: {
+      verified: result.verified,
+      failed: result.failed,
+      unverified: result.unverified,
+      skipped: outcome.counts.skipped,
+      clamped: outcome.counts.clamped,
+    },
+    reasons: messages.slice(0, 5),
+  });
 
   return {
     runId: run.id,

--- a/app/services/campaigns/tags.server.ts
+++ b/app/services/campaigns/tags.server.ts
@@ -1,0 +1,311 @@
+/**
+ * Applying and removing a campaign's product tags.
+ *
+ * The tag kit is how a theme badges sale items without the app shipping a line of
+ * theme code — which was a deliberate scope decision, not an omission. Theme-facing
+ * code risks the Built-for-Shopify performance budget and drags the app into theme
+ * support forever; a tag is an integration point any theme can key off and nobody has
+ * to maintain.
+ *
+ * Tags go through the same discipline as prices, for the same reason:
+ *
+ *   Ledger before write. A tag added with no record is a tag a revert cannot remove,
+ *   and the merchant is left with "SALE" badges on full-price products with nothing to
+ *   explain them.
+ *
+ *   Read back and verify. `tagsAdd` reports success for a mutation that did nothing
+ *   useful often enough that trusting it is how badges go missing on a live sale.
+ *
+ * The one asymmetry with prices: ownership. A price is simply set, but a tag might
+ * already have been there, and taking back something the merchant put there is worse
+ * than never adding it. So the delta is computed against the product's live tags
+ * immediately before writing, and only the delta is ever removed.
+ */
+
+import prisma from "../../db.server";
+import { classifyFailure } from "../../lib/execution/classify";
+import type { AdminClient } from "../../lib/execution/sync-executor";
+import { normaliseTag, planTagRemoval, planTagsFor } from "../../lib/tags/plan";
+import { isThrottledError, withRetry } from "../../lib/shopify/budget";
+
+export const PRODUCT_TAGS_QUERY = `#graphql
+  query AnchorProductTags($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      ... on Product { id tags }
+    }
+  }
+`;
+
+export const TAGS_ADD = `#graphql
+  mutation AnchorTagsAdd($id: ID!, $tags: [String!]!) {
+    tagsAdd(id: $id, tags: $tags) {
+      node { id }
+      userErrors { field message }
+    }
+  }
+`;
+
+export const TAGS_REMOVE = `#graphql
+  mutation AnchorTagsRemove($id: ID!, $tags: [String!]!) {
+    tagsRemove(id: $id, tags: $tags) {
+      node { id }
+      userErrors { field message }
+    }
+  }
+`;
+
+export interface TagOutcome {
+  products: number;
+  tagged: number;
+  failed: number;
+  /** Tags asked for that the product already had, and were left alone. */
+  leftAlone: number;
+  messages: string[];
+}
+
+interface TagsResponse {
+  tagsAdd?: { userErrors?: Array<{ message: string }> };
+  tagsRemove?: { userErrors?: Array<{ message: string }> };
+}
+
+interface NodesTagsResponse {
+  nodes?: Array<{ id: string; tags?: string[] } | null>;
+}
+
+/** Reads live tags for a set of products, in batches Shopify will accept. */
+async function liveTags(
+  client: AdminClient,
+  productGids: string[],
+): Promise<Map<string, string[]>> {
+  const out = new Map<string, string[]>();
+  const BATCH = 50;
+
+  for (let i = 0; i < productGids.length; i += BATCH) {
+    const ids = productGids.slice(i, i + BATCH);
+    const response = await withRetry(
+      () => client.request<NodesTagsResponse>(PRODUCT_TAGS_QUERY, { ids }),
+      isThrottledError,
+    );
+    for (const node of response.data?.nodes ?? []) {
+      if (node?.id) out.set(node.id, node.tags ?? []);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Applies the campaign's tag kit to every product it priced.
+ *
+ * Live tags are read immediately before writing rather than taken from the mirror.
+ * The mirror is a cache and can lag a merchant's own tag edit by a webhook; being
+ * wrong here does not mean a stale display, it means recording a merchant's tag as
+ * ours and deleting it on revert.
+ */
+export async function applyCampaignTags(
+  shopId: string,
+  campaignId: string,
+  runId: string,
+  productGids: string[],
+  tagKit: string[],
+  client: AdminClient,
+): Promise<TagOutcome> {
+  const kit = tagKit.map((t) => t.trim()).filter(Boolean);
+  if (kit.length === 0 || productGids.length === 0) {
+    return { products: 0, tagged: 0, failed: 0, leftAlone: 0, messages: [] };
+  }
+
+  const current = await liveTags(client, productGids);
+  const messages: string[] = [];
+  let tagged = 0;
+  let failed = 0;
+  let leftAlone = 0;
+
+  for (const productGid of productGids) {
+    const plan = planTagsFor(productGid, kit, current.get(productGid) ?? []);
+    leftAlone += plan.alreadyPresent.length;
+
+    // Ledgered even when there is nothing to add. "We looked and everything was
+    // already there" is a different fact from "we never got to this product", and a
+    // revert that cannot tell them apart is a revert that guesses.
+    await prisma.tagChange.upsert({
+      where: { runId_productGid: { runId, productGid } },
+      create: {
+        shopId,
+        runId,
+        campaignId,
+        productGid,
+        addedTags: plan.toAdd,
+        alreadyPresent: plan.alreadyPresent,
+        status: plan.toAdd.length === 0 ? "SKIPPED" : "PENDING",
+        appliedAt: plan.toAdd.length === 0 ? new Date() : null,
+      },
+      update: {
+        addedTags: plan.toAdd,
+        alreadyPresent: plan.alreadyPresent,
+        status: plan.toAdd.length === 0 ? "SKIPPED" : "PENDING",
+      },
+    });
+
+    if (plan.toAdd.length === 0) continue;
+
+    try {
+      const response = await withRetry(
+        () => client.request<TagsResponse>(TAGS_ADD, { id: productGid, tags: plan.toAdd }),
+        isThrottledError,
+      );
+
+      const errors = response.data?.tagsAdd?.userErrors ?? [];
+      if (errors.length > 0) throw new Error(errors.map((e) => e.message).join("; "));
+
+      await prisma.tagChange.update({
+        where: { runId_productGid: { runId, productGid } },
+        data: { status: "APPLIED", appliedAt: new Date() },
+      });
+      tagged++;
+    } catch (error) {
+      const classified = classifyFailure(error);
+      failed++;
+      await prisma.tagChange.update({
+        where: { runId_productGid: { runId, productGid } },
+        data: {
+          status: "FAILED",
+          failureReason: `${classified.message} (Shopify said: ${
+            error instanceof Error ? error.message : String(error)
+          })`,
+        },
+      });
+      if (messages.length < 3) messages.push(classified.message);
+    }
+  }
+
+  // Read back what actually landed. A tag the theme keys its badge off is not
+  // something to take Shopify's word for.
+  const verified = await verifyTags(client, runId);
+
+  return {
+    products: productGids.length,
+    tagged: verified,
+    failed: failed + (tagged - verified),
+    leftAlone,
+    messages,
+  };
+}
+
+/** Confirms applied tags are really on the products, and marks the ledger. */
+async function verifyTags(client: AdminClient, runId: string): Promise<number> {
+  const applied = await prisma.tagChange.findMany({
+    where: { runId, status: "APPLIED" },
+    select: { productGid: true, addedTags: true },
+  });
+  if (applied.length === 0) return 0;
+
+  const live = await liveTags(client, applied.map((row) => row.productGid));
+  let verified = 0;
+
+  for (const row of applied) {
+    const have = new Set((live.get(row.productGid) ?? []).map(normaliseTag));
+    const missing = row.addedTags.filter((tag) => !have.has(normaliseTag(tag)));
+
+    if (missing.length === 0) {
+      await prisma.tagChange.updateMany({
+        where: { runId, productGid: row.productGid },
+        data: { status: "VERIFIED", verifiedAt: new Date() },
+      });
+      verified++;
+    } else {
+      await prisma.tagChange.updateMany({
+        where: { runId, productGid: row.productGid },
+        data: {
+          status: "FAILED",
+          failureReason: `Applied but not found on the product afterwards: ${missing.join(", ")}.`,
+        },
+      });
+    }
+  }
+
+  return verified;
+}
+
+/**
+ * Removes every tag this campaign added, across all of its runs.
+ *
+ * Driven entirely by the ledger, never by the current tag kit. A merchant who edited
+ * the kit mid-campaign would otherwise strand the old tags on the storefront — the
+ * badge stays, the sale is over, and nothing in the app admits it.
+ */
+export async function removeCampaignTags(
+  shopId: string,
+  campaignId: string,
+  client: AdminClient,
+): Promise<TagOutcome> {
+  const ledgered = await prisma.tagChange.findMany({
+    where: { shopId, campaignId, status: { in: ["APPLIED", "VERIFIED"] } },
+    select: { productGid: true, addedTags: true },
+  });
+  if (ledgered.length === 0) {
+    return { products: 0, tagged: 0, failed: 0, leftAlone: 0, messages: [] };
+  }
+
+  const removals = planTagRemoval(ledgered, await tagsOwedByOthers(shopId, campaignId));
+  const messages: string[] = [];
+  let removed = 0;
+  let failed = 0;
+
+  for (const { productGid, toRemove } of removals) {
+    try {
+      const response = await withRetry(
+        () => client.request<TagsResponse>(TAGS_REMOVE, { id: productGid, tags: toRemove }),
+        isThrottledError,
+      );
+      const errors = response.data?.tagsRemove?.userErrors ?? [];
+      if (errors.length > 0) throw new Error(errors.map((e) => e.message).join("; "));
+
+      await prisma.tagChange.updateMany({
+        where: { shopId, campaignId, productGid },
+        data: { status: "REVERTED", failureReason: null },
+      });
+      removed++;
+    } catch (error) {
+      const classified = classifyFailure(error);
+      failed++;
+      await prisma.tagChange.updateMany({
+        where: { shopId, campaignId, productGid },
+        data: { failureReason: `Could not remove tags: ${classified.message}` },
+      });
+      if (messages.length < 3) messages.push(classified.message);
+    }
+  }
+
+  return { products: removals.length, tagged: removed, failed, leftAlone: 0, messages };
+}
+
+/**
+ * Tags other still-running campaigns have on each product.
+ *
+ * Two overlapping sales both tagging "SALE" is ordinary, and ending one must not strip
+ * the badge from the other. Without this, the first campaign to finish silently
+ * un-badges the second.
+ */
+async function tagsOwedByOthers(
+  shopId: string,
+  campaignId: string,
+): Promise<Map<string, Set<string>>> {
+  const rows = await prisma.tagChange.findMany({
+    where: {
+      shopId,
+      campaignId: { not: campaignId },
+      status: { in: ["APPLIED", "VERIFIED"] },
+      run: { campaign: { status: { in: ["ACTIVE", "APPLYING", "PARTIAL"] } } },
+    },
+    select: { productGid: true, addedTags: true },
+  });
+
+  const owed = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const set = owed.get(row.productGid) ?? new Set<string>();
+    for (const tag of row.addedTags) set.add(normaliseTag(tag));
+    owed.set(row.productGid, set);
+  }
+  return owed;
+}

--- a/app/services/campaigns/types.ts
+++ b/app/services/campaigns/types.ts
@@ -27,6 +27,13 @@ export interface CampaignInput {
   /** Absent means the campaign only runs when applied by hand. */
   schedule?: Schedule;
   /**
+   * Product tags added when the campaign starts and removed when it ends.
+   *
+   * The storefront hook that lets the app ship no theme code at all: a theme keys its
+   * sale badge off a tag, and nothing in the app touches the theme.
+   */
+  tagKit?: string[];
+  /**
    * Target a saved segment instead of an inline filter.
    *
    * Stored as a reference, not copied, so editing the segment updates every campaign

--- a/app/services/digest.server.ts
+++ b/app/services/digest.server.ts
@@ -1,0 +1,93 @@
+/**
+ * The weekly summary.
+ *
+ * Opt-in and quiet by design. Its job is to be the email a merchant can ignore for six
+ * weeks and then read in ten seconds when something feels off — so it leads with what
+ * is *waiting* for them, and says plainly when nothing is.
+ *
+ * Sent from the scheduler tick rather than a cron of its own, so there is one thing
+ * that runs on a clock and one place to look when it stops.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { notify, readPreferences } from "./notifications.server";
+
+const WEEK_MS = 7 * 24 * 60 * 60_000;
+
+/**
+ * Sends the digest to any shop that is due one.
+ *
+ * "Due" is tracked in the audit log rather than on the shop row: it needs no
+ * migration, it is the same place every other "we told the merchant something" fact
+ * lives, and a missed week leaves a visible gap rather than a silently reset counter.
+ */
+export async function sendDueDigests(now: Date = new Date()): Promise<number> {
+  const shops = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { id: true, domain: true },
+  });
+
+  let sent = 0;
+
+  for (const shop of shops) {
+    try {
+      const preferences = await readPreferences(shop.id);
+      if (!preferences.weeklyDigest || !preferences.email) continue;
+
+      const lastSent = await prisma.auditLogEntry.findFirst({
+        where: { shopId: shop.id, action: "notification.digest" },
+        orderBy: { createdAt: "desc" },
+        select: { createdAt: true },
+      });
+
+      // A shop that has never had one waits a full week rather than getting a digest
+      // covering the day they installed, which would be an empty email as a welcome.
+      const since = lastSent?.createdAt ?? new Date(now.getTime() - WEEK_MS);
+      if (now.getTime() - since.getTime() < WEEK_MS) {
+        if (lastSent) continue;
+      }
+
+      const [campaignsRun, variantsChanged, driftOpen, partialRuns] = await Promise.all([
+        prisma.campaignRun.count({ where: { shopId: shop.id, createdAt: { gte: since } } }),
+        prisma.variantChange.count({
+          where: { shopId: shop.id, status: "VERIFIED", createdAt: { gte: since } },
+        }),
+        prisma.driftEvent.count({ where: { shopId: shop.id, resolution: "PENDING" } }),
+        prisma.campaignRun.count({
+          where: { shopId: shop.id, status: "PARTIAL", createdAt: { gte: since } },
+        }),
+      ]);
+
+      await prisma.auditLogEntry.create({
+        data: {
+          shopId: shop.id,
+          action: "notification.digest",
+          entity: "shop",
+          entityId: shop.id,
+          after: { campaignsRun, variantsChanged, driftOpen, partialRuns },
+        },
+      });
+
+      const result = await notify(shop.id, {
+        kind: "weekly-digest",
+        shopName: shop.domain,
+        campaignsRun,
+        variantsChanged,
+        driftOpen,
+        partialRuns,
+      });
+
+      if (result.sent) sent++;
+    } catch (error) {
+      // One shop's digest failing must not stop the others, and must never stop a
+      // tick that also has campaigns to run.
+      logger.warn("digest failed", {
+        shop: shop.domain,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return sent;
+}

--- a/app/services/drift.server.ts
+++ b/app/services/drift.server.ts
@@ -20,6 +20,7 @@
 import { createHash } from "node:crypto";
 
 import prisma from "../db.server";
+import { notify } from "./notifications.server";
 import { formatMinorUnits } from "../lib/money/format";
 import { holdForDrift } from "./campaigns/lifecycle.server";
 
@@ -115,7 +116,7 @@ export async function checkForDrift(
   const activeCampaign = await prisma.campaign.findFirst({
     where: { shopId, status: "ACTIVE" },
     orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
-    select: { id: true },
+    select: { id: true, name: true },
   });
   if (!activeCampaign) return false;
 
@@ -147,6 +148,8 @@ export async function checkForDrift(
       resolution: "PENDING",
     },
   });
+
+  await notifyDrift(shopId, activeCampaign.id, activeCampaign.name);
 
   // Hold the campaign as well as recording the event. Recording alone would leave the
   // campaign looking healthy while it quietly stopped controlling one of its prices.
@@ -270,4 +273,46 @@ export async function pruneWriteIntents(): Promise<number> {
     where: { writtenAt: { lt: new Date(Date.now() - INTENT_TTL_MS) } },
   });
   return result.count;
+}
+
+/**
+ * Tells the merchant that prices are being changed underneath a running campaign.
+ *
+ * Rate-limited to one email per campaign per hour, and it has to be. A bulk edit in
+ * Shopify's admin fires a webhook per product; without this, retagging a collection
+ * during a sale would put several hundred identical emails in somebody's inbox, and
+ * the next real one would arrive somewhere below them.
+ *
+ * The count is read at send time rather than incremented, so the one email that does
+ * go out reports the whole burst rather than the first of it.
+ */
+async function notifyDrift(shopId: string, campaignId: string, campaignName: string): Promise<void> {
+  const HOUR = 60 * 60_000;
+  const since = new Date(Date.now() - HOUR);
+
+  const [pending, alreadyTold] = await Promise.all([
+    prisma.driftEvent.count({ where: { shopId, campaignId, resolution: "PENDING" } }),
+    prisma.auditLogEntry.count({
+      where: {
+        shopId,
+        action: "notification.drift",
+        entityId: campaignId,
+        createdAt: { gte: since },
+      },
+    }),
+  ]);
+
+  if (alreadyTold > 0) return;
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      action: "notification.drift",
+      entity: "campaign",
+      entityId: campaignId,
+      after: { pending },
+    },
+  });
+
+  void notify(shopId, { kind: "drift-hold", campaignName, driftedCount: pending });
 }

--- a/app/services/notifications.server.ts
+++ b/app/services/notifications.server.ts
@@ -1,0 +1,174 @@
+/**
+ * Telling the merchant what happened while they were not watching.
+ *
+ * A campaign over a real catalogue runs for hours. If the only way to learn the
+ * outcome is to keep the tab open, the app has quietly made itself something you have
+ * to babysit — and the merchant who closes the laptop finds out about a partial run
+ * from a customer.
+ *
+ * Two things are deliberate:
+ *
+ *   Unconfigured is a no-op, not an error. Local development and self-hosted installs
+ *   have no Resend key, and a run that failed because it could not send an email about
+ *   succeeding would be a genuinely absurd way to lose a price change.
+ *
+ *   Sending never fails a run. The email is a report on work that already happened;
+ *   the ledger is the record. Throwing here would discard a successful campaign over
+ *   an SMTP hiccup.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { compose, type Notification } from "../lib/notifications/templates";
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+export interface DeliveryResult {
+  sent: boolean;
+  /** Why nothing was sent, when nothing was. Never an error the caller must handle. */
+  reason?: "unconfigured" | "no-recipient" | "muted" | "failed";
+}
+
+/** Which notifications a shop wants. Stored alongside the other shop settings. */
+export interface NotificationPreferences {
+  /** Where to send. Empty means notifications are effectively off. */
+  email: string | null;
+  onCompletion: boolean;
+  onPartialOrFailure: boolean;
+  onDrift: boolean;
+  onRevert: boolean;
+  weeklyDigest: boolean;
+}
+
+export const DEFAULT_PREFERENCES: NotificationPreferences = {
+  email: null,
+  // The ones that need a decision default on; the purely-good-news one defaults off.
+  // A merchant who is emailed about every successful run stops reading the emails,
+  // and then misses the partial one that mattered.
+  onCompletion: false,
+  onPartialOrFailure: true,
+  onDrift: true,
+  onRevert: true,
+  weeklyDigest: false,
+};
+
+export function parsePreferences(raw: unknown): NotificationPreferences {
+  const value = (raw ?? {}) as Partial<Record<keyof NotificationPreferences, unknown>>;
+  const bool = (key: keyof NotificationPreferences, fallback: boolean) =>
+    typeof value[key] === "boolean" ? (value[key] as boolean) : fallback;
+
+  const email = typeof value.email === "string" ? value.email.trim() : "";
+
+  return {
+    email: email.includes("@") ? email : null,
+    onCompletion: bool("onCompletion", DEFAULT_PREFERENCES.onCompletion),
+    onPartialOrFailure: bool("onPartialOrFailure", DEFAULT_PREFERENCES.onPartialOrFailure),
+    onDrift: bool("onDrift", DEFAULT_PREFERENCES.onDrift),
+    onRevert: bool("onRevert", DEFAULT_PREFERENCES.onRevert),
+    weeklyDigest: bool("weeklyDigest", DEFAULT_PREFERENCES.weeklyDigest),
+  };
+}
+
+export async function readPreferences(shopId: string): Promise<NotificationPreferences> {
+  const shop = await prisma.shop.findUnique({ where: { id: shopId }, select: { settings: true } });
+  const settings = (shop?.settings ?? {}) as { notifications?: unknown };
+  return parsePreferences(settings.notifications);
+}
+
+export async function writePreferences(
+  shopId: string,
+  preferences: NotificationPreferences,
+): Promise<NotificationPreferences> {
+  const parsed = parsePreferences(preferences);
+
+  // Merged into the existing blob rather than replacing it. Guardrails live in the
+  // same JSON column, and saving an email address must not quietly reset the floor
+  // that stops a campaign pricing below cost.
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { id: shopId },
+    select: { settings: true },
+  });
+
+  await prisma.shop.update({
+    where: { id: shopId },
+    data: { settings: { ...((shop.settings ?? {}) as object), notifications: parsed } as never },
+  });
+
+  return parsed;
+}
+
+/** Whether this shop asked to hear about this kind of thing. */
+export function wants(preferences: NotificationPreferences, notification: Notification): boolean {
+  switch (notification.kind) {
+    case "run-completed":
+      return preferences.onCompletion;
+    case "run-partial":
+    case "run-failed":
+      return preferences.onPartialOrFailure;
+    case "revert-completed":
+      return preferences.onRevert;
+    case "drift-hold":
+      return preferences.onDrift;
+    case "weekly-digest":
+      return preferences.weeklyDigest;
+  }
+}
+
+/**
+ * Sends one notification, if everything about it says to.
+ *
+ * Every path out of here is a resolved promise. Callers treat notification as
+ * best-effort reporting, and nothing about a mail provider should be able to change
+ * what happened to a merchant's prices.
+ */
+export async function notify(
+  shopId: string,
+  notification: Notification,
+): Promise<DeliveryResult> {
+  try {
+    const apiKey = process.env.RESEND_API_KEY;
+    const from = process.env.NOTIFICATION_FROM_EMAIL;
+    if (!apiKey || !from) return { sent: false, reason: "unconfigured" };
+
+    const preferences = await readPreferences(shopId);
+    if (!preferences.email) return { sent: false, reason: "no-recipient" };
+    if (!wants(preferences, notification)) return { sent: false, reason: "muted" };
+
+    const email = compose(notification);
+
+    const response = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to: [preferences.email],
+        subject: email.subject,
+        text: email.text,
+      }),
+    });
+
+    if (!response.ok) {
+      // Logged with the kind and status, never the body: the body is the email, and
+      // logs are one more place a merchant's business shows up unnecessarily.
+      logger.warn("notification not delivered", {
+        shopId,
+        kind: notification.kind,
+        status: response.status,
+      });
+      return { sent: false, reason: "failed" };
+    }
+
+    logger.info("notification sent", { shopId, kind: notification.kind });
+    return { sent: true };
+  } catch (error) {
+    logger.warn("notification threw", {
+      shopId,
+      kind: notification.kind,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { sent: false, reason: "failed" };
+  }
+}

--- a/app/services/notifications.test.ts
+++ b/app/services/notifications.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Preferences, and the defaults that decide whether anyone reads these emails.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PREFERENCES, parsePreferences, wants } from "./notifications.server";
+
+describe("parsePreferences", () => {
+  it("fills absent fields with defaults rather than turning everything off", () => {
+    // A shop that saved preferences before a new kind existed must keep hearing about
+    // the ones it already opted into.
+    expect(parsePreferences({})).toEqual(DEFAULT_PREFERENCES);
+    expect(parsePreferences(null)).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("treats an address without an @ as no address", () => {
+    // Better to send nothing than to hand a mail provider something that will bounce
+    // on every run for weeks.
+    expect(parsePreferences({ email: "not-an-email" }).email).toBeNull();
+    expect(parsePreferences({ email: "  ops@shop.com " }).email).toBe("ops@shop.com");
+  });
+
+  it("keeps explicit false rather than falling back to a true default", () => {
+    expect(parsePreferences({ onDrift: false }).onDrift).toBe(false);
+  });
+
+  it("defaults success emails off and decision emails on", () => {
+    // A merchant emailed about every successful run stops reading the emails, and
+    // then misses the partial one that mattered.
+    expect(DEFAULT_PREFERENCES.onCompletion).toBe(false);
+    expect(DEFAULT_PREFERENCES.onPartialOrFailure).toBe(true);
+    expect(DEFAULT_PREFERENCES.onDrift).toBe(true);
+  });
+});
+
+describe("wants", () => {
+  const prefs = { ...DEFAULT_PREFERENCES, email: "ops@shop.com" };
+  const run = (kind: "run-completed" | "run-partial" | "run-failed" | "revert-completed") =>
+    ({ kind, campaignName: "Summer", counts: { verified: 1, skipped: 0, clamped: 0, failed: 0, unverified: 0 } }) as const;
+
+  it("routes partial and failed through the same preference", () => {
+    // They are the same question to a merchant: something needs me.
+    expect(wants({ ...prefs, onPartialOrFailure: false }, run("run-partial"))).toBe(false);
+    expect(wants({ ...prefs, onPartialOrFailure: false }, run("run-failed"))).toBe(false);
+    expect(wants({ ...prefs, onPartialOrFailure: true }, run("run-failed"))).toBe(true);
+  });
+
+  it("does not send completion emails to a shop that only asked about problems", () => {
+    expect(wants(prefs, run("run-completed"))).toBe(false);
+  });
+
+  it("honours the revert and drift preferences separately", () => {
+    expect(wants({ ...prefs, onRevert: false }, run("revert-completed"))).toBe(false);
+    expect(
+      wants({ ...prefs, onDrift: false }, { kind: "drift-hold", campaignName: "S", driftedCount: 2 }),
+    ).toBe(false);
+  });
+});

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -13,6 +13,7 @@ import { runCampaign } from "./campaigns/run.server";
 import { adminClientForShop } from "./admin-client.server";
 import { claimEnrollment, pendingEnrollments } from "./auto-enroll.server";
 import { reclaimStaleRuns } from "./campaigns/reaper.server";
+import { sendDueDigests } from "./digest.server";
 
 export interface TickResult {
   examined: number;
@@ -22,6 +23,8 @@ export interface TickResult {
   enrolled: number;
   /** Runs whose process died and which this tick marked visibly partial. */
   reclaimed: number;
+  /** Weekly summaries sent this tick. */
+  digests: number;
   failures: Array<{ campaignId: string; error: string }>;
 }
 
@@ -38,6 +41,7 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
     reverted: 0,
     enrolled: 0,
     reclaimed: 0,
+    digests: 0,
     failures: [],
   };
 
@@ -89,6 +93,14 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
   }
 
   await drainEnrollments(result, transitioned);
+
+  // Last, and never able to hold up the work above it. A digest is a courtesy; a sale
+  // starting on time is not.
+  try {
+    result.digests = await sendDueDigests(now);
+  } catch {
+    // sendDueDigests already logs per shop; a throw here would be the loop itself.
+  }
 
   return result;
 }

--- a/chaos/harness/fake-shopify.ts
+++ b/chaos/harness/fake-shopify.ts
@@ -27,6 +27,12 @@ import type { QueryCost, ThrottleStatus } from "../../app/lib/shopify/budget";
 import type { BulkResultLine } from "../../app/lib/execution/jsonl";
 import type { BlobStore } from "./blob-store";
 
+export interface FakeProduct {
+  productGid: string;
+  /** Shopify stores tags per product, and treats them case-insensitively. */
+  tags: string[];
+}
+
 export interface FakeVariant {
   variantGid: string;
   productGid: string;
@@ -52,6 +58,9 @@ const DEFAULT_THROTTLE: ThrottleStatus = {
 
 export class FakeShopify {
   readonly variants = new Map<string, FakeVariant>();
+
+  /** Product-level state. Tags live here, not on variants, exactly as in Shopify. */
+  readonly products = new Map<string, FakeProduct>();
 
   /** Every variant write this fake has accepted, in order. Scenarios assert on it. */
   readonly writeLog: Array<{ variantGid: string; price: string }> = [];
@@ -81,6 +90,22 @@ export class FakeShopify {
 
   addVariant(variant: Omit<FakeVariant, "deleted">): void {
     this.variants.set(variant.variantGid, { ...variant, deleted: false });
+    if (!this.products.has(variant.productGid)) {
+      this.products.set(variant.productGid, { productGid: variant.productGid, tags: [] });
+    }
+  }
+
+  /** Tags currently on a product, as the storefront would see them. */
+  tagsOf(productGid: string): string[] {
+    return this.products.get(productGid)?.tags ?? [];
+  }
+
+  /** Puts a tag on a product without the app's involvement -- the merchant's own. */
+  addMerchantTag(productGid: string, tag: string): void {
+    const product = this.products.get(productGid);
+    if (product && !product.tags.some((t) => t.toLowerCase() === tag.toLowerCase())) {
+      product.tags.push(tag);
+    }
   }
 
   /**
@@ -115,8 +140,14 @@ export class FakeShopify {
     if (query.includes("currentBulkOperation")) {
       return this.currentBulkOperation() as { data?: T; extensions?: { cost?: QueryCost } };
     }
+    if (query.includes("tagsAdd")) {
+      return this.tagsAdd(variables) as { data?: T; extensions?: { cost?: QueryCost } };
+    }
+    if (query.includes("tagsRemove")) {
+      return this.tagsRemove(variables) as { data?: T; extensions?: { cost?: QueryCost } };
+    }
     if (query.includes("nodes(")) {
-      return this.nodes(variables) as { data?: T; extensions?: { cost?: QueryCost } };
+      return this.nodes(variables, query) as { data?: T; extensions?: { cost?: QueryCost } };
     }
     throw new Error(`FakeShopify has no handler for this query: ${query.slice(0, 80)}`);
   }
@@ -201,8 +232,28 @@ export class FakeShopify {
     };
   }
 
-  private nodes(variables: Record<string, unknown>) {
+  private nodes(variables: Record<string, unknown>, query = "") {
     const ids = (variables.ids ?? []) as string[];
+
+    // The same `nodes` field serves products and variants; the requested fragment is
+    // what distinguishes them, exactly as it does against the real API.
+    //
+    // Tested for `ProductVariant` first, because "... on ProductVariant" contains the
+    // substring "on Product" -- checking the shorter one first routed every price
+    // read-back to the tag handler, which answered with tags and no price, and every
+    // verified row in the suite turned unverified.
+    if (!query.includes("on ProductVariant") && query.includes("on Product")) {
+      return {
+        data: {
+          nodes: ids.map((id) => {
+            const product = this.products.get(id);
+            return product ? { id, tags: [...product.tags] } : null;
+          }),
+        },
+        extensions: this.cost(Math.max(1, ids.length)),
+      };
+    }
+
     return {
       data: {
         nodes: ids.map((id) => {
@@ -214,6 +265,42 @@ export class FakeShopify {
       },
       extensions: this.cost(Math.max(1, ids.length)),
     };
+  }
+
+  /** Case-insensitive, and a no-op for a tag already present -- as Shopify behaves. */
+  private tagsAdd(variables: Record<string, unknown>) {
+    const id = String(variables.id ?? "");
+    const tags = (variables.tags ?? []) as string[];
+    const product = this.products.get(id);
+
+    if (!product) {
+      return {
+        data: { tagsAdd: { node: null, userErrors: [{ field: ["id"], message: `Product ${id} does not exist.` }] } },
+        extensions: this.cost(10),
+      };
+    }
+
+    for (const tag of tags) {
+      if (!product.tags.some((t) => t.toLowerCase() === tag.toLowerCase())) product.tags.push(tag);
+    }
+
+    return { data: { tagsAdd: { node: { id }, userErrors: [] } }, extensions: this.cost(10) };
+  }
+
+  private tagsRemove(variables: Record<string, unknown>) {
+    const id = String(variables.id ?? "");
+    const tags = ((variables.tags ?? []) as string[]).map((t) => t.toLowerCase());
+    const product = this.products.get(id);
+
+    if (!product) {
+      return {
+        data: { tagsRemove: { node: null, userErrors: [{ field: ["id"], message: `Product ${id} does not exist.` }] } },
+        extensions: this.cost(10),
+      };
+    }
+
+    product.tags = product.tags.filter((t) => !tags.includes(t.toLowerCase()));
+    return { data: { tagsRemove: { node: { id }, userErrors: [] } }, extensions: this.cost(10) };
   }
 
   private stagedUploadsCreate() {

--- a/chaos/harness/scenario.ts
+++ b/chaos/harness/scenario.ts
@@ -56,6 +56,8 @@ export interface ChaosContext {
 export interface ChaosSpec {
   catalog: CatalogSpec;
   percent?: number;
+  /** Storefront tags the campaign applies while it runs. */
+  tagKit?: string[];
   /** Polls a bulk operation stays RUNNING. Higher exercises the fallback harder. */
   pollsBeforeComplete?: number;
 }
@@ -82,6 +84,7 @@ export async function withChaos(
     fake: server.fake,
     catalog: spec.catalog,
     percent: spec.percent,
+    tagKit: spec.tagKit,
   });
 
   const client = chaosAdminClient(server.endpoint());

--- a/chaos/harness/seed.ts
+++ b/chaos/harness/seed.ts
@@ -51,6 +51,8 @@ export interface SeedOptions {
   /** Percent change the campaign applies. Negative is a discount. */
   percent?: number;
   priority?: number;
+  /** Storefront tags the campaign applies while it runs. */
+  tagKit?: string[];
 }
 
 const TAG = "chaos";
@@ -141,6 +143,7 @@ export async function seedFixture(options: SeedOptions): Promise<Fixture> {
     rounding: "none",
     ast: { groups: [{ conditions: [{ field: "tag", value: TAG }] }] },
     schedule: { kind: "manual" },
+    tagKit: options.tagKit,
   });
 
   return { shopId: shop.id, domain, campaignId: campaign.id, variantGids, productOf, baseline };

--- a/chaos/scenarios/tag-kit.chaos.ts
+++ b/chaos/scenarios/tag-kit.chaos.ts
@@ -1,0 +1,148 @@
+/**
+ * Storefront tags, and the promise that they come off again.
+ *
+ * The tag kit is the app's entire storefront integration — a theme badges sale items
+ * by keying off a tag, and no theme code ships. That trade only holds if the tags are
+ * removed as reliably as the prices are, because the failure is uniquely visible:
+ * "SALE" on a full-price product, weeks after the sale ended, with the app insisting
+ * the campaign is over.
+ *
+ * Two claims, and the second is the one that could lose a merchant real merchandising:
+ *
+ *   A revert removes every tag the campaign added, across all of its runs — including
+ *   on products that joined after it started.
+ *
+ *   A revert never removes a tag the merchant put there. A campaign asking for "SALE"
+ *   on a product already tagged "SALE" adds nothing, so it owns nothing, and taking it
+ *   back would be deleting somebody else's work.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos } from "../harness/scenario";
+
+const has = (tags: string[], tag: string) =>
+  tags.some((t) => t.toLowerCase() === tag.toLowerCase());
+
+describe("chaos: the campaign tag kit", () => {
+  it("tags on apply, removes on revert, and never touches a merchant's own tag", async () => {
+    await withChaos(
+      "tag-kit",
+      { catalog: { products: 6, variantsPerProduct: 2 }, percent: -20, tagKit: ["SALE", "SUMMER"] },
+      async (chaos) => {
+        const productGids = [...new Set([...chaos.fixture.productOf.values()])];
+
+        // One product the merchant had already tagged SALE, in a different case, for
+        // their own reasons. The campaign must add SUMMER to it and leave SALE alone.
+        const preTagged = productGids[0];
+        chaos.fake.addMerchantTag(preTagged, "sale");
+
+        // ------------------------------------------------------------ apply
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        for (const productGid of productGids) {
+          const tags = chaos.fake.tagsOf(productGid);
+          expect(has(tags, "SALE")).toBe(true);
+          expect(has(tags, "SUMMER")).toBe(true);
+        }
+
+        // The ledger knows which tags are the app's. On the pre-tagged product only
+        // SUMMER is claimed; SALE is recorded as the merchant's.
+        const claimed = await prisma.tagChange.findFirst({
+          where: { runId: applied.runId, productGid: preTagged },
+        });
+        expect(claimed?.addedTags).toEqual(["SUMMER"]);
+        expect(claimed?.alreadyPresent).toEqual(["SALE"]);
+        expect(claimed?.status).toBe("VERIFIED");
+
+        // ----------------------------------------------------------- revert
+        await chaos.revert();
+
+        for (const productGid of productGids.slice(1)) {
+          const tags = chaos.fake.tagsOf(productGid);
+          expect(has(tags, "SALE")).toBe(false);
+          expect(has(tags, "SUMMER")).toBe(false);
+        }
+
+        // The claim that matters. The merchant's own SALE survives; only SUMMER,
+        // which the app genuinely added, is gone.
+        const survivors = chaos.fake.tagsOf(preTagged);
+        expect(has(survivors, "SALE")).toBe(true);
+        expect(has(survivors, "SUMMER")).toBe(false);
+      },
+    );
+  });
+
+  it("removes tags from products that joined after the campaign started", async () => {
+    await withChaos(
+      "tag-kit-enrolled",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -15, tagKit: ["SALE"] },
+      async (chaos) => {
+        const { shopId, variantGids, productOf } = chaos.fixture;
+
+        const first = await chaos.apply();
+        await chaos.expectHonest(first.runId);
+
+        // A product that enters scope mid-campaign: tagged in the catalogue and
+        // mirrored, exactly as auto-enroll leaves it before the next run.
+        const latecomerVariant = "gid://shopify/ProductVariant/latecomer";
+        const latecomerProduct = "gid://shopify/Product/latecomer";
+        chaos.fake.addVariant({
+          variantGid: latecomerVariant,
+          productGid: latecomerProduct,
+          price: "50.00",
+          compareAtPrice: null,
+        });
+        await prisma.variantIndex.create({
+          data: {
+            shopId,
+            variantGid: latecomerVariant,
+            productGid: latecomerProduct,
+            title: "Latecomer",
+            price: BigInt(5_000),
+            currency: "USD",
+            status: "ACTIVE",
+            tags: ["chaos"],
+          },
+        });
+        await prisma.priceSurfaceEntry.create({
+          data: {
+            shopId,
+            variantGid: latecomerVariant,
+            surfaceKind: "BASE",
+            priceListGid: "",
+            currency: "USD",
+            livePrice: BigInt(5_000),
+          },
+        });
+        await prisma.baseline.create({
+          data: {
+            shopId,
+            variantGid: latecomerVariant,
+            surfaceKind: "BASE",
+            priceListGid: "",
+            currency: "USD",
+            basePrice: BigInt(5_000),
+            source: "AUTO_ENROLL",
+          },
+        });
+
+        // The re-apply that auto-enroll triggers.
+        const second = await chaos.apply();
+        await chaos.expectHonest(second.runId);
+        expect(has(chaos.fake.tagsOf(latecomerProduct), "SALE")).toBe(true);
+
+        // Reverting must clear the latecomer too. Taking only the newest run's ledger
+        // rows would strand the original products' badges instead.
+        await chaos.revert();
+
+        expect(has(chaos.fake.tagsOf(latecomerProduct), "SALE")).toBe(false);
+        for (const gid of variantGids) {
+          expect(has(chaos.fake.tagsOf(productOf.get(gid)!), "SALE")).toBe(false);
+        }
+      },
+    );
+  });
+});

--- a/prisma/migrations/20260825230000_tag_changes/migration.sql
+++ b/prisma/migrations/20260825230000_tag_changes/migration.sql
@@ -1,0 +1,34 @@
+-- Ledger for campaign-applied product tags (P3.11).
+--
+-- Separate from variant_changes because tags are product-scoped where prices are
+-- variant-scoped. `addedTags` is the ownership record: only tags this run genuinely
+-- added are ever removed on revert, so a campaign can never delete a tag the merchant
+-- put there themselves.
+--
+-- Expand-only: a new table and its indexes, nothing altered, so the previous release
+-- runs unchanged against this schema.
+CREATE TABLE "tag_changes" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "campaignId" TEXT NOT NULL,
+    "productGid" TEXT NOT NULL,
+    "addedTags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "alreadyPresent" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "status" "ChangeStatus" NOT NULL DEFAULT 'PENDING',
+    "failureReason" TEXT,
+    "appliedAt" TIMESTAMP(3),
+    "verifiedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tag_changes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "tag_changes_runId_productGid_key" ON "tag_changes"("runId", "productGid");
+CREATE INDEX "tag_changes_shopId_campaignId_idx" ON "tag_changes"("shopId", "campaignId");
+CREATE INDEX "tag_changes_campaignId_status_idx" ON "tag_changes"("campaignId", "status");
+
+ALTER TABLE "tag_changes" ADD CONSTRAINT "tag_changes_shopId_fkey"
+  FOREIGN KEY ("shopId") REFERENCES "shops"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "tag_changes" ADD CONSTRAINT "tag_changes_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "campaign_runs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Shop {
   campaigns        Campaign[]
   campaignRuns     CampaignRun[]
   variantChanges   VariantChange[]
+  tagChanges       TagChange[]
   writeIntents     WriteIntent[]
   driftEvents      DriftEvent[]
   roundingProfiles RoundingProfileRecord[]
@@ -392,8 +393,9 @@ model CampaignRun {
 
   shop     Shop                  @relation(fields: [shopId], references: [id], onDelete: Cascade)
   campaign Campaign              @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  changes  VariantChange[]
-  bulkOps  BulkOperationRecord[]
+  changes    VariantChange[]
+  tagChanges TagChange[]
+  bulkOps    BulkOperationRecord[]
 
   @@unique([campaignId, occurrenceKey, kind])
   @@index([shopId, status])
@@ -468,6 +470,45 @@ model VariantChange {
 /// Fingerprint of every write we make, so the products/update webhook can tell our
 /// own echo from a real merchant edit. Without it, drift detection would flag every
 /// one of our own writes. TTL-pruned.
+/// Tags a campaign applied to a product, and — the part that matters — which of them
+/// it is entitled to take back.
+///
+/// A campaign asking for "SALE" on a product the merchant had already tagged "SALE"
+/// adds nothing, so removing it on revert would delete the merchant's own
+/// merchandising. `addedTags` records only what was genuinely absent beforehand;
+/// `alreadyPresent` records what was deliberately left alone, so the ledger shows the
+/// app knew about it rather than merely missing it.
+model TagChange {
+  id String @id @default(cuid())
+
+  shopId     String
+  runId      String
+  campaignId String
+  productGid String
+
+  /// Ours: absent before this run, and the only tags a revert removes.
+  addedTags      String[] @default([])
+  /// The merchant's: asked for by the kit, already on the product, never touched.
+  alreadyPresent String[] @default([])
+
+  status        ChangeStatus @default(PENDING)
+  failureReason String?
+
+  appliedAt  DateTime?
+  verifiedAt DateTime?
+  createdAt  DateTime  @default(now())
+
+  shop     Shop        @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  run      CampaignRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  /// One row per product per run: a resumed run must update its row rather than
+  /// claim ownership of the same tags twice.
+  @@unique([runId, productGid])
+  @@index([shopId, campaignId])
+  @@index([campaignId, status])
+  @@map("tag_changes")
+}
+
 model WriteIntent {
   id String @id @default(cuid())
 


### PR DESCRIPTION
Product tags added when a campaign starts and removed when it ends, so a theme can
badge sale items **without the app shipping a line of theme code**. That was a
deliberate scope decision: theme-facing code risks the Built-for-Shopify performance
budget and drags the app into theme support forever. A tag is an integration point any
theme can key off and nobody has to maintain.

## The whole feature is one question

**Is this tag ours to take back?**

A campaign asking for `SALE` on a product the merchant had *already* tagged `SALE` adds
nothing — `tagsAdd` is a no-op. A revert that removed it would delete the merchant's own
merchandising, with nothing in the app to explain where it went.

So the unit of truth is the **delta**: tags genuinely absent before the campaign touched
the product. Only those are ledgered as ours, and only those are ever removed. Tags left
alone are recorded explicitly, so the ledger shows the app *knew* about them rather than
merely missed them.

Comparison is case-insensitive, because Shopify treats `Sale` and `sale` as one tag and
a case-sensitive check would claim the merchant's.

## Same discipline as prices

A `tag_changes` row is committed before the write, and the result is read back
afterwards. `tagsAdd` reports success for mutations that achieved nothing often enough
that trusting it is how badges go missing on a live sale.

Removal is driven by **the ledger across every run**, never by the current tag kit:

- A merchant who edited the kit mid-campaign would otherwise strand the old tags on the
  storefront — badge stays, sale is over, app does not admit it.
- Tags another still-running campaign also applied are excluded. Two overlapping sales
  both tagging `SALE` is ordinary, and ending one must not un-badge the other.

Tagging never fails a run. A price that landed and a badge that did not is a visibly
incomplete campaign the merchant can retry; throwing would discard a successful price
write over a cosmetic one, and the ledger already names the products that missed out.

## Integration scenarios

Both are the ticket's acceptance criteria made executable:

- A merchant's pre-existing `sale` tag survives a full revert while the campaign's own
  `SUMMER` is removed. Claiming every tag in the kit as ours turns this red:
  `expected [ 'SALE', 'SUMMER' ] to deeply equal [ 'SUMMER' ]`
- A product that joined mid-campaign is tagged on the re-apply and **loses the tag on
  revert** — taking only the newest run's ledger rows would strand the originals.

## One bug in the harness, found by the suite

`"... on ProductVariant"` contains the substring `"on Product"`, so the new
product-tags branch was answering every *price* read-back with tags and no price —
turning six previously-green scenarios red. Caught by running the whole suite rather
than the new scenario alone.

- 300 unit tests (11 new), 12 chaos scenarios, typecheck/lint/build clean
- Expand-only migration: a new table and its indexes, nothing altered

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)