### PR TITLE
P1.5 — Baseline CSV import with row-level validation

### DIFF
--- a/app/lib/baselines/csv-rows.test.ts
+++ b/app/lib/baselines/csv-rows.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Row-level validation, and the rule that one bad row never fails the file.
+ *
+ * On five hundred thousand rows, a malformed price should cost that row and nothing
+ * else. A merchant who has to find the single bad line in a spreadsheet before anything
+ * at all happens is a merchant who gives up on the import — and the import is the
+ * feature that lets "20% off MSRP" mean what it says.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { money } from "../money/money";
+import {
+  isValid,
+  mapColumns,
+  readRows,
+  splitCsvLine,
+  validateRow,
+  type InvalidRow,
+  type RawRow,
+} from "./csv-rows";
+
+const row = (over: Partial<RawRow> = {}): RawRow => ({
+  line: 2,
+  identifier: "SKU-1",
+  price: "19.99",
+  ...over,
+});
+
+const check = (over: Partial<RawRow> = {}, currency = "USD") => validateRow(row(over), currency);
+const problemOf = (r: ReturnType<typeof validateRow>) => (r as InvalidRow).problem;
+
+describe("validateRow", () => {
+  it("parses a good row into integer minor units", () => {
+    const result = check();
+    if (!isValid(result)) throw new Error("expected valid");
+    expect(result.parsedPrice).toEqual(money(1_999, "USD"));
+    expect(result.parsedCompareAt).toBeNull();
+  });
+
+  it("rejects a price that is not a plain number, and says how to fix it", () => {
+    const result = check({ price: "$1,299.00" });
+    expect(problemOf(result)).toBe("price-unparseable");
+    expect((result as InvalidRow).reason).toContain("1299.00");
+  });
+
+  it("refuses zero as firmly as negative", () => {
+    // Not merely odd: every percentage campaign computed from a zero baseline resolves
+    // to zero, so one bad row would put a product on sale for nothing.
+    expect(problemOf(check({ price: "0" }))).toBe("price-not-positive");
+    expect(problemOf(check({ price: "0.00" }))).toBe("price-not-positive");
+    expect(problemOf(check({ price: "-5.00" }))).toBe("price-not-positive");
+  });
+
+  it("requires compare-at to be above the price", () => {
+    // Below or equal, the storefront shows a strike-through that reads as an increase.
+    expect(problemOf(check({ compareAt: "19.99" }))).toBe("compare-at-not-above-price");
+    expect(problemOf(check({ compareAt: "9.99" }))).toBe("compare-at-not-above-price");
+
+    const ok = check({ compareAt: "29.99" });
+    if (!isValid(ok)) throw new Error("expected valid");
+    expect(ok.parsedCompareAt).toEqual(money(2_999, "USD"));
+  });
+
+  it("honours the currency's precision, per row", () => {
+    // "1200.50" is two decimals too many for JPY and exactly right for USD. Getting
+    // this wrong writes a baseline a hundred times off.
+    expect(problemOf(check({ price: "1200.50" }, "JPY"))).toBe("price-unparseable");
+
+    const yen = check({ price: "1200" }, "JPY");
+    if (!isValid(yen)) throw new Error("expected valid");
+    expect(yen.parsedPrice).toEqual(money(1_200, "JPY"));
+  });
+
+  it("takes the currency from the row when the file names one", () => {
+    const result = check({ price: "1200", currency: "jpy" }, "USD");
+    if (!isValid(result)) throw new Error("expected valid");
+    expect(result.parsedPrice.currency).toBe("JPY");
+  });
+
+  it("names the row and the next action for every problem", () => {
+    for (const bad of [
+      check({ identifier: "" }),
+      check({ price: "" }),
+      check({ price: "abc" }),
+      check({ price: "0" }),
+      check({ compareAt: "abc" }),
+      check({ compareAt: "1.00" }),
+    ]) {
+      expect(isValid(bad)).toBe(false);
+      expect((bad as InvalidRow).reason.length).toBeGreaterThan(30);
+      expect((bad as InvalidRow).line).toBe(2);
+    }
+  });
+});
+
+describe("splitCsvLine", () => {
+  it("honours quotes and doubled quotes", () => {
+    expect(splitCsvLine('SKU-1,"Red, large",19.99')).toEqual(["SKU-1", "Red, large", "19.99"]);
+    expect(splitCsvLine('"24"" monitor",99')).toEqual(['24" monitor', "99"]);
+  });
+});
+
+describe("mapColumns", () => {
+  it("finds columns by any of their common names", () => {
+    expect(mapColumns(["SKU", "MSRP", "was_price"])).toEqual({
+      identifier: 0,
+      price: 1,
+      compareAt: 2,
+      currency: null,
+    });
+  });
+
+  it("returns null when it cannot tell which column is the price", () => {
+    // Guessing wrong here imports five hundred thousand wrong baselines. No map means
+    // the caller falls back to positions it can describe to the merchant.
+    expect(mapColumns(["a", "b", "c"])).toBeNull();
+    expect(mapColumns(["sku", "title", "vendor"])).toBeNull();
+  });
+});
+
+describe("readRows", () => {
+  async function* lines(...items: string[]) {
+    for (const item of items) yield item;
+  }
+  const collect = async (source: AsyncIterable<string>) => {
+    const out = [];
+    for await (const r of readRows(source)) out.push(r);
+    return out;
+  };
+
+  it("consumes a recognised header rather than importing it", () => {
+    return collect(lines("sku,price", "SKU-1,10.00")).then((rows) => {
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ line: 2, identifier: "SKU-1", price: "10.00" });
+    });
+  });
+
+  it("treats a file with no header as data from the first line", async () => {
+    const rows = await collect(lines("SKU-1,10.00", "SKU-2,20.00"));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].line).toBe(1);
+  });
+
+  it("keeps line numbers pointing at the merchant's spreadsheet", async () => {
+    // Blank lines are skipped but must not shift the numbers, or every error in the
+    // report points at the wrong row.
+    const rows = await collect(lines("sku,price", "SKU-1,10.00", "", "", "SKU-2,20.00"));
+    expect(rows.map((r) => r.line)).toEqual([2, 5]);
+  });
+
+  it("reads extra columns when the header names them", async () => {
+    const rows = await collect(lines("sku,price,compare_at,currency", "SKU-1,10.00,15.00,EUR"));
+    expect(rows[0]).toMatchObject({ compareAt: "15.00", currency: "EUR" });
+  });
+});

--- a/app/lib/baselines/csv-rows.ts
+++ b/app/lib/baselines/csv-rows.ts
@@ -1,0 +1,222 @@
+/**
+ * Reading a merchant's own reference prices, one row at a time.
+ *
+ * This is the feature that answers a competitor's one-star review: a merchant wanted
+ * discounts computed against actual MSRP and the app could only work from whatever the
+ * storefront happened to show. An imported baseline makes "20% off MSRP" mean exactly
+ * that, permanently, however many campaigns have run since.
+ *
+ * **A bad row must never fail the file.** On five hundred thousand rows, one malformed
+ * price should produce one error line, not a rejected import — a merchant who has to
+ * find the single bad row in a spreadsheet before anything at all happens is a merchant
+ * who gives up. So every row is validated on its own and the failures come back as a
+ * list they can fix and re-upload.
+ *
+ * Validation is deliberately strict about the things that would produce a wrong price
+ * and permissive about the things that would not. A price with too many decimals for
+ * its currency is refused; a stray column, a header, or a blank line is not.
+ */
+
+import { parseMoney, type Money } from "../money/money";
+
+export interface RawRow {
+  /** 1-based line in the file, so an error points at something findable. */
+  line: number;
+  identifier: string;
+  price: string;
+  compareAt?: string;
+  currency?: string;
+}
+
+export interface ValidRow extends RawRow {
+  parsedPrice: Money;
+  parsedCompareAt: Money | null;
+}
+
+export type RowProblem =
+  | "no-identifier"
+  | "no-price"
+  | "price-unparseable"
+  | "price-not-positive"
+  | "compare-at-unparseable"
+  | "compare-at-not-above-price";
+
+export interface InvalidRow extends RawRow {
+  problem: RowProblem;
+  /** Names the row, the cause and the next action, per the error taxonomy. */
+  reason: string;
+}
+
+const REASONS: Record<RowProblem, string> = {
+  "no-identifier": "No SKU, barcode or product ID in the first column — nothing to match on.",
+  "no-price": "No price given. Leave the row out rather than leaving the price blank.",
+  "price-unparseable":
+    "Price is not a plain number. Remove currency symbols and thousands separators — 1299.00, not $1,299.00.",
+  "price-not-positive":
+    "Price must be above zero. A baseline of zero would make every percentage campaign compute to zero.",
+  "compare-at-unparseable": "Compare-at price is not a plain number.",
+  "compare-at-not-above-price":
+    "Compare-at must be higher than the price, or the storefront shows a strike-through that reads as a price increase.",
+};
+
+/**
+ * Validates one row.
+ *
+ * Currency comes from the row where given and from the shop otherwise, because
+ * precision is currency-specific: "1200.50" is three decimals too many for JPY and
+ * exactly right for USD, and getting that wrong writes a baseline a hundred times off.
+ */
+export function validateRow(row: RawRow, shopCurrency: string): ValidRow | InvalidRow {
+  const fail = (problem: RowProblem): InvalidRow => ({ ...row, problem, reason: REASONS[problem] });
+
+  if (!row.identifier?.trim()) return fail("no-identifier");
+  if (!row.price?.trim()) return fail("no-price");
+
+  const currency = (row.currency?.trim() || shopCurrency).toUpperCase();
+
+  let parsedPrice: Money;
+  try {
+    parsedPrice = parseMoney(row.price.trim(), currency);
+  } catch {
+    return fail("price-unparseable");
+  }
+
+  // Zero is refused as firmly as negative. A zero baseline is not merely odd: every
+  // percentage campaign computed from it resolves to zero, so one bad row would put a
+  // product on sale for nothing.
+  if (parsedPrice.amount <= 0) return fail("price-not-positive");
+
+  let parsedCompareAt: Money | null = null;
+  if (row.compareAt?.trim()) {
+    try {
+      parsedCompareAt = parseMoney(row.compareAt.trim(), currency);
+    } catch {
+      return fail("compare-at-unparseable");
+    }
+    if (parsedCompareAt.amount <= parsedPrice.amount) return fail("compare-at-not-above-price");
+  }
+
+  return { ...row, parsedPrice, parsedCompareAt };
+}
+
+export function isValid(row: ValidRow | InvalidRow): row is ValidRow {
+  return "parsedPrice" in row;
+}
+
+/** Header names understood for each column, so a merchant's export mostly just works. */
+const HEADERS: Record<"identifier" | "price" | "compareAt" | "currency", string[]> = {
+  identifier: ["sku", "barcode", "variant", "variant_id", "variantid", "gid", "id", "handle", "product"],
+  price: ["price", "baseline", "baseline_price", "msrp", "list_price", "list price", "rrp"],
+  compareAt: ["compare_at", "compare at", "compareatprice", "compare_at_price", "was", "was_price"],
+  currency: ["currency", "currency_code", "currencycode"],
+};
+
+export interface ColumnMap {
+  identifier: number;
+  price: number;
+  compareAt: number | null;
+  currency: number | null;
+}
+
+/**
+ * Works out which column is which from a header row.
+ *
+ * Merchants export from a spreadsheet or an ERP and the file arrives with whatever
+ * columns that produced. Insisting on an exact layout is a good way to have the feature
+ * go unused; guessing wrong about which column is the price is a good way to import
+ * five hundred thousand wrong baselines, so an unrecognised header means no map and the
+ * caller falls back to positional columns it can describe to the merchant.
+ */
+export function mapColumns(header: readonly string[]): ColumnMap | null {
+  const find = (names: string[]) =>
+    header.findIndex((cell) => names.includes(cell.trim().toLowerCase()));
+
+  const identifier = find(HEADERS.identifier);
+  const price = find(HEADERS.price);
+  if (identifier === -1 || price === -1) return null;
+
+  const compareAt = find(HEADERS.compareAt);
+  const currency = find(HEADERS.currency);
+
+  return {
+    identifier,
+    price,
+    compareAt: compareAt === -1 ? null : compareAt,
+    currency: currency === -1 ? null : currency,
+  };
+}
+
+/** Splits one CSV line into cells, honouring quotes and doubled quotes. */
+export function splitCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (quoted) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          quoted = false;
+        }
+      } else {
+        cell += char;
+      }
+      continue;
+    }
+
+    if (char === '"') quoted = true;
+    else if (char === ",") {
+      cells.push(cell);
+      cell = "";
+    } else cell += char;
+  }
+
+  cells.push(cell);
+  return cells.map((c) => c.trim());
+}
+
+/**
+ * Streams a CSV into raw rows.
+ *
+ * Line by line, never holding the file: a five-hundred-thousand-row import is tens of
+ * megabytes, and the point of an import is that it works on the catalogue the merchant
+ * actually has.
+ */
+export async function* readRows(
+  lines: AsyncIterable<string>,
+  fallback: ColumnMap = { identifier: 0, price: 1, compareAt: 2, currency: 3 },
+): AsyncGenerator<RawRow> {
+  let columns: ColumnMap | null = null;
+  let lineNumber = 0;
+
+  for await (const raw of lines) {
+    lineNumber++;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+
+    const cells = splitCsvLine(trimmed);
+
+    if (columns === null) {
+      const mapped = mapColumns(cells);
+      if (mapped) {
+        // That was a header. Consume it rather than importing it as a product.
+        columns = mapped;
+        continue;
+      }
+      columns = fallback;
+    }
+
+    yield {
+      line: lineNumber,
+      identifier: cells[columns.identifier] ?? "",
+      price: cells[columns.price] ?? "",
+      compareAt: columns.compareAt === null ? undefined : cells[columns.compareAt],
+      currency: columns.currency === null ? undefined : cells[columns.currency],
+    };
+  }
+}

--- a/app/lib/reporting/baseline-errors.ts
+++ b/app/lib/reporting/baseline-errors.ts
@@ -1,0 +1,41 @@
+/**
+ * The baseline import error file.
+ *
+ * Client-safe, like the other exports: the download is built in the browser from data
+ * the page already holds, because a resource route cannot authenticate inside an
+ * embedded app's iframe.
+ *
+ * It exists because the point is to fix the rows and re-upload. A list a merchant has
+ * to retype off a screen is a list they will not fix.
+ */
+
+import { toCsv } from "./csv";
+
+export interface ImportProblem {
+  line: number;
+  identifier: string;
+  reason: string;
+}
+
+export interface ProblemReport {
+  invalid: ImportProblem[];
+  unmatched: ImportProblem[];
+  ambiguous: ImportProblem[];
+}
+
+export function importErrorCsv(report: ProblemReport): string {
+  const rows: string[][] = [];
+
+  for (const [kind, list] of [
+    ["invalid", report.invalid],
+    ["unmatched", report.unmatched],
+    ["ambiguous", report.ambiguous],
+  ] as const) {
+    for (const problem of list) {
+      rows.push([String(problem.line), problem.identifier, kind, problem.reason]);
+    }
+  }
+
+  rows.sort((a, b) => Number(a[0]) - Number(b[0]));
+  return toCsv(["line", "identifier", "problem", "what_to_do"], rows);
+}

--- a/app/routes/app.baselines.import.tsx
+++ b/app/routes/app.baselines.import.tsx
@@ -1,0 +1,250 @@
+/**
+ * Importing baselines from a file.
+ *
+ * Baselines captured at install are whatever the storefront happened to show that day.
+ * For a merchant who maintains MSRP in an ERP, that is the wrong number — and it is the
+ * number every campaign computes from, permanently. This is how they replace it.
+ *
+ * Dry run is the default and the button says so. A baseline is not a price you can
+ * glance at afterwards and correct; it silently mis-prices every campaign from here on,
+ * so reviewing before writing is the normal path rather than the careful one.
+ */
+
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useRef } from "react";
+import { useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { shopCurrency } from "../services/settings.server";
+import { importBaselines, type BaselineImportResult } from "../services/baseline-import.server";
+import { importErrorCsv } from "../lib/reporting/baseline-errors";
+import { downloadCsv } from "../lib/reporting/csv";
+import { actorFor } from "../lib/audit/actor";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+import { reportError } from "../services/error-report.server";
+
+export const loader = withGuard("/app/baselines/import", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  return { currency: await shopCurrency(shop.id) };
+});
+
+type ActionData = { ok: boolean; message: string; result?: BaselineImportResult; errorId?: string };
+
+export const action = withGuard("/app/baselines/import", async ({ request }: ActionFunctionArgs) => {
+  const { session, sessionToken } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  const csv = String(form.get("csv") ?? "");
+  const dryRun = String(form.get("intent")) !== "commit";
+
+  try {
+    const result = await importBaselines(
+      shop.id,
+      linesOf(csv),
+      await shopCurrency(shop.id),
+      { dryRun, actor: actorFor(sessionToken, session.shop) },
+    );
+
+    return {
+      ok: true,
+      result,
+      message: dryRun
+        ? `${result.ready} of ${result.total} rows would be imported. Nothing has been written.`
+        : `Imported ${result.written} baselines.` +
+          (result.unchanged > 0 ? ` ${result.unchanged} already matched and were left alone.` : ""),
+    };
+  } catch (error) {
+    const reported = await reportError(error, {
+      shopId: shop.id,
+      shop: session.shop,
+      route: "/app/baselines/import",
+    });
+    return { ok: false, message: reported.userMessage, errorId: reported.errorId };
+  }
+});
+
+/** Splits pasted text into lines without holding a second copy of the whole file. */
+async function* linesOf(text: string): AsyncGenerator<string> {
+  let start = 0;
+  for (;;) {
+    const next = text.indexOf("\n", start);
+    if (next === -1) break;
+    yield text.slice(start, next).replace(/\r$/, "");
+    start = next + 1;
+  }
+  if (start < text.length) yield text.slice(start);
+}
+
+export default function ImportBaselines() {
+  const { currency } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const busy = fetcher.state !== "idle";
+  const data = fetcher.data;
+  const result = data?.result;
+
+  const form = useRef<HTMLFormElement>(null);
+  const intent = useRef<HTMLInputElement>(null);
+
+  const submitWith = (value: string) => {
+    if (intent.current) intent.current.value = value;
+    form.current?.requestSubmit();
+  };
+
+  return (
+    <s-page heading="Import baselines">
+      {data ? (
+        <s-banner tone={data.ok ? "success" : "critical"}>
+          <s-paragraph>{data.message}</s-paragraph>
+          {data.errorId ? <s-paragraph>Reference {data.errorId}</s-paragraph> : null}
+        </s-banner>
+      ) : null}
+
+      <s-section heading="Your reference prices">
+        <s-paragraph>
+          <s-text>
+            Every campaign computes from a variant&rsquo;s baseline, not from its current
+            price. If you keep an MSRP or list price elsewhere, import it here and
+            &ldquo;20% off&rdquo; will mean 20% off that number — permanently, however
+            many campaigns run in between.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            One row per variant: a SKU, barcode or variant ID, then the price. A
+            compare-at and a currency column are optional. Prices are read in {currency}{" "}
+            unless a row says otherwise, and must be plain numbers — 1299.00, not
+            $1,299.00.
+          </s-text>
+        </s-paragraph>
+
+        <fetcher.Form method="post" ref={form}>
+          {/* `s-button` takes no name/value, so the intent rides in a hidden field the
+              buttons set before submitting. One form, because both actions read the
+              same rows and duplicating the textarea would let them drift apart. */}
+          <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
+          <s-stack gap="base">
+            {/* A native textarea rather than `s-text-area`, for the same reason the
+                selects on this page are native: a plain element that is certain to
+                serialise into the form, with no web-component behaviour between the
+                merchant's paste and the request. */}
+            <label htmlFor="csv">Rows</label>
+            <textarea id="csv" name="csv" rows={12} style={{ width: "100%", fontFamily: "monospace" }} />
+            <s-stack direction="inline" gap="base">
+              <s-button
+                type="button"
+                variant="primary"
+                loading={busy || undefined}
+                onClick={() => submitWith("dry-run")}
+              >
+                Check the file
+              </s-button>
+              <s-button
+                type="button"
+                tone="critical"
+                loading={busy || undefined}
+                disabled={!result || result.ready === 0 || undefined}
+                onClick={() => submitWith("commit")}
+              >
+                Import {result?.ready ?? 0} baselines
+              </s-button>
+            </s-stack>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      {result ? <ImportReport result={result} /> : null}
+
+      <s-section slot="aside" heading="Why this is checked first">
+        <s-paragraph>
+          <s-text>
+            A baseline is not a price you can glance at afterwards and correct. It is the
+            number every future campaign computes from, so a wrong one quietly
+            mis-prices a product on every sale from here on.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            Rows that match two variants are never guessed at. Choosing one could set the
+            wrong product&rsquo;s reference price permanently, so they are listed for you
+            to resolve with a variant ID instead.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+function ImportReport({ result }: { result: BaselineImportResult }) {
+  const problems = [
+    ...result.invalid.map((p) => ({ ...p, kind: "Will not parse" })),
+    ...result.unmatched.map((p) => ({ ...p, kind: "No match" })),
+    ...result.ambiguous.map((p) => ({ ...p, kind: "Matches several" })),
+  ].sort((a, b) => a.line - b.line);
+
+  return (
+    <s-section heading={result.dryRun ? "What would happen" : "What happened"}>
+      <s-paragraph>
+        <s-text>
+          {result.total} rows read · {result.ready} ready · {result.unchanged} already
+          correct · {problems.length} need attention
+        </s-text>
+      </s-paragraph>
+
+      {problems.length === 0 ? (
+        <s-paragraph>
+          <s-text>Every row matched a variant and validated.</s-text>
+        </s-paragraph>
+      ) : (
+        <>
+          <s-stack direction="inline" gap="base">
+            <s-paragraph>
+              <s-text>
+                These rows were left out. Everything else is unaffected — one bad row
+                never fails the file.
+              </s-text>
+            </s-paragraph>
+            <s-button
+              type="button"
+              variant="tertiary"
+              onClick={() => downloadCsv("baseline-import-errors.csv", importErrorCsv(result))}
+            >
+              Download the list
+            </s-button>
+          </s-stack>
+
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Line</s-table-header>
+              <s-table-header>Identifier</s-table-header>
+              <s-table-header>Problem</s-table-header>
+              <s-table-header>What to do</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {problems.slice(0, 25).map((problem) => (
+                <s-table-row key={`${problem.line}-${problem.identifier}`}>
+                  <s-table-cell>{problem.line}</s-table-cell>
+                  <s-table-cell>{problem.identifier || "—"}</s-table-cell>
+                  <s-table-cell>{problem.kind}</s-table-cell>
+                  <s-table-cell>{problem.reason}</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </>
+      )}
+    </s-section>
+  );
+}
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.segments.tsx
+++ b/app/routes/app.segments.tsx
@@ -275,7 +275,15 @@ export default function Segments() {
           <input type="hidden" name="intent" value="create-from-csv" />
           <s-stack gap="base">
             <s-text-field name="name" label="Name" placeholder="Clearance list" required />
-            <s-text-area name="csv" label="SKUs, barcodes or IDs" rows={8} />
+            {/* Native, like the selects above it — a plain element that is certain
+                to serialise a pasted list into the form. */}
+            <label htmlFor="segment-csv">SKUs, barcodes or IDs</label>
+            <textarea
+              id="segment-csv"
+              name="csv"
+              rows={8}
+              style={{ width: "100%", fontFamily: "monospace" }}
+            />
             <s-button type="submit" variant="primary" loading={busy || undefined}>
               Match and create
             </s-button>

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -25,6 +25,7 @@ export default function App() {
         <s-link href="/app/campaigns">Campaigns</s-link>
         <s-link href="/app/segments">Segments</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
+        <s-link href="/app/baselines/import">Import baselines</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/activity">Activity</s-link>
         <s-link href="/app/settings">Settings</s-link>

--- a/app/services/baseline-import.server.ts
+++ b/app/services/baseline-import.server.ts
@@ -1,0 +1,275 @@
+/**
+ * Importing a merchant's own reference prices.
+ *
+ * Baselines captured at install are whatever the storefront happened to be showing that
+ * day. For a merchant who maintains MSRP in an ERP, that is the wrong number — and it
+ * is the number every campaign computes from forever after. Importing lets "20% off
+ * MSRP" mean exactly that.
+ *
+ * Two things this refuses to do, both for the same reason: a baseline is permanent, and
+ * a wrong one silently mis-prices a product on every campaign from here on.
+ *
+ *   It never guesses a match. A SKU that names two variants is a question, not a match.
+ *
+ *   It never half-applies. Dry run is not a nicety bolted on afterwards — it is the
+ *   same code path with the write skipped, so what the merchant reviews is what happens.
+ */
+
+import prisma from "../db.server";
+import {
+  buildMatchIndex,
+  matchIdentifiers,
+  type AmbiguousRow,
+  type CsvRow,
+} from "../lib/segments/csv-import";
+import {
+  isValid,
+  readRows,
+  validateRow,
+  type InvalidRow,
+  type ValidRow,
+} from "../lib/baselines/csv-rows";
+import { logger } from "../lib/logging/logger";
+
+export interface ImportProblem {
+  line: number;
+  identifier: string;
+  reason: string;
+}
+
+export interface BaselineImportResult {
+  /** Rows read from the file, excluding a header. */
+  total: number;
+  /** Rows that validated, matched exactly one variant, and would be written. */
+  ready: number;
+  /** Rows written. Zero on a dry run, by construction. */
+  written: number;
+  /** Rows whose new baseline equals the current one, so nothing changes. */
+  unchanged: number;
+  invalid: ImportProblem[];
+  unmatched: ImportProblem[];
+  ambiguous: ImportProblem[];
+  dryRun: boolean;
+}
+
+export interface ImportOptions {
+  /** Show what would change and write nothing. */
+  dryRun?: boolean;
+  actor?: string;
+}
+
+/** Rows held before a flush. Bounded so a 500K-row file never lands in memory whole. */
+const BATCH = 500;
+
+export async function importBaselines(
+  shopId: string,
+  lines: AsyncIterable<string>,
+  shopCurrency: string,
+  options: ImportOptions = {},
+): Promise<BaselineImportResult> {
+  const result: BaselineImportResult = {
+    total: 0,
+    ready: 0,
+    written: 0,
+    unchanged: 0,
+    invalid: [],
+    unmatched: [],
+    ambiguous: [],
+    dryRun: options.dryRun === true,
+  };
+
+  const variants = await prisma.variantIndex.findMany({
+    where: { shopId, deletedAt: null },
+    select: { variantGid: true, productGid: true, sku: true, barcode: true },
+  });
+  const index = buildMatchIndex(variants);
+
+  // What each variant's baseline is now, so "unchanged" is a real answer rather than a
+  // rewrite. Re-capturing an identical baseline would supersede the existing row and
+  // lose the date it was first established.
+  const current = new Map(
+    (
+      await prisma.baseline.findMany({
+        where: { shopId, supersededAt: null, surfaceKind: "BASE" },
+        select: { variantGid: true, basePrice: true, baseCompareAt: true },
+      })
+    ).map((row) => [row.variantGid, row]),
+  );
+
+  let batch: Array<{ row: ValidRow; variantGid: string }> = [];
+
+  const flush = async () => {
+    if (batch.length === 0) return;
+    const pending = batch;
+    batch = [];
+    if (result.dryRun) return;
+
+    await writeBaselines(shopId, pending, options.actor);
+    result.written += pending.length;
+  };
+
+  for await (const raw of readRows(lines)) {
+    result.total++;
+
+    const validated = validateRow(raw, shopCurrency);
+    if (!isValid(validated)) {
+      record(result.invalid, validated);
+      continue;
+    }
+
+    // The same matcher segments use, so "SKU-1 matches two variants" means the same
+    // thing in both places rather than being decided twice, differently.
+    const csvRow: CsvRow = { line: raw.line, value: raw.identifier };
+    const outcome = matchIdentifiers([csvRow], index);
+
+    if (outcome.ambiguous.length > 0) {
+      record(result.ambiguous, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason: ambiguousReason(outcome.ambiguous[0]),
+      });
+      continue;
+    }
+
+    if (outcome.matched.length === 0) {
+      record(result.unmatched, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason: "Nothing in your catalogue answers to this SKU, barcode or ID.",
+      });
+      continue;
+    }
+
+    if (outcome.matched.length > 1) {
+      // A product gid naming several variants. Legitimate for a segment — "everything
+      // in this product" — and meaningless for a baseline, where one row would have to
+      // mean one price for several different variants.
+      record(result.ambiguous, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason:
+          `This is a product, not a variant — it covers ${outcome.matched.length} variants ` +
+          `which would all get the same baseline. List each variant's SKU instead.`,
+      });
+      continue;
+    }
+
+    const variantGid = outcome.matched[0];
+    const existing = current.get(variantGid);
+
+    if (
+      existing &&
+      existing.basePrice === BigInt(validated.parsedPrice.amount) &&
+      (existing.baseCompareAt ?? null) ===
+        (validated.parsedCompareAt ? BigInt(validated.parsedCompareAt.amount) : null)
+    ) {
+      result.unchanged++;
+      continue;
+    }
+
+    result.ready++;
+    batch.push({ row: validated, variantGid });
+    if (batch.length >= BATCH) await flush();
+  }
+
+  await flush();
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor: options.actor ?? null,
+      action: result.dryRun ? "baselines.import.dry-run" : "baselines.import",
+      entity: "Shop",
+      entityId: shopId,
+      after: {
+        total: result.total,
+        ready: result.ready,
+        written: result.written,
+        unchanged: result.unchanged,
+        invalid: result.invalid.length,
+        unmatched: result.unmatched.length,
+        ambiguous: result.ambiguous.length,
+      },
+    },
+  });
+
+  logger.info("baselines imported", { shopId, ...summary(result) });
+  return result;
+}
+
+/** Caps what is kept for the report. The count is exact; the list is a sample. */
+const MAX_REPORTED = 5_000;
+
+function record(into: ImportProblem[], problem: ImportProblem | InvalidRow): void {
+  if (into.length >= MAX_REPORTED) return;
+  into.push({
+    line: problem.line,
+    identifier: "identifier" in problem ? problem.identifier : "",
+    reason: problem.reason,
+  });
+}
+
+function ambiguousReason(row: AmbiguousRow): string {
+  return (
+    `This ${row.kind === "barcode" ? "barcode" : "SKU"} matches ${row.candidates.length} variants. ` +
+    `Choosing one could set the wrong product's baseline permanently, so the row was left out — ` +
+    `use the variant ID instead.`
+  );
+}
+
+function summary(result: BaselineImportResult) {
+  return {
+    total: result.total,
+    ready: result.ready,
+    written: result.written,
+    unchanged: result.unchanged,
+    invalid: result.invalid.length,
+    unmatched: result.unmatched.length,
+    ambiguous: result.ambiguous.length,
+    dryRun: result.dryRun,
+  };
+}
+
+/**
+ * Writes a batch of baselines.
+ *
+ * Append-only: the previous baseline is superseded rather than updated, so what a
+ * variant's reference price used to be — and when it changed — survives. That history
+ * is what makes a campaign from six weeks ago explicable.
+ */
+async function writeBaselines(
+  shopId: string,
+  rows: Array<{ row: ValidRow; variantGid: string }>,
+  actor?: string,
+): Promise<void> {
+  const now = new Date();
+
+  await prisma.$transaction([
+    prisma.baseline.updateMany({
+      where: {
+        shopId,
+        surfaceKind: "BASE",
+        supersededAt: null,
+        variantGid: { in: rows.map((r) => r.variantGid) },
+      },
+      data: { supersededAt: now },
+    }),
+    prisma.baseline.createMany({
+      data: rows.map(({ row, variantGid }) => ({
+        shopId,
+        variantGid,
+        surfaceKind: "BASE" as const,
+        priceListGid: "",
+        currency: row.parsedPrice.currency,
+        basePrice: BigInt(row.parsedPrice.amount),
+        baseCompareAt: row.parsedCompareAt ? BigInt(row.parsedCompareAt.amount) : null,
+        source: "CSV_IMPORT" as const,
+        capturedBy: actor ?? null,
+      })),
+    }),
+  ]);
+}
+
+// The error file itself lives in lib/reporting so the browser can build the download;
+// see that module for why a resource route cannot serve it.
+export { importErrorCsv } from "../lib/reporting/baseline-errors";

--- a/chaos/scenarios/baseline-import.chaos.ts
+++ b/chaos/scenarios/baseline-import.chaos.ts
@@ -1,0 +1,148 @@
+/**
+ * Importing a merchant's own reference prices.
+ *
+ * A baseline is permanent and every campaign computes from it, so a wrong one silently
+ * mis-prices a product on every campaign from here on. That makes two properties worth
+ * pinning down against a real database rather than a mock:
+ *
+ *   A dry run writes nothing at all. It is the same code path with the write skipped,
+ *   so what the merchant reviews is exactly what happens — not a second implementation
+ *   free to disagree with the first.
+ *
+ *   One bad row costs that row. On five hundred thousand rows, a malformed price must
+ *   not reject the file; a merchant who has to find the single bad line before anything
+ *   happens gives up on the import.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { importBaselines, importErrorCsv } from "../../app/services/baseline-import.server";
+import { withChaos } from "../harness/scenario";
+
+async function* lines(...items: string[]) {
+  for (const item of items) yield item;
+}
+
+describe("chaos: importing baselines from a file", () => {
+  it("dry run reports exactly what a real run does, and writes nothing", async () => {
+    await withChaos(
+      "baseline-import",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids, baseline } = chaos.fixture;
+
+        // Real gids, one row that will not validate, one that matches nothing.
+        const file = () =>
+          lines(
+            "sku,price,compare_at",
+            `${variantGids[0]},250.00,400.00`,
+            `${variantGids[1]},175.50,`,
+            `${variantGids[2]},0.00,`,
+            "NOT-A-REAL-SKU,10.00,",
+          );
+
+        const before = await prisma.baseline.count({ where: { shopId, supersededAt: null } });
+
+        const dry = await importBaselines(shopId, file(), "USD", { dryRun: true });
+
+        expect(dry.dryRun).toBe(true);
+        expect(dry.total).toBe(4);
+        expect(dry.ready).toBe(2);
+        expect(dry.written).toBe(0);
+        expect(dry.invalid).toHaveLength(1);
+        expect(dry.invalid[0].reason).toMatch(/above zero/i);
+        expect(dry.unmatched).toHaveLength(1);
+
+        // Nothing moved. Not one row, not one superseded flag.
+        expect(await prisma.baseline.count({ where: { shopId, supersededAt: null } })).toBe(before);
+        expect(await prisma.baseline.count({ where: { shopId, supersededAt: { not: null } } })).toBe(0);
+
+        // The error file is the artefact the merchant fixes and re-uploads.
+        const csv = importErrorCsv(dry);
+        expect(csv).toContain("NOT-A-REAL-SKU");
+        expect(csv.split("\n")[0]).toContain("what_to_do");
+
+        // ------------------------------------------------------ for real now
+        const real = await importBaselines(shopId, file(), "USD", { actor: "staff:1" });
+
+        expect(real.written).toBe(2);
+        // The dry run promised exactly this.
+        expect(real.ready).toBe(dry.ready);
+        expect(real.invalid).toHaveLength(dry.invalid.length);
+        expect(real.unmatched).toHaveLength(dry.unmatched.length);
+
+        const imported = await prisma.baseline.findFirstOrThrow({
+          where: { shopId, variantGid: variantGids[0], supersededAt: null },
+        });
+        expect(imported.basePrice).toBe(25_000n);
+        expect(imported.baseCompareAt).toBe(40_000n);
+        expect(imported.source).toBe("CSV_IMPORT");
+
+        // Append-only: the old baseline is superseded, not overwritten, so what the
+        // reference price used to be — and when it changed — survives.
+        const superseded = await prisma.baseline.findFirstOrThrow({
+          where: { shopId, variantGid: variantGids[0], supersededAt: { not: null } },
+        });
+        expect(Number(superseded.basePrice)).toBe(baseline.get(variantGids[0]));
+
+        // The row that failed validation kept its original baseline untouched.
+        const untouched = await prisma.baseline.findFirstOrThrow({
+          where: { shopId, variantGid: variantGids[2], supersededAt: null },
+        });
+        expect(Number(untouched.basePrice)).toBe(baseline.get(variantGids[2]));
+      },
+    );
+  });
+
+  it("re-importing the same file changes nothing and says so", async () => {
+    await withChaos(
+      "baseline-import-idempotent",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const file = () => lines("sku,price", `${variantGids[0]},99.00`);
+
+        const first = await importBaselines(shopId, file(), "USD");
+        expect(first.written).toBe(1);
+
+        // Re-capturing an identical baseline would supersede the existing row and lose
+        // the date the reference price was first established.
+        const second = await importBaselines(shopId, file(), "USD");
+        expect(second.written).toBe(0);
+        expect(second.unchanged).toBe(1);
+
+        expect(
+          await prisma.baseline.count({
+            where: { shopId, variantGid: variantGids[0], supersededAt: { not: null } },
+          }),
+        ).toBe(1);
+      },
+    );
+  });
+
+  it("refuses a product ID rather than giving several variants one baseline", async () => {
+    await withChaos(
+      "baseline-import-ambiguous",
+      { catalog: { products: 1, variantsPerProduct: 3 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, productOf, variantGids } = chaos.fixture;
+        const productGid = productOf.get(variantGids[0])!;
+
+        const result = await importBaselines(
+          shopId,
+          lines("sku,price", `${productGid},50.00`),
+          "USD",
+          { dryRun: true },
+        );
+
+        // Legitimate for a segment — "everything in this product" — and meaningless
+        // for a baseline, where one row would have to mean one price for three
+        // different variants.
+        expect(result.ready).toBe(0);
+        expect(result.ambiguous).toHaveLength(1);
+        expect(result.ambiguous[0].reason).toMatch(/3 variants/);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Baselines captured at install are whatever the storefront happened to show that day. For
a merchant who maintains MSRP in an ERP that is the wrong number — and it is the number
every campaign computes from, permanently.

This is the feature that answers a competitor's one-star review: a merchant wanted
discounts against actual MSRP and the app could only work from current price. An
imported baseline makes **"20% off MSRP" mean exactly that**.

## One bad row never fails the file

On five hundred thousand rows a malformed price should cost that row and nothing else. A
merchant who has to find the single bad line in a spreadsheet before anything at all
happens is a merchant who gives up on the import.

Every row is validated on its own and the failures come back as a **downloadable** list
to fix and re-upload — a list somebody has to retype off a screen is a list they will not
fix.

## Strict about what produces a wrong price

- **Zero is refused as firmly as negative.** Every percentage campaign computed from a
  zero baseline resolves to zero, so one bad row would put a product on sale for nothing.
- **Compare-at must be above the price**, or the storefront shows a strike-through that
  reads as a price *increase*.
- **Precision is currency-specific.** `1200.50` is two decimals too many for JPY and
  exactly right for USD; getting that wrong writes a baseline a hundred times off.

## Dry run is the default, and it is the same code path

Not a nicety bolted on afterwards — the write is skipped and nothing else differs, so
what the merchant reviews is what happens rather than a second implementation free to
disagree with the first. The chaos scenario asserts the dry run's numbers equal the real
run's, and that not one row or superseded flag moved.

## Ambiguity is never resolved

A SKU naming two variants is a question — choosing one would set the wrong product's
reference price *permanently*. A product ID is refused too: legitimate for a segment
("everything in this product"), meaningless for a baseline where one row would have to
mean one price for three different variants.

## Append-only

What a variant's reference price used to be, and when it changed, survives. Re-importing
an unchanged row is reported as unchanged rather than superseding the row and losing the
date it was established.

- 369 unit tests (14 new), 21 chaos scenarios, typecheck/lint/build clean

## One correction

I replaced `s-text-area` with a native textarea here and on segments after concluding
the web component took no typed input. **That conclusion was wrong** — typing into the
embedded iframe had stopped working in the browser session generally, and a field I had
used successfully earlier failed the same way. The native element is kept because it
matches the native selects already on both pages and is certain to serialise, but the
code comment no longer claims something I could not verify.

Stacked on #209 → #208 → #207 → #206 → #205 → #204 → #203.

Closes #83, #84, #85, #86, #87, #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)