### PR TITLE
P1.4 — Scoped recapture with a guard the operation deserves

### DIFF
--- a/app/lib/baselines/recapture.test.ts
+++ b/app/lib/baselines/recapture.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The guard on the most destructive thing this app can do.
+ *
+ * Recapture replaces every baseline in scope with today's live price. Run it during a
+ * sale and the sale prices become the merchant's normal prices — permanently, for every
+ * campaign afterwards. There is no undo that makes that not have happened.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { assessRecapture, confirmationMatches, DANGEROUS_PHRASE } from "./recapture";
+
+describe("assessRecapture", () => {
+  it("asks for nothing extra when no campaign is running", () => {
+    // Demanding a typed phrase every time is how a merchant learns to type it without
+    // reading, and then types it on the day it mattered.
+    const assessment = assessRecapture(1_200, []);
+    expect(assessment.risk).toBe("safe");
+    expect(assessment.confirmationPhrase).toBeNull();
+    expect(assessment.warning).toBeNull();
+  });
+
+  it("names each campaign and how many variants it covers", () => {
+    // "This will affect 412 products in Summer Sale" is a fact somebody can act on.
+    // "Some campaigns may be affected" is a dialog people click through.
+    const assessment = assessRecapture(1_000, [
+      { campaignId: "c1", campaignName: "Summer Sale", variants: 412 },
+      { campaignId: "c2", campaignName: "Clearance", variants: 88 },
+    ]);
+
+    expect(assessment.risk).toBe("overlaps-active-campaign");
+    expect(assessment.warning).toContain("Summer Sale");
+    expect(assessment.warning).toContain("412");
+    expect(assessment.warning).toContain("Clearance");
+    expect(assessment.warning).toContain("500 of these 1000");
+  });
+
+  it("says what actually goes wrong, not that it is dangerous", () => {
+    const { warning } = assessRecapture(10, [
+      { campaignId: "c1", campaignName: "Sale", variants: 10 },
+    ]);
+    expect(warning).toContain("new normal");
+    expect(warning).toContain("permanently");
+    // The remedy, not just the hazard.
+    expect(warning).toContain("Revert those campaigns first");
+  });
+
+  it("ignores a campaign that overlaps no variants in scope", () => {
+    // Running elsewhere in the catalogue is not a reason to alarm somebody recapturing
+    // a segment it does not touch.
+    const assessment = assessRecapture(50, [
+      { campaignId: "c1", campaignName: "Elsewhere", variants: 0 },
+    ]);
+    expect(assessment.risk).toBe("safe");
+    expect(assessment.overlaps).toEqual([]);
+  });
+});
+
+describe("confirmationMatches", () => {
+  it("accepts the phrase whatever the capitalisation", () => {
+    // The requirement is that they read the sentence and type the words, not that they
+    // reproduce capitalisation. Strictness turns a safety check into a puzzle, and a
+    // puzzle gets copy-pasted.
+    expect(confirmationMatches(DANGEROUS_PHRASE, DANGEROUS_PHRASE)).toBe(true);
+    expect(confirmationMatches("replace baselines", DANGEROUS_PHRASE)).toBe(true);
+    expect(confirmationMatches("  Replace Baselines  ", DANGEROUS_PHRASE)).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(confirmationMatches("yes", DANGEROUS_PHRASE)).toBe(false);
+    expect(confirmationMatches("", DANGEROUS_PHRASE)).toBe(false);
+    expect(confirmationMatches("REPLACE BASELINE", DANGEROUS_PHRASE)).toBe(false);
+  });
+
+  it("requires nothing when nothing is at risk", () => {
+    expect(confirmationMatches("", null)).toBe(true);
+  });
+});

--- a/app/lib/baselines/recapture.ts
+++ b/app/lib/baselines/recapture.ts
@@ -1,0 +1,85 @@
+/**
+ * Deciding whether a recapture is safe to run.
+ *
+ * Recapture replaces every baseline in its scope with today's live price. Run it while a
+ * sale is live and the sale prices *become* the merchant's normal prices — permanently,
+ * for every campaign from then on, with the real prices gone from the current row and
+ * recoverable only by reading superseded history. There is no undo button that makes
+ * that not have happened.
+ *
+ * So the rules here are deliberately harder than "are you sure":
+ *
+ *   Overlap with a running campaign is named, per campaign, with how many variants each
+ *   one covers. "This will affect 412 products in Summer Sale" is a fact somebody can
+ *   act on; "some campaigns may be affected" is a dialog people click through.
+ *
+ *   Confirmation is typed, and typed exactly. A button is muscle memory by the third
+ *   time; typing the word is not.
+ */
+
+export interface ActiveOverlap {
+  campaignId: string;
+  campaignName: string;
+  /** Variants in the recapture scope that this campaign is currently pricing. */
+  variants: number;
+}
+
+export type RecaptureRisk = "safe" | "overlaps-active-campaign";
+
+export interface RecaptureAssessment {
+  risk: RecaptureRisk;
+  /** Variants the recapture would rewrite. */
+  scope: number;
+  overlaps: ActiveOverlap[];
+  /** The exact word the merchant must type. Absent when nothing is at risk. */
+  confirmationPhrase: string | null;
+  /** What to tell them, in their terms. */
+  warning: string | null;
+}
+
+/** What a merchant must type to recapture over a live campaign. */
+export const DANGEROUS_PHRASE = "REPLACE BASELINES";
+
+export function assessRecapture(scope: number, overlaps: readonly ActiveOverlap[]): RecaptureAssessment {
+  const affected = overlaps.filter((overlap) => overlap.variants > 0);
+
+  if (affected.length === 0) {
+    return {
+      risk: "safe",
+      scope,
+      overlaps: [],
+      // No phrase for the safe case. Demanding one every time is how a merchant learns
+      // to type it without reading, and then types it on the day it mattered.
+      confirmationPhrase: null,
+      warning: null,
+    };
+  }
+
+  const total = affected.reduce((sum, overlap) => sum + overlap.variants, 0);
+  const names = affected.map((overlap) => `"${overlap.campaignName}" (${overlap.variants})`);
+
+  return {
+    risk: "overlaps-active-campaign",
+    scope,
+    overlaps: affected,
+    confirmationPhrase: DANGEROUS_PHRASE,
+    warning:
+      `${total} of these ${scope} variants are on sale right now under ` +
+      `${names.join(", ")}. Recapturing would make the sale price their new normal ` +
+      `price, permanently — every future campaign would compute its discount from the ` +
+      `discounted price. Revert those campaigns first unless that is genuinely what you ` +
+      `want.`,
+  };
+}
+
+/**
+ * Whether the typed confirmation matches.
+ *
+ * Trimmed and case-folded, because the requirement is that the merchant read the
+ * sentence and type the words — not that they reproduce capitalisation. Being strict
+ * about the case turns a safety check into a puzzle, and a puzzle gets copy-pasted.
+ */
+export function confirmationMatches(typed: string, expected: string | null): boolean {
+  if (!expected) return true;
+  return typed.trim().toLowerCase() === expected.trim().toLowerCase();
+}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -153,18 +153,10 @@ export const action = withGuard("/app", async ({ request }: ActionFunctionArgs) 
     };
   }
 
-  if (intent === "recapture") {
-    const capture = await captureBaselines(shop.id, {
-      recapture: true,
-      source: "RECAPTURE",
-      capturedBy: session.shop,
-    });
-    return {
-      ok: true,
-      message: `Recaptured ${capture.captured} baselines (${capture.superseded} superseded).`,
-      errors: [],
-    };
-  }
+  // The unguarded store-wide recapture that used to live here is gone. It took one
+  // click, warned generically, checked nothing, and would happily enshrine a live sale's
+  // prices as a merchant's permanent normal. /app/baselines/recapture does the same job
+  // with the scope, the overlap check and the typed confirmation it always needed.
 
   return { ok: false, message: `Unknown action: ${intent}`, errors: [] };
 });
@@ -390,16 +382,16 @@ export default function Dashboard() {
             </s-text>
           </s-paragraph>
           <s-paragraph>
-            Recapturing replaces every baseline with today&rsquo;s live prices. Do not
-            do this while a sale is running — it would make the sale prices your new
-            normal, permanently.
+            <s-text>
+              Recapturing replaces baselines with today&rsquo;s live prices. Done while a
+              sale is running it makes the sale price the new normal, permanently — so it
+              has its own page, which shows you which campaigns your scope would catch
+              before anything is replaced.
+            </s-text>
           </s-paragraph>
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="recapture" />
-            <s-button type="submit" tone="critical" loading={busy || undefined}>
-              Recapture all baselines
-            </s-button>
-          </fetcher.Form>
+          {/* A link, not a button. One click from the dashboard was not enough ceremony
+              for the most destructive operation in the app. */}
+          <s-link href="/app/baselines/recapture">Recapture baselines…</s-link>
         </s-section>
       ) : null}
     </s-page>

--- a/app/routes/app.baselines._index.tsx
+++ b/app/routes/app.baselines._index.tsx
@@ -8,6 +8,11 @@
  * Debug-grade polish is deliberate at this stage: the audience is us and, later,
  * support. It grows into the merchant-facing reconciliation view (P5.6), which is the
  * same question asked more politely.
+ *
+ * Named `_index` rather than `app.baselines`, because flat routes would otherwise make
+ * this file the *layout* for everything under /app/baselines — and a layout with no
+ * `<Outlet />` renders itself in place of its children. Naming it `app.baselines` broke
+ * both the import and recapture pages into showing this table instead.
  */
 
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";

--- a/app/routes/app.baselines.recapture.tsx
+++ b/app/routes/app.baselines.recapture.tsx
@@ -1,0 +1,209 @@
+/**
+ * Recapture: replacing baselines with today's live prices.
+ *
+ * Its own page rather than a button on the dashboard, because it is the most
+ * destructive thing this app can do and a button next to a paragraph is not enough
+ * ceremony for it. Recapturing during a sale makes the sale prices the merchant's
+ * normal prices, permanently, for every campaign afterwards — and nothing undoes that
+ * except reading superseded history and typing the old numbers back.
+ *
+ * The page's job is to make the merchant see which running campaigns their scope would
+ * enshrine, by name and by count, before they can proceed.
+ */
+
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import prisma from "../db.server";
+import { ensureShop } from "../services/shop.server";
+import { planRecapture, recapture } from "../services/recapture.server";
+import { actorFor } from "../lib/audit/actor";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+import { reportError } from "../services/error-report.server";
+
+export const loader = withGuard("/app/baselines/recapture", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const segmentId = new URL(request.url).searchParams.get("segment") ?? undefined;
+  const [plan, segments] = await Promise.all([
+    planRecapture(shop.id, { segmentId }),
+    prisma.segment.findMany({
+      where: { shopId: shop.id },
+      select: { id: true, name: true, kind: true },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  // The variant list itself never reaches the browser — it is up to half a million ids
+  // and the page only needs the count.
+  const assessment = {
+    risk: plan.risk,
+    scope: plan.scope,
+    overlaps: plan.overlaps,
+    confirmationPhrase: plan.confirmationPhrase,
+    warning: plan.warning,
+  };
+  return { assessment, segments, segmentId: segmentId ?? "" };
+});
+
+type ActionData = { ok: boolean; message: string; errorId?: string };
+
+export const action = withGuard("/app/baselines/recapture", async ({ request }: ActionFunctionArgs) => {
+  const { session, sessionToken } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  try {
+    const result = await recapture(shop.id, {
+      segmentId: String(form.get("segment") ?? "") || undefined,
+      confirmation: String(form.get("confirmation") ?? ""),
+      actor: actorFor(sessionToken, session.shop),
+    });
+
+    return {
+      ok: true,
+      message:
+        `Recaptured ${result.captured} baselines across ${result.scope} variants` +
+        (result.superseded > 0 ? `, superseding ${result.superseded}` : "") +
+        (result.alreadyCurrent > 0 ? `. ${result.alreadyCurrent} were already correct` : "") +
+        ".",
+    };
+  } catch (error) {
+    const reported = await reportError(error, {
+      shopId: shop.id,
+      shop: session.shop,
+      route: "/app/baselines/recapture",
+    });
+    return { ok: false, message: reported.userMessage, errorId: reported.errorId };
+  }
+});
+
+export default function Recapture() {
+  const { assessment, segments, segmentId } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const busy = fetcher.state !== "idle";
+  const data = fetcher.data;
+
+  return (
+    <s-page heading="Recapture baselines">
+      {data ? (
+        <s-banner tone={data.ok ? "success" : "critical"}>
+          <s-paragraph>{data.message}</s-paragraph>
+          {data.errorId ? <s-paragraph>Reference {data.errorId}</s-paragraph> : null}
+        </s-banner>
+      ) : null}
+
+      <s-section heading="What this does">
+        <s-paragraph>
+          <s-text>
+            Recapturing replaces the reference price of every variant in scope with the
+            price its storefront shows right now. Every campaign from then on computes
+            its discount from the new number.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            Do it when your real prices have genuinely changed — a supplier increase, a
+            new season. Do not do it while a sale is running, or the sale price becomes
+            the price you discount from next time.
+          </s-text>
+        </s-paragraph>
+
+        <fetcher.Form method="get">
+          <s-stack gap="base">
+            <label htmlFor="segment">Scope</label>
+            <select id="segment" name="segment" defaultValue={segmentId}>
+              <option value="">The whole catalogue</option>
+              {segments.map((segment) => (
+                <option key={segment.id} value={segment.id}>
+                  {segment.name} ({segment.kind === "DYNAMIC" ? "dynamic" : "frozen"})
+                </option>
+              ))}
+            </select>
+            <s-button type="submit">Check this scope</s-button>
+          </s-stack>
+        </fetcher.Form>
+
+        <s-paragraph>
+          <s-text>
+            {assessment.scope} variant{assessment.scope === 1 ? "" : "s"} in scope.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+
+      {assessment.risk === "overlaps-active-campaign" ? (
+        <s-section heading="These are on sale right now">
+          <s-banner tone="critical">
+            <s-paragraph>{assessment.warning}</s-paragraph>
+          </s-banner>
+
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Campaign</s-table-header>
+              <s-table-header>Variants in this scope</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {assessment.overlaps.map((overlap) => (
+                <s-table-row key={overlap.campaignId}>
+                  <s-table-cell>{overlap.campaignName}</s-table-cell>
+                  <s-table-cell>{overlap.variants}</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </s-section>
+      ) : null}
+
+      <s-section heading="Recapture">
+        <fetcher.Form method="post">
+          <input type="hidden" name="segment" value={segmentId} />
+          <s-stack gap="base">
+            {assessment.confirmationPhrase ? (
+              <s-text-field
+                name="confirmation"
+                label={`Type “${assessment.confirmationPhrase}” to confirm`}
+                details="Typed rather than clicked, because a button is muscle memory by the third time."
+              />
+            ) : null}
+
+            <s-button
+              type="submit"
+              tone="critical"
+              variant="primary"
+              loading={busy || undefined}
+              disabled={assessment.scope === 0 || undefined}
+            >
+              Replace {assessment.scope} baseline{assessment.scope === 1 ? "" : "s"}
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      <s-section slot="aside" heading="If you get this wrong">
+        <s-paragraph>
+          <s-text>
+            Baselines are append-only: the previous one is kept, marked superseded, with
+            the date it was replaced. Nothing is destroyed, so a mistaken recapture can
+            be traced — but putting it back means reading that history and setting the
+            old numbers again, which on a large catalogue is a bad afternoon.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>The Baselines page shows every version of every variant.</s-text>
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/services/recapture.server.ts
+++ b/app/services/recapture.server.ts
@@ -1,0 +1,178 @@
+/**
+ * Scoped recapture, with the checks the operation deserves.
+ *
+ * Recapture is the most destructive thing this app does. It replaces every baseline in
+ * scope with today's live price, and a baseline is what every campaign computes from
+ * forever after. Run it during a sale and the sale prices become the merchant's normal
+ * prices — permanently.
+ *
+ * The dashboard used to offer this as a button with a paragraph of warning next to it.
+ * That is not enough: the warning is generic, the scope is the whole store, and one
+ * click does it. This scopes it, works out which running campaigns it would enshrine,
+ * demands a typed confirmation when any do, and writes the whole thing to the audit log
+ * with who asked for it.
+ */
+
+import prisma from "../db.server";
+import { AppError } from "../lib/errors/app-error";
+import {
+  assessRecapture,
+  confirmationMatches,
+  type ActiveOverlap,
+  type RecaptureAssessment,
+} from "../lib/baselines/recapture";
+import { captureBaselines } from "./baselines.server";
+import { astToWhere, type FilterAst } from "./segments.server";
+import { scopeOf } from "./campaigns/model.server";
+
+export interface RecaptureScope {
+  /** A saved segment, or the whole catalogue when absent. */
+  segmentId?: string;
+}
+
+/**
+ * Works out what a recapture would do, without doing any of it.
+ *
+ * The same resolution the recapture itself uses, so the number the merchant confirms is
+ * the number that gets rewritten.
+ */
+export async function planRecapture(
+  shopId: string,
+  scope: RecaptureScope = {},
+): Promise<RecaptureAssessment & { variantGids: string[] }> {
+  const variantGids = await resolveScope(shopId, scope);
+  const overlaps = await activeOverlaps(shopId, variantGids);
+
+  return { ...assessRecapture(variantGids.length, overlaps), variantGids };
+}
+
+export interface RecaptureOptions extends RecaptureScope {
+  /** What the merchant typed. Checked against the phrase the assessment demanded. */
+  confirmation?: string;
+  actor?: string;
+}
+
+export async function recapture(shopId: string, options: RecaptureOptions = {}) {
+  const plan = await planRecapture(shopId, options);
+
+  if (!confirmationMatches(options.confirmation ?? "", plan.confirmationPhrase)) {
+    throw new AppError({
+      code: "VALIDATION",
+      userMessage:
+        `${plan.warning ?? ""} Type “${plan.confirmationPhrase}” to confirm you want to do this anyway.`.trim(),
+      context: { shopId, scope: plan.scope, overlaps: plan.overlaps.map((o) => o.campaignId) },
+    });
+  }
+
+  if (plan.scope === 0) {
+    throw new AppError({
+      code: "VALIDATION",
+      userMessage:
+        "That scope matches no variants, so there is nothing to recapture. Check the segment you picked.",
+    });
+  }
+
+  const result = await captureBaselines(shopId, {
+    variantGids: plan.variantGids,
+    // The flag that makes this a recapture rather than a no-op. `captureBaselines`
+    // leaves existing baselines alone by default — it runs after every sync, and
+    // silently re-anchoring to live prices each time would destroy the whole
+    // guarantee. Replacing them is the entire point here, which is why everything
+    // above this line exists.
+    recapture: true,
+    source: "RECAPTURE",
+    capturedBy: options.actor,
+  });
+
+  // Written whatever the outcome, and written with the overlaps. Six weeks later the
+  // question is not "did somebody recapture" but "did somebody recapture over a live
+  // sale", and only this row can answer it.
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor: options.actor ?? null,
+      action: "baselines.recapture",
+      entity: "Shop",
+      entityId: shopId,
+      after: {
+        scope: plan.scope,
+        segmentId: options.segmentId ?? null,
+        captured: result.captured,
+        superseded: result.superseded,
+        alreadyCurrent: result.alreadyCurrent,
+        overActiveCampaigns: plan.overlaps.map((o) => ({ id: o.campaignId, variants: o.variants })),
+      },
+    },
+  });
+
+  return { ...result, scope: plan.scope, overlaps: plan.overlaps };
+}
+
+async function resolveScope(shopId: string, scope: RecaptureScope): Promise<string[]> {
+  if (!scope.segmentId) {
+    const all = await prisma.variantIndex.findMany({
+      where: { shopId, deletedAt: null },
+      select: { variantGid: true },
+    });
+    return all.map((row) => row.variantGid);
+  }
+
+  const segment = await prisma.segment.findFirst({
+    where: { id: scope.segmentId, shopId },
+    select: { kind: true, filterAst: true, frozenVariantGids: true },
+  });
+  if (!segment) {
+    throw new AppError({
+      code: "NOT_FOUND",
+      userMessage: "That segment no longer exists. Pick another, or recapture the whole catalogue.",
+    });
+  }
+
+  if (segment.kind === "FROZEN") return segment.frozenVariantGids;
+
+  const rows = await prisma.variantIndex.findMany({
+    where: astToWhere(shopId, astOf(segment.filterAst)),
+    select: { variantGid: true },
+  });
+  return rows.map((row) => row.variantGid);
+}
+
+/**
+ * Which running campaigns are currently pricing variants in the scope.
+ *
+ * Counted per campaign rather than as a total, because the merchant's decision is
+ * usually "revert that one first" and that needs a name attached to a number.
+ */
+/** Prisma hands back JSON; the AST shape has to be asserted through `unknown`. */
+function astOf(stored: unknown): FilterAst {
+  const ast = stored as FilterAst | null;
+  return ast && Array.isArray(ast.groups) ? ast : { groups: [] };
+}
+
+async function activeOverlaps(shopId: string, variantGids: string[]): Promise<ActiveOverlap[]> {
+  if (variantGids.length === 0) return [];
+
+  const campaigns = await prisma.campaign.findMany({
+    where: { shopId, status: { in: ["ACTIVE", "APPLYING", "PARTIAL"] } },
+    select: { id: true, name: true, schedule: true },
+  });
+
+  const inScope = new Set(variantGids);
+  const overlaps: ActiveOverlap[] = [];
+
+  for (const campaign of campaigns) {
+    // The campaign's real scope, resolved the same way a run resolves it — so a
+    // segment-targeted campaign is counted against its segment rather than against an
+    // empty inline filter, which would match the whole catalogue.
+    const ast = await scopeOf(shopId, campaign);
+    const covered = await prisma.variantIndex.findMany({
+      where: astToWhere(shopId, ast),
+      select: { variantGid: true },
+    });
+
+    const variants = covered.filter((row) => inScope.has(row.variantGid)).length;
+    overlaps.push({ campaignId: campaign.id, campaignName: campaign.name, variants });
+  }
+
+  return overlaps;
+}

--- a/chaos/scenarios/recapture.chaos.ts
+++ b/chaos/scenarios/recapture.chaos.ts
@@ -1,0 +1,141 @@
+/**
+ * The guard on the most destructive thing this app does.
+ *
+ * Recapture replaces every baseline in scope with today's live price. Run it while a
+ * sale is on and the sale prices *become* the merchant's normal prices — permanently,
+ * for every campaign afterwards, because every campaign computes from the baseline.
+ * A 20%-off campaign applied to an already-discounted baseline compounds, and the
+ * merchant has no way to notice until the margin is gone.
+ *
+ * The dashboard used to offer this as one click behind a paragraph of warning. This
+ * proves the replacement actually stops it, against a real campaign holding real
+ * prices.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { planRecapture, recapture } from "../../app/services/recapture.server";
+import { DANGEROUS_PHRASE } from "../../app/lib/baselines/recapture";
+import { withChaos } from "../harness/scenario";
+
+describe("chaos: recapturing baselines", () => {
+  it("refuses to enshrine a live sale without a typed confirmation", async () => {
+    await withChaos(
+      "recapture",
+      { catalog: { products: 5, variantsPerProduct: 2 }, percent: -25 },
+      async (chaos) => {
+        const { shopId, variantGids, baseline } = chaos.fixture;
+
+        // Nothing running: recapture is unremarkable and asks for nothing extra.
+        const quiet = await planRecapture(shopId);
+        expect(quiet.risk).toBe("safe");
+        expect(quiet.confirmationPhrase).toBeNull();
+
+        // Now put the catalogue on sale for real.
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const atRisk = await planRecapture(shopId);
+        expect(atRisk.risk).toBe("overlaps-active-campaign");
+        expect(atRisk.overlaps[0].variants).toBe(variantGids.length);
+        expect(atRisk.warning).toContain("new normal");
+
+        // Unconfirmed, it refuses — and the message names the campaign rather than
+        // saying something vague about danger.
+        await expect(recapture(shopId, {})).rejects.toThrow(/new normal|permanently/i);
+
+        // And it refused without touching anything. This is the assertion that
+        // matters: a guard that warns after writing is not a guard.
+        for (const gid of variantGids) {
+          const current = await prisma.baseline.findFirstOrThrow({
+            where: { shopId, variantGid: gid, supersededAt: null },
+          });
+          expect(Number(current.basePrice)).toBe(baseline.get(gid));
+        }
+        expect(await prisma.baseline.count({ where: { shopId, source: "RECAPTURE" } })).toBe(0);
+      },
+    );
+  });
+
+  it("goes ahead when the merchant types the words, and keeps the old baseline", async () => {
+    await withChaos(
+      "recapture-confirmed",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids, baseline } = chaos.fixture;
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const result = await recapture(shopId, {
+          confirmation: DANGEROUS_PHRASE,
+          actor: "staff:1",
+        });
+        expect(result.captured).toBe(variantGids.length);
+
+        // The sale price is now the baseline — which is exactly what the merchant was
+        // warned about and chose.
+        const gid = variantGids[0];
+        const current = await prisma.baseline.findFirstOrThrow({
+          where: { shopId, variantGid: gid, supersededAt: null },
+        });
+        expect(Number(current.basePrice)).toBe(Math.round(baseline.get(gid)! * 0.8));
+        expect(current.source).toBe("RECAPTURE");
+
+        // Append-only: the real price is still there, marked superseded. Nothing is
+        // destroyed, which is what makes a mistaken recapture traceable.
+        const previous = await prisma.baseline.findFirstOrThrow({
+          where: { shopId, variantGid: gid, supersededAt: { not: null } },
+        });
+        expect(Number(previous.basePrice)).toBe(baseline.get(gid));
+
+        // And the whole thing is in the audit log, with the campaigns it overrode.
+        const entry = await prisma.auditLogEntry.findFirstOrThrow({
+          where: { shopId, action: "baselines.recapture" },
+          orderBy: { createdAt: "desc" },
+        });
+        expect(entry.actor).toBe("staff:1");
+        expect(JSON.stringify(entry.after)).toContain("overActiveCampaigns");
+      },
+    );
+  });
+
+  it("only counts campaigns that actually overlap the scope", async () => {
+    await withChaos(
+      "recapture-scoped",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // A frozen segment holding one variant the campaign does cover.
+        const { createSegment } = await import("../../app/services/segments-crud.server");
+        const overlapping = await createSegment(shopId, {
+          name: `recapture-overlap-${chaos.seed}`,
+          kind: "FROZEN",
+          variantGids: [variantGids[0]],
+        });
+
+        const plan = await planRecapture(shopId, { segmentId: overlapping.id });
+        expect(plan.scope).toBe(1);
+        expect(plan.risk).toBe("overlaps-active-campaign");
+        expect(plan.overlaps[0].variants).toBe(1);
+
+        // A segment holding a variant nothing is pricing: alarming somebody about a
+        // campaign running elsewhere in the catalogue would train them to ignore it.
+        const elsewhere = await createSegment(shopId, {
+          name: `recapture-elsewhere-${chaos.seed}`,
+          kind: "FROZEN",
+          variantGids: ["gid://shopify/ProductVariant/not-in-this-campaign"],
+        });
+
+        const clear = await planRecapture(shopId, { segmentId: elsewhere.id });
+        expect(clear.risk).toBe("safe");
+        expect(clear.confirmationPhrase).toBeNull();
+      },
+    );
+  });
+});


### PR DESCRIPTION
Recapture is **the most destructive thing this app does.** It replaces every baseline in
scope with today's live price, and a baseline is what every campaign computes from
forever after. Run it while a sale is on and the sale prices *become* the merchant's
normal prices — permanently. A 20%-off campaign then computes from an already-discounted
number, and nobody notices until the margin is gone.

The dashboard offered this as one click behind a paragraph of generic warning,
store-wide, checking nothing. That is gone.

## What replaces it

Its own page, which resolves the scope, works out which running campaigns that scope
would enshrine, and **names each one with how many variants it covers**:

> 4 of these 1616 variants are on sale right now under "Gift card test sale" (4).
> Recapturing would make the sale price their new normal price, permanently — every
> future campaign would compute its discount from the discounted price. **Revert those
> campaigns first** unless that is genuinely what you want.

That is a fact somebody can act on. *"Some campaigns may be affected"* is a dialog people
click through. The warning says what actually goes wrong and what to do instead, not that
the operation is dangerous.

Confirmation is **typed, and only when something is at risk**. Demanding a phrase every
time is how a merchant learns to type it without reading, and then types it on the day
it mattered. Capitalisation is not enforced — the requirement is that they read the
sentence and type the words; strictness turns a safety check into a puzzle that gets
copy-pasted.

Overlap is resolved the same way a *run* resolves scope, so a segment-targeted campaign
is counted against its segment rather than against an empty inline filter — which would
match the whole catalogue and alarm somebody about every recapture they ever attempt.

## Two bugs found by opening the page

**`app.baselines.tsx` had become a flat-routes layout** for everything under
`/app/baselines`, and a layout with no `<Outlet />` renders itself in place of its
children. It was silently swallowing both this page *and* the import page built earlier,
showing the baseline table at all three URLs. Renamed to `_index`.

**The service called `captureBaselines` without `recapture: true`**, so it captured
nothing. That flag is off by default precisely because capture runs after every sync and
silently re-anchoring each time would destroy the guarantee — replacing baselines is the
entire point *here*, which is what everything above that line exists to gate.

## Three chaos scenarios

- A live sale refused, with **nothing written** — a guard that warns after writing is not
  a guard
- The same recapture going ahead on a typed confirmation, with the real price kept as a
  superseded row and the whole thing in the audit log with the campaigns it overrode
- A segment overlapping nothing correctly staying quiet

Blinding the guard turns the first and third red.

The partial unique index enforcing one current baseline per variant per surface was
already in place and correct.

## Not met

A **live progress screen** during capture. The explanatory screen exists and explains
what a baseline is while the first sync runs, but progress is not streamed — the sync
happens inside the request, which is its own piece of work to move to the worker.

- 406 unit tests (7 new), 26 chaos scenarios, typecheck/lint/build clean

Closes #77, #78, #79, #81, #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)