### PR TITLE
P3.13 — Dashboard, activity log and audit export

### DIFF
--- a/app/components/ActivityTable.tsx
+++ b/app/components/ActivityTable.tsx
@@ -1,0 +1,55 @@
+import type { ActivityEntry } from "../lib/reporting/activity-csv";
+import { describeActor } from "../lib/audit/actor";
+
+/**
+ * Every state-changing action, with who and what changed.
+ *
+ * A separate component like every other table in the app. That is not only tidiness:
+ * rendering `s-table` inline in a route alongside a filter form reliably produced a
+ * blank page here, where the same markup in its own component renders fine.
+ */
+export function ActivityTable({
+  entries,
+  timeZone,
+}: {
+  entries: ActivityEntry[];
+  timeZone: string;
+}) {
+  return (
+    <s-table>
+      <s-table-header-row>
+        <s-table-header>When</s-table-header>
+        <s-table-header>Who</s-table-header>
+        <s-table-header>Action</s-table-header>
+        <s-table-header>What changed</s-table-header>
+      </s-table-header-row>
+      <s-table-body>
+        {entries.map((entry) => (
+          <s-table-row key={entry.id}>
+            <s-table-cell>{formatWhen(entry.at, timeZone)}</s-table-cell>
+            {/* Unattended work is the scheduler, and saying so beats an empty cell
+                somebody has to guess at. Staff show as an id rather than a name: the
+                session token carries the id, and names would mean online tokens. */}
+            <s-table-cell>{describeActor(entry.actor)}</s-table-cell>
+            <s-table-cell>{entry.action}</s-table-cell>
+            <s-table-cell>{entry.summary}</s-table-cell>
+          </s-table-row>
+        ))}
+      </s-table-body>
+    </s-table>
+  );
+}
+
+/**
+ * The shop's own timezone, falling back to the raw timestamp.
+ *
+ * A bad zone string throws a RangeError out of `toLocaleString`, which would take the
+ * whole page down over a display preference.
+ */
+function formatWhen(iso: string, timeZone: string): string {
+  try {
+    return new Date(iso).toLocaleString("en-GB", { timeZone });
+  } catch {
+    return iso;
+  }
+}

--- a/app/lib/audit/actor.ts
+++ b/app/lib/audit/actor.ts
@@ -1,0 +1,49 @@
+/**
+ * Who did this.
+ *
+ * The audit log is only worth keeping if it can answer "who turned the cost floor
+ * off?", and until now every entry was attributed to the shop domain or to the string
+ * "system" — which answers nothing on a store where four people have admin access.
+ *
+ * Staff identity is available without switching the app to online tokens: App Bridge
+ * signs every embedded request with a session token whose `sub` claim is the staff
+ * user's id, and `authenticate.admin` has already verified it by the time a loader
+ * runs. Online tokens would carry a name as well, but they change the OAuth flow and
+ * force a reinstall, which is not a trade worth making for a display string.
+ *
+ * So entries carry a stable per-staff id. It is not a name, and the log says as much
+ * rather than implying it is one.
+ *
+ * Not a `.server` module, deliberately. `describeActor` renders in the browser, and
+ * anything under a `.server` name is stripped from the client bundle — it would be
+ * `undefined` at render time with nothing at build time to say so. The only server
+ * concept here is a type, which is erased anyway.
+ */
+
+import type { JwtPayload } from "@shopify/shopify-api";
+
+/** What an unattended action is attributed to. */
+export const SCHEDULER_ACTOR = "scheduler";
+
+/**
+ * The actor for an admin request.
+ *
+ * Falls back to the shop domain rather than to null: an action that definitely had a
+ * person behind it should not be recorded as if the scheduler did it, even when the
+ * token is shaped unexpectedly.
+ */
+export function actorFor(
+  sessionToken: JwtPayload | undefined,
+  shopDomain: string,
+): string {
+  const sub = sessionToken?.sub;
+  return typeof sub === "string" && sub.length > 0 ? `staff:${sub}` : shopDomain;
+}
+
+/** Renders an actor for display, without pretending an id is a name. */
+export function describeActor(actor: string | null): string {
+  if (!actor || actor === SCHEDULER_ACTOR || actor === "system") return "Scheduler";
+  if (actor === "drift-detector") return "Drift detector";
+  if (actor.startsWith("staff:")) return `Staff ${actor.slice("staff:".length)}`;
+  return actor;
+}

--- a/app/lib/notifications/templates.test.ts
+++ b/app/lib/notifications/templates.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The rule this module exists to keep: no price value ever reaches an email body.
+ *
+ * Email is unencrypted in transit, lands in a mailbox the app does not control, gets
+ * forwarded, indexed by mail providers and read on shared screens. A merchant's
+ * pricing is commercially sensitive and none of it belongs there — counts carry
+ * everything an email needs to, and the app is one click away for the specifics.
+ *
+ * A rule kept by care is a rule that lapses the first time somebody adds a field to a
+ * template in a hurry, so it is asserted with a property test over generated counts
+ * rather than checked by eye.
+ */
+
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { compose, type RunCounts } from "./templates";
+
+const counts = (over: Partial<RunCounts> = {}): RunCounts => ({
+  verified: 12,
+  skipped: 0,
+  clamped: 0,
+  failed: 0,
+  unverified: 0,
+  ...over,
+});
+
+describe("compose", () => {
+  it("leads with the outcome, not the campaign name, in the subject", () => {
+    // A merchant scanning an inbox needs the verdict before the label.
+    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    expect(email.subject).toContain("finished");
+    expect(email.subject).toContain("12 variants updated");
+  });
+
+  it("says a partial run is partial, and how to finish it", () => {
+    const email = compose({
+      kind: "run-partial",
+      campaignName: "Summer",
+      counts: counts({ verified: 8, failed: 4 }),
+      reasons: ["Shopify rate-limited this write. It will be retried automatically."],
+    });
+
+    expect(email.subject).toContain("partially");
+    expect(email.text).toContain("Failed: 4");
+    expect(email.text).toContain("Resuming");
+    expect(email.text).toContain("rate-limited");
+  });
+
+  it("omits zero counts rather than listing them", () => {
+    // "0 failed, 0 skipped, 0 clamped" is noise that hides the number that matters.
+    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    expect(email.text).not.toContain("Failed: 0");
+    expect(email.text).not.toContain("Skipped: 0");
+  });
+
+  it("explains that a revert recomputes rather than restores", () => {
+    // The single most misunderstood thing the app does. A merchant expecting prices
+    // to snap back to full will read a correct revert as a bug without this.
+    const email = compose({
+      kind: "revert-completed",
+      campaignName: "Summer",
+      counts: counts(),
+    });
+    expect(email.text).toContain("recomputes");
+    expect(email.text).toContain("another campaign still covers");
+  });
+
+  it("tells a drift email that the edits were deliberate and untouched", () => {
+    const email = compose({ kind: "drift-hold", campaignName: "Summer", driftedCount: 3 });
+    expect(email.subject).toContain("changed outside the app");
+    expect(email.text).toContain("has not overwritten them");
+  });
+
+  it("says plainly when a digest needs nothing from the merchant", () => {
+    const quiet = compose({
+      kind: "weekly-digest",
+      shopName: "DartMode",
+      campaignsRun: 2,
+      variantsChanged: 40,
+      driftOpen: 0,
+      partialRuns: 0,
+    });
+    expect(quiet.text).toContain("Nothing is waiting for you.");
+  });
+});
+
+describe("no price values in any email body", () => {
+  /**
+   * Anything that reads as money. Deliberately broad — a decimal, a currency symbol,
+   * or a currency code all count as a leak, and being over-strict here costs nothing
+   * because legitimate content is counts and prose.
+   */
+  const MONEY = /[$£€¥]|\b\d+\.\d{2}\b|\b(USD|EUR|GBP|JPY|CAD|AUD)\b/;
+
+  it("holds for every run notification, whatever the counts", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          verified: fc.nat({ max: 1_000_000 }),
+          skipped: fc.nat({ max: 1_000_000 }),
+          clamped: fc.nat({ max: 1_000_000 }),
+          failed: fc.nat({ max: 1_000_000 }),
+          unverified: fc.nat({ max: 1_000_000 }),
+        }),
+        fc.constantFrom("run-completed", "run-partial", "run-failed", "revert-completed" as const),
+        (generated, kind) => {
+          const email = compose({
+            kind: kind as "run-completed",
+            campaignName: "Summer sale",
+            counts: generated,
+          });
+          expect(email.subject).not.toMatch(MONEY);
+          expect(email.text).not.toMatch(MONEY);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it("holds when a campaign is named after a price", () => {
+    // The merchant chose the name; the app still must not be the thing that puts a
+    // price in a subject line. Names are echoed, so this documents the one place a
+    // money-shaped string can legitimately appear.
+    const email = compose({
+      kind: "run-completed",
+      campaignName: "$5 off everything",
+      counts: counts(),
+    });
+    expect(email.subject).toContain("$5 off everything");
+    // Everything the app itself generated is still clean.
+    expect(email.text.replace("$5 off everything", "")).not.toMatch(MONEY);
+  });
+
+  it("holds for a digest", () => {
+    const email = compose({
+      kind: "weekly-digest",
+      shopName: "DartMode",
+      campaignsRun: 9,
+      variantsChanged: 123_456,
+      driftOpen: 2,
+      partialRuns: 1,
+    });
+    expect(email.text).not.toMatch(MONEY);
+  });
+});

--- a/app/lib/notifications/templates.ts
+++ b/app/lib/notifications/templates.ts
@@ -1,0 +1,217 @@
+/**
+ * What the app tells a merchant by email, and what it deliberately does not.
+ *
+ * Campaigns run for hours. The merchant has to be able to close the tab and still find
+ * out what happened, which is the entire reason these exist.
+ *
+ * The hard constraint is that **no price value ever appears in an email body**. Not
+ * the old price, not the new one, not a single variant's. Email is unencrypted in
+ * transit to a mailbox the app does not control, forwarded, indexed by mail providers
+ * and read on shared screens; a merchant's pricing is commercially sensitive and none
+ * of it belongs there. Aggregate counts carry everything an email needs to carry, and
+ * the app itself is one click away for anything specific.
+ *
+ * That is a rule about this module, so it is enforced by a test rather than by care —
+ * these functions take counts and names, and are never handed a Money.
+ */
+
+export type NotificationKind =
+  | "run-completed"
+  | "run-partial"
+  | "run-failed"
+  | "revert-completed"
+  | "drift-hold"
+  | "weekly-digest";
+
+export interface RunCounts {
+  verified: number;
+  skipped: number;
+  clamped: number;
+  failed: number;
+  unverified: number;
+}
+
+export interface RunNotification {
+  kind: Exclude<NotificationKind, "weekly-digest" | "drift-hold">;
+  campaignName: string;
+  counts: RunCounts;
+  /** Merchant-facing reasons, already through the error taxonomy. Never raw errors. */
+  reasons?: string[];
+  /** Deep link back into the app, where the specifics live. */
+  campaignUrl?: string;
+}
+
+export interface DriftNotification {
+  kind: "drift-hold";
+  campaignName: string;
+  driftedCount: number;
+  campaignUrl?: string;
+}
+
+export interface DigestNotification {
+  kind: "weekly-digest";
+  shopName: string;
+  campaignsRun: number;
+  variantsChanged: number;
+  driftOpen: number;
+  partialRuns: number;
+}
+
+export type Notification = RunNotification | DriftNotification | DigestNotification;
+
+export interface Email {
+  subject: string;
+  /** Plain text. Deliverability is better and there is nothing here worth styling. */
+  text: string;
+}
+
+export function compose(notification: Notification): Email {
+  switch (notification.kind) {
+    case "run-completed":
+      return runCompleted(notification);
+    case "run-partial":
+      return runPartial(notification);
+    case "run-failed":
+      return runFailed(notification);
+    case "revert-completed":
+      return revertCompleted(notification);
+    case "drift-hold":
+      return driftHold(notification);
+    case "weekly-digest":
+      return digest(notification);
+  }
+}
+
+function runCompleted(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" finished — ${n.counts.verified} variants updated`,
+    text: [
+      `"${n.campaignName}" has finished and every row was read back and confirmed.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      "Your storefront now shows the campaign price for these products.",
+      link(n.campaignUrl),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function runPartial(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" finished partially — ${n.counts.failed} rows need attention`,
+    text: [
+      `"${n.campaignName}" has finished, but not every row landed.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      // Named plainly, because the alternative reading of a partial run is that the
+      // app does not know what it did. It does, per row.
+      "Nothing is hidden: every row that did not complete has a reason recorded against",
+      "it, and the prices that did apply are live. Resuming retries only the rows that",
+      "are outstanding.",
+      ...reasonLines(n.reasons),
+      link(n.campaignUrl, "Open the campaign to review and resume"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function runFailed(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" could not run`,
+    text: [
+      `"${n.campaignName}" stopped before it could finish.`,
+      "",
+      ...countLines(n.counts),
+      ...reasonLines(n.reasons),
+      "",
+      "Prices already written are unchanged and recorded. Fixing the cause and resuming",
+      "picks up exactly where this run stopped.",
+      link(n.campaignUrl, "Open the campaign"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function revertCompleted(n: RunNotification): Email {
+  return {
+    subject: `"${n.campaignName}" has been reverted`,
+    text: [
+      `"${n.campaignName}" is over and its prices have been recomputed without it.`,
+      "",
+      ...countLines(n.counts),
+      "",
+      // Worth saying every time: this is the single most misunderstood thing the app
+      // does, and a merchant expecting a snap-back to full price will otherwise read
+      // a correct revert as a bug.
+      "Reverting recomputes each price rather than restoring a saved number. Where",
+      "another campaign still covers a product, that campaign's price stays in place.",
+      link(n.campaignUrl),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function driftHold(n: DriftNotification): Email {
+  return {
+    subject: `"${n.campaignName}" — ${n.driftedCount} prices changed outside the app`,
+    text: [
+      `${n.driftedCount} product${n.driftedCount === 1 ? "" : "s"} covered by`,
+      `"${n.campaignName}" ${n.driftedCount === 1 ? "has" : "have"} been repriced somewhere other than this app.`,
+      "",
+      "Those edits were made on purpose by someone, so the app has not overwritten them.",
+      "Each one is waiting for a decision: keep the new price as the new normal, put the",
+      "campaign price back, or leave it alone this time.",
+      link(n.campaignUrl, "Review the drift queue"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
+function digest(n: DigestNotification): Email {
+  return {
+    subject: `${n.shopName}: ${n.campaignsRun} campaign${n.campaignsRun === 1 ? "" : "s"} this week`,
+    text: [
+      `A week of pricing on ${n.shopName}.`,
+      "",
+      `Campaigns run: ${n.campaignsRun}`,
+      `Variants changed: ${n.variantsChanged}`,
+      `Runs finished partially: ${n.partialRuns}`,
+      `Drift waiting on a decision: ${n.driftOpen}`,
+      "",
+      n.partialRuns > 0 || n.driftOpen > 0
+        ? "Anything above zero on the last two lines is waiting for you."
+        : "Nothing is waiting for you.",
+    ].join("\n"),
+  };
+}
+
+/**
+ * The counts, and only the counts.
+ *
+ * Zeroes are omitted rather than listed. "0 failed, 0 skipped, 0 clamped" is three
+ * lines of noise that makes the one number that matters harder to find.
+ */
+function countLines(counts: RunCounts): string[] {
+  const lines = [`Variants updated and verified: ${counts.verified}`];
+  if (counts.failed > 0) lines.push(`Failed: ${counts.failed}`);
+  if (counts.unverified > 0) lines.push(`Applied but not confirmed: ${counts.unverified}`);
+  if (counts.skipped > 0) lines.push(`Skipped: ${counts.skipped}`);
+  if (counts.clamped > 0) lines.push(`Adjusted to stay within your guardrails: ${counts.clamped}`);
+  return lines;
+}
+
+function reasonLines(reasons?: string[]): string[] {
+  if (!reasons?.length) return [];
+  return ["", "What went wrong:", ...reasons.slice(0, 5).map((reason) => `  - ${reason}`)];
+}
+
+function link(url?: string, label = "Open the campaign"): string {
+  return url ? `\n${label}: ${url}` : "";
+}

--- a/app/lib/reporting/activity-csv.ts
+++ b/app/lib/reporting/activity-csv.ts
@@ -1,0 +1,38 @@
+/**
+ * The activity log as CSV.
+ *
+ * Client-safe, like the rollback export and for the same reason: the download is built
+ * in the browser from data the page already holds, because a resource route cannot
+ * authenticate inside an embedded app's iframe. A serialiser living beside the query
+ * in a `.server` module would be stripped from the client bundle and be `undefined` at
+ * the moment somebody clicked Export.
+ */
+
+import { toCsv } from "./csv";
+
+export interface ActivityEntry {
+  id: string;
+  at: string;
+  /** Null for the scheduler and other unattended work. */
+  actor: string | null;
+  action: string;
+  entity: string | null;
+  entityId: string | null;
+  summary: string;
+}
+
+export function activityCsv(entries: readonly ActivityEntry[]): string {
+  return toCsv(
+    ["timestamp", "actor", "action", "entity", "entity_id", "change"],
+    entries.map((entry) => [
+      entry.at,
+      // "system" rather than blank: an empty cell in an exported audit log reads as
+      // missing data rather than as unattended work.
+      entry.actor ?? "system",
+      entry.action,
+      entry.entity ?? "",
+      entry.entityId ?? "",
+      entry.summary,
+    ]),
+  );
+}

--- a/app/lib/tags/plan.test.ts
+++ b/app/lib/tags/plan.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tag ownership.
+ *
+ * Adding a tag is harmless. Removing one is not: a merchant who already had "SALE" on
+ * a product for their own reasons, and watched a campaign's revert delete it, has lost
+ * merchandising the app never created and has nothing explaining where it went.
+ *
+ * So every test here is really the same question asked from a different angle — is
+ * this tag ours to take back?
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { planTagRemoval, planTagsFor } from "./plan";
+
+describe("planTagsFor", () => {
+  it("adds tags the product does not have", () => {
+    const plan = planTagsFor("p1", ["SALE", "SUMMER"], ["NEW"]);
+    expect(plan.toAdd).toEqual(["SALE", "SUMMER"]);
+    expect(plan.alreadyPresent).toEqual([]);
+  });
+
+  it("never claims a tag the product already carried", () => {
+    // The one that matters. `tagsAdd` is a no-op here, so removing it later would
+    // delete the merchant's own tag.
+    const plan = planTagsFor("p1", ["SALE"], ["SALE", "NEW"]);
+    expect(plan.toAdd).toEqual([]);
+    expect(plan.alreadyPresent).toEqual(["SALE"]);
+  });
+
+  it("compares case-insensitively, as Shopify does", () => {
+    // Shopify treats "Sale" and "sale" as one tag. A case-sensitive comparison would
+    // record "Sale" as ours and strip the merchant's "sale" on revert.
+    const plan = planTagsFor("p1", ["Sale"], ["sale"]);
+    expect(plan.toAdd).toEqual([]);
+    expect(plan.alreadyPresent).toEqual(["Sale"]);
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(planTagsFor("p1", ["  SALE  "], ["SALE"]).toAdd).toEqual([]);
+  });
+
+  it("drops empty entries rather than adding a blank tag", () => {
+    expect(planTagsFor("p1", ["", "   ", "SALE"], []).toAdd).toEqual(["SALE"]);
+  });
+
+  it("counts a tag listed twice in the kit only once", () => {
+    // Otherwise the ledger claims ownership of two copies of something that exists
+    // once, and the second removal would be removing nothing -- or worse, a merchant's.
+    const plan = planTagsFor("p1", ["SALE", "sale"], []);
+    expect(plan.toAdd).toEqual(["SALE"]);
+  });
+});
+
+describe("planTagRemoval", () => {
+  it("removes what the ledger says was added", () => {
+    expect(planTagRemoval([{ productGid: "p1", addedTags: ["SALE"] }])).toEqual([
+      { productGid: "p1", toRemove: ["SALE"] },
+    ]);
+  });
+
+  it("unions across every run of the campaign", () => {
+    // A recurring sale, or one resumed after a failure, adds tags over several runs.
+    // Taking only the newest run's row strands the earlier ones on the storefront --
+    // the "SALE badge on a full-price product weeks later" this exists to prevent.
+    const out = planTagRemoval([
+      { productGid: "p1", addedTags: ["SALE"] },
+      { productGid: "p1", addedTags: ["SUMMER"] },
+      { productGid: "p2", addedTags: ["SALE"] },
+    ]);
+
+    expect(out).toHaveLength(2);
+    expect(out.find((r) => r.productGid === "p1")?.toRemove.sort()).toEqual(["SALE", "SUMMER"]);
+  });
+
+  it("leaves a tag another running campaign still owes", () => {
+    // Two overlapping sales both tagging "SALE" is ordinary. Ending one must not
+    // strip the badge from the other.
+    const out = planTagRemoval(
+      [{ productGid: "p1", addedTags: ["SALE", "CLEARANCE"] }],
+      new Map([["p1", new Set(["sale"])]]),
+    );
+
+    expect(out).toEqual([{ productGid: "p1", toRemove: ["CLEARANCE"] }]);
+  });
+
+  it("emits no work for a product whose every tag is still owed", () => {
+    const out = planTagRemoval(
+      [{ productGid: "p1", addedTags: ["SALE"] }],
+      new Map([["p1", new Set(["sale"])]]),
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("returns nothing when the campaign never tagged anything", () => {
+    expect(planTagRemoval([])).toEqual([]);
+  });
+});

--- a/app/lib/tags/plan.ts
+++ b/app/lib/tags/plan.ts
@@ -1,0 +1,102 @@
+/**
+ * Deciding which tags a campaign may add, and — far more importantly — which it is
+ * allowed to take away again.
+ *
+ * The tag kit is the deliberate alternative to shipping theme code: a theme keys its
+ * sale badge off a tag, and the app never touches the storefront. That only works if
+ * the app is scrupulous about ownership.
+ *
+ * The danger is not adding a tag, it is removing one. If a merchant already had "SALE"
+ * on a product for their own reasons and a campaign also asks for "SALE", then
+ * `tagsAdd` is a no-op — and a revert that removed it would delete something the app
+ * never added. The merchant loses their own merchandising, with no record of why.
+ *
+ * So the unit of truth is the *delta*: the tags that were genuinely absent before this
+ * campaign touched the product. Those are ledgered, and those are the only ones a
+ * revert removes. Tags the product already had are recorded too, explicitly, so the
+ * ledger can show that the app knew about them and deliberately left them alone.
+ */
+
+export interface TagPlan {
+  productGid: string;
+  /** Absent before, so ours to add — and ours to remove later. */
+  toAdd: string[];
+  /** Asked for but already present. Never removed, recorded so the choice is visible. */
+  alreadyPresent: string[];
+}
+
+/** Normalises for comparison. Shopify tags are case-insensitive and space-trimmed. */
+export function normaliseTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+/**
+ * Splits a campaign's tag kit against what a product already carries.
+ *
+ * Comparison is case-insensitive because Shopify treats "Sale" and "sale" as the same
+ * tag. Adding "Sale" to a product tagged "sale" changes nothing, and a case-sensitive
+ * comparison would record it as ours and remove the merchant's tag on revert.
+ */
+export function planTagsFor(
+  productGid: string,
+  tagKit: readonly string[],
+  currentTags: readonly string[],
+): TagPlan {
+  const current = new Set(currentTags.map(normaliseTag));
+  const toAdd: string[] = [];
+  const alreadyPresent: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of tagKit) {
+    const tag = raw.trim();
+    if (!tag) continue;
+
+    const key = normaliseTag(tag);
+    // A kit listing the same tag twice must not add it twice, or the ledger would
+    // claim ownership of one copy of something that only exists once.
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    if (current.has(key)) alreadyPresent.push(tag);
+    else toAdd.push(tag);
+  }
+
+  return { productGid, toAdd, alreadyPresent };
+}
+
+/**
+ * What a revert should remove, given what the apply runs recorded.
+ *
+ * Union across every run of the campaign: a recurring sale, or one resumed after a
+ * failure, adds tags over several runs and all of them are the campaign's. Taking only
+ * the newest run's row would strand tags from earlier ones on the storefront forever —
+ * which is the "SALE badge on a full-price product weeks later" this ticket exists to
+ * prevent.
+ *
+ * Tags another still-active campaign also applied are excluded. Two overlapping sales
+ * both tagging "SALE" is ordinary, and ending one must not strip the badge from the
+ * other.
+ */
+export function planTagRemoval(
+  ledgered: ReadonlyArray<{ productGid: string; addedTags: string[] }>,
+  /** Tags still owed by other campaigns, per product. */
+  stillOwed: ReadonlyMap<string, ReadonlySet<string>> = new Map(),
+): Array<{ productGid: string; toRemove: string[] }> {
+  const byProduct = new Map<string, Set<string>>();
+
+  for (const row of ledgered) {
+    const existing = byProduct.get(row.productGid) ?? new Set<string>();
+    for (const tag of row.addedTags) existing.add(tag);
+    byProduct.set(row.productGid, existing);
+  }
+
+  const out: Array<{ productGid: string; toRemove: string[] }> = [];
+
+  for (const [productGid, tags] of byProduct) {
+    const owed = stillOwed.get(productGid);
+    const toRemove = [...tags].filter((tag) => !owed?.has(normaliseTag(tag)));
+    if (toRemove.length > 0) out.push({ productGid, toRemove });
+  }
+
+  return out;
+}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -14,10 +14,41 @@ export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) 
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
-  const [health, campaigns] = await Promise.all([
+  // Counted in parallel and as aggregates, never by loading rows. This is the landing
+  // page and it has a sub-second budget; a card that costs a table scan is a card that
+  // makes the whole app feel slow.
+  const [health, campaigns, live, upcoming, driftOpen, lastRun, recent] = await Promise.all([
     baselineHealth(shop.id),
     prisma.campaign.count({ where: { shopId: shop.id } }),
+    prisma.campaign.count({ where: { shopId: shop.id, status: { in: ["ACTIVE", "APPLYING"] } } }),
+    prisma.campaign.count({ where: { shopId: shop.id, status: "SCHEDULED" } }),
+    prisma.driftEvent.count({ where: { shopId: shop.id, resolution: "PENDING" } }),
+    prisma.campaignRun.findFirst({
+      where: { shopId: shop.id },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        kind: true,
+        status: true,
+        verifiedRows: true,
+        failedRows: true,
+        finishedAt: true,
+        campaign: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.auditLogEntry.findMany({
+      where: { shopId: shop.id },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      select: { id: true, actor: true, action: true, createdAt: true },
+    }),
   ]);
+
+  // Runs that need somebody: the number a merchant should act on, distinct from how
+  // many campaigns exist.
+  const needsAttention = await prisma.campaign.count({
+    where: { shopId: shop.id, status: { in: ["PARTIAL", "HELD"] } },
+  });
 
   return {
     shopDomain: shop.domain,
@@ -27,6 +58,28 @@ export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) 
       oldestCapturedAt: health.oldestCapturedAt?.toISOString() ?? null,
     },
     campaigns,
+    live,
+    upcoming,
+    driftOpen,
+    needsAttention,
+    lastRun: lastRun
+      ? {
+          id: lastRun.id,
+          kind: lastRun.kind,
+          status: lastRun.status,
+          verified: lastRun.verifiedRows,
+          failed: lastRun.failedRows,
+          finishedAt: lastRun.finishedAt?.toISOString() ?? null,
+          campaignId: lastRun.campaign.id,
+          campaignName: lastRun.campaign.name,
+        }
+      : null,
+    recent: recent.map((entry) => ({
+      id: entry.id,
+      actor: entry.actor,
+      action: entry.action,
+      at: entry.createdAt.toISOString(),
+    })),
   };
 });
 
@@ -81,7 +134,18 @@ export const action = withGuard("/app", async ({ request }: ActionFunctionArgs) 
 type ActionData = { ok: boolean; message: string; errors: string[] };
 
 export default function Dashboard() {
-  const { shopDomain, syncedAt, health, campaigns } = useLoaderData<typeof loader>();
+  const {
+    shopDomain,
+    syncedAt,
+    health,
+    campaigns,
+    live,
+    upcoming,
+    driftOpen,
+    needsAttention,
+    lastRun,
+    recent,
+  } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
   const result = fetcher.data;
@@ -139,6 +203,16 @@ export default function Dashboard() {
             </s-box>
           </s-stack>
 
+          {health.withBaseline > health.variants ? (
+            <s-paragraph>
+              <s-text>
+                More baselines than variants is expected: baselines are kept for products
+                you have deleted, so a campaign that priced them can still be explained
+                and reverted.
+              </s-text>
+            </s-paragraph>
+          ) : null}
+
           {health.missing > 0 ? (
             <s-banner tone="warning">
               <s-paragraph>
@@ -160,6 +234,88 @@ export default function Dashboard() {
         </s-section>
       )}
 
+      {!neverSynced ? (
+        <s-section heading="What is live right now">
+          <s-stack direction="inline" gap="large">
+            <s-box>
+              <s-text>Campaigns running</s-text>
+              <s-heading>{live}</s-heading>
+            </s-box>
+            <s-box>
+              <s-text>Scheduled</s-text>
+              <s-heading>{upcoming}</s-heading>
+            </s-box>
+            <s-box>
+              <s-text>Need attention</s-text>
+              <s-heading>{needsAttention}</s-heading>
+            </s-box>
+            <s-box>
+              <s-text>Prices changed outside the app</s-text>
+              <s-heading>{driftOpen}</s-heading>
+            </s-box>
+          </s-stack>
+
+          {live === 0 && upcoming === 0 && campaigns === 0 ? (
+            <s-paragraph>
+              <s-text>
+                No campaigns yet. A <strong>campaign</strong> is a rule — “20% off
+                everything tagged Summer” — plus when it should run. Anchor computes each
+                price from that variant&rsquo;s baseline, so running it twice changes
+                nothing the second time, and ending it puts prices back exactly.
+              </s-text>
+            </s-paragraph>
+          ) : null}
+
+          {needsAttention > 0 ? (
+            <s-banner tone="warning">
+              <s-paragraph>
+                {needsAttention} campaign{needsAttention === 1 ? "" : "s"} did not finish
+                cleanly. Every row that did not complete has a reason recorded, and
+                resuming retries only those.
+              </s-paragraph>
+            </s-banner>
+          ) : null}
+
+          {driftOpen > 0 ? (
+            <s-banner tone="info">
+              <s-paragraph>
+                {driftOpen} price{driftOpen === 1 ? " was" : "s were"} changed somewhere
+                other than Anchor while a campaign was running. Those edits were
+                deliberate, so nothing has been overwritten — each is waiting on your
+                decision.
+              </s-paragraph>
+            </s-banner>
+          ) : null}
+
+          {lastRun ? (
+            <s-paragraph>
+              <s-text>
+                Last run: {lastRun.kind.toLowerCase()} of “{lastRun.campaignName}” —{" "}
+                {lastRun.status.toLowerCase()}, {lastRun.verified} verified
+                {lastRun.failed > 0 ? `, ${lastRun.failed} failed` : ""}
+                {lastRun.finishedAt
+                  ? ` on ${new Date(lastRun.finishedAt).toLocaleString()}`
+                  : " (still running)"}
+                .
+              </s-text>
+            </s-paragraph>
+          ) : (
+            <s-paragraph>
+              <s-text>
+                Nothing has been applied to your storefront yet. Every run records what it
+                changed, row by row, and stays readable for as long as you have the app.
+              </s-text>
+            </s-paragraph>
+          )}
+
+          <s-stack direction="inline" gap="base">
+            <s-link href="/app/campaigns">Campaigns</s-link>
+            <s-link href="/app/drift">Drift queue</s-link>
+            <s-link href="/app/activity">Activity log</s-link>
+          </s-stack>
+        </s-section>
+      ) : null}
+
       <s-section slot="aside" heading="Store">
         <s-paragraph>{shopDomain}</s-paragraph>
         <s-paragraph>
@@ -168,6 +324,20 @@ export default function Dashboard() {
           </s-text>
         </s-paragraph>
       </s-section>
+
+      {!neverSynced && recent.length > 0 ? (
+        <s-section slot="aside" heading="Recent activity">
+          {recent.map((entry) => (
+            <s-paragraph key={entry.id}>
+              <s-text>
+                {entry.action} · {entry.actor ?? "Scheduler"} ·{" "}
+                {new Date(entry.at).toLocaleString()}
+              </s-text>
+            </s-paragraph>
+          ))}
+          <s-link href="/app/activity">See everything</s-link>
+        </s-section>
+      ) : null}
 
       {!neverSynced ? (
         <s-section slot="aside" heading="Baselines">

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -1,0 +1,169 @@
+/**
+ * The activity log.
+ *
+ * Everything the app or a member of staff did that changed state, with who and when
+ * and what it changed. The bar is that somebody can answer "why is this product on
+ * sale?" or "who turned the cost floor off?" without opening a database client.
+ */
+
+import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useLoaderData, useSearchParams } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { activity } from "../services/activity.server";
+import { activityCsv } from "../lib/reporting/activity-csv";
+import { ActivityTable } from "../components/ActivityTable";
+import { FilterForm } from "../components/FilterForm";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { downloadCsv } from "../lib/reporting/csv";
+import { describeActor } from "../lib/audit/actor";
+import { withGuard } from "../lib/errors/guard.server";
+
+const FILTER_FIELDS = ["actor", "action", "from", "to"] as const;
+
+/**
+ * Rows per page.
+ *
+ * Kept small deliberately. A hundred rows of four cells each reliably rendered this
+ * page blank — Polaris's `s-table` stops coping somewhere above a few hundred cells,
+ * and it fails by rendering nothing rather than by erroring, so there is no console
+ * message to find. Twenty-five is well inside that and is a better page size for a log
+ * somebody is scanning anyway.
+ */
+export const PAGE_SIZE = 25;
+
+export const loader = withGuard("/app/activity", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const url = new URL(request.url);
+  const filters = {
+    actor: url.searchParams.get("actor") ?? undefined,
+    action: url.searchParams.get("action") ?? undefined,
+    from: url.searchParams.get("from") ?? undefined,
+    to: url.searchParams.get("to") ?? undefined,
+  };
+  const page = Math.max(1, Number(url.searchParams.get("page") ?? 1) || 1);
+
+  const result = await activity(shop.id, filters, page);
+  return { ...result, page, filters, timeZone: shop.timezone };
+});
+
+export default function Activity() {
+  const { entries, total, actors, actions, page, filters, timeZone } =
+    useLoaderData<typeof loader>();
+  const [, setSearchParams] = useSearchParams();
+
+  const pageSize = PAGE_SIZE;
+  const lastPage = Math.max(1, Math.ceil(total / pageSize));
+  const goTo = (next: number) =>
+    setSearchParams((params) => {
+      params.set("page", String(next));
+      return params;
+    });
+
+  return (
+    <s-page heading="Activity">
+      <s-section>
+        <FilterForm fields={FILTER_FIELDS}>
+          <s-stack gap="base">
+            <label htmlFor="actor">Who</label>
+            <select id="actor" name="actor" defaultValue={filters.actor ?? ""}>
+              <option value="">Anyone</option>
+              {actors.map((actor) => (
+                <option key={actor} value={actor}>
+                  {describeActor(actor)}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="action">What</label>
+            <select id="action" name="action" defaultValue={filters.action ?? ""}>
+              <option value="">Any action</option>
+              {actions.map((action) => (
+                <option key={action} value={action}>
+                  {action}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="from">From</label>
+            <input id="from" type="date" name="from" defaultValue={filters.from ?? ""} />
+
+            <label htmlFor="to">To</label>
+            <input id="to" type="date" name="to" defaultValue={filters.to ?? ""} />
+
+            <s-button type="submit">Filter</s-button>
+          </s-stack>
+        </FilterForm>
+
+        {total === 0 ? (
+          <s-paragraph>
+            Nothing has been recorded yet for these filters. Every action that changes
+            state — applying a campaign, editing a guardrail, resolving drift — is
+            written here as it happens, with who did it and what it changed.
+          </s-paragraph>
+        ) : (
+          <>
+            <s-stack direction="inline" gap="base">
+              <s-paragraph>
+                <s-text>
+                  {total} entr{total === 1 ? "y" : "ies"} · times shown in {timeZone}
+                </s-text>
+              </s-paragraph>
+              <s-button
+                type="button"
+                variant="tertiary"
+                onClick={() => downloadCsv("anchor-activity.csv", activityCsv(entries))}
+              >
+                Export this page (CSV)
+              </s-button>
+            </s-stack>
+
+            <ActivityTable entries={entries} timeZone={timeZone} />
+
+            {lastPage > 1 ? (
+              <s-stack direction="inline" gap="base">
+                <s-button disabled={page <= 1} onClick={() => goTo(page - 1)}>
+                  Previous
+                </s-button>
+                <s-text>
+                  Page {page} of {lastPage}
+                </s-text>
+                <s-button disabled={page >= lastPage} onClick={() => goTo(page + 1)}>
+                  Next
+                </s-button>
+              </s-stack>
+            ) : null}
+          </>
+        )}
+      </s-section>
+
+      <s-section slot="aside" heading="What is kept">
+        <s-paragraph>
+          <s-text>
+            Everything, for as long as you have the app. Retention is not a paid tier
+            here — charging for the ability to find out what an app did to your prices
+            would be the wrong trade.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            Actions taken by the scheduler show as “Scheduler”. Anything else carries
+            the staff account that did it.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -26,6 +26,7 @@ import { RunHistoryTable } from "../components/RunHistoryTable";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { reportError } from "../services/error-report.server";
 import { withGuard } from "../lib/errors/guard.server";
+import { actorFor } from "../lib/audit/actor";
 import {
   canTransition,
   describeState,
@@ -95,8 +96,9 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
 });
 
 export const action = withGuard("/app/campaigns/$id", async ({ request, params }: ActionFunctionArgs) => {
-  const { admin, session } = await authenticate.admin(request);
+  const { admin, session, sessionToken } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
+  const actor = actorFor(sessionToken, session.shop);
   const form = await request.formData();
   const intent = String(form.get("intent"));
   const reverting = intent === "revert";
@@ -109,11 +111,11 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
       const result =
         intent === "revert-variant"
           ? await revertVariant(shop.id, String(params.id), variantGid, toAdminClient(admin), {
-              actor: session.shop,
+              actor,
               excludeOnly: form.get("excludeOnly") === "1",
             })
           : await reinstateVariant(shop.id, String(params.id), variantGid, toAdminClient(admin), {
-              actor: session.shop,
+              actor,
             });
 
       return {

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -145,6 +145,10 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
     priority: Number(form.get("priority") ?? 100) || 100,
     // An unchecked checkbox is simply absent from the form, so presence is the value.
     autoEnroll: form.get("autoEnroll") !== null,
+    tagKit: String(form.get("tagKit") ?? "")
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean),
     schedule,
   });
 
@@ -279,6 +283,13 @@ export default function NewCampaign() {
               label="Priority"
               defaultValue="100"
               details="Higher wins when two campaigns cover the same variant. They never stack."
+            />
+
+            <s-text-field
+              name="tagKit"
+              label="Storefront tags (optional)"
+              placeholder="SALE, SUMMER"
+              details="Comma separated. Added to each product while the campaign runs and removed when it ends, so your theme can badge sale items. Tags a product already has are never removed."
             />
 
             <s-checkbox

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -7,6 +7,7 @@ import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
 import { readPreferences, writePreferences } from "../services/notifications.server";
+import { actorFor } from "../lib/audit/actor";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 
@@ -35,8 +36,9 @@ export const loader = withGuard("/app/settings", async ({ request }: LoaderFunct
 });
 
 export const action = withGuard("/app/settings", async ({ request }: ActionFunctionArgs) => {
-  const { session } = await authenticate.admin(request);
+  const { session, sessionToken } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
+  const actor = actorFor(sessionToken, session.shop);
   const form = await request.formData();
 
   if (String(form.get("intent")) === "notifications") {
@@ -51,13 +53,17 @@ export const action = withGuard("/app/settings", async ({ request }: ActionFunct
     return { ok: true, message: "Notification preferences saved." };
   }
 
-  const saved = await writeSettings(shop.id, {
-    neverBelowCost: form.get("neverBelowCost") === "on",
-    minMarginPercent: emptyToNull(form.get("minMarginPercent")),
-    minPrice: emptyToNull(form.get("minPrice")),
-    violationPolicy: asPolicy(form.get("violationPolicy")),
-    missingCostPolicy: form.get("missingCostPolicy") === "error" ? "error" : "skip",
-  });
+  const saved = await writeSettings(
+    shop.id,
+    {
+      neverBelowCost: form.get("neverBelowCost") === "on",
+      minMarginPercent: emptyToNull(form.get("minMarginPercent")),
+      minPrice: emptyToNull(form.get("minPrice")),
+      violationPolicy: asPolicy(form.get("violationPolicy")),
+      missingCostPolicy: form.get("missingCostPolicy") === "error" ? "error" : "skip",
+    },
+    actor,
+  );
 
   return { ok: true, message: "Guardrails saved. They apply to every campaign.", saved };
 });

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -6,6 +6,7 @@ import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
+import { readPreferences, writePreferences } from "../services/notifications.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 
@@ -13,20 +14,42 @@ export const loader = withGuard("/app/settings", async ({ request }: LoaderFunct
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
-  const [settings, currency, withCost, variants] = await Promise.all([
+  const [settings, currency, withCost, variants, notifications] = await Promise.all([
     readSettings(shop.id),
     shopCurrency(shop.id),
     prisma.variantIndex.count({ where: { shopId: shop.id, cost: { not: null } } }),
     prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } }),
+    readPreferences(shop.id),
   ]);
 
-  return { settings, currency, withCost, variants };
+  return {
+    settings,
+    currency,
+    withCost,
+    variants,
+    notifications,
+    // Whether the deployment can actually send. Shown rather than hidden: a merchant
+    // ticking boxes that silently do nothing is worse than being told why.
+    mailConfigured: Boolean(process.env.RESEND_API_KEY && process.env.NOTIFICATION_FROM_EMAIL),
+  };
 });
 
 export const action = withGuard("/app/settings", async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
   const form = await request.formData();
+
+  if (String(form.get("intent")) === "notifications") {
+    await writePreferences(shop.id, {
+      email: String(form.get("email") ?? ""),
+      onCompletion: form.get("onCompletion") === "on",
+      onPartialOrFailure: form.get("onPartialOrFailure") === "on",
+      onDrift: form.get("onDrift") === "on",
+      onRevert: form.get("onRevert") === "on",
+      weeklyDigest: form.get("weeklyDigest") === "on",
+    });
+    return { ok: true, message: "Notification preferences saved." };
+  }
 
   const saved = await writeSettings(shop.id, {
     neverBelowCost: form.get("neverBelowCost") === "on",
@@ -52,7 +75,8 @@ function asPolicy(value: FormDataEntryValue | null): "clamp" | "skip" | "block" 
 type ActionData = { ok: boolean; message: string };
 
 export default function Settings() {
-  const { settings, currency, withCost, variants } = useLoaderData<typeof loader>();
+  const { settings, currency, withCost, variants, notifications, mailConfigured } =
+    useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
 
@@ -138,6 +162,78 @@ export default function Settings() {
             </s-button>
           </s-stack>
         </fetcher.Form>
+      </s-section>
+
+      <s-section heading="Notifications">
+        <s-paragraph>
+          <s-text>
+            A campaign over a large catalogue runs for a while. These let you close the
+            tab and still find out what happened.
+          </s-text>
+        </s-paragraph>
+
+        {!mailConfigured ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              Email is not configured on this deployment, so nothing is sent yet. Your
+              preferences are saved and take effect once it is.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="notifications" />
+          <s-stack gap="base">
+            <s-text-field
+              name="email"
+              label="Send to"
+              placeholder="ops@yourshop.com"
+              defaultValue={notifications.email ?? ""}
+              details="Leave blank to turn notifications off entirely."
+            />
+
+            <s-checkbox
+              name="onPartialOrFailure"
+              label="A run did not finish cleanly"
+              details="Something needs you: rows failed, or the run stopped early."
+              defaultChecked={notifications.onPartialOrFailure || undefined}
+            />
+            <s-checkbox
+              name="onDrift"
+              label="Someone changed a price outside the app"
+              details="Those edits are held for your decision rather than overwritten."
+              defaultChecked={notifications.onDrift || undefined}
+            />
+            <s-checkbox
+              name="onRevert"
+              label="A campaign was reverted"
+              defaultChecked={notifications.onRevert || undefined}
+            />
+            <s-checkbox
+              name="onCompletion"
+              label="A run finished cleanly"
+              details="Off by default. Being emailed about every success is how the one email that mattered gets skimmed past."
+              defaultChecked={notifications.onCompletion || undefined}
+            />
+            <s-checkbox
+              name="weeklyDigest"
+              label="Weekly summary"
+              defaultChecked={notifications.weeklyDigest || undefined}
+            />
+
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
+              Save notification preferences
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+
+        <s-paragraph>
+          <s-text>
+            Emails carry counts only — how many variants changed, failed or were
+            skipped. No prices are ever included, because email is not a place your
+            pricing should end up.
+          </s-text>
+        </s-paragraph>
       </s-section>
 
       <s-section slot="aside" heading="Why floors are checked last">

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -26,6 +26,7 @@ export default function App() {
         <s-link href="/app/segments">Segments</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/drift">Drift</s-link>
+        <s-link href="/app/activity">Activity</s-link>
         <s-link href="/app/settings">Settings</s-link>
         <s-link href="/app/debug">Diagnostics</s-link>
       </s-app-nav>

--- a/app/services/activity.server.ts
+++ b/app/services/activity.server.ts
@@ -1,0 +1,172 @@
+/**
+ * Every state-changing action, who did it, and what it changed.
+ *
+ * The forensic record. The bar is that somebody can answer "why is this product
+ * £8.40?" six weeks later without opening a database client — and, just as often,
+ * "who turned that guardrail off?"
+ *
+ * Deliberately unlimited on every tier. Competitors sell 30/60/90-day history as a
+ * paid axis; charging a merchant for the ability to find out what an app did to their
+ * prices is the wrong trade.
+ */
+
+import prisma from "../db.server";
+import type { ActivityEntry } from "../lib/reporting/activity-csv";
+
+// Re-exported so callers have one import for "the activity log", while the serialiser
+// itself stays client-safe -- see lib/reporting/activity-csv for why that matters.
+export { activityCsv, type ActivityEntry } from "../lib/reporting/activity-csv";
+
+export interface ActivityFilters {
+  actor?: string;
+  action?: string;
+  /** Inclusive ISO dates, as the filter form supplies them. */
+  from?: string;
+  to?: string;
+}
+
+export interface ActivityPage {
+  entries: ActivityEntry[];
+  total: number;
+  /** Distinct values present in this shop's log, for the filter controls. */
+  actors: string[];
+  actions: string[];
+}
+
+/** Matches the page's own page size; see the note there for why it is small. */
+const PAGE_SIZE = 25;
+
+export async function activity(
+  shopId: string,
+  filters: ActivityFilters = {},
+  page = 1,
+): Promise<ActivityPage> {
+  const where = buildWhere(shopId, filters);
+
+  const [rows, total, actors, actions] = await Promise.all([
+    prisma.auditLogEntry.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip: (Math.max(1, page) - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+    }),
+    prisma.auditLogEntry.count({ where }),
+    // Distinct over the whole shop, not the filtered set: a filter control that only
+    // offers values matching the current filter cannot be used to change it.
+    prisma.auditLogEntry.findMany({
+      where: { shopId, actor: { not: null } },
+      distinct: ["actor"],
+      select: { actor: true },
+      take: 50,
+    }),
+    prisma.auditLogEntry.findMany({
+      where: { shopId },
+      distinct: ["action"],
+      select: { action: true },
+      take: 100,
+    }),
+  ]);
+
+  return {
+    entries: rows.map(toEntry),
+    total,
+    actors: actors.map((a) => a.actor!).filter(Boolean).sort(),
+    actions: actions.map((a) => a.action).sort(),
+  };
+}
+
+/** The whole filtered log, for export. Capped so one click cannot exhaust memory. */
+export async function activityForExport(
+  shopId: string,
+  filters: ActivityFilters = {},
+  limit = 10_000,
+): Promise<ActivityEntry[]> {
+  const rows = await prisma.auditLogEntry.findMany({
+    where: buildWhere(shopId, filters),
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+  return rows.map(toEntry);
+}
+
+function buildWhere(shopId: string, filters: ActivityFilters) {
+  const where: Record<string, unknown> = { shopId };
+
+  if (filters.actor) where.actor = filters.actor;
+  if (filters.action) where.action = filters.action;
+
+  if (filters.from || filters.to) {
+    const range: Record<string, Date> = {};
+    if (filters.from) range.gte = new Date(`${filters.from}T00:00:00.000Z`);
+    // The whole of the end day, not midnight at the start of it. A merchant filtering
+    // "to today" and seeing nothing from today would reasonably conclude the log is
+    // broken.
+    if (filters.to) range.lte = new Date(`${filters.to}T23:59:59.999Z`);
+    where.createdAt = range;
+  }
+
+  return where;
+}
+
+type Row = Awaited<ReturnType<typeof prisma.auditLogEntry.findMany>>[number];
+
+function toEntry(row: Row): ActivityEntry {
+  return {
+    id: row.id,
+    at: row.createdAt.toISOString(),
+    actor: row.actor,
+    action: row.action,
+    entity: row.entity,
+    entityId: row.entityId,
+    summary: summarise(row.action, row.before, row.after),
+  };
+}
+
+/**
+ * One readable line for a row.
+ *
+ * Built from the stored before/after rather than a message written at the time, so
+ * entries recorded before a summary existed still read as something. Field-level
+ * differences are shown for edits, because "settings updated" answers none of the
+ * questions anybody opens this page with.
+ */
+export function summarise(action: string, before: unknown, after: unknown): string {
+  const from = asRecord(before);
+  const to = asRecord(after);
+
+  if (from && to) {
+    const changed = Object.keys({ ...from, ...to }).filter(
+      (key) => JSON.stringify(from[key]) !== JSON.stringify(to[key]),
+    );
+    if (changed.length > 0) {
+      return changed
+        .slice(0, 6)
+        .map((key) => `${key}: ${render(from[key])} → ${render(to[key])}`)
+        .join(", ");
+    }
+    return "no fields changed";
+  }
+
+  const only = to ?? from;
+  if (only) {
+    const parts = Object.entries(only)
+      .slice(0, 6)
+      .map(([key, value]) => `${key}: ${render(value)}`);
+    if (parts.length > 0) return parts.join(", ");
+  }
+
+  return action;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function render(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return value.length > 60 ? `${value.slice(0, 57)}…` : value;
+  if (Array.isArray(value)) return value.length === 0 ? "none" : `${value.length} item(s)`;
+  if (typeof value === "object") return JSON.stringify(value).slice(0, 60);
+  return String(value);
+}

--- a/app/services/activity.test.ts
+++ b/app/services/activity.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Turning a stored before/after into a line somebody can read.
+ *
+ * The audit log answers two questions: "what did this app do to my prices?" and "who
+ * turned that off?". A summary reading "settings updated" answers neither, so the
+ * field-level difference is the point rather than a nicety.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { summarise } from "./activity.server";
+
+describe("summarise", () => {
+  it("names the fields that changed and both values", () => {
+    expect(
+      summarise("settings.guardrails.update", { minPrice: null }, { minPrice: 5 }),
+    ).toBe("minPrice: — → 5");
+  });
+
+  it("reports several changes in one line", () => {
+    const line = summarise(
+      "settings.guardrails.update",
+      { neverBelowCost: false, violationPolicy: "clamp" },
+      { neverBelowCost: true, violationPolicy: "block" },
+    );
+    expect(line).toContain("neverBelowCost: false → true");
+    expect(line).toContain("violationPolicy: clamp → block");
+  });
+
+  it("says so when an update changed nothing", () => {
+    // Distinct from "no record". A merchant who saved a form and sees the entry needs
+    // to know the save landed and simply moved nothing.
+    expect(summarise("settings.guardrails.update", { minPrice: 5 }, { minPrice: 5 })).toBe(
+      "no fields changed",
+    );
+  });
+
+  it("describes a creation, which has an after and no before", () => {
+    expect(summarise("campaign.variant.excluded", null, { variantGid: "gid://v/1" })).toBe(
+      "variantGid: gid://v/1",
+    );
+  });
+
+  it("falls back to the action name when there is nothing stored", () => {
+    // Entries recorded before summaries existed must still read as something.
+    expect(summarise("campaign.transition", null, null)).toBe("campaign.transition");
+  });
+
+  it("summarises arrays by count rather than dumping them", () => {
+    // A frozen segment's variant list is thousands of gids. Rendering it would make
+    // the row unreadable and the page enormous.
+    expect(summarise("segment.update", null, { variantGids: ["a", "b", "c"] })).toBe(
+      "variantGids: 3 item(s)",
+    );
+    expect(summarise("segment.update", null, { variantGids: [] })).toBe("variantGids: none");
+  });
+
+  it("truncates a long string rather than letting one row swallow the table", () => {
+    const long = "x".repeat(200);
+    const line = summarise("campaign.transition", null, { reason: long });
+    expect(line.length).toBeLessThan(80);
+    expect(line).toContain("…");
+  });
+});

--- a/app/services/baselines.server.ts
+++ b/app/services/baselines.server.ts
@@ -162,36 +162,51 @@ export interface BaselineHealth {
  * campaign is running and a warning sign when none is. The dashboard says which.
  */
 export async function baselineHealth(shopId: string): Promise<BaselineHealth> {
-  const [variants, current] = await Promise.all([
-    prisma.variantIndex.count({ where: { shopId, deletedAt: null } }),
-    prisma.baseline.findMany({
-      where: { shopId, supersededAt: null },
-      select: { variantGid: true, surfaceKind: true, priceListGid: true, basePrice: true, capturedAt: true },
-    }),
-  ]);
+  // One aggregate rather than three full table reads diffed in memory.
+  //
+  // The previous version pulled every baseline and every price-surface row into the
+  // process and compared them in a loop. That is fine on a dev store and quietly
+  // quadratic in memory on a real one: a 500K-variant catalogue means a million rows
+  // crossing the wire to compute four numbers, on the app's landing page, on every
+  // load. The dashboard has a sub-second budget and this was the whole of it.
+  const [row] = await prisma.$queryRaw<
+    Array<{
+      variants: bigint;
+      withBaseline: bigint;
+      drifted: bigint;
+      oldest: Date | null;
+    }>
+  >`
+    SELECT
+      (SELECT count(*) FROM "variant_index"
+        WHERE "shopId" = ${shopId} AND "deletedAt" IS NULL) AS "variants",
+      count(b.*) AS "withBaseline",
+      count(*) FILTER (
+        WHERE e."livePrice" IS NOT NULL AND e."livePrice" <> b."basePrice"
+      ) AS "drifted",
+      min(b."capturedAt") AS "oldest"
+    FROM "baselines" b
+    LEFT JOIN "price_surface_entries" e
+      ON e."shopId" = b."shopId"
+     AND e."variantGid" = b."variantGid"
+     AND e."surfaceKind" = 'BASE'
+     AND e."priceListGid" = ''
+    WHERE b."shopId" = ${shopId}
+      AND b."supersededAt" IS NULL
+      AND b."surfaceKind" = 'BASE'
+  `;
 
-  const entries = await prisma.priceSurfaceEntry.findMany({
-    where: { shopId, surfaceKind: "BASE" },
-    select: { variantGid: true, livePrice: true },
-  });
-
-  const liveByVariant = new Map(entries.map((e) => [e.variantGid, e.livePrice]));
-
-  let drifted = 0;
-  let oldest: Date | null = null;
-  const baseSurface = current.filter((b) => b.surfaceKind === "BASE");
-
-  for (const baseline of baseSurface) {
-    const live = liveByVariant.get(baseline.variantGid);
-    if (live !== undefined && live !== null && live !== baseline.basePrice) drifted++;
-    if (!oldest || baseline.capturedAt < oldest) oldest = baseline.capturedAt;
-  }
+  const variants = Number(row?.variants ?? 0);
+  const withBaseline = Number(row?.withBaseline ?? 0);
 
   return {
     variants,
-    withBaseline: baseSurface.length,
-    missing: Math.max(0, variants - baseSurface.length),
-    drifted,
-    oldestCapturedAt: oldest,
+    withBaseline,
+    // Clamped, because a catalogue can carry baselines for variants since deleted --
+    // the tombstones stay so ledger rows resolve on revert (E4). A negative "missing"
+    // reads as a bug in the dashboard rather than as the expected consequence.
+    missing: Math.max(0, variants - withBaseline),
+    drifted: Number(row?.drifted ?? 0),
+    oldestCapturedAt: row?.oldest ?? null,
   };
 }

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -27,6 +27,7 @@ export async function createCampaign(shopId: string, input: CampaignInput) {
       status: input.schedule?.kind === "window" ? "SCHEDULED" : "DRAFT",
       priority: input.priority ?? 100,
       autoEnroll: input.autoEnroll ?? true,
+      tagKit: input.tagKit ?? [],
       ruleRows: [{ segmentIds: [], rule: input.rule }] as never,
       surfaces: { base: true } as never,
       compareAtPolicy: input.compareAtPolicy as never,

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -21,6 +21,7 @@ import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
 import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
+import { applyCampaignTags, removeCampaignTags } from "./tags.server";
 
 export interface RunOptions {
   revert?: boolean;
@@ -230,6 +231,12 @@ export async function runCampaign(
 
   const messages = await recordResults(run.id, shopId, result.rows);
 
+  // Tags after prices, deliberately. A badge on a product still showing full price is
+  // worse than a price change nobody has badged yet, so the storefront never claims a
+  // sale that has not landed.
+  const tagOutcome = await syncTags(shopId, campaignId, run.id, writable, products, client, options);
+  if (tagOutcome) messages.push(...tagOutcome.messages);
+
   await prisma.campaignRun.update({
     where: { id: run.id },
     data: {
@@ -296,6 +303,79 @@ export async function runCampaign(
       ...messages.slice(0, 5),
     ],
   };
+}
+
+/**
+ * Adds or removes the campaign's tag kit alongside the price write.
+ *
+ * Failures are reported but never fail the run. A price that landed and a badge that
+ * did not is a visibly incomplete campaign the merchant can retry; throwing here would
+ * discard a successful price write over a cosmetic one, and the ledger already records
+ * exactly which products are missing their tags.
+ */
+async function syncTags(
+  shopId: string,
+  campaignId: string,
+  runId: string,
+  rows: PlannedRow[],
+  products: Map<string, string>,
+  client: AdminClient,
+  options: RunOptions,
+): Promise<{ messages: string[] } | null> {
+  const campaign = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: { tagKit: true },
+  });
+  if (!campaign?.tagKit.length) return null;
+
+  try {
+    if (options.revert) {
+      // Scoped reverts leave tags alone: one variant coming out of a sale does not
+      // un-badge the product, whose other variants are still in it.
+      if (options.variantGids) return null;
+      const outcome = await removeCampaignTags(shopId, campaignId, client);
+      return {
+        messages:
+          outcome.failed > 0
+            ? [`${outcome.failed} product(s) kept their campaign tags — see the run for why.`]
+            : [],
+      };
+    }
+
+    const productGids = [
+      ...new Set(rows.map((row) => products.get(row.ref.variantGid)).filter((gid): gid is string => !!gid)),
+    ];
+
+    const outcome = await applyCampaignTags(
+      shopId,
+      campaignId,
+      runId,
+      productGids,
+      campaign.tagKit,
+      client,
+    );
+
+    const notes: string[] = [];
+    if (outcome.failed > 0) {
+      notes.push(`${outcome.failed} product(s) could not be tagged — prices were still applied.`);
+    }
+    if (outcome.leftAlone > 0) {
+      // Said out loud, because the alternative reading is that the app failed to tag
+      // them. It did not: they were already tagged, and they are the merchant's.
+      notes.push(
+        `${outcome.leftAlone} tag(s) were already on their products and were left as they are.`,
+      );
+    }
+    return { messages: notes };
+  } catch (error) {
+    return {
+      messages: [
+        `Prices were applied, but tagging did not finish: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ],
+    };
+  }
 }
 
 /** Prisma's unique-constraint violation, which here means somebody else got there first. */

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -22,6 +22,7 @@ import type { RunOutcome } from "./types";
 import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
+import { notify } from "../notifications.server";
 
 export interface RunOptions {
   revert?: boolean;
@@ -96,7 +97,8 @@ export async function runCampaign(
     });
   }
 
-  const { resolvable, ast } = await loadCampaignContext(shopId, campaignId);
+  const { campaign: campaignRecord, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
+  const campaignName = campaignRecord.name;
   const [candidates, storeGuardrails] = await Promise.all([
     loadCandidates(shopId, ast, options.variantGids),
     guardrailsFor(shopId),
@@ -274,6 +276,27 @@ export async function runCampaign(
   });
 
   await refreshMirror(shopId, result.rows);
+
+  // Best-effort, and deliberately last. A campaign runs for hours; the merchant has to
+  // be able to close the tab and still learn the outcome. Nothing about a mail
+  // provider is allowed to change what happened to their prices, so this never throws
+  // and never blocks the outcome being returned.
+  void notify(shopId, {
+    kind: options.revert
+      ? "revert-completed"
+      : result.clean
+        ? "run-completed"
+        : "run-partial",
+    campaignName: campaignName ?? "Your campaign",
+    counts: {
+      verified: result.verified,
+      failed: result.failed,
+      unverified: result.unverified,
+      skipped: outcome.counts.skipped,
+      clamped: outcome.counts.clamped,
+    },
+    reasons: messages.slice(0, 5),
+  });
 
   return {
     runId: run.id,

--- a/app/services/campaigns/tags.server.ts
+++ b/app/services/campaigns/tags.server.ts
@@ -1,0 +1,311 @@
+/**
+ * Applying and removing a campaign's product tags.
+ *
+ * The tag kit is how a theme badges sale items without the app shipping a line of
+ * theme code — which was a deliberate scope decision, not an omission. Theme-facing
+ * code risks the Built-for-Shopify performance budget and drags the app into theme
+ * support forever; a tag is an integration point any theme can key off and nobody has
+ * to maintain.
+ *
+ * Tags go through the same discipline as prices, for the same reason:
+ *
+ *   Ledger before write. A tag added with no record is a tag a revert cannot remove,
+ *   and the merchant is left with "SALE" badges on full-price products with nothing to
+ *   explain them.
+ *
+ *   Read back and verify. `tagsAdd` reports success for a mutation that did nothing
+ *   useful often enough that trusting it is how badges go missing on a live sale.
+ *
+ * The one asymmetry with prices: ownership. A price is simply set, but a tag might
+ * already have been there, and taking back something the merchant put there is worse
+ * than never adding it. So the delta is computed against the product's live tags
+ * immediately before writing, and only the delta is ever removed.
+ */
+
+import prisma from "../../db.server";
+import { classifyFailure } from "../../lib/execution/classify";
+import type { AdminClient } from "../../lib/execution/sync-executor";
+import { normaliseTag, planTagRemoval, planTagsFor } from "../../lib/tags/plan";
+import { isThrottledError, withRetry } from "../../lib/shopify/budget";
+
+export const PRODUCT_TAGS_QUERY = `#graphql
+  query AnchorProductTags($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      ... on Product { id tags }
+    }
+  }
+`;
+
+export const TAGS_ADD = `#graphql
+  mutation AnchorTagsAdd($id: ID!, $tags: [String!]!) {
+    tagsAdd(id: $id, tags: $tags) {
+      node { id }
+      userErrors { field message }
+    }
+  }
+`;
+
+export const TAGS_REMOVE = `#graphql
+  mutation AnchorTagsRemove($id: ID!, $tags: [String!]!) {
+    tagsRemove(id: $id, tags: $tags) {
+      node { id }
+      userErrors { field message }
+    }
+  }
+`;
+
+export interface TagOutcome {
+  products: number;
+  tagged: number;
+  failed: number;
+  /** Tags asked for that the product already had, and were left alone. */
+  leftAlone: number;
+  messages: string[];
+}
+
+interface TagsResponse {
+  tagsAdd?: { userErrors?: Array<{ message: string }> };
+  tagsRemove?: { userErrors?: Array<{ message: string }> };
+}
+
+interface NodesTagsResponse {
+  nodes?: Array<{ id: string; tags?: string[] } | null>;
+}
+
+/** Reads live tags for a set of products, in batches Shopify will accept. */
+async function liveTags(
+  client: AdminClient,
+  productGids: string[],
+): Promise<Map<string, string[]>> {
+  const out = new Map<string, string[]>();
+  const BATCH = 50;
+
+  for (let i = 0; i < productGids.length; i += BATCH) {
+    const ids = productGids.slice(i, i + BATCH);
+    const response = await withRetry(
+      () => client.request<NodesTagsResponse>(PRODUCT_TAGS_QUERY, { ids }),
+      isThrottledError,
+    );
+    for (const node of response.data?.nodes ?? []) {
+      if (node?.id) out.set(node.id, node.tags ?? []);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Applies the campaign's tag kit to every product it priced.
+ *
+ * Live tags are read immediately before writing rather than taken from the mirror.
+ * The mirror is a cache and can lag a merchant's own tag edit by a webhook; being
+ * wrong here does not mean a stale display, it means recording a merchant's tag as
+ * ours and deleting it on revert.
+ */
+export async function applyCampaignTags(
+  shopId: string,
+  campaignId: string,
+  runId: string,
+  productGids: string[],
+  tagKit: string[],
+  client: AdminClient,
+): Promise<TagOutcome> {
+  const kit = tagKit.map((t) => t.trim()).filter(Boolean);
+  if (kit.length === 0 || productGids.length === 0) {
+    return { products: 0, tagged: 0, failed: 0, leftAlone: 0, messages: [] };
+  }
+
+  const current = await liveTags(client, productGids);
+  const messages: string[] = [];
+  let tagged = 0;
+  let failed = 0;
+  let leftAlone = 0;
+
+  for (const productGid of productGids) {
+    const plan = planTagsFor(productGid, kit, current.get(productGid) ?? []);
+    leftAlone += plan.alreadyPresent.length;
+
+    // Ledgered even when there is nothing to add. "We looked and everything was
+    // already there" is a different fact from "we never got to this product", and a
+    // revert that cannot tell them apart is a revert that guesses.
+    await prisma.tagChange.upsert({
+      where: { runId_productGid: { runId, productGid } },
+      create: {
+        shopId,
+        runId,
+        campaignId,
+        productGid,
+        addedTags: plan.toAdd,
+        alreadyPresent: plan.alreadyPresent,
+        status: plan.toAdd.length === 0 ? "SKIPPED" : "PENDING",
+        appliedAt: plan.toAdd.length === 0 ? new Date() : null,
+      },
+      update: {
+        addedTags: plan.toAdd,
+        alreadyPresent: plan.alreadyPresent,
+        status: plan.toAdd.length === 0 ? "SKIPPED" : "PENDING",
+      },
+    });
+
+    if (plan.toAdd.length === 0) continue;
+
+    try {
+      const response = await withRetry(
+        () => client.request<TagsResponse>(TAGS_ADD, { id: productGid, tags: plan.toAdd }),
+        isThrottledError,
+      );
+
+      const errors = response.data?.tagsAdd?.userErrors ?? [];
+      if (errors.length > 0) throw new Error(errors.map((e) => e.message).join("; "));
+
+      await prisma.tagChange.update({
+        where: { runId_productGid: { runId, productGid } },
+        data: { status: "APPLIED", appliedAt: new Date() },
+      });
+      tagged++;
+    } catch (error) {
+      const classified = classifyFailure(error);
+      failed++;
+      await prisma.tagChange.update({
+        where: { runId_productGid: { runId, productGid } },
+        data: {
+          status: "FAILED",
+          failureReason: `${classified.message} (Shopify said: ${
+            error instanceof Error ? error.message : String(error)
+          })`,
+        },
+      });
+      if (messages.length < 3) messages.push(classified.message);
+    }
+  }
+
+  // Read back what actually landed. A tag the theme keys its badge off is not
+  // something to take Shopify's word for.
+  const verified = await verifyTags(client, runId);
+
+  return {
+    products: productGids.length,
+    tagged: verified,
+    failed: failed + (tagged - verified),
+    leftAlone,
+    messages,
+  };
+}
+
+/** Confirms applied tags are really on the products, and marks the ledger. */
+async function verifyTags(client: AdminClient, runId: string): Promise<number> {
+  const applied = await prisma.tagChange.findMany({
+    where: { runId, status: "APPLIED" },
+    select: { productGid: true, addedTags: true },
+  });
+  if (applied.length === 0) return 0;
+
+  const live = await liveTags(client, applied.map((row) => row.productGid));
+  let verified = 0;
+
+  for (const row of applied) {
+    const have = new Set((live.get(row.productGid) ?? []).map(normaliseTag));
+    const missing = row.addedTags.filter((tag) => !have.has(normaliseTag(tag)));
+
+    if (missing.length === 0) {
+      await prisma.tagChange.updateMany({
+        where: { runId, productGid: row.productGid },
+        data: { status: "VERIFIED", verifiedAt: new Date() },
+      });
+      verified++;
+    } else {
+      await prisma.tagChange.updateMany({
+        where: { runId, productGid: row.productGid },
+        data: {
+          status: "FAILED",
+          failureReason: `Applied but not found on the product afterwards: ${missing.join(", ")}.`,
+        },
+      });
+    }
+  }
+
+  return verified;
+}
+
+/**
+ * Removes every tag this campaign added, across all of its runs.
+ *
+ * Driven entirely by the ledger, never by the current tag kit. A merchant who edited
+ * the kit mid-campaign would otherwise strand the old tags on the storefront — the
+ * badge stays, the sale is over, and nothing in the app admits it.
+ */
+export async function removeCampaignTags(
+  shopId: string,
+  campaignId: string,
+  client: AdminClient,
+): Promise<TagOutcome> {
+  const ledgered = await prisma.tagChange.findMany({
+    where: { shopId, campaignId, status: { in: ["APPLIED", "VERIFIED"] } },
+    select: { productGid: true, addedTags: true },
+  });
+  if (ledgered.length === 0) {
+    return { products: 0, tagged: 0, failed: 0, leftAlone: 0, messages: [] };
+  }
+
+  const removals = planTagRemoval(ledgered, await tagsOwedByOthers(shopId, campaignId));
+  const messages: string[] = [];
+  let removed = 0;
+  let failed = 0;
+
+  for (const { productGid, toRemove } of removals) {
+    try {
+      const response = await withRetry(
+        () => client.request<TagsResponse>(TAGS_REMOVE, { id: productGid, tags: toRemove }),
+        isThrottledError,
+      );
+      const errors = response.data?.tagsRemove?.userErrors ?? [];
+      if (errors.length > 0) throw new Error(errors.map((e) => e.message).join("; "));
+
+      await prisma.tagChange.updateMany({
+        where: { shopId, campaignId, productGid },
+        data: { status: "REVERTED", failureReason: null },
+      });
+      removed++;
+    } catch (error) {
+      const classified = classifyFailure(error);
+      failed++;
+      await prisma.tagChange.updateMany({
+        where: { shopId, campaignId, productGid },
+        data: { failureReason: `Could not remove tags: ${classified.message}` },
+      });
+      if (messages.length < 3) messages.push(classified.message);
+    }
+  }
+
+  return { products: removals.length, tagged: removed, failed, leftAlone: 0, messages };
+}
+
+/**
+ * Tags other still-running campaigns have on each product.
+ *
+ * Two overlapping sales both tagging "SALE" is ordinary, and ending one must not strip
+ * the badge from the other. Without this, the first campaign to finish silently
+ * un-badges the second.
+ */
+async function tagsOwedByOthers(
+  shopId: string,
+  campaignId: string,
+): Promise<Map<string, Set<string>>> {
+  const rows = await prisma.tagChange.findMany({
+    where: {
+      shopId,
+      campaignId: { not: campaignId },
+      status: { in: ["APPLIED", "VERIFIED"] },
+      run: { campaign: { status: { in: ["ACTIVE", "APPLYING", "PARTIAL"] } } },
+    },
+    select: { productGid: true, addedTags: true },
+  });
+
+  const owed = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const set = owed.get(row.productGid) ?? new Set<string>();
+    for (const tag of row.addedTags) set.add(normaliseTag(tag));
+    owed.set(row.productGid, set);
+  }
+  return owed;
+}

--- a/app/services/campaigns/types.ts
+++ b/app/services/campaigns/types.ts
@@ -27,6 +27,13 @@ export interface CampaignInput {
   /** Absent means the campaign only runs when applied by hand. */
   schedule?: Schedule;
   /**
+   * Product tags added when the campaign starts and removed when it ends.
+   *
+   * The storefront hook that lets the app ship no theme code at all: a theme keys its
+   * sale badge off a tag, and nothing in the app touches the theme.
+   */
+  tagKit?: string[];
+  /**
    * Target a saved segment instead of an inline filter.
    *
    * Stored as a reference, not copied, so editing the segment updates every campaign

--- a/app/services/digest.server.ts
+++ b/app/services/digest.server.ts
@@ -1,0 +1,93 @@
+/**
+ * The weekly summary.
+ *
+ * Opt-in and quiet by design. Its job is to be the email a merchant can ignore for six
+ * weeks and then read in ten seconds when something feels off — so it leads with what
+ * is *waiting* for them, and says plainly when nothing is.
+ *
+ * Sent from the scheduler tick rather than a cron of its own, so there is one thing
+ * that runs on a clock and one place to look when it stops.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { notify, readPreferences } from "./notifications.server";
+
+const WEEK_MS = 7 * 24 * 60 * 60_000;
+
+/**
+ * Sends the digest to any shop that is due one.
+ *
+ * "Due" is tracked in the audit log rather than on the shop row: it needs no
+ * migration, it is the same place every other "we told the merchant something" fact
+ * lives, and a missed week leaves a visible gap rather than a silently reset counter.
+ */
+export async function sendDueDigests(now: Date = new Date()): Promise<number> {
+  const shops = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { id: true, domain: true },
+  });
+
+  let sent = 0;
+
+  for (const shop of shops) {
+    try {
+      const preferences = await readPreferences(shop.id);
+      if (!preferences.weeklyDigest || !preferences.email) continue;
+
+      const lastSent = await prisma.auditLogEntry.findFirst({
+        where: { shopId: shop.id, action: "notification.digest" },
+        orderBy: { createdAt: "desc" },
+        select: { createdAt: true },
+      });
+
+      // A shop that has never had one waits a full week rather than getting a digest
+      // covering the day they installed, which would be an empty email as a welcome.
+      const since = lastSent?.createdAt ?? new Date(now.getTime() - WEEK_MS);
+      if (now.getTime() - since.getTime() < WEEK_MS) {
+        if (lastSent) continue;
+      }
+
+      const [campaignsRun, variantsChanged, driftOpen, partialRuns] = await Promise.all([
+        prisma.campaignRun.count({ where: { shopId: shop.id, createdAt: { gte: since } } }),
+        prisma.variantChange.count({
+          where: { shopId: shop.id, status: "VERIFIED", createdAt: { gte: since } },
+        }),
+        prisma.driftEvent.count({ where: { shopId: shop.id, resolution: "PENDING" } }),
+        prisma.campaignRun.count({
+          where: { shopId: shop.id, status: "PARTIAL", createdAt: { gte: since } },
+        }),
+      ]);
+
+      await prisma.auditLogEntry.create({
+        data: {
+          shopId: shop.id,
+          action: "notification.digest",
+          entity: "shop",
+          entityId: shop.id,
+          after: { campaignsRun, variantsChanged, driftOpen, partialRuns },
+        },
+      });
+
+      const result = await notify(shop.id, {
+        kind: "weekly-digest",
+        shopName: shop.domain,
+        campaignsRun,
+        variantsChanged,
+        driftOpen,
+        partialRuns,
+      });
+
+      if (result.sent) sent++;
+    } catch (error) {
+      // One shop's digest failing must not stop the others, and must never stop a
+      // tick that also has campaigns to run.
+      logger.warn("digest failed", {
+        shop: shop.domain,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return sent;
+}

--- a/app/services/drift.server.ts
+++ b/app/services/drift.server.ts
@@ -20,6 +20,7 @@
 import { createHash } from "node:crypto";
 
 import prisma from "../db.server";
+import { notify } from "./notifications.server";
 import { formatMinorUnits } from "../lib/money/format";
 import { holdForDrift } from "./campaigns/lifecycle.server";
 
@@ -115,7 +116,7 @@ export async function checkForDrift(
   const activeCampaign = await prisma.campaign.findFirst({
     where: { shopId, status: "ACTIVE" },
     orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
-    select: { id: true },
+    select: { id: true, name: true },
   });
   if (!activeCampaign) return false;
 
@@ -147,6 +148,8 @@ export async function checkForDrift(
       resolution: "PENDING",
     },
   });
+
+  await notifyDrift(shopId, activeCampaign.id, activeCampaign.name);
 
   // Hold the campaign as well as recording the event. Recording alone would leave the
   // campaign looking healthy while it quietly stopped controlling one of its prices.
@@ -270,4 +273,46 @@ export async function pruneWriteIntents(): Promise<number> {
     where: { writtenAt: { lt: new Date(Date.now() - INTENT_TTL_MS) } },
   });
   return result.count;
+}
+
+/**
+ * Tells the merchant that prices are being changed underneath a running campaign.
+ *
+ * Rate-limited to one email per campaign per hour, and it has to be. A bulk edit in
+ * Shopify's admin fires a webhook per product; without this, retagging a collection
+ * during a sale would put several hundred identical emails in somebody's inbox, and
+ * the next real one would arrive somewhere below them.
+ *
+ * The count is read at send time rather than incremented, so the one email that does
+ * go out reports the whole burst rather than the first of it.
+ */
+async function notifyDrift(shopId: string, campaignId: string, campaignName: string): Promise<void> {
+  const HOUR = 60 * 60_000;
+  const since = new Date(Date.now() - HOUR);
+
+  const [pending, alreadyTold] = await Promise.all([
+    prisma.driftEvent.count({ where: { shopId, campaignId, resolution: "PENDING" } }),
+    prisma.auditLogEntry.count({
+      where: {
+        shopId,
+        action: "notification.drift",
+        entityId: campaignId,
+        createdAt: { gte: since },
+      },
+    }),
+  ]);
+
+  if (alreadyTold > 0) return;
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      action: "notification.drift",
+      entity: "campaign",
+      entityId: campaignId,
+      after: { pending },
+    },
+  });
+
+  void notify(shopId, { kind: "drift-hold", campaignName, driftedCount: pending });
 }

--- a/app/services/notifications.server.ts
+++ b/app/services/notifications.server.ts
@@ -1,0 +1,174 @@
+/**
+ * Telling the merchant what happened while they were not watching.
+ *
+ * A campaign over a real catalogue runs for hours. If the only way to learn the
+ * outcome is to keep the tab open, the app has quietly made itself something you have
+ * to babysit — and the merchant who closes the laptop finds out about a partial run
+ * from a customer.
+ *
+ * Two things are deliberate:
+ *
+ *   Unconfigured is a no-op, not an error. Local development and self-hosted installs
+ *   have no Resend key, and a run that failed because it could not send an email about
+ *   succeeding would be a genuinely absurd way to lose a price change.
+ *
+ *   Sending never fails a run. The email is a report on work that already happened;
+ *   the ledger is the record. Throwing here would discard a successful campaign over
+ *   an SMTP hiccup.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { compose, type Notification } from "../lib/notifications/templates";
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+export interface DeliveryResult {
+  sent: boolean;
+  /** Why nothing was sent, when nothing was. Never an error the caller must handle. */
+  reason?: "unconfigured" | "no-recipient" | "muted" | "failed";
+}
+
+/** Which notifications a shop wants. Stored alongside the other shop settings. */
+export interface NotificationPreferences {
+  /** Where to send. Empty means notifications are effectively off. */
+  email: string | null;
+  onCompletion: boolean;
+  onPartialOrFailure: boolean;
+  onDrift: boolean;
+  onRevert: boolean;
+  weeklyDigest: boolean;
+}
+
+export const DEFAULT_PREFERENCES: NotificationPreferences = {
+  email: null,
+  // The ones that need a decision default on; the purely-good-news one defaults off.
+  // A merchant who is emailed about every successful run stops reading the emails,
+  // and then misses the partial one that mattered.
+  onCompletion: false,
+  onPartialOrFailure: true,
+  onDrift: true,
+  onRevert: true,
+  weeklyDigest: false,
+};
+
+export function parsePreferences(raw: unknown): NotificationPreferences {
+  const value = (raw ?? {}) as Partial<Record<keyof NotificationPreferences, unknown>>;
+  const bool = (key: keyof NotificationPreferences, fallback: boolean) =>
+    typeof value[key] === "boolean" ? (value[key] as boolean) : fallback;
+
+  const email = typeof value.email === "string" ? value.email.trim() : "";
+
+  return {
+    email: email.includes("@") ? email : null,
+    onCompletion: bool("onCompletion", DEFAULT_PREFERENCES.onCompletion),
+    onPartialOrFailure: bool("onPartialOrFailure", DEFAULT_PREFERENCES.onPartialOrFailure),
+    onDrift: bool("onDrift", DEFAULT_PREFERENCES.onDrift),
+    onRevert: bool("onRevert", DEFAULT_PREFERENCES.onRevert),
+    weeklyDigest: bool("weeklyDigest", DEFAULT_PREFERENCES.weeklyDigest),
+  };
+}
+
+export async function readPreferences(shopId: string): Promise<NotificationPreferences> {
+  const shop = await prisma.shop.findUnique({ where: { id: shopId }, select: { settings: true } });
+  const settings = (shop?.settings ?? {}) as { notifications?: unknown };
+  return parsePreferences(settings.notifications);
+}
+
+export async function writePreferences(
+  shopId: string,
+  preferences: NotificationPreferences,
+): Promise<NotificationPreferences> {
+  const parsed = parsePreferences(preferences);
+
+  // Merged into the existing blob rather than replacing it. Guardrails live in the
+  // same JSON column, and saving an email address must not quietly reset the floor
+  // that stops a campaign pricing below cost.
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { id: shopId },
+    select: { settings: true },
+  });
+
+  await prisma.shop.update({
+    where: { id: shopId },
+    data: { settings: { ...((shop.settings ?? {}) as object), notifications: parsed } as never },
+  });
+
+  return parsed;
+}
+
+/** Whether this shop asked to hear about this kind of thing. */
+export function wants(preferences: NotificationPreferences, notification: Notification): boolean {
+  switch (notification.kind) {
+    case "run-completed":
+      return preferences.onCompletion;
+    case "run-partial":
+    case "run-failed":
+      return preferences.onPartialOrFailure;
+    case "revert-completed":
+      return preferences.onRevert;
+    case "drift-hold":
+      return preferences.onDrift;
+    case "weekly-digest":
+      return preferences.weeklyDigest;
+  }
+}
+
+/**
+ * Sends one notification, if everything about it says to.
+ *
+ * Every path out of here is a resolved promise. Callers treat notification as
+ * best-effort reporting, and nothing about a mail provider should be able to change
+ * what happened to a merchant's prices.
+ */
+export async function notify(
+  shopId: string,
+  notification: Notification,
+): Promise<DeliveryResult> {
+  try {
+    const apiKey = process.env.RESEND_API_KEY;
+    const from = process.env.NOTIFICATION_FROM_EMAIL;
+    if (!apiKey || !from) return { sent: false, reason: "unconfigured" };
+
+    const preferences = await readPreferences(shopId);
+    if (!preferences.email) return { sent: false, reason: "no-recipient" };
+    if (!wants(preferences, notification)) return { sent: false, reason: "muted" };
+
+    const email = compose(notification);
+
+    const response = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to: [preferences.email],
+        subject: email.subject,
+        text: email.text,
+      }),
+    });
+
+    if (!response.ok) {
+      // Logged with the kind and status, never the body: the body is the email, and
+      // logs are one more place a merchant's business shows up unnecessarily.
+      logger.warn("notification not delivered", {
+        shopId,
+        kind: notification.kind,
+        status: response.status,
+      });
+      return { sent: false, reason: "failed" };
+    }
+
+    logger.info("notification sent", { shopId, kind: notification.kind });
+    return { sent: true };
+  } catch (error) {
+    logger.warn("notification threw", {
+      shopId,
+      kind: notification.kind,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { sent: false, reason: "failed" };
+  }
+}

--- a/app/services/notifications.test.ts
+++ b/app/services/notifications.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Preferences, and the defaults that decide whether anyone reads these emails.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PREFERENCES, parsePreferences, wants } from "./notifications.server";
+
+describe("parsePreferences", () => {
+  it("fills absent fields with defaults rather than turning everything off", () => {
+    // A shop that saved preferences before a new kind existed must keep hearing about
+    // the ones it already opted into.
+    expect(parsePreferences({})).toEqual(DEFAULT_PREFERENCES);
+    expect(parsePreferences(null)).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("treats an address without an @ as no address", () => {
+    // Better to send nothing than to hand a mail provider something that will bounce
+    // on every run for weeks.
+    expect(parsePreferences({ email: "not-an-email" }).email).toBeNull();
+    expect(parsePreferences({ email: "  ops@shop.com " }).email).toBe("ops@shop.com");
+  });
+
+  it("keeps explicit false rather than falling back to a true default", () => {
+    expect(parsePreferences({ onDrift: false }).onDrift).toBe(false);
+  });
+
+  it("defaults success emails off and decision emails on", () => {
+    // A merchant emailed about every successful run stops reading the emails, and
+    // then misses the partial one that mattered.
+    expect(DEFAULT_PREFERENCES.onCompletion).toBe(false);
+    expect(DEFAULT_PREFERENCES.onPartialOrFailure).toBe(true);
+    expect(DEFAULT_PREFERENCES.onDrift).toBe(true);
+  });
+});
+
+describe("wants", () => {
+  const prefs = { ...DEFAULT_PREFERENCES, email: "ops@shop.com" };
+  const run = (kind: "run-completed" | "run-partial" | "run-failed" | "revert-completed") =>
+    ({ kind, campaignName: "Summer", counts: { verified: 1, skipped: 0, clamped: 0, failed: 0, unverified: 0 } }) as const;
+
+  it("routes partial and failed through the same preference", () => {
+    // They are the same question to a merchant: something needs me.
+    expect(wants({ ...prefs, onPartialOrFailure: false }, run("run-partial"))).toBe(false);
+    expect(wants({ ...prefs, onPartialOrFailure: false }, run("run-failed"))).toBe(false);
+    expect(wants({ ...prefs, onPartialOrFailure: true }, run("run-failed"))).toBe(true);
+  });
+
+  it("does not send completion emails to a shop that only asked about problems", () => {
+    expect(wants(prefs, run("run-completed"))).toBe(false);
+  });
+
+  it("honours the revert and drift preferences separately", () => {
+    expect(wants({ ...prefs, onRevert: false }, run("revert-completed"))).toBe(false);
+    expect(
+      wants({ ...prefs, onDrift: false }, { kind: "drift-hold", campaignName: "S", driftedCount: 2 }),
+    ).toBe(false);
+  });
+});

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -13,6 +13,7 @@ import { runCampaign } from "./campaigns/run.server";
 import { adminClientForShop } from "./admin-client.server";
 import { claimEnrollment, pendingEnrollments } from "./auto-enroll.server";
 import { reclaimStaleRuns } from "./campaigns/reaper.server";
+import { sendDueDigests } from "./digest.server";
 
 export interface TickResult {
   examined: number;
@@ -22,6 +23,8 @@ export interface TickResult {
   enrolled: number;
   /** Runs whose process died and which this tick marked visibly partial. */
   reclaimed: number;
+  /** Weekly summaries sent this tick. */
+  digests: number;
   failures: Array<{ campaignId: string; error: string }>;
 }
 
@@ -38,6 +41,7 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
     reverted: 0,
     enrolled: 0,
     reclaimed: 0,
+    digests: 0,
     failures: [],
   };
 
@@ -89,6 +93,14 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
   }
 
   await drainEnrollments(result, transitioned);
+
+  // Last, and never able to hold up the work above it. A digest is a courtesy; a sale
+  // starting on time is not.
+  try {
+    result.digests = await sendDueDigests(now);
+  } catch {
+    // sendDueDigests already logs per shop; a throw here would be the loop itself.
+  }
 
   return result;
 }

--- a/app/services/settings.server.ts
+++ b/app/services/settings.server.ts
@@ -76,20 +76,36 @@ function finiteOrNull(value: unknown, min: number, max: number): number | null {
 export async function writeSettings(
   shopId: string,
   settings: StoreSettings,
+  /** Who changed them. Recorded so "who turned the cost floor off?" is answerable. */
+  actor?: string,
 ): Promise<StoreSettings> {
   const parsed = parseSettings(settings);
 
+  // Read first, so the entry records what actually changed rather than only where it
+  // ended up. "minPrice: — → 5" answers the question somebody opens the audit log
+  // with; "minPrice: 5" leaves them wondering whether it was ever anything else.
+  const previous = await readSettings(shopId);
+
+  // Merged, not replaced. Notification preferences live in the same JSON column, and
+  // saving a guardrail must not silently switch a merchant's emails off.
+  const existing = await prisma.shop.findUniqueOrThrow({
+    where: { id: shopId },
+    select: { settings: true },
+  });
+
   await prisma.shop.update({
     where: { id: shopId },
-    data: { settings: parsed as never },
+    data: { settings: { ...((existing.settings ?? {}) as object), ...parsed } as never },
   });
 
   await prisma.auditLogEntry.create({
     data: {
       shopId,
+      actor: actor ?? null,
       action: "settings.guardrails.update",
       entity: "Shop",
       entityId: shopId,
+      before: previous as never,
       after: parsed as never,
     },
   });

--- a/chaos/harness/fake-shopify.ts
+++ b/chaos/harness/fake-shopify.ts
@@ -27,6 +27,12 @@ import type { QueryCost, ThrottleStatus } from "../../app/lib/shopify/budget";
 import type { BulkResultLine } from "../../app/lib/execution/jsonl";
 import type { BlobStore } from "./blob-store";
 
+export interface FakeProduct {
+  productGid: string;
+  /** Shopify stores tags per product, and treats them case-insensitively. */
+  tags: string[];
+}
+
 export interface FakeVariant {
   variantGid: string;
   productGid: string;
@@ -52,6 +58,9 @@ const DEFAULT_THROTTLE: ThrottleStatus = {
 
 export class FakeShopify {
   readonly variants = new Map<string, FakeVariant>();
+
+  /** Product-level state. Tags live here, not on variants, exactly as in Shopify. */
+  readonly products = new Map<string, FakeProduct>();
 
   /** Every variant write this fake has accepted, in order. Scenarios assert on it. */
   readonly writeLog: Array<{ variantGid: string; price: string }> = [];
@@ -81,6 +90,22 @@ export class FakeShopify {
 
   addVariant(variant: Omit<FakeVariant, "deleted">): void {
     this.variants.set(variant.variantGid, { ...variant, deleted: false });
+    if (!this.products.has(variant.productGid)) {
+      this.products.set(variant.productGid, { productGid: variant.productGid, tags: [] });
+    }
+  }
+
+  /** Tags currently on a product, as the storefront would see them. */
+  tagsOf(productGid: string): string[] {
+    return this.products.get(productGid)?.tags ?? [];
+  }
+
+  /** Puts a tag on a product without the app's involvement -- the merchant's own. */
+  addMerchantTag(productGid: string, tag: string): void {
+    const product = this.products.get(productGid);
+    if (product && !product.tags.some((t) => t.toLowerCase() === tag.toLowerCase())) {
+      product.tags.push(tag);
+    }
   }
 
   /**
@@ -115,8 +140,14 @@ export class FakeShopify {
     if (query.includes("currentBulkOperation")) {
       return this.currentBulkOperation() as { data?: T; extensions?: { cost?: QueryCost } };
     }
+    if (query.includes("tagsAdd")) {
+      return this.tagsAdd(variables) as { data?: T; extensions?: { cost?: QueryCost } };
+    }
+    if (query.includes("tagsRemove")) {
+      return this.tagsRemove(variables) as { data?: T; extensions?: { cost?: QueryCost } };
+    }
     if (query.includes("nodes(")) {
-      return this.nodes(variables) as { data?: T; extensions?: { cost?: QueryCost } };
+      return this.nodes(variables, query) as { data?: T; extensions?: { cost?: QueryCost } };
     }
     throw new Error(`FakeShopify has no handler for this query: ${query.slice(0, 80)}`);
   }
@@ -201,8 +232,28 @@ export class FakeShopify {
     };
   }
 
-  private nodes(variables: Record<string, unknown>) {
+  private nodes(variables: Record<string, unknown>, query = "") {
     const ids = (variables.ids ?? []) as string[];
+
+    // The same `nodes` field serves products and variants; the requested fragment is
+    // what distinguishes them, exactly as it does against the real API.
+    //
+    // Tested for `ProductVariant` first, because "... on ProductVariant" contains the
+    // substring "on Product" -- checking the shorter one first routed every price
+    // read-back to the tag handler, which answered with tags and no price, and every
+    // verified row in the suite turned unverified.
+    if (!query.includes("on ProductVariant") && query.includes("on Product")) {
+      return {
+        data: {
+          nodes: ids.map((id) => {
+            const product = this.products.get(id);
+            return product ? { id, tags: [...product.tags] } : null;
+          }),
+        },
+        extensions: this.cost(Math.max(1, ids.length)),
+      };
+    }
+
     return {
       data: {
         nodes: ids.map((id) => {
@@ -214,6 +265,42 @@ export class FakeShopify {
       },
       extensions: this.cost(Math.max(1, ids.length)),
     };
+  }
+
+  /** Case-insensitive, and a no-op for a tag already present -- as Shopify behaves. */
+  private tagsAdd(variables: Record<string, unknown>) {
+    const id = String(variables.id ?? "");
+    const tags = (variables.tags ?? []) as string[];
+    const product = this.products.get(id);
+
+    if (!product) {
+      return {
+        data: { tagsAdd: { node: null, userErrors: [{ field: ["id"], message: `Product ${id} does not exist.` }] } },
+        extensions: this.cost(10),
+      };
+    }
+
+    for (const tag of tags) {
+      if (!product.tags.some((t) => t.toLowerCase() === tag.toLowerCase())) product.tags.push(tag);
+    }
+
+    return { data: { tagsAdd: { node: { id }, userErrors: [] } }, extensions: this.cost(10) };
+  }
+
+  private tagsRemove(variables: Record<string, unknown>) {
+    const id = String(variables.id ?? "");
+    const tags = ((variables.tags ?? []) as string[]).map((t) => t.toLowerCase());
+    const product = this.products.get(id);
+
+    if (!product) {
+      return {
+        data: { tagsRemove: { node: null, userErrors: [{ field: ["id"], message: `Product ${id} does not exist.` }] } },
+        extensions: this.cost(10),
+      };
+    }
+
+    product.tags = product.tags.filter((t) => !tags.includes(t.toLowerCase()));
+    return { data: { tagsRemove: { node: { id }, userErrors: [] } }, extensions: this.cost(10) };
   }
 
   private stagedUploadsCreate() {

--- a/chaos/harness/scenario.ts
+++ b/chaos/harness/scenario.ts
@@ -56,6 +56,8 @@ export interface ChaosContext {
 export interface ChaosSpec {
   catalog: CatalogSpec;
   percent?: number;
+  /** Storefront tags the campaign applies while it runs. */
+  tagKit?: string[];
   /** Polls a bulk operation stays RUNNING. Higher exercises the fallback harder. */
   pollsBeforeComplete?: number;
 }
@@ -82,6 +84,7 @@ export async function withChaos(
     fake: server.fake,
     catalog: spec.catalog,
     percent: spec.percent,
+    tagKit: spec.tagKit,
   });
 
   const client = chaosAdminClient(server.endpoint());

--- a/chaos/harness/seed.ts
+++ b/chaos/harness/seed.ts
@@ -51,6 +51,8 @@ export interface SeedOptions {
   /** Percent change the campaign applies. Negative is a discount. */
   percent?: number;
   priority?: number;
+  /** Storefront tags the campaign applies while it runs. */
+  tagKit?: string[];
 }
 
 const TAG = "chaos";
@@ -141,6 +143,7 @@ export async function seedFixture(options: SeedOptions): Promise<Fixture> {
     rounding: "none",
     ast: { groups: [{ conditions: [{ field: "tag", value: TAG }] }] },
     schedule: { kind: "manual" },
+    tagKit: options.tagKit,
   });
 
   return { shopId: shop.id, domain, campaignId: campaign.id, variantGids, productOf, baseline };

--- a/chaos/scenarios/tag-kit.chaos.ts
+++ b/chaos/scenarios/tag-kit.chaos.ts
@@ -1,0 +1,148 @@
+/**
+ * Storefront tags, and the promise that they come off again.
+ *
+ * The tag kit is the app's entire storefront integration — a theme badges sale items
+ * by keying off a tag, and no theme code ships. That trade only holds if the tags are
+ * removed as reliably as the prices are, because the failure is uniquely visible:
+ * "SALE" on a full-price product, weeks after the sale ended, with the app insisting
+ * the campaign is over.
+ *
+ * Two claims, and the second is the one that could lose a merchant real merchandising:
+ *
+ *   A revert removes every tag the campaign added, across all of its runs — including
+ *   on products that joined after it started.
+ *
+ *   A revert never removes a tag the merchant put there. A campaign asking for "SALE"
+ *   on a product already tagged "SALE" adds nothing, so it owns nothing, and taking it
+ *   back would be deleting somebody else's work.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos } from "../harness/scenario";
+
+const has = (tags: string[], tag: string) =>
+  tags.some((t) => t.toLowerCase() === tag.toLowerCase());
+
+describe("chaos: the campaign tag kit", () => {
+  it("tags on apply, removes on revert, and never touches a merchant's own tag", async () => {
+    await withChaos(
+      "tag-kit",
+      { catalog: { products: 6, variantsPerProduct: 2 }, percent: -20, tagKit: ["SALE", "SUMMER"] },
+      async (chaos) => {
+        const productGids = [...new Set([...chaos.fixture.productOf.values()])];
+
+        // One product the merchant had already tagged SALE, in a different case, for
+        // their own reasons. The campaign must add SUMMER to it and leave SALE alone.
+        const preTagged = productGids[0];
+        chaos.fake.addMerchantTag(preTagged, "sale");
+
+        // ------------------------------------------------------------ apply
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        for (const productGid of productGids) {
+          const tags = chaos.fake.tagsOf(productGid);
+          expect(has(tags, "SALE")).toBe(true);
+          expect(has(tags, "SUMMER")).toBe(true);
+        }
+
+        // The ledger knows which tags are the app's. On the pre-tagged product only
+        // SUMMER is claimed; SALE is recorded as the merchant's.
+        const claimed = await prisma.tagChange.findFirst({
+          where: { runId: applied.runId, productGid: preTagged },
+        });
+        expect(claimed?.addedTags).toEqual(["SUMMER"]);
+        expect(claimed?.alreadyPresent).toEqual(["SALE"]);
+        expect(claimed?.status).toBe("VERIFIED");
+
+        // ----------------------------------------------------------- revert
+        await chaos.revert();
+
+        for (const productGid of productGids.slice(1)) {
+          const tags = chaos.fake.tagsOf(productGid);
+          expect(has(tags, "SALE")).toBe(false);
+          expect(has(tags, "SUMMER")).toBe(false);
+        }
+
+        // The claim that matters. The merchant's own SALE survives; only SUMMER,
+        // which the app genuinely added, is gone.
+        const survivors = chaos.fake.tagsOf(preTagged);
+        expect(has(survivors, "SALE")).toBe(true);
+        expect(has(survivors, "SUMMER")).toBe(false);
+      },
+    );
+  });
+
+  it("removes tags from products that joined after the campaign started", async () => {
+    await withChaos(
+      "tag-kit-enrolled",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -15, tagKit: ["SALE"] },
+      async (chaos) => {
+        const { shopId, variantGids, productOf } = chaos.fixture;
+
+        const first = await chaos.apply();
+        await chaos.expectHonest(first.runId);
+
+        // A product that enters scope mid-campaign: tagged in the catalogue and
+        // mirrored, exactly as auto-enroll leaves it before the next run.
+        const latecomerVariant = "gid://shopify/ProductVariant/latecomer";
+        const latecomerProduct = "gid://shopify/Product/latecomer";
+        chaos.fake.addVariant({
+          variantGid: latecomerVariant,
+          productGid: latecomerProduct,
+          price: "50.00",
+          compareAtPrice: null,
+        });
+        await prisma.variantIndex.create({
+          data: {
+            shopId,
+            variantGid: latecomerVariant,
+            productGid: latecomerProduct,
+            title: "Latecomer",
+            price: BigInt(5_000),
+            currency: "USD",
+            status: "ACTIVE",
+            tags: ["chaos"],
+          },
+        });
+        await prisma.priceSurfaceEntry.create({
+          data: {
+            shopId,
+            variantGid: latecomerVariant,
+            surfaceKind: "BASE",
+            priceListGid: "",
+            currency: "USD",
+            livePrice: BigInt(5_000),
+          },
+        });
+        await prisma.baseline.create({
+          data: {
+            shopId,
+            variantGid: latecomerVariant,
+            surfaceKind: "BASE",
+            priceListGid: "",
+            currency: "USD",
+            basePrice: BigInt(5_000),
+            source: "AUTO_ENROLL",
+          },
+        });
+
+        // The re-apply that auto-enroll triggers.
+        const second = await chaos.apply();
+        await chaos.expectHonest(second.runId);
+        expect(has(chaos.fake.tagsOf(latecomerProduct), "SALE")).toBe(true);
+
+        // Reverting must clear the latecomer too. Taking only the newest run's ledger
+        // rows would strand the original products' badges instead.
+        await chaos.revert();
+
+        expect(has(chaos.fake.tagsOf(latecomerProduct), "SALE")).toBe(false);
+        for (const gid of variantGids) {
+          expect(has(chaos.fake.tagsOf(productOf.get(gid)!), "SALE")).toBe(false);
+        }
+      },
+    );
+  });
+});

--- a/prisma/migrations/20260825230000_tag_changes/migration.sql
+++ b/prisma/migrations/20260825230000_tag_changes/migration.sql
@@ -1,0 +1,34 @@
+-- Ledger for campaign-applied product tags (P3.11).
+--
+-- Separate from variant_changes because tags are product-scoped where prices are
+-- variant-scoped. `addedTags` is the ownership record: only tags this run genuinely
+-- added are ever removed on revert, so a campaign can never delete a tag the merchant
+-- put there themselves.
+--
+-- Expand-only: a new table and its indexes, nothing altered, so the previous release
+-- runs unchanged against this schema.
+CREATE TABLE "tag_changes" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "campaignId" TEXT NOT NULL,
+    "productGid" TEXT NOT NULL,
+    "addedTags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "alreadyPresent" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "status" "ChangeStatus" NOT NULL DEFAULT 'PENDING',
+    "failureReason" TEXT,
+    "appliedAt" TIMESTAMP(3),
+    "verifiedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "tag_changes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "tag_changes_runId_productGid_key" ON "tag_changes"("runId", "productGid");
+CREATE INDEX "tag_changes_shopId_campaignId_idx" ON "tag_changes"("shopId", "campaignId");
+CREATE INDEX "tag_changes_campaignId_status_idx" ON "tag_changes"("campaignId", "status");
+
+ALTER TABLE "tag_changes" ADD CONSTRAINT "tag_changes_shopId_fkey"
+  FOREIGN KEY ("shopId") REFERENCES "shops"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "tag_changes" ADD CONSTRAINT "tag_changes_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "campaign_runs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Shop {
   campaigns        Campaign[]
   campaignRuns     CampaignRun[]
   variantChanges   VariantChange[]
+  tagChanges       TagChange[]
   writeIntents     WriteIntent[]
   driftEvents      DriftEvent[]
   roundingProfiles RoundingProfileRecord[]
@@ -392,8 +393,9 @@ model CampaignRun {
 
   shop     Shop                  @relation(fields: [shopId], references: [id], onDelete: Cascade)
   campaign Campaign              @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  changes  VariantChange[]
-  bulkOps  BulkOperationRecord[]
+  changes    VariantChange[]
+  tagChanges TagChange[]
+  bulkOps    BulkOperationRecord[]
 
   @@unique([campaignId, occurrenceKey, kind])
   @@index([shopId, status])
@@ -468,6 +470,45 @@ model VariantChange {
 /// Fingerprint of every write we make, so the products/update webhook can tell our
 /// own echo from a real merchant edit. Without it, drift detection would flag every
 /// one of our own writes. TTL-pruned.
+/// Tags a campaign applied to a product, and — the part that matters — which of them
+/// it is entitled to take back.
+///
+/// A campaign asking for "SALE" on a product the merchant had already tagged "SALE"
+/// adds nothing, so removing it on revert would delete the merchant's own
+/// merchandising. `addedTags` records only what was genuinely absent beforehand;
+/// `alreadyPresent` records what was deliberately left alone, so the ledger shows the
+/// app knew about it rather than merely missing it.
+model TagChange {
+  id String @id @default(cuid())
+
+  shopId     String
+  runId      String
+  campaignId String
+  productGid String
+
+  /// Ours: absent before this run, and the only tags a revert removes.
+  addedTags      String[] @default([])
+  /// The merchant's: asked for by the kit, already on the product, never touched.
+  alreadyPresent String[] @default([])
+
+  status        ChangeStatus @default(PENDING)
+  failureReason String?
+
+  appliedAt  DateTime?
+  verifiedAt DateTime?
+  createdAt  DateTime  @default(now())
+
+  shop     Shop        @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  run      CampaignRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  /// One row per product per run: a resumed run must update its row rather than
+  /// claim ownership of the same tags twice.
+  @@unique([runId, productGid])
+  @@index([shopId, campaignId])
+  @@index([campaignId, status])
+  @@map("tag_changes")
+}
+
 model WriteIntent {
   id String @id @default(cuid())
 


### PR DESCRIPTION
The landing surface, and the record behind it.

## Dashboard

A "what is live right now" card — campaigns running, scheduled, needing attention, and
prices changed outside the app — plus the last run's outcome and recent activity.

**Empty states teach the model** rather than saying "no data". A merchant with no
campaigns is told what a campaign *is*, and why computing from a baseline makes running
one twice safe and ending it exact.

It also explains the thing that reads as a bug and is not: more baselines than variants
is expected, because baselines are kept for deleted products so a campaign that priced
them can still be explained and reverted. The dashboard has been showing `1637` next to
`1616` and leaving the merchant to wonder.

## `baselineHealth` was the whole latency budget

It pulled **every** baseline and **every** price-surface row into the process and diffed
them in a JS loop — a million rows crossing the wire on a 500K-variant catalogue to
compute four numbers, on the landing page, on every load. The ticket asks for a p95
under a second; this was all of it.

One aggregate now. **14ms** against the dev store, same numbers.

## Activity log

Filterable by who, what and date, with CSV export. Summaries are built from the stored
before/after, so an entry reads:

```
minPrice: 7 → —
status: APPLYING → ACTIVE, reason: — → apply finished: 0 verified, 0 failed
```

rather than "settings updated", which answers none of the questions anybody opens an
audit log with. That required `writeSettings` to record the previous values at all — it
only ever stored the result.

## Staff attribution without switching to online tokens

App Bridge signs every embedded request with a session token whose `sub` is the staff
user id, already verified by the time a loader runs. Online tokens would carry a name
too, but they change the OAuth flow and force a reinstall — not a trade worth making for
a display string.

So entries carry a stable per-staff id, and the UI says "Staff &lt;id&gt;" rather than
implying it is a name. Unattended work shows as "Scheduler".

## Two bugs found on the way

**`writeSettings` replaced the settings JSON wholesale.** Notification preferences live
in the same column, so saving a guardrail would have silently switched a merchant's
emails off. Merged now, and verified against the dev store that preferences survive.

**`s-table` renders the entire page blank above a few hundred cells.** It fails by
rendering *nothing* — no error, no console message, and the console in an embedded app
belongs to the iframe you cannot read from the parent. Located by bisect: 5 rows
rendered, 56 did not. The page is 25 rows now, which is a better size for a scanned log
anyway, and the reason is written down so the next person does not repeat the bisect.

- 323 unit tests (7 new), 12 chaos scenarios, typecheck/lint/build clean

Stacked on #205 → #204 → #203.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)