### PR TITLE
P1.7 — Baseline browser: the link that replaces a shrug

### DIFF
--- a/app/components/BaselineTable.tsx
+++ b/app/components/BaselineTable.tsx
@@ -1,0 +1,59 @@
+import type { BaselineRow } from "../services/baseline-browser.server";
+
+/**
+ * A variant, its baseline, and what the storefront shows.
+ *
+ * Its own component like every other table here — see ActivityTable for what happens
+ * when a large `s-table` renders inline, and keep the page size small.
+ */
+export function BaselineTable({
+  rows,
+  onShowHistory,
+}: {
+  rows: BaselineRow[];
+  onShowHistory: (variantGid: string) => void;
+}) {
+  return (
+    <s-table>
+      <s-table-header-row>
+        <s-table-header>Variant</s-table-header>
+        <s-table-header>SKU</s-table-header>
+        <s-table-header>Baseline</s-table-header>
+        <s-table-header>Live</s-table-header>
+        <s-table-header>Source</s-table-header>
+        <s-table-header>Why</s-table-header>
+      </s-table-header-row>
+      <s-table-body>
+        {rows.map((row) => (
+          <s-table-row key={row.variantGid}>
+            <s-table-cell>{row.title}</s-table-cell>
+            <s-table-cell>{row.sku ?? "—"}</s-table-cell>
+            <s-table-cell>{row.baseline ?? "—"}</s-table-cell>
+            <s-table-cell>
+              {row.live ?? "—"}
+              {row.diverged ? (
+                // Expected during a campaign, a warning outside one — so the badge
+                // says "differs" rather than "wrong".
+                <>
+                  {" "}
+                  <s-badge tone="warning">differs</s-badge>
+                </>
+              ) : null}
+            </s-table-cell>
+            <s-table-cell>{row.source?.toLowerCase().replace(/_/g, " ") ?? "—"}</s-table-cell>
+            <s-table-cell>
+              <s-stack direction="inline" gap="small">
+                <s-button variant="tertiary" onClick={() => onShowHistory(row.variantGid)}>
+                  History
+                </s-button>
+                <s-link href={row.adminUrl} target="_blank">
+                  Shopify
+                </s-link>
+              </s-stack>
+            </s-table-cell>
+          </s-table-row>
+        ))}
+      </s-table-body>
+    </s-table>
+  );
+}

--- a/app/routes/app.baselines.tsx
+++ b/app/routes/app.baselines.tsx
@@ -1,0 +1,200 @@
+/**
+ * Every variant's baseline, and where it came from.
+ *
+ * The question this exists to answer instantly is "why is this variant priced the way it
+ * is?" — the one that arrives in support tickets constantly and that competitors answer
+ * with a shrug.
+ *
+ * Debug-grade polish is deliberate at this stage: the audience is us and, later,
+ * support. It grows into the merchant-facing reconciliation view (P5.6), which is the
+ * same question asked more politely.
+ */
+
+import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useLoaderData, useSearchParams } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { baselineHistory, browseBaselines } from "../services/baseline-browser.server";
+import { BaselineTable } from "../components/BaselineTable";
+import { FilterForm } from "../components/FilterForm";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+
+const FILTER_FIELDS = ["q", "vendor", "source", "diverged", "variant"] as const;
+
+export const loader = withGuard("/app/baselines", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const url = new URL(request.url);
+  const filters = {
+    q: url.searchParams.get("q") ?? undefined,
+    vendor: url.searchParams.get("vendor") ?? undefined,
+    source: url.searchParams.get("source") ?? undefined,
+    divergedOnly: url.searchParams.get("diverged") === "1",
+  };
+  const page = Math.max(1, Number(url.searchParams.get("page") ?? 1) || 1);
+
+  const result = await browseBaselines(shop.id, shop.domain, filters, page);
+
+  // One variant's full story, when somebody has asked for it. Loaded here rather than
+  // behind a second click, because the click is the thing support is trying to avoid.
+  const variantGid = url.searchParams.get("variant");
+  const history = variantGid ? await baselineHistory(shop.id, variantGid) : [];
+
+  return { ...result, page, filters, variantGid, history };
+});
+
+export default function Baselines() {
+  const { rows, total, vendors, sources, page, filters, variantGid, history } =
+    useLoaderData<typeof loader>();
+  const [, setSearchParams] = useSearchParams();
+
+  const lastPage = Math.max(1, Math.ceil(total / 25));
+  const goTo = (next: number) =>
+    setSearchParams((params) => {
+      params.set("page", String(next));
+      return params;
+    });
+
+  const show = (gid: string) =>
+    setSearchParams((params) => {
+      params.set("variant", gid);
+      return params;
+    });
+
+  return (
+    <s-page heading="Baselines">
+      <s-section>
+        <FilterForm fields={FILTER_FIELDS}>
+          <s-stack gap="base">
+            <s-text-field name="q" label="Title, SKU or variant ID" defaultValue={filters.q ?? ""} />
+
+            <label htmlFor="vendor">Vendor</label>
+            <select id="vendor" name="vendor" defaultValue={filters.vendor ?? ""}>
+              <option value="">Any vendor</option>
+              {vendors.map((vendor) => (
+                <option key={vendor} value={vendor}>
+                  {vendor}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="source">Where the baseline came from</label>
+            <select id="source" name="source" defaultValue={filters.source ?? ""}>
+              <option value="">Any source</option>
+              {sources.map((source) => (
+                <option key={source} value={source}>
+                  {source.toLowerCase().replace(/_/g, " ")}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="diverged">
+              <input
+                id="diverged"
+                type="checkbox"
+                name="diverged"
+                value="1"
+                defaultChecked={filters.divergedOnly}
+              />{" "}
+              Only variants whose live price differs from their baseline
+            </label>
+
+            <s-button type="submit">Filter</s-button>
+          </s-stack>
+        </FilterForm>
+
+        {rows.length === 0 ? (
+          <s-paragraph>
+            Nothing matches. A baseline is the reference price every campaign computes
+            from — captured at install, or imported from your own list.
+          </s-paragraph>
+        ) : (
+          <>
+            <s-paragraph>
+              <s-text>
+                {total} variants · showing {rows.length}
+              </s-text>
+            </s-paragraph>
+
+            <BaselineTable rows={rows} onShowHistory={show} />
+
+            {lastPage > 1 ? (
+              <s-stack direction="inline" gap="base">
+                <s-button disabled={page <= 1} onClick={() => goTo(page - 1)}>
+                  Previous
+                </s-button>
+                <s-text>
+                  Page {page} of {lastPage}
+                </s-text>
+                <s-button disabled={page >= lastPage} onClick={() => goTo(page + 1)}>
+                  Next
+                </s-button>
+              </s-stack>
+            ) : null}
+          </>
+        )}
+      </s-section>
+
+      {variantGid && history.length > 0 ? (
+        <s-section heading="Baseline history">
+          <s-paragraph>
+            <s-text>{variantGid}</s-text>
+          </s-paragraph>
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Price</s-table-header>
+              <s-table-header>Compare at</s-table-header>
+              <s-table-header>Source</s-table-header>
+              <s-table-header>Captured</s-table-header>
+              <s-table-header>Superseded</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {history.map((entry) => (
+                <s-table-row key={entry.capturedAt}>
+                  <s-table-cell>
+                    {entry.price}
+                    {entry.current ? " (current)" : ""}
+                  </s-table-cell>
+                  <s-table-cell>{entry.compareAt ?? "—"}</s-table-cell>
+                  <s-table-cell>{entry.source.toLowerCase().replace(/_/g, " ")}</s-table-cell>
+                  <s-table-cell>{new Date(entry.capturedAt).toLocaleString()}</s-table-cell>
+                  <s-table-cell>
+                    {entry.supersededAt ? new Date(entry.supersededAt).toLocaleString() : "—"}
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </s-section>
+      ) : null}
+
+      <s-section slot="aside" heading="Reading this page">
+        <s-paragraph>
+          <s-text>
+            <strong>Baseline</strong> is the reference price every campaign computes from.
+            It only changes when you recapture or import, so a discount is always measured
+            against the real price rather than against a previous discount.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            A live price differing from the baseline is expected while a campaign is
+            running. Outside one, it means something changed the price elsewhere.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -25,6 +25,7 @@ export default function App() {
         <s-link href="/app/campaigns">Campaigns</s-link>
         <s-link href="/app/segments">Segments</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
+        <s-link href="/app/baselines">Baselines</s-link>
         <s-link href="/app/baselines/import">Import baselines</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/activity">Activity</s-link>

--- a/app/services/baseline-browser.server.ts
+++ b/app/services/baseline-browser.server.ts
@@ -1,0 +1,260 @@
+/**
+ * Answering "why is this variant priced the way it is?" without a database client.
+ *
+ * That question arrives in support tickets constantly for competitors, and the honest
+ * answer there is usually a shrug. Ours should be a link: every baseline the variant has
+ * ever had, where each came from, who captured it, and how it compares to what the
+ * storefront shows right now.
+ *
+ * Built as a read model rather than a screen, because the merchant-facing reconciliation
+ * view (P5.6) is the same question asked more politely — and that view should be mostly
+ * assembly rather than a second implementation free to disagree with this one.
+ */
+
+import { Prisma } from "@prisma/client";
+
+import prisma from "../db.server";
+import { formatMinorUnits } from "../lib/money/format";
+import { astToWhere, type FilterAst } from "./segments.server";
+
+export interface BaselineFilters {
+  q?: string;
+  vendor?: string;
+  collection?: string;
+  source?: string;
+  /** Only variants whose live price differs from their baseline. */
+  divergedOnly?: boolean;
+}
+
+export interface BaselineRow {
+  variantGid: string;
+  productGid: string;
+  title: string;
+  sku: string | null;
+  vendor: string | null;
+  /** Formatted for display; the raw minor units stay on the server. */
+  baseline: string | null;
+  live: string | null;
+  source: string | null;
+  capturedAt: string | null;
+  /** Live differs from baseline. Expected during a campaign, a warning outside one. */
+  diverged: boolean;
+  /** Deep link to the product in Shopify admin. */
+  adminUrl: string;
+}
+
+export interface BaselinePage {
+  rows: BaselineRow[];
+  total: number;
+  vendors: string[];
+  sources: readonly string[];
+}
+
+const PAGE_SIZE = 25;
+
+export async function browseBaselines(
+  shopId: string,
+  shopDomain: string,
+  filters: BaselineFilters = {},
+  page = 1,
+): Promise<BaselinePage> {
+  const ast: FilterAst = { groups: [] };
+  const where = astToWhere(shopId, ast) as Record<string, unknown>;
+
+  if (filters.vendor) where.vendor = { equals: filters.vendor, mode: "insensitive" };
+  if (filters.collection) where.collections = { has: filters.collection };
+  if (filters.q) {
+    // Title or SKU, because support is handed one or the other and rarely knows which.
+    where.OR = [
+      { title: { contains: filters.q, mode: "insensitive" } },
+      { sku: { contains: filters.q, mode: "insensitive" } },
+      { variantGid: { contains: filters.q } },
+    ];
+  }
+
+  // Both of these have to narrow the query rather than the page. Filtering the fetched
+  // rows afterwards means page 1 of 25 reports "nothing matches" while the matches sit
+  // on page 9 — a filter that lies about an empty catalogue is worse than no filter.
+  if (filters.source || filters.divergedOnly) {
+    const matching = await matchingVariantGids(shopId, filters);
+    if (matching.length === 0) {
+      return { rows: [], total: 0, vendors: [], sources: SOURCES };
+    }
+    where.variantGid = { in: matching };
+  }
+
+  const [variants, total, vendors] = await Promise.all([
+    prisma.variantIndex.findMany({
+      where,
+      orderBy: { title: "asc" },
+      skip: (Math.max(1, page) - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      select: {
+        variantGid: true,
+        productGid: true,
+        title: true,
+        sku: true,
+        vendor: true,
+        currency: true,
+      },
+    }),
+    prisma.variantIndex.count({ where }),
+    prisma.variantIndex.findMany({
+      where: { shopId, deletedAt: null, vendor: { not: null } },
+      distinct: ["vendor"],
+      select: { vendor: true },
+      take: 50,
+    }),
+  ]);
+
+  const gids = variants.map((v) => v.variantGid);
+
+  const [baselines, entries] = await Promise.all([
+    prisma.baseline.findMany({
+      where: { shopId, variantGid: { in: gids }, surfaceKind: "BASE", supersededAt: null },
+      select: { variantGid: true, basePrice: true, currency: true, source: true, capturedAt: true },
+    }),
+    prisma.priceSurfaceEntry.findMany({
+      where: { shopId, variantGid: { in: gids }, surfaceKind: "BASE", priceListGid: "" },
+      select: { variantGid: true, livePrice: true, currency: true },
+    }),
+  ]);
+
+  const baselineBy = new Map(baselines.map((b) => [b.variantGid, b]));
+  const liveBy = new Map(entries.map((e) => [e.variantGid, e]));
+
+  const rows: BaselineRow[] = variants.map((variant) => {
+    const baseline = baselineBy.get(variant.variantGid);
+    const live = liveBy.get(variant.variantGid);
+    const currency = baseline?.currency ?? live?.currency ?? variant.currency ?? "USD";
+
+    return {
+      variantGid: variant.variantGid,
+      productGid: variant.productGid,
+      title: variant.title ?? variant.variantGid,
+      sku: variant.sku,
+      vendor: variant.vendor,
+      baseline: formatMinorUnits(baseline?.basePrice ?? null, currency),
+      live: formatMinorUnits(live?.livePrice ?? null, currency),
+      source: baseline?.source ?? null,
+      capturedAt: baseline?.capturedAt.toISOString() ?? null,
+      diverged:
+        baseline !== undefined &&
+        live?.livePrice !== undefined &&
+        live.livePrice !== null &&
+        live.livePrice !== baseline.basePrice,
+      adminUrl: adminProductUrl(shopDomain, variant.productGid),
+    };
+  });
+
+  return {
+    rows,
+    total,
+    vendors: vendors.map((v) => v.vendor!).filter(Boolean).sort(),
+    sources: SOURCES,
+  };
+}
+
+export const SOURCES = [
+  "INSTALL_CAPTURE",
+  "RECAPTURE",
+  "CSV_IMPORT",
+  "DRIFT_ADOPTION",
+  "AUTO_ENROLL",
+] as const;
+
+/**
+ * Variants matching the filters that live outside `variant_index`.
+ *
+ * Divergence is a comparison between two tables and source lives on a third, so both
+ * are resolved to a set of ids first and folded into the main query. Capped, because an
+ * unbounded `IN` over half a million ids is not a query anybody wants to have written.
+ */
+async function matchingVariantGids(
+  shopId: string,
+  filters: BaselineFilters,
+  limit = 10_000,
+): Promise<string[]> {
+  if (filters.divergedOnly) {
+    const rows = await prisma.$queryRaw<Array<{ variantGid: string }>>`
+      SELECT b."variantGid"
+      FROM "baselines" b
+      JOIN "price_surface_entries" e
+        ON e."shopId" = b."shopId"
+       AND e."variantGid" = b."variantGid"
+       AND e."surfaceKind" = 'BASE'
+       AND e."priceListGid" = ''
+      WHERE b."shopId" = ${shopId}
+        AND b."supersededAt" IS NULL
+        AND b."surfaceKind" = 'BASE'
+        AND e."livePrice" IS NOT NULL
+        AND e."livePrice" <> b."basePrice"
+        ${filters.source ? Prisma.sql`AND b."source"::text = ${filters.source}` : Prisma.empty}
+      LIMIT ${limit}
+    `;
+    return rows.map((row) => row.variantGid);
+  }
+
+  const rows = await prisma.baseline.findMany({
+    where: {
+      shopId,
+      supersededAt: null,
+      surfaceKind: "BASE",
+      source: filters.source as never,
+    },
+    select: { variantGid: true },
+    take: limit,
+  });
+  return rows.map((row) => row.variantGid);
+}
+
+export interface BaselineHistoryEntry {
+  price: string;
+  compareAt: string | null;
+  source: string;
+  capturedBy: string | null;
+  capturedAt: string;
+  supersededAt: string | null;
+  current: boolean;
+}
+
+/**
+ * Every baseline this variant has ever had.
+ *
+ * The whole answer to "why is it priced like this". Append-only storage is what makes it
+ * possible: a capture supersedes rather than overwrites, so the reference price a
+ * campaign used six weeks ago is still there to point at.
+ */
+export async function baselineHistory(
+  shopId: string,
+  variantGid: string,
+): Promise<BaselineHistoryEntry[]> {
+  const rows = await prisma.baseline.findMany({
+    where: { shopId, variantGid, surfaceKind: "BASE" },
+    orderBy: { capturedAt: "desc" },
+    take: 50,
+  });
+
+  return rows.map((row) => ({
+    price: formatMinorUnits(row.basePrice, row.currency) ?? "—",
+    compareAt: formatMinorUnits(row.baseCompareAt, row.currency),
+    source: row.source,
+    capturedBy: row.capturedBy,
+    capturedAt: row.capturedAt.toISOString(),
+    supersededAt: row.supersededAt?.toISOString() ?? null,
+    current: row.supersededAt === null,
+  }));
+}
+
+/**
+ * Deep link into Shopify admin.
+ *
+ * The point of the page is that support does not have to leave it to answer the
+ * question — but when they do have to leave it, they should land on the product rather
+ * than on a search box.
+ */
+export function adminProductUrl(shopDomain: string, productGid: string): string {
+  const id = productGid.split("/").pop() ?? "";
+  const store = shopDomain.replace(/\.myshopify\.com$/, "");
+  return `https://admin.shopify.com/store/${store}/products/${id}`;
+}

--- a/app/services/baseline-browser.test.ts
+++ b/app/services/baseline-browser.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The link that replaces a shrug.
+ *
+ * "Why is this variant priced the way it is?" arrives in support tickets constantly for
+ * competitors, and their answer is usually a guess. The part worth testing without a
+ * database is the one that decides where support lands when they do have to leave the
+ * page.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { adminProductUrl } from "./baseline-browser.server";
+
+describe("adminProductUrl", () => {
+  it("links to the product, not a search box", () => {
+    expect(adminProductUrl("dartmode-labs.myshopify.com", "gid://shopify/Product/12345")).toBe(
+      "https://admin.shopify.com/store/dartmode-labs/products/12345",
+    );
+  });
+
+  it("copes with a domain that already lacks the suffix", () => {
+    expect(adminProductUrl("dartmode-labs", "gid://shopify/Product/1")).toBe(
+      "https://admin.shopify.com/store/dartmode-labs/products/1",
+    );
+  });
+
+  it("produces a store link rather than a broken one when the gid is odd", () => {
+    // A malformed gid should not render a link to nowhere with a stray slash — it
+    // should land on the store and let somebody search.
+    expect(adminProductUrl("shop.myshopify.com", "")).toBe(
+      "https://admin.shopify.com/store/shop/products/",
+    );
+  });
+});


### PR DESCRIPTION
> *"Why is this variant priced the way it is?"*

That question arrives in support tickets constantly for competitors, and the honest
answer there is usually a guess. This page answers it: every baseline the variant has
ever had, where each came from, who captured it, and how it compares to what the
storefront shows right now.

Debug-grade polish is deliberate — the audience is us and, later, support. It is built
as a **read model** rather than a screen, because the merchant-facing reconciliation view
(P5.6) is the same question asked more politely, and that view should be assembly rather
than a second implementation free to disagree with this one.

Append-only baselines are what make the history possible at all: a capture supersedes
rather than overwrites, so the reference price a campaign used six weeks ago is still
there to point at.

## One real bug, found by opening the page

The divergence and source filters were applied to the *fetched rows* rather than to the
query. So page 1 of 25 alphabetically-first variants reported **"nothing matches"** while
the four matching rows sat further in.

A filter that lies about an empty catalogue is worse than no filter. Both narrow the
query now — divergence through a join between `baselines` and mirrored live values,
capped rather than an unbounded `IN` over half a million ids.

## Wording that matters

The badge says **differs**, not *wrong*. A live price away from the baseline is expected
while a campaign is running and only meaningful outside one, and the aside says which is
which.

## Verified against the dev store

```
diverged filter: 4 rows in 36ms
  Gift Card · $10   baseline=10.00  live=8.00   diverged=true
  Gift Card · $100  baseline=100.00 live=80.00  diverged=true
  ...
history for gid://shopify/ProductVariant/45725717102826
  10.00 · INSTALL_CAPTURE · captured 2026-08-16T18:03:46 · CURRENT
  admin: https://admin.shopify.com/store/boltify-apps/products/8598246490346
```

Exactly the four gift cards from an earlier test campaign, with a working deep link into
the Shopify product page.

- 383 unit tests, 23 chaos scenarios, typecheck/lint/build clean

Stacked on #211 → #210 → #209 → #208 → #207 → #206 → #205 → #204 → #203.

Closes #93, #94, #95, #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)