### PR TITLE
#200 — Key a scheduled run on its occurrence, not on the instant it started

### DIFF
--- a/app/lib/scheduling/occurrence.test.ts
+++ b/app/lib/scheduling/occurrence.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Which occurrence a scheduled run belongs to.
+ *
+ * The unique index on (campaign, occurrence, kind) is documented as making recurring
+ * runs idempotent so a duplicate tick cannot double-apply. It only does that if the key
+ * names the occurrence. Keyed on the instant a run started — as it was — two ticks two
+ * milliseconds apart produce two keys and two runs, and the index fires only on an
+ * exact-millisecond collision, which is the case where it is least useful.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { occurrenceKeyFor, type Schedule } from "./window";
+
+const window = (over: Partial<Extract<Schedule, { kind: "window" }>> = {}): Schedule => ({
+  kind: "window",
+  startAt: "2026-09-01T09:00:00.000Z",
+  endAt: "2026-09-08T23:00:00.000Z",
+  ...over,
+});
+
+describe("occurrenceKeyFor", () => {
+  it("gives two ticks of the same window the same key", () => {
+    // The whole point. Whichever tick loses the insert stands down instead of applying
+    // a second time.
+    const a = occurrenceKeyFor(window(), "apply", new Date("2026-09-01T09:00:00Z"));
+    const b = occurrenceKeyFor(window(), "apply", new Date("2026-09-01T09:00:02Z"));
+    expect(a).toBe(b);
+  });
+
+  it("keys an apply on the start and a revert on the end", () => {
+    expect(occurrenceKeyFor(window(), "apply")).toBe("APPLY@2026-09-01T09:00:00.000Z");
+    expect(occurrenceKeyFor(window(), "revert")).toBe("REVERT@2026-09-08T23:00:00.000Z");
+  });
+
+  it("treats apply and revert of one window as different occurrences", () => {
+    // They are, and the index keys on kind as well — but the instants differing is what
+    // makes the intent readable in the table.
+    expect(occurrenceKeyFor(window(), "apply")).not.toBe(occurrenceKeyFor(window(), "revert"));
+  });
+
+  it("normalises equivalent timestamps to one occurrence", () => {
+    // "…T09:00:00Z" and "…T09:00:00.000Z" are the same moment. Keying on the raw string
+    // would make them two occurrences and let the same window apply twice.
+    const terse = occurrenceKeyFor(window({ startAt: "2026-09-01T09:00:00Z" }), "apply");
+    const precise = occurrenceKeyFor(window({ startAt: "2026-09-01T09:00:00.000Z" }), "apply");
+    expect(terse).toBe(precise);
+  });
+
+  it("distinguishes different windows", () => {
+    const september = occurrenceKeyFor(window(), "apply");
+    const october = occurrenceKeyFor(window({ startAt: "2026-10-01T09:00:00.000Z" }), "apply");
+    expect(september).not.toBe(october);
+  });
+
+  it("falls back to the instant for a window with no end", () => {
+    // Reverted by hand, so there is no scheduled instant to name.
+    const key = occurrenceKeyFor(
+      window({ endAt: undefined }),
+      "revert",
+      new Date("2026-09-10T12:00:00.000Z"),
+    );
+    expect(key).toBe("REVERT@2026-09-10T12:00:00.000Z");
+  });
+
+  it("keeps manual runs keyed on the instant", () => {
+    // Deduplicating those is not what the index is for. A merchant clicking Apply is
+    // watching the screen and the button disables itself; collapsing two deliberate
+    // applies seconds apart would break apply/revert/apply-again for no safety gained.
+    const first = occurrenceKeyFor({ kind: "manual" }, "apply", new Date(1_000));
+    const second = occurrenceKeyFor({ kind: "manual" }, "apply", new Date(2_000));
+    expect(first).not.toBe(second);
+    expect(first).toBe("APPLY-1000");
+  });
+});

--- a/app/lib/scheduling/window.ts
+++ b/app/lib/scheduling/window.ts
@@ -264,3 +264,46 @@ export function utcToLocalInput(iso: string | undefined, timeZone: string): stri
   const hour = get("hour") === "24" ? "00" : get("hour");
   return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}`;
 }
+
+/**
+ * Which occurrence a scheduled run is for.
+ *
+ * `campaign_runs` carries a unique index on (campaign, occurrence, kind), documented as
+ * making recurring runs idempotent so a duplicate scheduler tick cannot double-apply.
+ * That only works if the key identifies the *occurrence*. It used to be
+ * `${kind}-${Date.now()}`, which identifies the instant a run happened to start — so two
+ * ticks two milliseconds apart produced two different keys and two runs, and the index
+ * fired only on an exact-millisecond collision, which is the one case where it was least
+ * useful.
+ *
+ * A windowed campaign has a real answer: the window's own start or end. Two ticks that
+ * both find the same window due now produce the same key, the second loses the insert,
+ * and the loser stands down instead of applying a second time.
+ *
+ * Manual runs keep the instant, deliberately. Deduplicating those is not what the index
+ * is for — a merchant clicking Apply is watching the screen, the button disables itself,
+ * and collapsing two deliberate applies seconds apart would break the ordinary
+ * apply/revert/apply-again rhythm for no safety gained.
+ */
+export function occurrenceKeyFor(
+  schedule: Schedule,
+  transition: Transition,
+  now: Date = new Date(),
+): string {
+  const kind = transition === "apply" ? "APPLY" : "REVERT";
+
+  if (schedule.kind !== "window") return `${kind}-${now.getTime()}`;
+
+  // Normalised through Date, so "2026-08-26T10:00:00Z" and "2026-08-26T10:00:00.000Z"
+  // are the same occurrence rather than two.
+  const instant =
+    transition === "apply"
+      ? new Date(schedule.startAt).toISOString()
+      : schedule.endAt
+        ? new Date(schedule.endAt).toISOString()
+        // A window with no end is reverted by hand, so the occurrence is the moment it
+        // was asked for. There is no scheduled instant to name.
+        : new Date(now).toISOString();
+
+  return `${kind}@${instant}`;
+}

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -8,7 +8,12 @@
  */
 
 import prisma from "../db.server";
-import { dueTransition, parseSchedule, type Transition } from "../lib/scheduling/window";
+import {
+  dueTransition,
+  occurrenceKeyFor,
+  parseSchedule,
+  type Transition,
+} from "../lib/scheduling/window";
 import { runCampaign } from "./campaigns/run.server";
 import { adminClientForShop } from "./admin-client.server";
 import { claimEnrollment, pendingEnrollments } from "./auto-enroll.server";
@@ -79,7 +84,16 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
     if (!transition) continue;
 
     try {
-      await runTransition(campaign.shop.id, campaign.shop.domain, campaign.id, transition);
+      await runTransition(
+        campaign.shop.id,
+        campaign.shop.domain,
+        campaign.id,
+        transition,
+        // The occurrence this tick is acting on, not the instant it happened to run.
+        // Two ticks that both find this window due produce the same key, and the unique
+        // index turns the second into a no-op rather than a second apply.
+        occurrenceKeyFor(parseSchedule(campaign.schedule), transition, now),
+      );
       if (transition === "apply") {
         result.applied++;
         transitioned.add(campaign.id);
@@ -216,6 +230,7 @@ async function runTransition(
   shopDomain: string,
   campaignId: string,
   transition: Transition,
+  occurrenceKey: string,
 ): Promise<void> {
   const client = await adminClientForShop(shopDomain);
   if (!client) throw new Error(`No usable session for ${shopDomain}`);
@@ -233,7 +248,10 @@ async function runTransition(
 
   if (claimed.count === 0) return; // someone else took it
 
-  await runCampaign(shopId, campaignId, client, { revert: transition === "revert" });
+  await runCampaign(shopId, campaignId, client, {
+    revert: transition === "revert",
+    occurrenceKey,
+  });
 }
 
 /** Campaigns with a schedule that has not yet fired, for the UI. */

--- a/chaos/scenarios/duplicate-tick.chaos.ts
+++ b/chaos/scenarios/duplicate-tick.chaos.ts
@@ -1,0 +1,100 @@
+/**
+ * A duplicate scheduler tick must not apply a campaign twice.
+ *
+ * `campaign_runs` carries a unique index on (campaign, occurrence, kind), documented as
+ * exactly this guarantee. It was keyed on `${kind}-${Date.now()}` — the instant a run
+ * started rather than the occurrence it was for — so two ticks two milliseconds apart
+ * produced two keys and two runs, and the index fired only on an exact-millisecond
+ * collision. The guarantee the schema claimed was, in practice, absent.
+ *
+ * The realistic trigger is a leader-lock gap: a Redis restart, a slow renewal, a deploy
+ * overlap. Two workers each tick, each find the same window due, and each start a run
+ * for one occurrence.
+ *
+ * Survivable even then, because campaign maths reads the baseline — that is what the
+ * redis-restart scenario proves. This proves the layer that is supposed to stop it
+ * happening at all.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { occurrenceKeyFor, parseSchedule } from "../../app/lib/scheduling/window";
+import { withChaos } from "../harness/scenario";
+
+describe("chaos: a duplicate scheduler tick", () => {
+  it("produces one run for one window, however many ticks see it", async () => {
+    await withChaos(
+      "duplicate-tick",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { campaignId, variantGids, baseline } = chaos.fixture;
+
+        // A window that opened an hour ago and has not closed.
+        const startAt = new Date(Date.now() - 60 * 60_000);
+        const campaign = await prisma.campaign.findUniqueOrThrow({ where: { id: campaignId } });
+        const schedule = {
+          ...(campaign.schedule as object),
+          kind: "window" as const,
+          startAt: startAt.toISOString(),
+        };
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { status: "SCHEDULED", startAt, schedule: schedule as never },
+        });
+
+        // What two ticks, seconds apart, each compute for this window. The scheduler
+        // itself needs a Shopify session the fixture shop does not have, so the key is
+        // derived here exactly as `tick` derives it and handed to the same run path —
+        // which is the part the guarantee actually rests on.
+        const first = occurrenceKeyFor(parseSchedule(schedule), "apply", new Date());
+        const second = occurrenceKeyFor(parseSchedule(schedule), "apply", new Date(Date.now() + 2_000));
+        expect(second).toBe(first);
+        expect(first).toBe(`APPLY@${startAt.toISOString()}`);
+
+        const applied = await chaos.apply({ occurrenceKey: first });
+        await chaos.expectHonest(applied.runId);
+        expect(applied.verified).toBe(variantGids.length);
+
+        // The second tick. It must stand down rather than apply a second time.
+        const duplicate = await chaos.apply({ occurrenceKey: second });
+        expect(duplicate.deferredTo).toBe(applied.runId);
+        expect(duplicate.verified).toBe(0);
+
+        // One run for one occurrence.
+        expect(
+          await prisma.campaignRun.count({ where: { campaignId, occurrenceKey: first } }),
+        ).toBe(1);
+
+        // And the prices are where one application puts them — not compounded.
+        for (const gid of variantGids) {
+          const once = Math.round(baseline.get(gid)! * 0.8);
+          expect(chaos.fake.priceOf(gid)).toBe((once / 100).toFixed(2));
+        }
+      },
+    );
+  });
+
+  it("still lets a merchant apply, revert, and apply again by hand", async () => {
+    await withChaos(
+      "duplicate-tick-manual",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        // Manual runs stay keyed on the instant, deliberately. Collapsing two
+        // deliberate applies seconds apart would break the ordinary rhythm for no
+        // safety gained — the merchant is watching the screen and the button disables
+        // itself.
+        const first = await chaos.apply();
+        await chaos.expectHonest(first.runId);
+
+        await chaos.revert();
+
+        const again = await chaos.apply();
+        await chaos.expectHonest(again.runId);
+
+        expect(again.runId).not.toBe(first.runId);
+        expect(again.verified).toBe(3);
+      },
+    );
+  });
+});


### PR DESCRIPTION
`campaign_runs` carries a unique index on `(campaign, occurrence, kind)`, documented as
making recurring runs idempotent so that *"a duplicate scheduler tick cannot
double-apply"*.

The key was `${kind}-${Date.now()}`.

That identifies **the instant a run happened to start**, not the occurrence it was for.
Two ticks two milliseconds apart produced two different keys and two runs; the index
fired only on an exact-millisecond collision — the one case where it was least useful,
and before #199 it fired by throwing a raw Prisma error out of `runCampaign`. The
guarantee the schema claimed was, in practice, absent.

## A window has a real answer

Its own start or end. Two ticks that both find the same window due now compute the same
key, the second loses the insert, and the loser stands down instead of applying again.

Timestamps are normalised through `Date`, so `…T09:00:00Z` and `…T09:00:00.000Z` are one
occurrence rather than two.

**Manual runs keep the instant, deliberately.** Deduplicating those is not what the index
is for — a merchant clicking Apply is watching the screen, the button disables itself,
and collapsing two deliberate applies seconds apart would break the ordinary
apply/revert/apply-again rhythm for no safety gained.

## Why it matters

The realistic trigger is a leader-lock gap: a Redis restart, a slow renewal, a deploy
overlap. Two workers each tick, each find the same window due.

That is survivable even without this, because campaign maths reads the baseline — which
the `redis-restart` scenario proves. **This is the layer that is supposed to stop it
happening at all.**

## Two scenarios

- Two ticks of one window → exactly one run, the second deferring to the first, prices
  landing where a *single* application puts them
- A merchant can still apply, revert and apply again by hand

Reverting to the instant key turns the first red:
`expected 'APPLY-1787686990884' to be 'APPLY-1787686988884'`

The first version of that scenario was **vacuous** — it called `tick()` twice, which
needs a Shopify session the fixture shop does not have, so no runs were created and every
assertion passed over an empty array. It now derives the key exactly as the scheduler
does and drives the same run path.

- 413 unit tests (7 new), 31 chaos scenarios, typecheck/lint/build clean

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)