### PR TITLE
P1.2 — Mirror Markets and B2B price lists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 SHOPIFY_API_KEY=
 SHOPIFY_API_SECRET=
 SHOPIFY_APP_URL=http://localhost:3000
-SCOPES=write_products
+SCOPES=write_products,read_markets,write_markets
 
 # --- Datastores (match docker-compose.yml) -----------------------------------
 DATABASE_URL=postgresql://anchor:anchor@localhost:5432/anchor_dev

--- a/app/lib/markets/adjustment.test.ts
+++ b/app/lib/markets/adjustment.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Market adjustments, in integers.
+ *
+ * Shopify reports a percentage as a JSON number. Carrying that float through a
+ * six-figure catalogue is how a market ends up full of prices a penny off that nobody
+ * can account for — so it becomes basis points at the boundary and stays integer.
+ */
+
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { money } from "../money/money";
+import { applyAdjustment, isFixedOrigin, isRelative, toBasisPoints, toPercent } from "./adjustment";
+
+describe("toBasisPoints", () => {
+  it("makes a decrease negative, so direction rides with the number", () => {
+    expect(toBasisPoints({ type: "PERCENTAGE_DECREASE", value: 5 })).toBe(-500);
+    expect(toBasisPoints({ type: "PERCENTAGE_INCREASE", value: 5 })).toBe(500);
+  });
+
+  it("keeps two decimal places of a percentage", () => {
+    expect(toBasisPoints({ type: "PERCENTAGE_DECREASE", value: 12.5 })).toBe(-1250);
+    expect(toBasisPoints({ type: "PERCENTAGE_DECREASE", value: 0.01 })).toBe(-1);
+  });
+
+  it("treats zero as a real adjustment, not as absent", () => {
+    // A list with a 0% parent adjustment is relative and repriceable in one mutation.
+    // Reading it as "no adjustment" would send us down the per-variant write path.
+    expect(toBasisPoints({ type: "PERCENTAGE_DECREASE", value: 0 })).toBe(-0);
+    expect(isRelative(toBasisPoints({ type: "PERCENTAGE_DECREASE", value: 0 }))).toBe(true);
+  });
+
+  it("returns null for anything it does not recognise", () => {
+    // Distinct from zero. Conflating "unparseable" with "no change" would mirror a
+    // market at the wrong price with nothing to indicate it.
+    expect(toBasisPoints(null)).toBeNull();
+    expect(toBasisPoints(undefined)).toBeNull();
+    expect(toBasisPoints({ type: "SOMETHING_NEW" as never, value: 5 })).toBeNull();
+    expect(toBasisPoints({ type: "PERCENTAGE_DECREASE", value: NaN })).toBeNull();
+  });
+
+  it("round-trips through a percentage", () => {
+    expect(toPercent(-500)).toBe(-5);
+    expect(toPercent(1250)).toBe(12.5);
+  });
+});
+
+describe("applyAdjustment", () => {
+  it("applies a decrease", () => {
+    expect(applyAdjustment(money(10_000, "USD"), -500)).toEqual(money(9_500, "USD"));
+  });
+
+  it("applies an increase", () => {
+    expect(applyAdjustment(money(10_000, "USD"), 1_000)).toEqual(money(11_000, "USD"));
+  });
+
+  it("leaves a zero adjustment exactly where it was", () => {
+    expect(applyAdjustment(money(1_234, "USD"), 0)).toEqual(money(1_234, "USD"));
+  });
+
+  it("keeps the currency of the base price", () => {
+    expect(applyAdjustment(money(1_000, "JPY"), -1_000).currency).toBe("JPY");
+  });
+
+  it("never produces a fractional minor unit", () => {
+    // The whole point of integer arithmetic. A market price of 949.9999 is not a price.
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 10_000_000 }),
+        fc.integer({ min: -9_900, max: 100_000 }),
+        (amount, bps) => {
+          const result = applyAdjustment(money(amount, "USD"), bps);
+          expect(Number.isInteger(result.amount)).toBe(true);
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+
+  it("is symmetric about the rounding boundary", () => {
+    // Rounds half away from zero, as Shopify does. Asymmetric rounding would make a
+    // market price drift by a penny every time a campaign recomputed it.
+    expect(applyAdjustment(money(101, "USD"), -5_000)).toEqual(money(51, "USD"));
+    expect(applyAdjustment(money(101, "USD"), 5_000)).toEqual(money(152, "USD"));
+  });
+});
+
+describe("origin", () => {
+  it("counts only FIXED entries as worth mirroring per variant", () => {
+    // A RELATIVE entry is the parent percentage applied. Mirroring it would restate
+    // one number a few million times across a large catalogue.
+    expect(isFixedOrigin("FIXED")).toBe(true);
+    expect(isFixedOrigin("RELATIVE")).toBe(false);
+    expect(isFixedOrigin(null)).toBe(false);
+  });
+});

--- a/app/lib/markets/adjustment.ts
+++ b/app/lib/markets/adjustment.ts
@@ -1,0 +1,88 @@
+/**
+ * Price list parent adjustments, in integer arithmetic.
+ *
+ * A market price list usually does not store prices. It stores a percentage against
+ * another list, and Shopify derives every price from it. That single fact decides how
+ * a campaign can write to the surface at all: a relative list can be repriced with one
+ * mutation against the adjustment (P5.2), where a fixed list needs a row per variant.
+ *
+ * The adjustment is kept in **basis points**, and never as a float. Shopify reports it
+ * as a JSON number, and 5% arriving as 5.000000000000001 would be harmless right up
+ * until it multiplied a six-figure catalogue and left a trail of prices a penny off
+ * that nobody could account for. Integers in, integers out, one rounding step that is
+ * written down.
+ */
+
+import { money, type Money } from "../money/money";
+
+/** Shopify's adjustment types on `PriceListParent`. */
+export type AdjustmentType = "PERCENTAGE_DECREASE" | "PERCENTAGE_INCREASE";
+
+export interface ParentAdjustment {
+  /**
+   * A plain string, not the union.
+   *
+   * It arrives from the API, which is free to grow a new adjustment kind without
+   * asking. Narrowing at the boundary would turn that into a runtime cast we would
+   * forget; accepting the string and rejecting what we do not recognise keeps the
+   * unknown case explicit — and `toBasisPoints` returning null is what makes an
+   * unrecognised kind visible rather than silently zero.
+   */
+  type: string;
+  /** Percent, as Shopify reports it. 5 means five percent. */
+  value: number;
+}
+
+/**
+ * Converts an adjustment to signed basis points.
+ *
+ * A decrease is negative, so a single number carries direction and there is no second
+ * field to forget to check. Returns null for anything unrecognised rather than
+ * defaulting to zero: zero is a real adjustment meaning "same as base", and silently
+ * conflating "no adjustment" with "unparseable" would mirror a market at the wrong
+ * price with nothing to indicate it.
+ */
+export function toBasisPoints(adjustment: ParentAdjustment | null | undefined): number | null {
+  if (!adjustment || !Number.isFinite(adjustment.value)) return null;
+  if (adjustment.type !== "PERCENTAGE_DECREASE" && adjustment.type !== "PERCENTAGE_INCREASE") {
+    return null;
+  }
+
+  const magnitude = Math.round(Math.abs(adjustment.value) * 100);
+  return adjustment.type === "PERCENTAGE_DECREASE" ? -magnitude : magnitude;
+}
+
+/** Renders basis points back as a percentage, for display and for writing back. */
+export function toPercent(bps: number): number {
+  return bps / 100;
+}
+
+/**
+ * Applies an adjustment to a base price.
+ *
+ * Rounds half away from zero, which is what Shopify does and — more to the point — is
+ * symmetric: a 10% decrease and the matching increase land on the same place from
+ * either direction, so a market price does not drift by a penny each time a campaign
+ * recomputes it.
+ */
+export function applyAdjustment(base: Money, bps: number): Money {
+  const scaled = (base.amount * (10_000 + bps)) / 10_000;
+  const rounded = scaled < 0 ? -Math.round(-scaled) : Math.round(scaled);
+  return money(rounded, base.currency);
+}
+
+/** True when a list derives its prices rather than storing them. */
+export function isRelative(adjustmentBps: number | null | undefined): boolean {
+  return adjustmentBps !== null && adjustmentBps !== undefined;
+}
+
+/**
+ * Whether a mirrored price entry is one Shopify derived or one somebody set.
+ *
+ * `RELATIVE` entries are the parent adjustment applied, and mirroring them per variant
+ * would restate a single percentage a few million times. Only `FIXED` entries carry
+ * information the rule does not already hold.
+ */
+export function isFixedOrigin(originType: string | null | undefined): boolean {
+  return originType === "FIXED";
+}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -7,6 +7,8 @@ import prisma from "../db.server";
 import { ensureShop, markSyncComplete } from "../services/shop.server";
 import { fetchShopBasics, syncCatalog } from "../services/catalog-sync.server";
 import { baselineHealth, captureBaselines } from "../services/baselines.server";
+import { syncMarkets } from "../services/markets-sync.server";
+import { toAdminClient } from "../services/admin-client.server";
 import { OnboardingCard } from "../components/OnboardingCard";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { onboarding } from "../lib/onboarding/steps";
@@ -112,6 +114,10 @@ export const action = withGuard("/app", async ({ request }: ActionFunctionArgs) 
 
     const sync = await syncCatalog(admin, shop.id, basics.currency);
 
+    // After the catalogue, never alongside it: Shopify allows one bulk operation per
+    // shop, and the market sync checks for a running one rather than racing it.
+    const markets = await syncMarkets(toAdminClient(admin), shop.id);
+
     // Capture baselines immediately: a variant with no baseline cannot be priced by
     // a campaign, and capturing at sync time is the only moment we can be confident
     // the live price is the merchant's normal price.
@@ -124,6 +130,11 @@ export const action = withGuard("/app", async ({ request }: ActionFunctionArgs) 
         `Synced ${sync.variants} variants across ${sync.products} products. ` +
         `Captured ${capture.captured} baselines` +
         (capture.alreadyCurrent > 0 ? `, ${capture.alreadyCurrent} already current` : "") +
+        (markets.priceLists > 0
+          ? `. Mirrored ${markets.priceLists} price list${markets.priceLists === 1 ? "" : "s"}` +
+            (markets.relative > 0 ? ` (${markets.relative} derived from a percentage)` : "") +
+            (markets.entries > 0 ? `, ${markets.entries} fixed prices` : "")
+          : "") +
         ".",
       errors: sync.errors.slice(0, 5),
     };

--- a/app/services/markets-sync.server.ts
+++ b/app/services/markets-sync.server.ts
@@ -1,0 +1,300 @@
+/**
+ * Mirroring every market and B2B price list into `price_surface_entries`.
+ *
+ * Until this existed the app could not see a single market price. Every surface row was
+ * written with an empty `priceListGid`, which is to say the base surface and nothing
+ * else — so a product positioned as a multi-market price campaign manager had no read
+ * side for the markets at all.
+ *
+ * Two decisions carry the design:
+ *
+ *   **Base rows live here too.** It is tempting to read base prices from `variant_index`
+ *   and reserve this table for markets. Resist it. One uniform shape for "the live value
+ *   on surface X" is what lets the resolver, preview, planner and reconciliation treat
+ *   base, market and B2B identically instead of branching in four places — and four
+ *   branches is four chances for the market path to disagree with the base one about a
+ *   merchant's prices.
+ *
+ *   **A relative list is stored as its rule, never expanded.** Most market lists do not
+ *   hold prices; they hold a percentage against the base list and Shopify derives the
+ *   rest. Mirroring those per variant would turn one number into two million rows on a
+ *   500K-variant catalogue across four markets, all restating the same percentage, all
+ *   needing to be kept in step. Only `FIXED` entries — the ones somebody set by hand —
+ *   carry information the rule does not already have.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import type { AdminClient } from "../lib/execution/sync-executor";
+import { isFixedOrigin, toBasisPoints } from "../lib/markets/adjustment";
+import { parseMoney } from "../lib/money/money";
+import { isThrottledError, withRetry } from "../lib/shopify/budget";
+
+export const PRICE_LISTS_QUERY = `#graphql
+  query AnchorPriceLists($cursor: String) {
+    priceLists(first: 50, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        name
+        currency
+        parent { adjustment { type value } }
+        catalog { id title __typename }
+      }
+    }
+  }
+`;
+
+export const PRICE_LIST_PRICES_QUERY = `#graphql
+  query AnchorPriceListPrices($id: ID!, $cursor: String) {
+    priceList(id: $id) {
+      id
+      prices(first: 250, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          originType
+          variant { id }
+          price { amount currencyCode }
+          compareAtPrice { amount currencyCode }
+        }
+      }
+    }
+  }
+`;
+
+interface PriceListNode {
+  id: string;
+  name: string;
+  currency: string;
+  parent?: { adjustment?: { type: string; value: number } | null } | null;
+  catalog?: { id: string; title: string; __typename?: string } | null;
+}
+
+interface PricesNode {
+  originType?: string | null;
+  variant?: { id: string } | null;
+  price?: { amount: string; currencyCode: string } | null;
+  compareAtPrice?: { amount: string; currencyCode: string } | null;
+}
+
+export interface MarketsSyncResult {
+  priceLists: number;
+  relative: number;
+  fixed: number;
+  /** Per-variant rows written for lists that store prices rather than deriving them. */
+  entries: number;
+  errors: string[];
+}
+
+/**
+ * Reads the shop's price-list topology and mirrors what it holds.
+ *
+ * Serialised against the catalogue bulk query: Shopify permits one bulk operation per
+ * shop at a time, and a market sync racing a catalogue sync would have one of them
+ * fail with an error about the other that says nothing useful about either.
+ */
+export async function syncMarkets(
+  client: AdminClient,
+  shopId: string,
+): Promise<MarketsSyncResult> {
+  const result: MarketsSyncResult = {
+    priceLists: 0,
+    relative: 0,
+    fixed: 0,
+    entries: 0,
+    errors: [],
+  };
+
+  const running = await prisma.bulkOperationRecord.findFirst({
+    where: { shopId, status: { in: ["CREATED", "RUNNING"] } },
+    select: { shopifyGid: true },
+  });
+  if (running) {
+    result.errors.push(
+      "A catalogue sync is already running for this shop. Market prices are mirrored " +
+        "once it finishes — Shopify allows one bulk operation at a time.",
+    );
+    return result;
+  }
+
+  const lists = await readPriceLists(client);
+  const seen: string[] = [];
+
+  for (const list of lists) {
+    const adjustmentBps = toBasisPoints(list.parent?.adjustment ?? null);
+
+    // A catalog is a market catalog or a company-location one. Absent means B2B in
+    // practice: the list is attached to companies rather than to a market.
+    const surfaceKind =
+      list.catalog?.__typename === "CompanyLocationCatalog" || !list.catalog ? "B2B" : "MARKET";
+
+    await prisma.priceListRecord.upsert({
+      where: { shopId_priceListGid: { shopId, priceListGid: list.id } },
+      create: {
+        shopId,
+        priceListGid: list.id,
+        name: list.name,
+        currency: list.currency,
+        surfaceKind,
+        catalogGid: list.catalog?.id ?? null,
+        catalogTitle: list.catalog?.title ?? null,
+        adjustmentBps,
+      },
+      update: {
+        name: list.name,
+        currency: list.currency,
+        surfaceKind,
+        catalogGid: list.catalog?.id ?? null,
+        catalogTitle: list.catalog?.title ?? null,
+        adjustmentBps,
+        syncedAt: new Date(),
+      },
+    });
+
+    result.priceLists++;
+    seen.push(list.id);
+
+    if (adjustmentBps !== null) {
+      // Derived. The rule is the mirror; expanding it would restate one percentage
+      // once per variant per market.
+      result.relative++;
+      continue;
+    }
+
+    result.fixed++;
+    try {
+      result.entries += await mirrorFixedPrices(client, shopId, list, surfaceKind);
+    } catch (error) {
+      result.errors.push(
+        `Could not read prices for "${list.name}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  // Lists the merchant deleted in Shopify. Their mirrored rows go too, or a campaign
+  // would keep resolving against a surface that no longer exists.
+  if (seen.length > 0) {
+    const gone = await prisma.priceListRecord.findMany({
+      where: { shopId, priceListGid: { notIn: seen } },
+      select: { priceListGid: true },
+    });
+    if (gone.length > 0) {
+      const gids = gone.map((row) => row.priceListGid);
+      await prisma.priceSurfaceEntry.deleteMany({ where: { shopId, priceListGid: { in: gids } } });
+      await prisma.priceListRecord.deleteMany({ where: { shopId, priceListGid: { in: gids } } });
+    }
+  }
+
+  logger.info("markets mirrored", {
+    shopId,
+    priceLists: result.priceLists,
+    relative: result.relative,
+    fixed: result.fixed,
+    entries: result.entries,
+  });
+
+  return result;
+}
+
+async function readPriceLists(client: AdminClient): Promise<PriceListNode[]> {
+  const lists: PriceListNode[] = [];
+  let cursor: string | null = null;
+
+  for (;;) {
+    const response: { data?: { priceLists?: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: PriceListNode[] } } } =
+      await withRetry(
+        () => client.request(PRICE_LISTS_QUERY, cursor ? { cursor } : {}),
+        isThrottledError,
+      );
+
+    const page = response.data?.priceLists;
+    if (!page) break;
+
+    lists.push(...page.nodes);
+    if (!page.pageInfo.hasNextPage) break;
+    cursor = page.pageInfo.endCursor;
+  }
+
+  return lists;
+}
+
+/**
+ * Mirrors the per-variant prices a fixed list actually stores.
+ *
+ * `RELATIVE` entries are skipped even here. Shopify returns them alongside fixed ones —
+ * they are the parent adjustment already applied — and storing them would make the
+ * mirror disagree with itself about whether the list is derived.
+ */
+async function mirrorFixedPrices(
+  client: AdminClient,
+  shopId: string,
+  list: PriceListNode,
+  surfaceKind: "MARKET" | "B2B",
+): Promise<number> {
+  let cursor: string | null = null;
+  let written = 0;
+
+  for (;;) {
+    const response: { data?: { priceList?: { prices: { pageInfo: { hasNextPage: boolean; endCursor: string }; nodes: PricesNode[] } } } } =
+      await withRetry(
+        () => client.request(PRICE_LIST_PRICES_QUERY, { id: list.id, ...(cursor ? { cursor } : {}) }),
+        isThrottledError,
+      );
+
+    const page = response.data?.priceList?.prices;
+    if (!page) break;
+
+    for (const node of page.nodes) {
+      if (!isFixedOrigin(node.originType) || !node.variant?.id || !node.price) continue;
+
+      const currency = node.price.currencyCode ?? list.currency;
+      const price = parseMoney(node.price.amount, currency);
+      const compareAt = node.compareAtPrice
+        ? parseMoney(node.compareAtPrice.amount, node.compareAtPrice.currencyCode ?? currency)
+        : null;
+
+      await prisma.priceSurfaceEntry.upsert({
+        where: {
+          shopId_variantGid_surfaceKind_priceListGid: {
+            shopId,
+            variantGid: node.variant.id,
+            surfaceKind,
+            priceListGid: list.id,
+          },
+        },
+        create: {
+          shopId,
+          variantGid: node.variant.id,
+          surfaceKind,
+          priceListGid: list.id,
+          currency,
+          livePrice: BigInt(price.amount),
+          liveCompareAt: compareAt ? BigInt(compareAt.amount) : null,
+        },
+        update: {
+          currency,
+          livePrice: BigInt(price.amount),
+          liveCompareAt: compareAt ? BigInt(compareAt.amount) : null,
+          syncedAt: new Date(),
+        },
+      });
+
+      written++;
+    }
+
+    if (!page.pageInfo.hasNextPage) break;
+    cursor = page.pageInfo.endCursor;
+  }
+
+  return written;
+}
+
+/** The shop's mirrored surfaces, for the dashboard and the surfaces wizard step. */
+export async function surfaces(shopId: string) {
+  return prisma.priceListRecord.findMany({
+    where: { shopId },
+    orderBy: [{ surfaceKind: "asc" }, { name: "asc" }],
+  });
+}

--- a/chaos/harness/fake-shopify.ts
+++ b/chaos/harness/fake-shopify.ts
@@ -33,6 +33,22 @@ export interface FakeProduct {
   tags: string[];
 }
 
+export interface FakePriceList {
+  id: string;
+  name: string;
+  currency: string;
+  /** Percentage adjustment, or null when the list stores fixed per-variant prices. */
+  adjustment: { type: string; value: number } | null;
+  catalog: { id: string; title: string; __typename: string } | null;
+  /** Per-variant entries, as Shopify reports them -- fixed and derived alike. */
+  prices: Array<{
+    variantGid: string;
+    amount: string;
+    compareAt: string | null;
+    originType: "FIXED" | "RELATIVE";
+  }>;
+}
+
 export interface FakeVariant {
   variantGid: string;
   productGid: string;
@@ -61,6 +77,9 @@ export class FakeShopify {
 
   /** Product-level state. Tags live here, not on variants, exactly as in Shopify. */
   readonly products = new Map<string, FakeProduct>();
+
+  /** Market and B2B price lists. */
+  readonly priceLists: FakePriceList[] = [];
 
   /** Every variant write this fake has accepted, in order. Scenarios assert on it. */
   readonly writeLog: Array<{ variantGid: string; price: string }> = [];
@@ -139,6 +158,12 @@ export class FakeShopify {
     }
     if (query.includes("currentBulkOperation")) {
       return this.currentBulkOperation() as { data?: T; extensions?: { cost?: QueryCost } };
+    }
+    if (query.includes("priceLists(")) {
+      return this.listPriceLists() as { data?: T; extensions?: { cost?: QueryCost } };
+    }
+    if (query.includes("priceList(")) {
+      return this.priceListPrices(variables) as { data?: T; extensions?: { cost?: QueryCost } };
     }
     if (query.includes("tagsAdd")) {
       return this.tagsAdd(variables) as { data?: T; extensions?: { cost?: QueryCost } };
@@ -264,6 +289,60 @@ export class FakeShopify {
         }),
       },
       extensions: this.cost(Math.max(1, ids.length)),
+    };
+  }
+
+  addPriceList(list: FakePriceList): void {
+    this.priceLists.push(list);
+  }
+
+  private listPriceLists() {
+    return {
+      data: {
+        priceLists: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: this.priceLists.map((list) => ({
+            id: list.id,
+            name: list.name,
+            currency: list.currency,
+            parent: list.adjustment ? { adjustment: list.adjustment } : null,
+            catalog: list.catalog,
+          })),
+        },
+      },
+      extensions: this.cost(10),
+    };
+  }
+
+  /**
+   * Prices on one list.
+   *
+   * Returns derived entries alongside fixed ones, as the real API does — that mixture
+   * is the whole reason the mirror has to look at `originType` rather than storing
+   * whatever it is handed.
+   */
+  private priceListPrices(variables: Record<string, unknown>) {
+    const list = this.priceLists.find((l) => l.id === String(variables.id ?? ""));
+    if (!list) return { data: { priceList: null }, extensions: this.cost(1) };
+
+    return {
+      data: {
+        priceList: {
+          id: list.id,
+          prices: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: list.prices.map((entry) => ({
+              originType: entry.originType,
+              variant: { id: entry.variantGid },
+              price: { amount: entry.amount, currencyCode: list.currency },
+              compareAtPrice: entry.compareAt
+                ? { amount: entry.compareAt, currencyCode: list.currency }
+                : null,
+            })),
+          },
+        },
+      },
+      extensions: this.cost(5),
     };
   }
 

--- a/chaos/scenarios/markets-mirror.chaos.ts
+++ b/chaos/scenarios/markets-mirror.chaos.ts
@@ -1,0 +1,169 @@
+/**
+ * Mirroring markets and B2B price lists.
+ *
+ * The failure that matters here is one of scale rather than of correctness. Most market
+ * price lists do not store prices — they hold a percentage against the base list and
+ * Shopify derives the rest — and a mirror that expanded those per variant would turn one
+ * number into two million rows on a 500K-variant catalogue across four markets. Every
+ * one of them restating the same percentage, and every one of them needing to stay in
+ * step with it.
+ *
+ * So the scenario asserts what is *absent* as carefully as what is present: a relative
+ * list contributes its rule and not a single mirrored row, even though Shopify returns
+ * a price per variant when asked.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { syncMarkets } from "../../app/services/markets-sync.server";
+import { chaosAdminClient } from "../harness/http-client";
+import { withChaos } from "../harness/scenario";
+
+describe("chaos: mirroring market and B2B price lists", () => {
+  it("stores a relative list as its rule and a fixed list as rows", async () => {
+    await withChaos(
+      "markets-mirror",
+      { catalog: { products: 4, variantsPerProduct: 2 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        // A market list that derives everything from a 5% decrease. Shopify answers
+        // with a price per variant regardless, all marked RELATIVE.
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/relative",
+          name: "Canada",
+          currency: "CAD",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 5 },
+          catalog: { id: "gid://shopify/MarketCatalog/1", title: "Canada", __typename: "MarketCatalog" },
+          prices: variantGids.map((gid) => ({
+            variantGid: gid,
+            amount: "1.00",
+            compareAt: null,
+            originType: "RELATIVE" as const,
+          })),
+        });
+
+        // A B2B list that genuinely stores prices. No catalog, which is how a
+        // company-location list presents.
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/fixed",
+          name: "Wholesale",
+          currency: "USD",
+          adjustment: null,
+          catalog: null,
+          prices: [
+            { variantGid: variantGids[0], amount: "12.34", compareAt: "20.00", originType: "FIXED" },
+            { variantGid: variantGids[1], amount: "56.78", compareAt: null, originType: "FIXED" },
+            // Mixed in, as the real API does. Storing it would make the mirror
+            // disagree with itself about whether the list is derived.
+            { variantGid: variantGids[2], amount: "99.99", compareAt: null, originType: "RELATIVE" },
+          ],
+        });
+
+        const result = await syncMarkets(client, shopId);
+
+        expect(result.priceLists).toBe(2);
+        expect(result.relative).toBe(1);
+        expect(result.fixed).toBe(1);
+        // Two fixed entries. Not three, and emphatically not eight plus three.
+        expect(result.entries).toBe(2);
+        expect(result.errors).toEqual([]);
+
+        // ------------------------------------------------- the rule, not the rows
+        const relative = await prisma.priceListRecord.findFirstOrThrow({
+          where: { shopId, priceListGid: "gid://shopify/PriceList/relative" },
+        });
+        expect(relative.adjustmentBps).toBe(-500);
+        expect(relative.surfaceKind).toBe("MARKET");
+        expect(relative.currency).toBe("CAD");
+
+        const expandedAnyway = await prisma.priceSurfaceEntry.count({
+          where: { shopId, priceListGid: "gid://shopify/PriceList/relative" },
+        });
+        expect(expandedAnyway).toBe(0);
+
+        // ------------------------------------------------------ the fixed rows
+        const fixed = await prisma.priceListRecord.findFirstOrThrow({
+          where: { shopId, priceListGid: "gid://shopify/PriceList/fixed" },
+        });
+        expect(fixed.adjustmentBps).toBeNull();
+        // No catalog means a company-location list, which is B2B rather than a market.
+        expect(fixed.surfaceKind).toBe("B2B");
+
+        const rows = await prisma.priceSurfaceEntry.findMany({
+          where: { shopId, priceListGid: "gid://shopify/PriceList/fixed" },
+          orderBy: { variantGid: "asc" },
+        });
+        expect(rows).toHaveLength(2);
+        expect(rows.map((r) => Number(r.livePrice)).sort((a, b) => a - b)).toEqual([1_234, 5_678]);
+        // Compare-at is mirrored per surface where it exists, and left null where not.
+        expect(rows.filter((r) => r.liveCompareAt !== null)).toHaveLength(1);
+
+        // ----------------------------------------- base rows are still uniform
+        // The temptation is to read base prices from variant_index and reserve this
+        // table for markets. One shape for "the live value on surface X" is what lets
+        // everything downstream read all three surfaces without branching.
+        const base = await prisma.priceSurfaceEntry.count({
+          where: { shopId, surfaceKind: "BASE", priceListGid: "" },
+        });
+        expect(base).toBe(variantGids.length);
+      },
+    );
+  });
+
+  it("forgets a list the merchant deleted, and its mirrored rows with it", async () => {
+    await withChaos(
+      "markets-deleted",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/doomed",
+          name: "Temporary",
+          currency: "USD",
+          adjustment: null,
+          catalog: null,
+          prices: [
+            { variantGid: variantGids[0], amount: "5.00", compareAt: null, originType: "FIXED" },
+          ],
+        });
+
+        await syncMarkets(client, shopId);
+        expect(
+          await prisma.priceSurfaceEntry.count({
+            where: { shopId, priceListGid: "gid://shopify/PriceList/doomed" },
+          }),
+        ).toBe(1);
+
+        // Deleted in Shopify. Its mirrored rows must go too, or a campaign keeps
+        // resolving against a surface that no longer exists.
+        chaos.fake.priceLists.length = 0;
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/survivor",
+          name: "Kept",
+          currency: "USD",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/2", title: "EU", __typename: "MarketCatalog" },
+          prices: [],
+        });
+
+        await syncMarkets(client, shopId);
+
+        expect(
+          await prisma.priceListRecord.count({
+            where: { shopId, priceListGid: "gid://shopify/PriceList/doomed" },
+          }),
+        ).toBe(0);
+        expect(
+          await prisma.priceSurfaceEntry.count({
+            where: { shopId, priceListGid: "gid://shopify/PriceList/doomed" },
+          }),
+        ).toBe(0);
+      },
+    );
+  });
+});

--- a/prisma/migrations/20260825234500_price_lists/migration.sql
+++ b/prisma/migrations/20260825234500_price_lists/migration.sql
@@ -1,0 +1,29 @@
+-- Market and B2B price list topology (P1.2).
+--
+-- `adjustmentBps` records a parent percentage adjustment in basis points rather than
+-- expanding it into a mirrored row per variant: a 500K-variant catalogue across four
+-- markets would otherwise be two million rows restating one percentage. Null means the
+-- list stores fixed per-variant prices, which are mirrored into price_surface_entries
+-- as usual.
+--
+-- Expand-only: a new table and its indexes.
+CREATE TABLE "price_lists" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "priceListGid" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "currency" TEXT NOT NULL,
+    "surfaceKind" "SurfaceKind" NOT NULL DEFAULT 'MARKET',
+    "catalogGid" TEXT,
+    "catalogTitle" TEXT,
+    "adjustmentBps" INTEGER,
+    "syncedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "price_lists_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "price_lists_shopId_priceListGid_key" ON "price_lists"("shopId", "priceListGid");
+CREATE INDEX "price_lists_shopId_surfaceKind_idx" ON "price_lists"("shopId", "surfaceKind");
+
+ALTER TABLE "price_lists" ADD CONSTRAINT "price_lists_shopId_fkey"
+  FOREIGN KEY ("shopId") REFERENCES "shops"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,7 @@ model Shop {
   writeIntents     WriteIntent[]
   driftEvents      DriftEvent[]
   roundingProfiles RoundingProfileRecord[]
+  priceLists       PriceListRecord[]
   webhookEvents    WebhookEvent[]
   bulkOps          BulkOperationRecord[]
   auditEntries     AuditLogEntry[]
@@ -567,6 +568,44 @@ model DriftEvent {
 enum RoundingMode {
   CHARM
   STEP
+}
+
+/// A market or B2B price list, and how it derives its prices.
+///
+/// The mode is load-bearing rather than informational. A list with a `PriceListParent`
+/// percentage adjustment *derives* every price from the base one; a list with fixed
+/// overrides *stores* them. That decides whether a campaign can be written with one
+/// mutation against the parent adjustment (P5.2) or has to write a row per variant —
+/// the difference between one API call and five hundred thousand.
+///
+/// It is also why a relative list is never expanded into `price_surface_entries`. A
+/// 500K-variant catalogue across four markets would be two million mirrored rows
+/// restating a single percentage.
+model PriceListRecord {
+  id String @id @default(cuid())
+
+  shopId       String
+  priceListGid String
+  name         String
+  currency     String
+
+  /// MARKET for a market catalog, B2B for a company-location one.
+  surfaceKind SurfaceKind @default(MARKET)
+
+  catalogGid   String?
+  catalogTitle String?
+
+  /// Basis points, so the adjustment never touches a float. A 5% decrease is -500.
+  /// Null means the list stores fixed per-variant prices instead.
+  adjustmentBps Int?
+
+  syncedAt DateTime @default(now())
+
+  shop Shop @relation(fields: [shopId], references: [id], onDelete: Cascade)
+
+  @@unique([shopId, priceListGid])
+  @@index([shopId, surfaceKind])
+  @@map("price_lists")
 }
 
 model RoundingProfileRecord {

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -30,7 +30,7 @@ api_version = "2026-07"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "write_products"
+scopes = "write_products,read_markets,write_markets"
 optional_scopes = [ ]
 use_legacy_install_flow = false
 


### PR DESCRIPTION
Until now **every** `price_surface_entries` row was written with an empty
`priceListGid` — the base surface and nothing else. A product positioned as a
*multi-market* price campaign manager had no read side for the markets at all, and all
of P5 sits on this.

## `write_products` is not enough

Which is the empirical answer P0.2 (#23) was asking for. Querying `markets` returns:

```
Access denied for markets field. Required access: `read_markets` for queries and
both `read_markets` as well as `write_markets` for mutations.
```

Added `read_markets` and `write_markets`, and recorded the finding on
[#23](https://github.com/rishu605/bulk-price-editor/issues/23#issuecomment-5414668291).

Every scope is friction at the install prompt and `write_markets` is a broad-sounding
thing to ask a merchant for — worth knowing you are making that trade. But there is no
version of this product that works without seeing a market price.

## A relative list is stored as its rule, never expanded

Most market lists do not hold prices. They hold a percentage against the base list and
Shopify derives the rest — returning a price per variant when asked, every one marked
`RELATIVE`.

Mirroring those would turn **one number into two million rows** on a 500K-variant
catalogue across four markets, all restating the same percentage, all needing to stay in
step with it. Only `FIXED` entries carry anything the rule does not already hold.

The mode is load-bearing beyond storage: it decides whether P5.2 can reprice a whole
market with one mutation against the parent adjustment, or has to write a row per
variant.

## Integers, and an honest unknown

The adjustment is basis points and never a float. Shopify reports it as a JSON number,
and 5% arriving as `5.000000000000001` is harmless right up until it multiplies a
six-figure catalogue.

An unrecognised adjustment kind returns `null`, not `0`. Zero is a *real* adjustment
meaning "same as base"; conflating the two would mirror a market at the wrong price with
nothing to indicate it.

## Base rows stay in the same table

Deliberately, and the ticket says so too. One uniform shape for "the live value on
surface X" is what lets the resolver, preview, planner and reconciliation read all three
surfaces without branching — and four branches is four chances for the market path to
disagree with the base one about a merchant's prices.

## Verified live

3 price lists mirrored in **509ms** against the dev store:

```
MARKET  CAD   -500bps  Canada Buyers      [Catalog for Canada]
MARKET  USD      0bps  pricing_by_market  [United States]
B2B     USD   -500bps  Price List example Buyers  [no catalog]
```

All three relative → **zero per-variant rows written**. The B2B list was classified from
having no catalog, which is how a company-location list presents.

Two chaos scenarios cover what the dev store cannot: a fixed list alongside a relative
one — with a `RELATIVE` entry mixed into the fixed list's prices as the real API does —
and a deleted list taking its mirrored rows with it. Expanding relative lists per variant
turns the first red (`expected 2 to be 1`).

- 343 unit tests (12 new, incl. a property test that no adjustment yields a fractional
  minor unit), 16 chaos scenarios, typecheck/lint/build clean

Stacked on #207 → #206 → #205 → #204 → #203.

Closes #67, #68, #69, #70, #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)