### PR TITLE
P1.6 — Nightly sampled mirror audit with divergence alerting

### DIFF
--- a/app/lib/audit/sampling.test.ts
+++ b/app/lib/audit/sampling.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The check that keeps "the mirror is a cache, Shopify is truth" honest.
+ *
+ * Without it, mirror drift is invisible until a campaign prices the wrong products — and
+ * "the app changed prices it should not have" is not a thing you explain your way out
+ * of. So the interesting cases are the ones where a lazy implementation would report a
+ * healthy mirror: a tiny shop, a variant Shopify has forgotten, a price hidden behind a
+ * compare-at difference on the same row.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { auditSample, sampleSize, MIN_SAMPLE } from "./sampling";
+
+const mirror = (gid: string, price: number | null, compareAt: number | null = null) => ({
+  variantGid: gid,
+  price: price === null ? null : BigInt(price),
+  compareAt: compareAt === null ? null : BigInt(compareAt),
+});
+
+describe("sampleSize", () => {
+  it("takes half a percent of a large catalogue", () => {
+    expect(sampleSize(500_000)).toBe(2_500);
+    expect(sampleSize(200_000)).toBe(1_000);
+  });
+
+  it("never drops below the floor on a small shop", () => {
+    // Half a percent of two hundred variants is one, which cannot tell a healthy
+    // mirror from a broken one: one mismatch reads as 100% divergence.
+    expect(sampleSize(200)).toBe(200);
+    expect(sampleSize(50_000)).toBe(MIN_SAMPLE);
+  });
+
+  it("never asks for more variants than exist", () => {
+    expect(sampleSize(10)).toBe(10);
+    expect(sampleSize(0)).toBe(0);
+  });
+});
+
+describe("auditSample", () => {
+  it("reports a clean mirror as clean", () => {
+    const verdict = auditSample([mirror("v1", 1_000)], [mirror("v1", 1_000)]);
+    expect(verdict.diverged).toBe(0);
+    expect(verdict.rate).toBe(0);
+    expect(verdict.alert).toBe(false);
+  });
+
+  it("catches a price that has moved underneath the mirror", () => {
+    const verdict = auditSample([mirror("v1", 1_000)], [mirror("v1", 900)]);
+    expect(verdict.divergences[0]).toMatchObject({ kind: "price", mirror: 1_000n, live: 900n });
+  });
+
+  it("counts a variant Shopify no longer knows about", () => {
+    // A mirror full of products that no longer exist will enroll them in a campaign,
+    // where every row then fails — and a run reporting four hundred failures nobody
+    // can act on is a run nobody reads.
+    const verdict = auditSample([mirror("v1", 1_000)], []);
+    expect(verdict.divergences[0].kind).toBe("unknown-to-shopify");
+    expect(verdict.diverged).toBe(1);
+  });
+
+  it("does not let a compare-at difference hide a price one on the same row", () => {
+    const verdict = auditSample([mirror("v1", 1_000, 2_000)], [mirror("v1", 900, 3_000)]);
+    expect(verdict.divergences).toHaveLength(1);
+    expect(verdict.divergences[0].kind).toBe("price");
+  });
+
+  it("still reports a compare-at difference when the price agrees", () => {
+    const verdict = auditSample([mirror("v1", 1_000, 2_000)], [mirror("v1", 1_000, 3_000)]);
+    expect(verdict.divergences[0].kind).toBe("compare-at");
+  });
+
+  it("alerts above the threshold and not at it", () => {
+    // A threshold that fires at exactly the line means every shop sitting on it alerts
+    // every night, and the alert stops meaning anything.
+    const rows = Array.from({ length: 200 }, (_, i) => mirror(`v${i}`, 1_000));
+    const oneOff = rows.map((r, i) => (i === 0 ? mirror("v0", 999) : r));
+
+    const exactly = auditSample(rows, oneOff, 0.005);
+    expect(exactly.rate).toBe(0.005);
+    expect(exactly.alert).toBe(false);
+
+    const over = auditSample(rows, rows.map((r, i) => (i < 2 ? mirror(`v${i}`, 999) : r)), 0.005);
+    expect(over.alert).toBe(true);
+  });
+
+  it("never alerts on an empty sample", () => {
+    // A shop with nothing mirrored has not diverged, it has not started.
+    const verdict = auditSample([], []);
+    expect(verdict.rate).toBe(0);
+    expect(verdict.alert).toBe(false);
+  });
+
+  it("treats a null price and a zero price as different", () => {
+    // "We do not know this variant's price" and "this variant costs nothing" are not
+    // the same fact, and conflating them hides a real divergence.
+    expect(auditSample([mirror("v1", null)], [mirror("v1", 0)]).diverged).toBe(1);
+  });
+});

--- a/app/lib/audit/sampling.ts
+++ b/app/lib/audit/sampling.ts
@@ -1,0 +1,136 @@
+/**
+ * Choosing what to check, and deciding what the answer means.
+ *
+ * The mirror is a cache and Shopify is truth. Webhooks get missed, payloads arrive out
+ * of order, bugs slip in — and without an independent check, mirror drift is invisible
+ * until a merchant's campaign prices the wrong products. By then the trust is gone,
+ * because "the app changed prices it should not have" is not a thing you explain your
+ * way out of.
+ *
+ * Sampling rather than a full re-sync every night. Half a percent of a catalogue is
+ * enough to detect *systematic* divergence cheaply, and a full re-sync is the response
+ * to detection rather than the routine — a nightly full read of 500K variants would
+ * spend a shop's entire rate-limit budget to confirm what a few hundred rows already
+ * said.
+ */
+
+/** Fraction of the catalogue sampled each night. */
+export const SAMPLE_RATE = 0.005;
+
+/**
+ * Floor on the sample size.
+ *
+ * Half a percent of a two-hundred-variant shop is one variant, which cannot distinguish
+ * a healthy mirror from a broken one — a single mismatch would read as 100% divergence
+ * and a single match as perfect. Five hundred is enough to make the rate mean something
+ * on a small catalogue, and is nothing on a large one.
+ */
+export const MIN_SAMPLE = 500;
+
+/** Divergence above this is systematic rather than incidental, and gets a response. */
+export const ALERT_THRESHOLD = 0.005;
+
+export function sampleSize(total: number): number {
+  if (total <= 0) return 0;
+  return Math.min(total, Math.max(MIN_SAMPLE, Math.ceil(total * SAMPLE_RATE)));
+}
+
+export interface MirrorRow {
+  variantGid: string;
+  price: bigint | null;
+  compareAt: bigint | null;
+}
+
+export interface LiveRow {
+  variantGid: string;
+  price: bigint | null;
+  compareAt: bigint | null;
+  /** Absent from Shopify entirely — deleted since the mirror last saw it. */
+  missing?: boolean;
+}
+
+export type DivergenceKind = "price" | "compare-at" | "deleted" | "unknown-to-shopify";
+
+export interface Divergence {
+  variantGid: string;
+  kind: DivergenceKind;
+  mirror: bigint | null;
+  live: bigint | null;
+}
+
+export interface AuditVerdict {
+  checked: number;
+  diverged: number;
+  /** Diverged over checked. The number the alert threshold is compared against. */
+  rate: number;
+  divergences: Divergence[];
+  /** True when divergence is systematic enough to warrant a re-sync and an alert. */
+  alert: boolean;
+}
+
+/**
+ * Diffs a fresh read against the mirror.
+ *
+ * A variant Shopify no longer knows about counts as divergence rather than being
+ * skipped. A mirror full of products that no longer exist will happily enroll them in a
+ * campaign, where every row then fails — and a run reporting four hundred failures
+ * nobody can act on is a run nobody reads.
+ */
+export function auditSample(
+  mirror: readonly MirrorRow[],
+  live: readonly LiveRow[],
+  threshold = ALERT_THRESHOLD,
+): AuditVerdict {
+  const liveByGid = new Map(live.map((row) => [row.variantGid, row]));
+  const divergences: Divergence[] = [];
+
+  for (const row of mirror) {
+    const fresh = liveByGid.get(row.variantGid);
+
+    if (!fresh || fresh.missing) {
+      divergences.push({
+        variantGid: row.variantGid,
+        kind: fresh ? "deleted" : "unknown-to-shopify",
+        mirror: row.price,
+        live: null,
+      });
+      continue;
+    }
+
+    if (fresh.price !== row.price) {
+      divergences.push({
+        variantGid: row.variantGid,
+        kind: "price",
+        mirror: row.price,
+        live: fresh.price,
+      });
+      continue;
+    }
+
+    // Checked separately and second. A compare-at that has drifted matters less than a
+    // price that has, and reporting only the first difference found would let a price
+    // divergence hide behind a compare-at one on the same row.
+    if (fresh.compareAt !== row.compareAt) {
+      divergences.push({
+        variantGid: row.variantGid,
+        kind: "compare-at",
+        mirror: row.compareAt,
+        live: fresh.compareAt,
+      });
+    }
+  }
+
+  const checked = mirror.length;
+  const rate = checked === 0 ? 0 : divergences.length / checked;
+
+  return {
+    checked,
+    diverged: divergences.length,
+    rate,
+    divergences,
+    // Strictly greater than: a threshold of exactly 0.5% should not fire at exactly
+    // 0.5%, or every shop sitting on the line alerts every night and the alert stops
+    // meaning anything.
+    alert: checked > 0 && rate > threshold,
+  };
+}

--- a/app/services/mirror-audit.server.ts
+++ b/app/services/mirror-audit.server.ts
@@ -1,0 +1,180 @@
+/**
+ * The nightly check that keeps the mirror honest.
+ *
+ * Every claim this app makes rests on the mirror being an accurate picture of the
+ * merchant's catalogue. Webhooks get missed, payloads arrive out of order, bugs slip in
+ * — and mirror drift is invisible until a campaign prices the wrong products. By then
+ * there is no recovering the trust, because "the app changed prices it should not have"
+ * is not something you explain your way out of.
+ *
+ * So a sample is fresh-read from Shopify every night and diffed against what we hold.
+ * Divergence is healed on the spot and recorded as a rate; a rate above half a percent
+ * is systematic rather than incidental and says something is wrong with the pipeline
+ * rather than with one webhook.
+ *
+ * Runs from the scheduler tick, off-peak, and through the rate-limit budget like
+ * everything else. An audit that throttled a merchant's own campaign to check up on
+ * itself would be a poor trade.
+ */
+
+import prisma from "../db.server";
+import {
+  ALERT_THRESHOLD,
+  auditSample,
+  sampleSize,
+  type AuditVerdict,
+  type LiveRow,
+} from "../lib/audit/sampling";
+import { logger } from "../lib/logging/logger";
+import type { AdminClient } from "../lib/execution/sync-executor";
+import { isThrottledError, withRetry } from "../lib/shopify/budget";
+
+export const AUDIT_VARIANTS_QUERY = `#graphql
+  query AnchorAuditVariants($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      ... on ProductVariant { id price compareAtPrice }
+    }
+  }
+`;
+
+export interface AuditResult extends AuditVerdict {
+  shopId: string;
+  /** Rows corrected in the mirror as a result. */
+  healed: number;
+  /** Variants Shopify no longer knows about, tombstoned rather than deleted. */
+  tombstoned: number;
+}
+
+/** Read in batches Shopify will accept, and small enough not to dominate the budget. */
+const BATCH = 100;
+
+export async function auditMirror(
+  client: AdminClient,
+  shopId: string,
+  options: { threshold?: number; now?: Date } = {},
+): Promise<AuditResult> {
+  const threshold = options.threshold ?? ALERT_THRESHOLD;
+  const now = options.now ?? new Date();
+
+  const total = await prisma.variantIndex.count({ where: { shopId, deletedAt: null } });
+  const size = sampleSize(total);
+
+  if (size === 0) {
+    return { shopId, checked: 0, diverged: 0, rate: 0, divergences: [], alert: false, healed: 0, tombstoned: 0 };
+  }
+
+  // Random rows rather than the first N. Ordering by id would check the same variants
+  // every night and leave the rest of the catalogue permanently unexamined — which is
+  // where drift would then live.
+  const sample = await prisma.$queryRaw<
+    Array<{ variantGid: string; price: bigint | null; compareAt: bigint | null }>
+  >`
+    SELECT "variantGid", "price", "compareAt"
+    FROM "variant_index"
+    WHERE "shopId" = ${shopId} AND "deletedAt" IS NULL
+    ORDER BY random()
+    LIMIT ${size}
+  `;
+
+  const live: LiveRow[] = [];
+
+  for (let i = 0; i < sample.length; i += BATCH) {
+    const ids = sample.slice(i, i + BATCH).map((row) => row.variantGid);
+
+    const response = await withRetry(
+      () =>
+        client.request<{
+          nodes?: Array<{ id: string; price?: string | null; compareAtPrice?: string | null } | null>;
+        }>(AUDIT_VARIANTS_QUERY, { ids }),
+      isThrottledError,
+    );
+
+    const nodes = response.data?.nodes ?? [];
+    nodes.forEach((node, index) => {
+      const variantGid = ids[index];
+      // A null node is Shopify saying it has never heard of this id. Recorded as such
+      // rather than skipped, because a mirror full of ghosts enrolls them in campaigns.
+      if (!node) {
+        live.push({ variantGid, price: null, compareAt: null, missing: true });
+        return;
+      }
+      live.push({
+        variantGid: node.id,
+        price: node.price ? BigInt(Math.round(Number(node.price) * 100)) : null,
+        compareAt: node.compareAtPrice
+          ? BigInt(Math.round(Number(node.compareAtPrice) * 100))
+          : null,
+      });
+    });
+  }
+
+  const verdict = auditSample(sample, live, threshold);
+  const result: AuditResult = { shopId, ...verdict, healed: 0, tombstoned: 0 };
+
+  // Healed as they are found. The point of the audit is a mirror that is right
+  // afterwards, not a report saying it was wrong.
+  for (const divergence of verdict.divergences) {
+    const fresh = live.find((row) => row.variantGid === divergence.variantGid);
+
+    if (divergence.kind === "unknown-to-shopify" || divergence.kind === "deleted") {
+      // Tombstoned, never deleted: ledger rows still reference this variant and have to
+      // stay resolvable on revert (E4).
+      await prisma.variantIndex.updateMany({
+        where: { shopId, variantGid: divergence.variantGid },
+        data: { deletedAt: now },
+      });
+      result.tombstoned++;
+      continue;
+    }
+
+    await prisma.variantIndex.updateMany({
+      where: { shopId, variantGid: divergence.variantGid },
+      data: { price: fresh?.price ?? null, compareAt: fresh?.compareAt ?? null, syncedAt: now },
+    });
+    await prisma.priceSurfaceEntry.updateMany({
+      where: { shopId, variantGid: divergence.variantGid, surfaceKind: "BASE", priceListGid: "" },
+      data: { livePrice: fresh?.price ?? null, liveCompareAt: fresh?.compareAt ?? null, syncedAt: now },
+    });
+    result.healed++;
+  }
+
+  // Recorded whether or not it alerted. A rate that is fine tonight and fine tomorrow
+  // and creeping the week after is the signal worth having, and it only exists if the
+  // quiet nights are written down too.
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      action: "mirror.audit",
+      entity: "Shop",
+      entityId: shopId,
+      after: {
+        checked: verdict.checked,
+        diverged: verdict.diverged,
+        // Two significant figures: the exact float is noise on a sample of five hundred.
+        ratePercent: Number((verdict.rate * 100).toFixed(2)),
+        healed: result.healed,
+        tombstoned: result.tombstoned,
+        alert: verdict.alert,
+      },
+    },
+  });
+
+  const line = {
+    shopId,
+    checked: verdict.checked,
+    diverged: verdict.diverged,
+    ratePercent: Number((verdict.rate * 100).toFixed(2)),
+    healed: result.healed,
+    tombstoned: result.tombstoned,
+  };
+
+  if (verdict.alert) {
+    // Systematic. One missed webhook is a row; half a percent of a sample is a
+    // pipeline, and the response is a full re-sync rather than more healing.
+    logger.error("mirror divergence above threshold", line);
+  } else {
+    logger.info("mirror audited", line);
+  }
+
+  return result;
+}

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -14,6 +14,8 @@ import { adminClientForShop } from "./admin-client.server";
 import { claimEnrollment, pendingEnrollments } from "./auto-enroll.server";
 import { reclaimStaleRuns } from "./campaigns/reaper.server";
 import { sendDueDigests } from "./digest.server";
+import { auditMirror } from "./mirror-audit.server";
+import { logger } from "../lib/logging/logger";
 
 export interface TickResult {
   examined: number;
@@ -25,6 +27,8 @@ export interface TickResult {
   reclaimed: number;
   /** Weekly summaries sent this tick. */
   digests: number;
+  /** Shops whose mirror was sampled and checked against Shopify this tick. */
+  audited: number;
   failures: Array<{ campaignId: string; error: string }>;
 }
 
@@ -42,6 +46,7 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
     enrolled: 0,
     reclaimed: 0,
     digests: 0,
+    audited: 0,
     failures: [],
   };
 
@@ -102,7 +107,70 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
     // sendDueDigests already logs per shop; a throw here would be the loop itself.
   }
 
+  try {
+    result.audited = await auditDueMirrors(now);
+  } catch {
+    // Per-shop failures are already logged; a throw here would be the loop itself.
+  }
+
   return result;
+}
+
+/**
+ * Samples each shop's mirror against Shopify, once a day, off-peak.
+ *
+ * Off-peak because it spends rate-limit budget: an audit that throttled a merchant's own
+ * campaign to check up on itself would be a poor trade. The window is judged in the
+ * shop's own timezone rather than the server's, or every shop on the platform would be
+ * audited in the same hour.
+ */
+async function auditDueMirrors(now: Date): Promise<number> {
+  const DAY = 24 * 60 * 60_000;
+  const shops = await prisma.shop.findMany({
+    where: { uninstalledAt: null, initialSyncCompletedAt: { not: null } },
+    select: { id: true, domain: true, timezone: true },
+  });
+
+  let audited = 0;
+
+  for (const shop of shops) {
+    try {
+      if (!isOffPeak(now, shop.timezone)) continue;
+
+      const last = await prisma.auditLogEntry.findFirst({
+        where: { shopId: shop.id, action: "mirror.audit" },
+        orderBy: { createdAt: "desc" },
+        select: { createdAt: true },
+      });
+      if (last && now.getTime() - last.createdAt.getTime() < DAY) continue;
+
+      const client = await adminClientForShop(shop.domain);
+      if (!client) continue;
+
+      await auditMirror(client, shop.id, { now });
+      audited++;
+    } catch (error) {
+      logger.warn("mirror audit failed", {
+        shop: shop.domain,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return audited;
+}
+
+/** Between 2am and 5am in the shop's own zone. */
+function isOffPeak(now: Date, timeZone: string): boolean {
+  try {
+    const hour = Number(
+      new Intl.DateTimeFormat("en-GB", { timeZone, hour: "numeric", hour12: false }).format(now),
+    );
+    return hour >= 2 && hour < 5;
+  } catch {
+    // An unrecognised zone must not exclude a shop from ever being audited.
+    return now.getUTCHours() >= 2 && now.getUTCHours() < 5;
+  }
 }
 
 /**

--- a/chaos/scenarios/mirror-audit.chaos.ts
+++ b/chaos/scenarios/mirror-audit.chaos.ts
@@ -1,0 +1,118 @@
+/**
+ * The nightly check that keeps "the mirror is a cache, Shopify is truth" honest.
+ *
+ * Webhooks get missed, payloads arrive out of order, bugs slip in. Without an
+ * independent check, mirror drift is invisible until a campaign prices the wrong
+ * products — and by then there is no recovering the trust, because "the app changed
+ * prices it should not have" is not something you explain your way out of.
+ *
+ * The ticket asks for injected divergence to be detected and healed. That is exactly
+ * what this does: the store is changed behind the app's back, the way a missed webhook
+ * leaves it, and the audit has to notice without being told.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { auditMirror } from "../../app/services/mirror-audit.server";
+import { chaosAdminClient } from "../harness/http-client";
+import { withChaos } from "../harness/scenario";
+
+describe("chaos: the nightly mirror audit", () => {
+  it("finds injected divergence, heals it, and says nothing was wrong when nothing was", async () => {
+    await withChaos(
+      "mirror-audit",
+      { catalog: { products: 6, variantsPerProduct: 2 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        // A mirror that matches reality reports so. Anything else and the audit is
+        // crying wolf every night, which is how a real alert gets ignored.
+        const clean = await auditMirror(client, shopId);
+        expect(clean.checked).toBe(variantGids.length);
+        expect(clean.diverged).toBe(0);
+        expect(clean.alert).toBe(false);
+
+        // ------------------------------------------------- inject divergence
+        // Changed in Shopify only. This is what a missed `products/update` webhook
+        // leaves behind: the store moved and the app has no idea.
+        const drifted = variantGids[0];
+        chaos.fake.variants.get(drifted)!.price = "3.21";
+
+        // And one the merchant deleted without us hearing about it.
+        const vanished = variantGids[1];
+        chaos.fake.deleteVariant(vanished);
+
+        const audit = await auditMirror(client, shopId);
+
+        expect(audit.diverged).toBe(2);
+        // "deleted" rather than "unknown-to-shopify": Shopify answers a null node for
+        // an id it no longer knows, which is a definite answer. The other kind is the
+        // defensive case where a response omits an id altogether.
+        expect(audit.divergences.map((d) => d.kind).sort()).toEqual(["deleted", "price"]);
+
+        // ---------------------------------------------------------- healed
+        // The point is a mirror that is right afterwards, not a report saying it was
+        // wrong.
+        const healed = await prisma.variantIndex.findUniqueOrThrow({
+          where: { shopId_variantGid: { shopId, variantGid: drifted } },
+        });
+        expect(healed.price).toBe(321n);
+
+        const surface = await prisma.priceSurfaceEntry.findFirstOrThrow({
+          where: { shopId, variantGid: drifted, surfaceKind: "BASE", priceListGid: "" },
+        });
+        expect(surface.livePrice).toBe(321n);
+
+        // Tombstoned, never deleted: ledger rows still reference it and have to stay
+        // resolvable on revert (E4).
+        const gone = await prisma.variantIndex.findUniqueOrThrow({
+          where: { shopId_variantGid: { shopId, variantGid: vanished } },
+        });
+        expect(gone.deletedAt).not.toBeNull();
+        expect(audit.tombstoned).toBe(1);
+
+        // -------------------------------------------------- and it stays healed
+        // A second pass finds nothing, which is the only way to know the healing was
+        // real rather than the audit forgetting.
+        const after = await auditMirror(client, shopId);
+        expect(after.diverged).toBe(0);
+        // The tombstoned variant is out of the sample now, so one fewer is checked.
+        expect(after.checked).toBe(variantGids.length - 1);
+
+        // Recorded on the quiet nights too. A rate that is fine tonight and creeping
+        // next week is the signal worth having, and it only exists if the clean runs
+        // are written down.
+        const entries = await prisma.auditLogEntry.count({
+          where: { shopId, action: "mirror.audit" },
+        });
+        expect(entries).toBe(3);
+      },
+    );
+  });
+
+  it("alerts when divergence is systematic rather than incidental", async () => {
+    await withChaos(
+      "mirror-audit-alert",
+      { catalog: { products: 10, variantsPerProduct: 2 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        // A quarter of the catalogue moved. One missed webhook is a row; this is a
+        // pipeline, and the response is a re-sync rather than more healing.
+        for (const gid of variantGids.slice(0, 5)) {
+          chaos.fake.variants.get(gid)!.price = "1.11";
+        }
+
+        const audit = await auditMirror(client, shopId);
+
+        expect(audit.diverged).toBe(5);
+        expect(audit.rate).toBeGreaterThan(0.005);
+        expect(audit.alert).toBe(true);
+        expect(audit.healed).toBe(5);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Every claim this app makes rests on the mirror being an accurate picture of the
merchant's catalogue. Webhooks get missed, payloads arrive out of order, bugs slip in —
and mirror drift is **invisible** until a campaign prices the wrong products. By then
there is no recovering the trust, because *"the app changed prices it should not have"*
is not something you explain your way out of.

## Sampling, not a nightly re-sync

Half a percent is enough to detect *systematic* divergence. A nightly full read of 500K
variants would spend a shop's entire rate-limit budget confirming what a few hundred
rows already said — a full re-sync is the **response** to detection, not the routine.

The floor of five hundred is what makes the rate mean anything on a small shop. Half a
percent of two hundred variants is *one* variant, where a single mismatch reads as 100%
divergence and a single match as a perfect mirror.

Rows are picked at random rather than by id, or the audit checks the same variants every
night and leaves the rest of the catalogue permanently unexamined — which is exactly
where drift would then live.

## Healed, not merely reported

The point is a mirror that is right afterwards. A variant Shopify no longer knows about
is **tombstoned, never deleted** — ledger rows still reference it and have to stay
resolvable on revert (E4) — and counting it as divergence rather than skipping it
matters, because a mirror full of ghosts enrolls them in campaigns where every row then
fails, and a run reporting four hundred failures nobody can act on is a run nobody reads.

## Two details about the alert

- **Recorded on the quiet nights too.** A rate that is fine tonight and fine tomorrow and
  creeping the week after is the signal worth having, and it only exists if the clean
  runs are written down.
- **Strictly above the threshold, not at it.** A shop sitting exactly on the line would
  otherwise alert every night, and an alert that fires every night is an alert nobody
  reads.

Runs off-peak **in the shop's own timezone**, not the server's — otherwise every shop on
the platform gets audited in the same hour. An audit that throttled a merchant's own
campaign to check up on itself would be a poor trade.

## The test the ticket asks for

> Injected divergence on staging is detected and healed

Exactly that: the store is changed behind the app's back — the way a missed webhook
leaves it — plus a variant deleted without notice. The audit finds both without being
told, heals the price in `variant_index` and `price_surface_entries`, tombstones the
deleted one, and a second pass confirms it stayed healed rather than the audit having
forgotten.

Comparing the mirror against itself turns both scenarios red.

- 380 unit tests (11 new), 23 chaos scenarios, typecheck/lint/build clean

Stacked on #210 → #209 → #208 → #207 → #206 → #205 → #204 → #203.

Closes #89, #90, #91, #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)