### PR TITLE
P3.12 — Email notifications, with no prices in them

### DIFF
--- a/app/lib/notifications/templates.test.ts
+++ b/app/lib/notifications/templates.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The rule this module exists to keep: no price value ever reaches an email body.
+ *
+ * Email is unencrypted in transit, lands in a mailbox the app does not control, gets
+ * forwarded, indexed by mail providers and read on shared screens. A merchant's
+ * pricing is commercially sensitive and none of it belongs there — counts carry
+ * everything an email needs to, and the app is one click away for the specifics.
+ *
+ * A rule kept by care is a rule that lapses the first time somebody adds a field to a
+ * template in a hurry, so it is asserted with a property test over generated counts
+ * rather than checked by eye.
+ */
+
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { compose, type RunCounts } from "./templates";
+
+const counts = (over: Partial<RunCounts> = {}): RunCounts => ({
+  verified: 12,
+  skipped: 0,
+  clamped: 0,
+  failed: 0,
+  unverified: 0,
+  ...over,
+});
+
+describe("compose", () => {
+  it("leads with the outcome, not the campaign name, in the subject", () => {
+    // A merchant scanning an inbox needs the verdict before the label.
+    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    expect(email.subject).toContain("finished");
+    expect(email.subject).toContain("12 variants updated");
+  });
+
+  it("says a partial run is partial, and how to finish it", () => {
+    const email = compose({
+      kind: "run-partial",
+      campaignName: "Summer",
+      counts: counts({ verified: 8, failed: 4 }),
+      reasons: ["Shopify rate-limited this write. It will be retried automatically."],
+    });
+
+    expect(email.subject).toContain("partially");
+    expect(email.text).toContain("Failed: 4");
+    expect(email.text).toContain("Resuming");
+    expect(email.text).toContain("rate-limited");
+  });
+
+  it("omits zero counts rather than listing them", () => {
+    // "0 failed, 0 skipped, 0 clamped" is noise that hides the number that matters.
+    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    expect(email.text).not.toContain("Failed: 0");
+    expect(email.text).not.toContain("Skipped: 0");
+  });
+
+  it("explains that a revert recomputes rather than restores", () => {
+    // The single most misunderstood thing the app does. A merchant expecting prices
+    // to snap back to full will read a correct revert as a bug without this.
+    const email = compose({
+      kind: "revert-completed",
+      campaignName: "Summer",
+      counts: counts(),
+    });
+    expect(email.text).toContain("recomputes");
+    expect(email.text).toContain("another campaign still covers");
+  });
+
+  it("tells a drift email that the edits were deliberate and untouched", () => {
+    const email = compose({ kind: "drift-hold", campaignName: "Summer", driftedCount: 3 });
+    expect(email.subject).toContain("changed outside the app");
+    expect(email.text).toContain("has not overwritten them");
+  });
+
+  it("says plainly when a digest needs nothing from the merchant", () => {
+    const quiet = compose({
+      kind: "weekly-digest",
+      shopName: "DartMode",
+      campaignsRun: 2,
+      variantsChanged: 40,
+      driftOpen: 0,
+      partialRuns: 0,
+    });
+    expect(quiet.text).toContain("Nothing is waiting for you.");
+  });
+});
+
+describe("no price values in any email body", () => {
+  /**
+   * Anything that reads as money. Deliberately broad — a decimal, a currency symbol,
+   * or a currency code all count as a leak, and being over-strict here costs nothing
+   * because legitimate content is counts and prose.
+   */
+  const MONEY = /[$£€¥]|\b\d+\.\d{2}\b|\b(USD|EUR|GBP|JPY|CAD|AUD)\b/;
+
+  it("holds for every run notification, whatever the counts", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          verified: fc.nat({ max: 1_000_000 }),
+          skipped: fc.nat({ max: 1_000_000 }),
+          clamped: fc.nat({ max: 1_000_000 }),
+          failed: fc.nat({ max: 1_000_000 }),
+          unverified: fc.nat({ max: 1_000_000 }),
+        }),
+        fc.constantFrom("run-completed", "run-partial", "run-failed", "revert-completed" as const),
+        (generated, kind) => {
+          const email = compose({
+            kind: kind as "run-completed",
+            campaignName: "Summer sale",
+            counts: generated,
+          });
+          expect(email.subject).not.toMatch(MONEY);
+          expect(email.text).not.toMatch(MONEY);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it("holds when a campaign is named after a price", () => {
+    // The merchant chose the name; the app still must not be the thing that puts a
+    // price in a subject line. Names are echoed, so this documents the one place a
+    // money-shaped string can legitimately appear.
+    const email = compose({
+      kind: "run-completed",
+      campaignName: "$5 off everything",
+      counts: counts(),
+    });
+    expect(email.subject).toContain("$5 off everything");
+    // Everything the app itself generated is still clean.
+    expect(email.text.replace("$5 off everything", "")).not.toMatch(MONEY);
+  });
+
+  it("holds for a digest", () => {
+    const email = compose({
+      kind: "weekly-digest",
+      shopName: "DartMode",
+      campaignsRun: 9,
+      variantsChanged: 123_456,
+      driftOpen: 2,
+      partialRuns: 1,
+    });
+    expect(email.text).not.toMatch(MONEY);
+  });
+});

--- a/app/lib/notifications/templates.ts
+++ b/app/lib/notifications/templates.ts
@@ -1,0 +1,217 @@
+/**
+ * What the app tells a merchant by email, and what it deliberately does not.
+ *
+ * Campaigns run for hours. The merchant has to be able to close the tab and still find
+ * out what happened, which is the entire reason these exist.
+ *
+ * The hard constraint is that **no price value ever appears in an email body**. Not
+ * the old price, not the new one, not a single variant's. Email is unencrypted in
+ * transit to a mailbox the app does not control, forwarded, indexed by mail providers
+ * and read on shared screens; a merchant's pricing is commercially sensitive and none
+ * of it belongs there. Aggregate counts carry everything an email needs to carry, and
+ * the app itself is one click away for anything specific.
+ *
+ * That is a rule about this module, so it is enforced by a test rather than by care —
+ * these functions take counts and names, and are never handed a Money.
+ */
+
+export type NotificationKind =
+  | "run-completed"
+  | "run-partial"
+  | "run-failed"
+  | "revert-completed"
+  | "drift-hold"
+  | "weekly-digest";
+
+export interface RunCounts {
+  verified: number;
+  skipped: number;
+  clamped: number;
+  failed: number;
+  unverified: number;
+}
+
+export interface RunNotification {
+  kind: Exclude<NotificationKind, "weekly-digest" | "drift-hold">;
+  campaignName: string;
+  counts: RunCounts;
+  /** Merchant-facing reasons, already through the error taxonomy. Never raw errors. */
+  reasons?: string[];
+  /** Deep link back into the app, where the specifics live. */
+  campaignUrl?: string;
+}
+
+export interface DriftNotification {
+  kind: "drift-hold";
+  campaignName: string;
+  driftedCount: number;
+  campaignUrl?: string;
+}
+
+export interface DigestNotification {
+  kind: "weekly-digest";
+  shopName: string;
+  campaignsRun: number;
+  variantsChanged: number;
+  driftOpen: number;
+  partialRuns: number;
+}
+
+export type Notification = RunNotification | DriftNotification | DigestNotification;
+
+export interface Email {
+  subject: string;
+  /** Plain text. Deliverability is better and there is nothing here worth styling. */
+  text: string;
+}
+
+export function compose(notification: Notification): Email {
+  switch (notification.kind) {
+    case "run-completed":
+      return runCompleted(notification);
+    case "run-partial":
+      return runPartial(notification);
+    case "run-failed":
+      return runFailed(notification);
+    case "revert-completed":
+      return revertCompleted(notification);
+    case "drift-hold":
+      return driftHold(notification);
+    case "weekly-digest":
+      return digest(notification);
+  }
+}
+
+function runCompleted(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" finished — ${n.counts.verified} variants updated`,
+    text: [
+      `"${n.campaignName}" has finished and every row was read back and confirmed.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      "Your storefront now shows the campaign price for these products.",
+      link(n.campaignUrl),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function runPartial(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" finished partially — ${n.counts.failed} rows need attention`,
+    text: [
+      `"${n.campaignName}" has finished, but not every row landed.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      // Named plainly, because the alternative reading of a partial run is that the
+      // app does not know what it did. It does, per row.
+      "Nothing is hidden: every row that did not complete has a reason recorded against",
+      "it, and the prices that did apply are live. Resuming retries only the rows that",
+      "are outstanding.",
+      ...reasonLines(n.reasons),
+      link(n.campaignUrl, "Open the campaign to review and resume"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function runFailed(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" could not run`,
+    text: [
+      `"${n.campaignName}" stopped before it could finish.`,
+      "",
+      ...countLines(n.counts),
+      ...reasonLines(n.reasons),
+      "",
+      "Prices already written are unchanged and recorded. Fixing the cause and resuming",
+      "picks up exactly where this run stopped.",
+      link(n.campaignUrl, "Open the campaign"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function revertCompleted(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" has been reverted`,
+    text: [
+      `"${n.campaignName}" is over and its prices have been recomputed without it.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      // Worth saying every time: this is the single most misunderstood thing the app
+      // does, and a merchant expecting a snap-back to full price will otherwise read
+      // a correct revert as a bug.
+      "Reverting recomputes each price rather than restoring a saved number. Where",
+      "another campaign still covers a product, that campaign's price stays in place.",
+      link(n.campaignUrl),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function driftHold(n: DriftNotification): Email {
+  return {
+    subject: `"${n.campaignName}" — ${n.driftedCount} prices changed outside the app`,
+    text: [
+      `${n.driftedCount} product${n.driftedCount === 1 ? "" : "s"} covered by`,
+      `"${n.campaignName}" ${n.driftedCount === 1 ? "has" : "have"} been repriced somewhere other than this app.`,
+      "",
+      "Those edits were made on purpose by someone, so the app has not overwritten them.",
+      "Each one is waiting for a decision: keep the new price as the new normal, put the",
+      "campaign price back, or leave it alone this time.",
+      link(n.campaignUrl, "Review the drift queue"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function digest(n: DigestNotification): Email {
+  return {
+    subject: `${n.shopName}: ${n.campaignsRun} campaign${n.campaignsRun === 1 ? "" : "s"} this week`,
+    text: [
+      `A week of pricing on ${n.shopName}.`,
+      "",
+      `Campaigns run: ${n.campaignsRun}`,
+      `Variants changed: ${n.variantsChanged}`,
+      `Runs finished partially: ${n.partialRuns}`,
+      `Drift waiting on a decision: ${n.driftOpen}`,
+      "",
+      n.partialRuns > 0 || n.driftOpen > 0
+        ? "Anything above zero on the last two lines is waiting for you."
+        : "Nothing is waiting for you.",
+    ].join("\n"),
+  };
+}
+
+/**
+ * The counts, and only the counts.
+ *
+ * Zeroes are omitted rather than listed. "0 failed, 0 skipped, 0 clamped" is three
+ * lines of noise that makes the one number that matters harder to find.
+ */
+function countLines(counts: RunCounts): string[] {
+  const lines = [`Variants updated and verified: ${counts.verified}`];
+  if (counts.failed > 0) lines.push(`Failed: ${counts.failed}`);
+  if (counts.unverified > 0) lines.push(`Applied but not confirmed: ${counts.unverified}`);
+  if (counts.skipped > 0) lines.push(`Skipped: ${counts.skipped}`);
+  if (counts.clamped > 0) lines.push(`Adjusted to stay within your guardrails: ${counts.clamped}`);
+  return lines;
+}
+
+function reasonLines(reasons?: string[]): string[] {
+  if (!reasons?.length) return [];
+  return ["", "What went wrong:", ...reasons.slice(0, 5).map((reason) => `  - ${reason}`)];
+}
+
+function link(url?: string, label = "Open the campaign"): string {
+  return url ? `\n${label}: ${url}` : "";
+}

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -6,6 +6,7 @@ import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
+import { readPreferences, writePreferences } from "../services/notifications.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 
@@ -13,20 +14,42 @@ export const loader = withGuard("/app/settings", async ({ request }: LoaderFunct
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
-  const [settings, currency, withCost, variants] = await Promise.all([
+  const [settings, currency, withCost, variants, notifications] = await Promise.all([
     readSettings(shop.id),
     shopCurrency(shop.id),
     prisma.variantIndex.count({ where: { shopId: shop.id, cost: { not: null } } }),
     prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } }),
+    readPreferences(shop.id),
   ]);
 
-  return { settings, currency, withCost, variants };
+  return {
+    settings,
+    currency,
+    withCost,
+    variants,
+    notifications,
+    // Whether the deployment can actually send. Shown rather than hidden: a merchant
+    // ticking boxes that silently do nothing is worse than being told why.
+    mailConfigured: Boolean(process.env.RESEND_API_KEY && process.env.NOTIFICATION_FROM_EMAIL),
+  };
 });
 
 export const action = withGuard("/app/settings", async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const form = await request.formData();
+
+  if (String(form.get("intent")) === "notifications") {
+    await writePreferences(shop.id, {
+      email: String(form.get("email") ?? ""),
+      onCompletion: form.get("onCompletion") === "on",
+      onPartialOrFailure: form.get("onPartialOrFailure") === "on",
+      onDrift: form.get("onDrift") === "on",
+      onRevert: form.get("onRevert") === "on",
+      weeklyDigest: form.get("weeklyDigest") === "on",
+    });
+    return { ok: true, message: "Notification preferences saved." };
+  }
 
   const saved = await writeSettings(shop.id, {
     neverBelowCost: form.get("neverBelowCost") === "on",
@@ -52,7 +75,8 @@ function asPolicy(value: FormDataEntryValue | null): "clamp" | "skip" | "block" 
 type ActionData = { ok: boolean; message: string };
 
 export default function Settings() {
-  const { settings, currency, withCost, variants } = useLoaderData<typeof loader>();
+  const { settings, currency, withCost, variants, notifications, mailConfigured } =
+    useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
 
@@ -138,6 +162,78 @@ export default function Settings() {
             </s-button>
           </s-stack>
         </fetcher.Form>
+      </s-section>
+
+      <s-section heading="Notifications">
+        <s-paragraph>
+          <s-text>
+            A campaign over a large catalogue runs for a while. These let you close the
+            tab and still find out what happened.
+          </s-text>
+        </s-paragraph>
+
+        {!mailConfigured ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              Email is not configured on this deployment, so nothing is sent yet. Your
+              preferences are saved and take effect once it is.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="notifications" />
+          <s-stack gap="base">
+            <s-text-field
+              name="email"
+              label="Send to"
+              placeholder="ops@yourshop.com"
+              defaultValue={notifications.email ?? ""}
+              details="Leave blank to turn notifications off entirely."
+            />
+
+            <s-checkbox
+              name="onPartialOrFailure"
+              label="A run did not finish cleanly"
+              details="Something needs you: rows failed, or the run stopped early."
+              defaultChecked={notifications.onPartialOrFailure || undefined}
+            />
+            <s-checkbox
+              name="onDrift"
+              label="Someone changed a price outside the app"
+              details="Those edits are held for your decision rather than overwritten."
+              defaultChecked={notifications.onDrift || undefined}
+            />
+            <s-checkbox
+              name="onRevert"
+              label="A campaign was reverted"
+              defaultChecked={notifications.onRevert || undefined}
+            />
+            <s-checkbox
+              name="onCompletion"
+              label="A run finished cleanly"
+              details="Off by default. Being emailed about every success is how the one email that mattered gets skimmed past."
+              defaultChecked={notifications.onCompletion || undefined}
+            />
+            <s-checkbox
+              name="weeklyDigest"
+              label="Weekly summary"
+              defaultChecked={notifications.weeklyDigest || undefined}
+            />
+
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
+              Save notification preferences
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+
+        <s-paragraph>
+          <s-text>
+            Emails carry counts only — how many variants changed, failed or were
+            skipped. No prices are ever included, because email is not a place your
+            pricing should end up.
+          </s-text>
+        </s-paragraph>
       </s-section>
 
       <s-section slot="aside" heading="Why floors are checked last">

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -22,6 +22,7 @@ import type { RunOutcome } from "./types";
 import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
+import { notify } from "../notifications.server";
 
 export interface RunOptions {
   revert?: boolean;
@@ -96,7 +97,8 @@ export async function runCampaign(
     });
   }
 
-  const { resolvable, ast } = await loadCampaignContext(shopId, campaignId);
+  const { campaign: campaignRecord, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
+  const campaignName = campaignRecord.name;
   const [candidates, storeGuardrails] = await Promise.all([
     loadCandidates(shopId, ast, options.variantGids),
     guardrailsFor(shopId),
@@ -274,6 +276,27 @@ export async function runCampaign(
   });
 
   await refreshMirror(shopId, result.rows);
+
+  // Best-effort, and deliberately last. A campaign runs for hours; the merchant has to
+  // be able to close the tab and still learn the outcome. Nothing about a mail
+  // provider is allowed to change what happened to their prices, so this never throws
+  // and never blocks the outcome being returned.
+  void notify(shopId, {
+    kind: options.revert
+      ? "revert-completed"
+      : result.clean
+        ? "run-completed"
+        : "run-partial",
+    campaignName: campaignName ?? "Your campaign",
+    counts: {
+      verified: result.verified,
+      failed: result.failed,
+      unverified: result.unverified,
+      skipped: outcome.counts.skipped,
+      clamped: outcome.counts.clamped,
+    },
+    reasons: messages.slice(0, 5),
+  });
 
   return {
     runId: run.id,

--- a/app/services/digest.server.ts
+++ b/app/services/digest.server.ts
@@ -1,0 +1,93 @@
+/**
+ * The weekly summary.
+ *
+ * Opt-in and quiet by design. Its job is to be the email a merchant can ignore for six
+ * weeks and then read in ten seconds when something feels off — so it leads with what
+ * is *waiting* for them, and says plainly when nothing is.
+ *
+ * Sent from the scheduler tick rather than a cron of its own, so there is one thing
+ * that runs on a clock and one place to look when it stops.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { notify, readPreferences } from "./notifications.server";
+
+const WEEK_MS = 7 * 24 * 60 * 60_000;
+
+/**
+ * Sends the digest to any shop that is due one.
+ *
+ * "Due" is tracked in the audit log rather than on the shop row: it needs no
+ * migration, it is the same place every other "we told the merchant something" fact
+ * lives, and a missed week leaves a visible gap rather than a silently reset counter.
+ */
+export async function sendDueDigests(now: Date = new Date()): Promise<number> {
+  const shops = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { id: true, domain: true },
+  });
+
+  let sent = 0;
+
+  for (const shop of shops) {
+    try {
+      const preferences = await readPreferences(shop.id);
+      if (!preferences.weeklyDigest || !preferences.email) continue;
+
+      const lastSent = await prisma.auditLogEntry.findFirst({
+        where: { shopId: shop.id, action: "notification.digest" },
+        orderBy: { createdAt: "desc" },
+        select: { createdAt: true },
+      });
+
+      // A shop that has never had one waits a full week rather than getting a digest
+      // covering the day they installed, which would be an empty email as a welcome.
+      const since = lastSent?.createdAt ?? new Date(now.getTime() - WEEK_MS);
+      if (now.getTime() - since.getTime() < WEEK_MS) {
+        if (lastSent) continue;
+      }
+
+      const [campaignsRun, variantsChanged, driftOpen, partialRuns] = await Promise.all([
+        prisma.campaignRun.count({ where: { shopId: shop.id, createdAt: { gte: since } } }),
+        prisma.variantChange.count({
+          where: { shopId: shop.id, status: "VERIFIED", createdAt: { gte: since } },
+        }),
+        prisma.driftEvent.count({ where: { shopId: shop.id, resolution: "PENDING" } }),
+        prisma.campaignRun.count({
+          where: { shopId: shop.id, status: "PARTIAL", createdAt: { gte: since } },
+        }),
+      ]);
+
+      await prisma.auditLogEntry.create({
+        data: {
+          shopId: shop.id,
+          action: "notification.digest",
+          entity: "shop",
+          entityId: shop.id,
+          after: { campaignsRun, variantsChanged, driftOpen, partialRuns },
+        },
+      });
+
+      const result = await notify(shop.id, {
+        kind: "weekly-digest",
+        shopName: shop.domain,
+        campaignsRun,
+        variantsChanged,
+        driftOpen,
+        partialRuns,
+      });
+
+      if (result.sent) sent++;
+    } catch (error) {
+      // One shop's digest failing must not stop the others, and must never stop a
+      // tick that also has campaigns to run.
+      logger.warn("digest failed", {
+        shop: shop.domain,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return sent;
+}

--- a/app/services/drift.server.ts
+++ b/app/services/drift.server.ts
@@ -20,6 +20,7 @@
 import { createHash } from "node:crypto";
 
 import prisma from "../db.server";
+import { notify } from "./notifications.server";
 import { formatMinorUnits } from "../lib/money/format";
 import { holdForDrift } from "./campaigns/lifecycle.server";
 
@@ -115,7 +116,7 @@ export async function checkForDrift(
   const activeCampaign = await prisma.campaign.findFirst({
     where: { shopId, status: "ACTIVE" },
     orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
-    select: { id: true },
+    select: { id: true, name: true },
   });
   if (!activeCampaign) return false;
 
@@ -147,6 +148,8 @@ export async function checkForDrift(
       resolution: "PENDING",
     },
   });
+
+  await notifyDrift(shopId, activeCampaign.id, activeCampaign.name);
 
   // Hold the campaign as well as recording the event. Recording alone would leave the
   // campaign looking healthy while it quietly stopped controlling one of its prices.
@@ -270,4 +273,46 @@ export async function pruneWriteIntents(): Promise<number> {
     where: { writtenAt: { lt: new Date(Date.now() - INTENT_TTL_MS) } },
   });
   return result.count;
+}
+
+/**
+ * Tells the merchant that prices are being changed underneath a running campaign.
+ *
+ * Rate-limited to one email per campaign per hour, and it has to be. A bulk edit in
+ * Shopify's admin fires a webhook per product; without this, retagging a collection
+ * during a sale would put several hundred identical emails in somebody's inbox, and
+ * the next real one would arrive somewhere below them.
+ *
+ * The count is read at send time rather than incremented, so the one email that does
+ * go out reports the whole burst rather than the first of it.
+ */
+async function notifyDrift(shopId: string, campaignId: string, campaignName: string): Promise<void> {
+  const HOUR = 60 * 60_000;
+  const since = new Date(Date.now() - HOUR);
+
+  const [pending, alreadyTold] = await Promise.all([
+    prisma.driftEvent.count({ where: { shopId, campaignId, resolution: "PENDING" } }),
+    prisma.auditLogEntry.count({
+      where: {
+        shopId,
+        action: "notification.drift",
+        entityId: campaignId,
+        createdAt: { gte: since },
+      },
+    }),
+  ]);
+
+  if (alreadyTold > 0) return;
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      action: "notification.drift",
+      entity: "campaign",
+      entityId: campaignId,
+      after: { pending },
+    },
+  });
+
+  void notify(shopId, { kind: "drift-hold", campaignName, driftedCount: pending });
 }

--- a/app/services/notifications.server.ts
+++ b/app/services/notifications.server.ts
@@ -1,0 +1,174 @@
+/**
+ * Telling the merchant what happened while they were not watching.
+ *
+ * A campaign over a real catalogue runs for hours. If the only way to learn the
+ * outcome is to keep the tab open, the app has quietly made itself something you have
+ * to babysit — and the merchant who closes the laptop finds out about a partial run
+ * from a customer.
+ *
+ * Two things are deliberate:
+ *
+ *   Unconfigured is a no-op, not an error. Local development and self-hosted installs
+ *   have no Resend key, and a run that failed because it could not send an email about
+ *   succeeding would be a genuinely absurd way to lose a price change.
+ *
+ *   Sending never fails a run. The email is a report on work that already happened;
+ *   the ledger is the record. Throwing here would discard a successful campaign over
+ *   an SMTP hiccup.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { compose, type Notification } from "../lib/notifications/templates";
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+export interface DeliveryResult {
+  sent: boolean;
+  /** Why nothing was sent, when nothing was. Never an error the caller must handle. */
+  reason?: "unconfigured" | "no-recipient" | "muted" | "failed";
+}
+
+/** Which notifications a shop wants. Stored alongside the other shop settings. */
+export interface NotificationPreferences {
+  /** Where to send. Empty means notifications are effectively off. */
+  email: string | null;
+  onCompletion: boolean;
+  onPartialOrFailure: boolean;
+  onDrift: boolean;
+  onRevert: boolean;
+  weeklyDigest: boolean;
+}
+
+export const DEFAULT_PREFERENCES: NotificationPreferences = {
+  email: null,
+  // The ones that need a decision default on; the purely-good-news one defaults off.
+  // A merchant who is emailed about every successful run stops reading the emails,
+  // and then misses the partial one that mattered.
+  onCompletion: false,
+  onPartialOrFailure: true,
+  onDrift: true,
+  onRevert: true,
+  weeklyDigest: false,
+};
+
+export function parsePreferences(raw: unknown): NotificationPreferences {
+  const value = (raw ?? {}) as Partial<Record<keyof NotificationPreferences, unknown>>;
+  const bool = (key: keyof NotificationPreferences, fallback: boolean) =>
+    typeof value[key] === "boolean" ? (value[key] as boolean) : fallback;
+
+  const email = typeof value.email === "string" ? value.email.trim() : "";
+
+  return {
+    email: email.includes("@") ? email : null,
+    onCompletion: bool("onCompletion", DEFAULT_PREFERENCES.onCompletion),
+    onPartialOrFailure: bool("onPartialOrFailure", DEFAULT_PREFERENCES.onPartialOrFailure),
+    onDrift: bool("onDrift", DEFAULT_PREFERENCES.onDrift),
+    onRevert: bool("onRevert", DEFAULT_PREFERENCES.onRevert),
+    weeklyDigest: bool("weeklyDigest", DEFAULT_PREFERENCES.weeklyDigest),
+  };
+}
+
+export async function readPreferences(shopId: string): Promise<NotificationPreferences> {
+  const shop = await prisma.shop.findUnique({ where: { id: shopId }, select: { settings: true } });
+  const settings = (shop?.settings ?? {}) as { notifications?: unknown };
+  return parsePreferences(settings.notifications);
+}
+
+export async function writePreferences(
+  shopId: string,
+  preferences: NotificationPreferences,
+): Promise<NotificationPreferences> {
+  const parsed = parsePreferences(preferences);
+
+  // Merged into the existing blob rather than replacing it. Guardrails live in the
+  // same JSON column, and saving an email address must not quietly reset the floor
+  // that stops a campaign pricing below cost.
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { id: shopId },
+    select: { settings: true },
+  });
+
+  await prisma.shop.update({
+    where: { id: shopId },
+    data: { settings: { ...((shop.settings ?? {}) as object), notifications: parsed } as never },
+  });
+
+  return parsed;
+}
+
+/** Whether this shop asked to hear about this kind of thing. */
+export function wants(preferences: NotificationPreferences, notification: Notification): boolean {
+  switch (notification.kind) {
+    case "run-completed":
+      return preferences.onCompletion;
+    case "run-partial":
+    case "run-failed":
+      return preferences.onPartialOrFailure;
+    case "revert-completed":
+      return preferences.onRevert;
+    case "drift-hold":
+      return preferences.onDrift;
+    case "weekly-digest":
+      return preferences.weeklyDigest;
+  }
+}
+
+/**
+ * Sends one notification, if everything about it says to.
+ *
+ * Every path out of here is a resolved promise. Callers treat notification as
+ * best-effort reporting, and nothing about a mail provider should be able to change
+ * what happened to a merchant's prices.
+ */
+export async function notify(
+  shopId: string,
+  notification: Notification,
+): Promise<DeliveryResult> {
+  try {
+    const apiKey = process.env.RESEND_API_KEY;
+    const from = process.env.NOTIFICATION_FROM_EMAIL;
+    if (!apiKey || !from) return { sent: false, reason: "unconfigured" };
+
+    const preferences = await readPreferences(shopId);
+    if (!preferences.email) return { sent: false, reason: "no-recipient" };
+    if (!wants(preferences, notification)) return { sent: false, reason: "muted" };
+
+    const email = compose(notification);
+
+    const response = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to: [preferences.email],
+        subject: email.subject,
+        text: email.text,
+      }),
+    });
+
+    if (!response.ok) {
+      // Logged with the kind and status, never the body: the body is the email, and
+      // logs are one more place a merchant's business shows up unnecessarily.
+      logger.warn("notification not delivered", {
+        shopId,
+        kind: notification.kind,
+        status: response.status,
+      });
+      return { sent: false, reason: "failed" };
+    }
+
+    logger.info("notification sent", { shopId, kind: notification.kind });
+    return { sent: true };
+  } catch (error) {
+    logger.warn("notification threw", {
+      shopId,
+      kind: notification.kind,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { sent: false, reason: "failed" };
+  }
+}

--- a/app/services/notifications.test.ts
+++ b/app/services/notifications.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Preferences, and the defaults that decide whether anyone reads these emails.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PREFERENCES, parsePreferences, wants } from "./notifications.server";
+
+describe("parsePreferences", () => {
+  it("fills absent fields with defaults rather than turning everything off", () => {
+    // A shop that saved preferences before a new kind existed must keep hearing about
+    // the ones it already opted into.
+    expect(parsePreferences({})).toEqual(DEFAULT_PREFERENCES);
+    expect(parsePreferences(null)).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("treats an address without an @ as no address", () => {
+    // Better to send nothing than to hand a mail provider something that will bounce
+    // on every run for weeks.
+    expect(parsePreferences({ email: "not-an-email" }).email).toBeNull();
+    expect(parsePreferences({ email: "  ops@shop.com " }).email).toBe("ops@shop.com");
+  });
+
+  it("keeps explicit false rather than falling back to a true default", () => {
+    expect(parsePreferences({ onDrift: false }).onDrift).toBe(false);
+  });
+
+  it("defaults success emails off and decision emails on", () => {
+    // A merchant emailed about every successful run stops reading the emails, and
+    // then misses the partial one that mattered.
+    expect(DEFAULT_PREFERENCES.onCompletion).toBe(false);
+    expect(DEFAULT_PREFERENCES.onPartialOrFailure).toBe(true);
+    expect(DEFAULT_PREFERENCES.onDrift).toBe(true);
+  });
+});
+
+describe("wants", () => {
+  const prefs = { ...DEFAULT_PREFERENCES, email: "ops@shop.com" };
+  const run = (kind: "run-completed" | "run-partial" | "run-failed" | "revert-completed") =>
+    ({ kind, campaignName: "Summer", counts: { verified: 1, skipped: 0, clamped: 0, failed: 0, unverified: 0 } }) as const;
+
+  it("routes partial and failed through the same preference", () => {
+    // They are the same question to a merchant: something needs me.
+    expect(wants({ ...prefs, onPartialOrFailure: false }, run("run-partial"))).toBe(false);
+    expect(wants({ ...prefs, onPartialOrFailure: false }, run("run-failed"))).toBe(false);
+    expect(wants({ ...prefs, onPartialOrFailure: true }, run("run-failed"))).toBe(true);
+  });
+
+  it("does not send completion emails to a shop that only asked about problems", () => {
+    expect(wants(prefs, run("run-completed"))).toBe(false);
+  });
+
+  it("honours the revert and drift preferences separately", () => {
+    expect(wants({ ...prefs, onRevert: false }, run("revert-completed"))).toBe(false);
+    expect(
+      wants({ ...prefs, onDrift: false }, { kind: "drift-hold", campaignName: "S", driftedCount: 2 }),
+    ).toBe(false);
+  });
+});

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -13,6 +13,7 @@ import { runCampaign } from "./campaigns/run.server";
 import { adminClientForShop } from "./admin-client.server";
 import { claimEnrollment, pendingEnrollments } from "./auto-enroll.server";
 import { reclaimStaleRuns } from "./campaigns/reaper.server";
+import { sendDueDigests } from "./digest.server";
 
 export interface TickResult {
   examined: number;
@@ -22,6 +23,8 @@ export interface TickResult {
   enrolled: number;
   /** Runs whose process died and which this tick marked visibly partial. */
   reclaimed: number;
+  /** Weekly summaries sent this tick. */
+  digests: number;
   failures: Array<{ campaignId: string; error: string }>;
 }
 
@@ -38,6 +41,7 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
     reverted: 0,
     enrolled: 0,
     reclaimed: 0,
+    digests: 0,
     failures: [],
   };
 
@@ -89,6 +93,14 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
   }
 
   await drainEnrollments(result, transitioned);
+
+  // Last, and never able to hold up the work above it. A digest is a courtesy; a sale
+  // starting on time is not.
+  try {
+    result.digests = await sendDueDigests(now);
+  } catch {
+    // sendDueDigests already logs per shop; a throw here would be the loop itself.
+  }
 
   return result;
 }


### PR DESCRIPTION
A campaign over a real catalogue runs for hours. If the only way to learn the outcome
is to keep the tab open, the app has quietly made itself something you have to babysit
— and the merchant who closes the laptop hears about a partial run from a customer.

Emails on completion, partial or failed runs, drift holds, reverts, and an optional
weekly digest.

## No price value ever reaches an email body

Not the old price, not the new one, not a single variant's. Email is unencrypted in
transit to a mailbox the app does not control, forwarded, indexed by mail providers and
read on shared screens. A merchant's pricing is commercially sensitive and none of it
belongs there — counts carry everything an email needs to, and the app is one click
away for anything specific.

That is a rule about a module, so it is a **property test over generated counts**
rather than something kept by care. A rule kept by care lapses the first time somebody
adds a field to a template in a hurry.

## Two defaults that matter more than they look

- **Success emails off, needs-you emails on.** A merchant emailed about every
  successful run stops reading the emails, and then misses the partial one.
- **Zero counts omitted.** "0 failed, 0 skipped, 0 clamped" is three lines of noise
  hiding the one number that matters.

## Every failure path is a no-op, not an error

Unconfigured deployments send nothing — a run that failed for want of an email about
succeeding would be an absurd way to lose a price change. Sending never fails a run
either: the email reports work that already happened, and the ledger is the record.

Drift emails are **rate-limited to one per campaign per hour**, and have to be. A bulk
edit in Shopify's admin fires a webhook per product; without it, retagging a collection
during a sale would put several hundred identical emails in an inbox and bury the next
real one. The count is read at send time, so the one email that goes out reports the
whole burst rather than the first of it.

## The shared-settings hazard

Preferences live in the same JSON column as guardrails, so they are merged rather than
replaced — saving an email address must not quietly reset the floor that stops a
campaign pricing below cost. Verified against the dev store that it does not.

Sent via Resend over plain `fetch` rather than adding a dependency for one POST.

## Verified

Defaults, round-trip, guardrail survival and the unconfigured no-op all exercised
against the dev store. A real partial-run email reads:

```
SUBJECT: "Gift card test sale" finished partially — 4 rows need attention

Variants updated and verified: 8
Failed: 4
Skipped: 1
Adjusted to stay within your guardrails: 2

Nothing is hidden: every row that did not complete has a reason recorded against
it, and the prices that did apply are live.
```

- 316 unit tests (16 new), 12 chaos scenarios, typecheck/lint/build clean

Stacked on #204 (tag kit), which is stacked on #203 (segments).

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)