### PR TITLE
P0.6 — Telemetry that cannot leak a price, and the SLO panels named

### DIFF
--- a/app/lib/logging/logger.ts
+++ b/app/lib/logging/logger.ts
@@ -6,9 +6,16 @@
  * search by when something has gone wrong at 2am: the error id the merchant quoted,
  * the shop, the route, and the code.
  *
- * Everything routes through `redact` on the way out -- see that module for why.
+ * Everything routes through two redaction passes on the way out. `logging/redact`
+ * strips secrets -- the object nearest a failed Shopify call is often the one holding
+ * an access token. `telemetry/redact` strips prices, which are commercial data that has
+ * no business in an aggregator with its own retention and its own access list.
+ *
+ * Both happen here rather than at every call site, because a rule kept by everyone
+ * remembering lasts until somebody adds a field in a hurry.
  */
 
+import { redactPrices } from "../telemetry/redact";
 import { redact } from "./redact";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -51,7 +58,11 @@ function isPretty(): boolean {
 function emit(level: LogLevel, message: string, fields: LogFields = {}): void {
   if (LEVELS[level] < threshold()) return;
 
-  const safe = redact(fields) as LogFields;
+  // Prices first, then secrets. The order matters: the secret pass renders a bigint as
+  // "8000n", and a price that has already become a string slips past a money-shaped
+  // check. Every price in this codebase is a bigint, so catching it while it still is
+  // one is the only reliable pass.
+  const safe = redact(redactPrices(fields)) as LogFields;
   const sink = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
 
   if (isPretty()) {

--- a/app/lib/telemetry/metrics.test.ts
+++ b/app/lib/telemetry/metrics.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The SLO numbers, and the empty case that decides whether they mean anything.
+ */
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { metric, rate } from "./metrics";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("rate", () => {
+  it("expresses a fraction", () => {
+    expect(rate(3, 4)).toBe(0.75);
+    expect(rate(0, 4)).toBe(0);
+  });
+
+  it("returns null for no data rather than zero", () => {
+    // Zero out of zero is not a zero rate. Reporting it as 0 makes an idle shop
+    // indistinguishable from a completely broken one on the same panel, and the alert
+    // built on that panel fires on the wrong one.
+    expect(rate(0, 0)).toBeNull();
+    expect(rate(5, -1)).toBeNull();
+  });
+});
+
+describe("metric", () => {
+  it("emits a named measurement with its labels", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    metric("run.duration_ms", 8_042, { shopId: "s1", runId: "r1" });
+
+    expect(log).toHaveBeenCalledOnce();
+    expect(String(log.mock.calls[0][0])).toContain("run.duration_ms");
+    expect(String(log.mock.calls[0][0])).toContain("8042");
+  });
+
+  it("never throws, whatever it is handed", () => {
+    // A metric describes work that already happened. An exporter failing must not be
+    // able to change the work.
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => metric("queue.depth", 1, cyclic as never)).not.toThrow();
+  });
+
+  it("carries no price into a label", () => {
+    // A metric label is worse than a log line for this: high-cardinality, long
+    // retention, indexed.
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    metric("run.rows", 3, { price: "19.99" } as never);
+    expect(String(log.mock.calls[0][0])).not.toContain("19.99");
+  });
+});

--- a/app/lib/telemetry/metrics.ts
+++ b/app/lib/telemetry/metrics.ts
@@ -1,0 +1,73 @@
+/**
+ * The numbers that say whether this app is working.
+ *
+ * Emitted as structured lines rather than through an OpenTelemetry SDK. That is a
+ * deliberate stopping point, not an oversight: the SDK is a large dependency whose
+ * export is inert without a collector, and there is no collector until there is a
+ * staging environment. A named metric with typed labels on stdout is scrapeable by
+ * anything, costs nothing, and is the same shape an exporter would take later — so
+ * adding one is wiring, not rework.
+ *
+ * The panel names come from RFC §11 and are fixed here so the dashboard, the alerts and
+ * the code cannot drift apart by someone renaming a string.
+ *
+ * Labels never carry a price. They go through the same redaction as logs, because a
+ * metric label is if anything worse than a log line: it is high-cardinality, retained
+ * for a long time, and indexed.
+ */
+
+import { logger } from "../logging/logger";
+
+/** The SLO panels. Stubbed where the feature does not exist yet, named so they can be. */
+export type Metric =
+  /** Fraction of runs where every row was read back and confirmed. The headline. */
+  | "run.verified_clean_rate"
+  /** How long a run took, end to end. */
+  | "run.duration_ms"
+  /** Rows a run wrote, by outcome. */
+  | "run.rows"
+  /** Delay between Shopify sending a webhook and us processing it. */
+  | "webhook.lag_ms"
+  /** Fraction of a sampled mirror that disagreed with Shopify. */
+  | "mirror.divergence_rate"
+  /** That the scheduler is alive and doing work. */
+  | "scheduler.tick"
+  /** How much of a shop's rate-limit budget a run consumed. */
+  | "budget.saturation"
+  /** Jobs waiting. Zero is healthy; a rising floor is not. */
+  | "queue.depth";
+
+export interface MetricLabels {
+  shopId?: string;
+  runId?: string;
+  campaignId?: string;
+  /** Free-form, redacted like everything else. Never a price. */
+  [key: string]: string | number | boolean | undefined;
+}
+
+/**
+ * Records one measurement.
+ *
+ * Never throws. A metric is a description of work that already happened; an exporter
+ * failing must not be able to change the work.
+ */
+export function metric(name: Metric, value: number, labels: MetricLabels = {}): void {
+  try {
+    logger.info("metric", { metric: name, value, ...labels });
+  } catch {
+    // Deliberately silent. There is nothing useful to do when the thing that reports
+    // problems is the problem, and recursing into the logger to say so is worse.
+  }
+}
+
+/**
+ * A rate expressed as a fraction, guarding the empty case.
+ *
+ * Zero out of zero is not a zero rate — it is no data. Reporting it as 0 would make an
+ * idle shop indistinguishable from a completely broken one on the same panel, and the
+ * alert built on that panel would fire on the wrong one.
+ */
+export function rate(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) return null;
+  return numerator / denominator;
+}

--- a/app/lib/telemetry/redact.test.ts
+++ b/app/lib/telemetry/redact.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The rule that telemetry never carries a price.
+ *
+ * It is in CLAUDE.md and it is absolute: shop id, plan, counts, durations, statuses.
+ * A merchant's pricing is commercially sensitive and a third-party error tracker is
+ * somewhere they never agreed to put it — with its own retention and its own access
+ * list.
+ *
+ * Enforced here rather than by everyone remembering, because a rule kept by memory lasts
+ * until somebody adds a field in a hurry. Which is exactly the case these tests are
+ * built around.
+ */
+
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { redactPrices, REDACTED } from "./redact";
+
+describe("redactPrices", () => {
+  it("redacts a field because of its name", () => {
+    expect(redactPrices({ price: 1999, shopId: "s1" })).toEqual({
+      price: REDACTED,
+      shopId: "s1",
+    });
+  });
+
+  it("catches the aliases prices actually travel under here", () => {
+    const out = redactPrices({
+      basePrice: 1n,
+      intendedPrice: 2n,
+      liveCompareAt: 3n,
+      observedPrice: 4n,
+    }) as Record<string, unknown>;
+    for (const value of Object.values(out)) expect(value).toBe(REDACTED);
+  });
+
+  it("redacts a money-shaped value whatever the field is called", () => {
+    // The failure mode that matters. A field named `price` is caught by name; a field
+    // named `value` holding "19.99" is the one somebody adds in a hurry.
+    expect(redactPrices({ value: "19.99" })).toEqual({ value: REDACTED });
+    expect(redactPrices({ note: "reverted to $42.00" })).toEqual({ note: REDACTED });
+    expect(redactPrices({ currency: "1200 JPY" })).toEqual({ currency: REDACTED });
+  });
+
+  it("redacts every bigint on sight", () => {
+    // BigInt is how every price in this codebase is stored, and nothing else uses it.
+    expect(redactPrices({ anything: 8_000n })).toEqual({ anything: REDACTED });
+  });
+
+  it("leaves the things telemetry is actually for", () => {
+    const context = {
+      shopId: "cmsw41td7",
+      runId: "cmt8u36qw",
+      verified: 1_615,
+      failed: 0,
+      durationMs: 8_042,
+      status: "COMPLETED",
+      plan: "advanced",
+    };
+    expect(redactPrices(context)).toEqual(context);
+  });
+
+  it("does not mistake an id or a count for money", () => {
+    // Over-redacting costs a count now and then, but redacting a run id would make the
+    // telemetry useless for the thing it exists to do.
+    expect(redactPrices({ runId: "cmt8u36qw000px9ii" })).toEqual({ runId: "cmt8u36qw000px9ii" });
+    expect(redactPrices({ variants: 1616, ms: 509 })).toEqual({ variants: 1616, ms: 509 });
+  });
+
+  it("reaches into nested objects and arrays", () => {
+    expect(
+      redactPrices({ rows: [{ sku: "A", price: 1n }, { sku: "B", note: "was £5.00" }] }),
+    ).toEqual({ rows: [{ sku: "A", price: REDACTED }, { sku: "B", note: REDACTED }] });
+  });
+
+  it("gives up rather than recursing forever", () => {
+    // Telemetry context is occasionally handed something with a cycle or a Prisma model
+    // hanging off it. A reporter that stack-overflows while reporting an error is worse
+    // than no reporter.
+    const deep: Record<string, unknown> = {};
+    let node = deep;
+    for (let i = 0; i < 30; i++) node = node.next = {} as Record<string, unknown>;
+    expect(() => redactPrices(deep)).not.toThrow();
+    expect(JSON.stringify(redactPrices(deep))).toContain("[truncated]");
+  });
+
+  it("lets no money-shaped value through, whatever the payload", () => {
+    const MONEY = /[$£€¥]\s?\d|(?:^|\s)\d+\.\d{2}(?:\s|$)|\b(USD|EUR|GBP|JPY)\b/;
+
+    /** Every leaf value, ignoring keys — the rule is about values, not field names. */
+    const values = (node: unknown): unknown[] =>
+      node && typeof node === "object"
+        ? Object.values(node as Record<string, unknown>).flatMap(values)
+        : [node];
+
+    fc.assert(
+      fc.property(
+        fc.dictionary(
+          fc.string({ minLength: 1, maxLength: 12 }),
+          fc.oneof(
+            fc.string({ maxLength: 40 }),
+            fc.integer(),
+            fc.bigInt({ min: 0n, max: 10_000_000n }),
+            fc.constantFrom("19.99", "$5", "1200 JPY", "£1.00"),
+          ),
+          { maxKeys: 8 },
+        ),
+        (payload) => {
+          for (const leaf of values(redactPrices(payload))) {
+            if (typeof leaf !== "string" || leaf === REDACTED) continue;
+            expect(leaf).not.toMatch(MONEY);
+          }
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+});

--- a/app/lib/telemetry/redact.ts
+++ b/app/lib/telemetry/redact.ts
@@ -1,0 +1,68 @@
+/**
+ * Keeping prices out of telemetry.
+ *
+ * The rule is absolute and it is in CLAUDE.md: telemetry carries shop id, plan, counts,
+ * durations and statuses — never a price. A merchant's pricing is commercially sensitive
+ * and a third-party error tracker is somewhere they never agreed to put it. It also
+ * leaves the building: Sentry, a log aggregator, a metrics vendor, each with their own
+ * retention and their own access list.
+ *
+ * A rule enforced by everyone remembering is a rule that lasts until somebody adds a
+ * field in a hurry. So it is enforced here, at the boundary, over whatever object it is
+ * handed — and the redaction is by key *and* by shape, because the two failure modes are
+ * different. A field named `price` is caught by name. A field named `value` holding
+ * "19.99" is not, and that is the one that gets added in a hurry.
+ */
+
+/** Keys whose values are prices whatever they are called. */
+const PRICE_KEYS =
+  /^(price|amount|cost|compare_?at|compareAtPrice|basePrice|baseCompareAt|livePrice|liveCompareAt|intendedPrice|intendedCompareAt|beforePrice|beforeCompareAt|observedPrice|expectedPrice|msrp|subtotal|total)$/i;
+
+/**
+ * A value that looks like money regardless of its key.
+ *
+ * Deliberately broad. A decimal with two places, a currency symbol, or a bare currency
+ * code all count — being over-strict here costs a redacted count now and then, and being
+ * under-strict costs a merchant's price list sitting in somebody's error tracker.
+ */
+const MONEY_SHAPE = /[$£€¥]\s?\d|(?:^|\s)\d+\.\d{2}(?:\s|$)|\b(?:USD|EUR|GBP|JPY|CAD|AUD|NZD|CHF|SEK)\b/;
+
+export const REDACTED = "[redacted:price]";
+
+/**
+ * Returns a copy safe to send to a third party.
+ *
+ * Depth-limited, because telemetry context is occasionally handed something with a
+ * cycle or a Prisma model hanging off it, and an error reporter that stack-overflows
+ * while reporting an error is worse than no reporter.
+ */
+export function redactPrices(value: unknown, depth = 0): unknown {
+  if (depth > 6) return "[truncated]";
+
+  if (typeof value === "string") return MONEY_SHAPE.test(value) ? REDACTED : value;
+
+  // BigInt is how every price in this codebase is stored. Nothing else uses it, so it
+  // is redacted on sight rather than inspected.
+  if (typeof value === "bigint") return REDACTED;
+
+  if (Array.isArray(value)) return value.map((entry) => redactPrices(entry, depth + 1));
+
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = PRICE_KEYS.test(key) ? REDACTED : redactPrices(entry, depth + 1);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+/** True when a payload still carries something that reads as money. */
+export function containsPrice(value: unknown): boolean {
+  return JSON.stringify(redactPrices(value)) !== JSON.stringify(stringifySafe(value));
+}
+
+function stringifySafe(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value, (_key, entry) => (typeof entry === "bigint" ? `${entry}` : entry)));
+}

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -24,6 +24,7 @@ import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
 import { notify } from "../notifications.server";
+import { metric } from "../../lib/telemetry/metrics";
 
 export interface RunOptions {
   revert?: boolean;
@@ -116,6 +117,7 @@ export async function runCampaign(
     });
   }
 
+  const startedAt = Date.now();
   const { campaign: campaignRecord, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
   const campaignName = campaignRecord.name;
   const [candidates, storeGuardrails] = await Promise.all([
@@ -275,6 +277,16 @@ export async function runCampaign(
   // what happened to those rows; the campaign's own state is left alone.
   if (options.variantGids) {
     await refreshMirror(shopId, result.rows);
+
+  // The headline panels, from the one place that knows the answer. Counts and durations
+  // only — the ledger holds what actually changed.
+  metric("run.duration_ms", Date.now() - startedAt, { shopId, campaignId, kind });
+  metric("run.verified_clean_rate", result.clean ? 1 : 0, { shopId, campaignId, kind });
+  metric("run.rows", result.verified, { shopId, campaignId, outcome: "verified" });
+  if (result.failed > 0) metric("run.rows", result.failed, { shopId, campaignId, outcome: "failed" });
+  if (result.unverified > 0) {
+    metric("run.rows", result.unverified, { shopId, campaignId, outcome: "unverified" });
+  }
     return scopedOutcome(run.id, outcome.counts.planned, result, messages);
   }
 
@@ -295,6 +307,16 @@ export async function runCampaign(
   });
 
   await refreshMirror(shopId, result.rows);
+
+  // The headline panels, from the one place that knows the answer. Counts and durations
+  // only — the ledger holds what actually changed.
+  metric("run.duration_ms", Date.now() - startedAt, { shopId, campaignId, kind });
+  metric("run.verified_clean_rate", result.clean ? 1 : 0, { shopId, campaignId, kind });
+  metric("run.rows", result.verified, { shopId, campaignId, outcome: "verified" });
+  if (result.failed > 0) metric("run.rows", result.failed, { shopId, campaignId, outcome: "failed" });
+  if (result.unverified > 0) {
+    metric("run.rows", result.unverified, { shopId, campaignId, outcome: "unverified" });
+  }
 
   // Best-effort, and deliberately last. A campaign runs for hours; the merchant has to
   // be able to close the tab and still learn the outcome. Nothing about a mail

--- a/app/services/mirror-audit.server.ts
+++ b/app/services/mirror-audit.server.ts
@@ -26,6 +26,7 @@ import {
   type LiveRow,
 } from "../lib/audit/sampling";
 import { logger } from "../lib/logging/logger";
+import { metric } from "../lib/telemetry/metrics";
 import type { AdminClient } from "../lib/execution/sync-executor";
 import { isThrottledError, withRetry } from "../lib/shopify/budget";
 
@@ -167,6 +168,8 @@ export async function auditMirror(
     healed: result.healed,
     tombstoned: result.tombstoned,
   };
+
+  metric("mirror.divergence_rate", verdict.rate, { shopId, checked: verdict.checked });
 
   if (verdict.alert) {
     // Systematic. One missed webhook is a row; half a percent of a sample is a

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -21,6 +21,7 @@ import { reclaimStaleRuns } from "./campaigns/reaper.server";
 import { sendDueDigests } from "./digest.server";
 import { auditMirror } from "./mirror-audit.server";
 import { logger } from "../lib/logging/logger";
+import { metric } from "../lib/telemetry/metrics";
 
 export interface TickResult {
   examined: number;
@@ -120,6 +121,17 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
   } catch {
     // sendDueDigests already logs per shop; a throw here would be the loop itself.
   }
+
+  // Emitted every tick, including the quiet ones. A scheduler panel that only has data
+  // when something happened cannot distinguish "nothing was due" from "the worker died"
+  // — and those need very different responses.
+  metric("scheduler.tick", 1, {
+    examined: result.examined,
+    applied: result.applied,
+    reverted: result.reverted,
+    reclaimed: result.reclaimed,
+    failed: result.failures.length,
+  });
 
   try {
     result.audited = await auditDueMirrors(now);


### PR DESCRIPTION
`CLAUDE.md` has one hard rule about telemetry: shop id, plan, counts, durations and
statuses — **never a price.** A merchant's pricing is commercially sensitive and a
third-party error tracker is somewhere they never agreed to put it, with its own
retention and its own access list.

## Prices were reaching logs

`logging/redact` strips *secrets*, which is a different concern — and it renders a
`bigint` as `"8000n"`. Every price in this codebase is a bigint, so they went out as
strings that no money-shaped check would catch afterwards.

Redaction now happens **by key and by shape**, and the two matter for different reasons:

- A field named `price` is caught by name.
- A field named `value` holding `"19.99"` is not — and that is the one somebody adds in
  a hurry.

Prices are stripped **before** secrets, because after the secret pass a bigint is already
a string. Both passes sit at the sink rather than at call sites: a rule kept by everyone
remembering lasts until it is not.

```
in : { shopId, runId, verified: 12, price: 1999n, intendedPrice: 800n,
       note: "reverted to $42.00", token: "shpat_abc123" }
out: { shopId, runId, verified: 12, price: "[redacted:price]",
       intendedPrice: "[redacted:price]", note: "[redacted:price]",
       token: "[redacted]" }
```

A property test over generated payloads asserts no money-shaped value survives.

## The panels are named, and four already emit

RFC §11's panels live in one place so the dashboard, the alerts and the code cannot
drift apart by somebody renaming a string. Emitting real numbers today: verified-clean
rate and run duration from the run path, divergence from the mirror audit, and a
**scheduler tick emitted every tick including the quiet ones** — a panel that only has
data when something happened cannot tell *"nothing was due"* from *"the worker died"*,
and those need very different responses.

A rate over an empty denominator returns **null, not zero**. Zero out of zero is not a
zero rate; reporting it as zero makes an idle shop indistinguishable from a completely
broken one on the same panel, and the alert built on it fires on the wrong one.

## Deliberately not done

Metrics are structured lines rather than an OpenTelemetry SDK. The SDK is a large
dependency whose export is **inert without a collector**, and there is no collector until
there is a staging environment. The line shape is what an exporter would take, so adding
one later is wiring rather than rework.

Sentry and the staging dashboard need accounts and a deployed environment — **#46, #47
and #49 stay open**, which is why this refs #45 rather than closing it.

## Verified against the dev store

A real mirror audit emits:

```json
{"metric":"mirror.divergence_rate","value":0,"shopId":"cmsw41td7…","checked":500}
```

- 427 unit tests (14 new), 31 chaos scenarios, typecheck/lint/build clean

Refs #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)