### PR TITLE
Use Polaris web components everywhere a control is visible

### DIFF
--- a/app/components/CalendarGrid.tsx
+++ b/app/components/CalendarGrid.tsx
@@ -25,16 +25,19 @@ export function CalendarGrid({ days, today }: { days: CalendarDay[]; today: stri
       {/* Which column is which day. Without it the grid is seven anonymous boxes and a
           merchant has to count from the first date to work out whether a sale lands on
           a weekend — which is usually the thing they came to check. */}
-      <s-stack direction="inline" gap="small">
+      <s-grid gridTemplateColumns="repeat(7, 1fr)" gap="small-200">
         {WEEKDAYS.map((weekday) => (
           <s-box key={weekday} padding="small-200">
             <s-text tone="neutral">{weekday}</s-text>
           </s-box>
         ))}
-      </s-stack>
+      </s-grid>
 
+      {/* A real grid rather than rows of boxes, so every day is the same width and the
+          columns line up under their weekday. Stacked boxes sized themselves to their
+          contents, which put a busy Tuesday under Wednesday's heading. */}
       {chunk(days, 7).map((week) => (
-        <s-stack key={week[0].date} direction="inline" gap="small">
+        <s-grid key={week[0].date} gridTemplateColumns="repeat(7, 1fr)" gap="small-200">
           {week.map((day) => (
             <s-box key={day.date} padding="small-200" borderWidth="base" borderRadius="base">
               <s-stack gap="small-500">
@@ -78,7 +81,7 @@ export function CalendarGrid({ days, today }: { days: CalendarDay[]; today: stri
               </s-stack>
             </s-box>
           ))}
-        </s-stack>
+        </s-grid>
       ))}
     </s-stack>
   );

--- a/app/lib/scheduling/window.test.ts
+++ b/app/lib/scheduling/window.test.ts
@@ -4,6 +4,7 @@ import fc from "fast-check";
 import {
   DEFAULT_REVERT_BUFFER_MINUTES,
   describeSchedule,
+  joinDateAndTime,
   dueTransition,
   effectiveBufferMs,
   scheduleWarnings,
@@ -229,5 +230,35 @@ describe("revert buffer capping", () => {
   it("has nothing to warn about for a manual schedule or a sane window", () => {
     expect(scheduleWarnings({ kind: "manual" })).toEqual([]);
     expect(scheduleWarnings(window())).toEqual([]);
+  });
+});
+
+
+describe("recombining a date field and a time field", () => {
+  it("joins them into a datetime-local value", () => {
+    expect(joinDateAndTime("2026-08-27", "14:30", "09:00")).toBe("2026-08-27T14:30");
+  });
+
+  it("takes the default hour when only a date was given", () => {
+    // Not an error. The merchant said which day and left the hour to us — refusing
+    // would lose a schedule they meant to set.
+    expect(joinDateAndTime("2026-08-27", "", "09:00")).toBe("2026-08-27T09:00");
+    expect(joinDateAndTime("2026-08-27", null, "23:59")).toBe("2026-08-27T23:59");
+  });
+
+  it("is nothing at all when only a time was given", () => {
+    // An hour on no particular day cannot be scheduled, and inventing a day would
+    // schedule a sale the merchant never asked for.
+    expect(joinDateAndTime("", "14:30", "09:00")).toBe("");
+    expect(joinDateAndTime(null, "14:30", "09:00")).toBe("");
+  });
+
+  it("ignores a malformed time rather than producing a malformed datetime", () => {
+    expect(joinDateAndTime("2026-08-27", "2pm", "09:00")).toBe("2026-08-27T09:00");
+    expect(joinDateAndTime("2026-08-27", "9:00", "09:00")).toBe("2026-08-27T09:00");
+  });
+
+  it("ignores a malformed date entirely", () => {
+    expect(joinDateAndTime("27/08/2026", "14:30", "09:00")).toBe("");
   });
 });

--- a/app/lib/scheduling/window.ts
+++ b/app/lib/scheduling/window.ts
@@ -203,6 +203,29 @@ export function describeSchedule(schedule: Schedule, timeZone: string): string {
  * zone, not the viewer's and not UTC. Reading it with `new Date()` would silently
  * use whatever zone the merchant's laptop happens to be in.
  */
+/**
+ * Recombines a separate date field and time field into a `datetime-local` value.
+ *
+ * They are separate in the interface because Polaris has no datetime component —
+ * `s-date-field` is date-only — and two Polaris fields beat one native input that would
+ * style itself differently from everything around it. This is where that seam closes.
+ *
+ * A date with no time is not an error: the merchant said which day and left the hour to
+ * us, so it takes the caller's default. A time with no date is nothing at all, because
+ * an hour on no particular day cannot be scheduled.
+ */
+export function joinDateAndTime(
+  date: string | null | undefined,
+  time: string | null | undefined,
+  fallbackTime: string,
+): string {
+  const day = String(date ?? "").trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return "";
+
+  const at = String(time ?? "").trim();
+  return `${day}T${/^\d{2}:\d{2}$/.test(at) ? at : fallbackTime}`;
+}
+
 export function localInputToUtc(value: string, timeZone: string): string | null {
   if (!value) return null;
 

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -69,31 +69,30 @@ export default function Activity() {
       <s-section>
         <FilterForm fields={FILTER_FIELDS}>
           <s-stack gap="base">
-            <label htmlFor="actor">Who</label>
-            <select id="actor" name="actor" defaultValue={filters.actor ?? ""}>
-              <option value="">Anyone</option>
+            <s-select name="actor" label="Who">
+              <s-option value="" defaultSelected={!filters.actor}>
+                Anyone
+              </s-option>
               {actors.map((actor) => (
-                <option key={actor} value={actor}>
+                <s-option key={actor} value={actor} defaultSelected={filters.actor === actor}>
                   {describeActor(actor)}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
-            <label htmlFor="action">What</label>
-            <select id="action" name="action" defaultValue={filters.action ?? ""}>
-              <option value="">Any action</option>
+            <s-select name="action" label="What">
+              <s-option value="" defaultSelected={!filters.action}>
+                Any action
+              </s-option>
               {actions.map((action) => (
-                <option key={action} value={action}>
+                <s-option key={action} value={action} defaultSelected={filters.action === action}>
                   {action}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
-            <label htmlFor="from">From</label>
-            <input id="from" type="date" name="from" defaultValue={filters.from ?? ""} />
-
-            <label htmlFor="to">To</label>
-            <input id="to" type="date" name="to" defaultValue={filters.to ?? ""} />
+            <s-date-field name="from" label="From" defaultValue={filters.from ?? ""} />
+            <s-date-field name="to" label="To" defaultValue={filters.to ?? ""} />
 
             <s-button type="submit">Filter</s-button>
           </s-stack>

--- a/app/routes/app.baselines._index.tsx
+++ b/app/routes/app.baselines._index.tsx
@@ -77,36 +77,34 @@ export default function Baselines() {
           <s-stack gap="base">
             <s-text-field name="q" label="Title, SKU or variant ID" defaultValue={filters.q ?? ""} />
 
-            <label htmlFor="vendor">Vendor</label>
-            <select id="vendor" name="vendor" defaultValue={filters.vendor ?? ""}>
-              <option value="">Any vendor</option>
+            <s-select name="vendor" label="Vendor">
+              <s-option value="" defaultSelected={!filters.vendor}>
+                Any vendor
+              </s-option>
               {vendors.map((vendor) => (
-                <option key={vendor} value={vendor}>
+                <s-option key={vendor} value={vendor} defaultSelected={filters.vendor === vendor}>
                   {vendor}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
-            <label htmlFor="source">Where the baseline came from</label>
-            <select id="source" name="source" defaultValue={filters.source ?? ""}>
-              <option value="">Any source</option>
+            <s-select name="source" label="Where the baseline came from">
+              <s-option value="" defaultSelected={!filters.source}>
+                Any source
+              </s-option>
               {sources.map((source) => (
-                <option key={source} value={source}>
+                <s-option key={source} value={source} defaultSelected={filters.source === source}>
                   {source.toLowerCase().replace(/_/g, " ")}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
-            <label htmlFor="diverged">
-              <input
-                id="diverged"
-                type="checkbox"
-                name="diverged"
-                value="1"
-                defaultChecked={filters.divergedOnly}
-              />{" "}
-              Only variants whose live price differs from their baseline
-            </label>
+            <s-checkbox
+              name="diverged"
+              value="1"
+              label="Only variants whose live price differs from their baseline"
+              defaultChecked={filters.divergedOnly || undefined}
+            />
 
             <s-button type="submit">Filter</s-button>
           </s-stack>

--- a/app/routes/app.baselines.import.tsx
+++ b/app/routes/app.baselines.import.tsx
@@ -128,12 +128,12 @@ export default function ImportBaselines() {
               same rows and duplicating the textarea would let them drift apart. */}
           <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
           <s-stack gap="base">
-            {/* A native textarea rather than `s-text-area`, for the same reason the
-                selects on this page are native: a plain element that is certain to
-                serialise into the form, with no web-component behaviour between the
-                merchant's paste and the request. */}
-            <label htmlFor="csv">Rows</label>
-            <textarea id="csv" name="csv" rows={12} style={{ width: "100%", fontFamily: "monospace" }} />
+                        <s-text-area
+              name="csv"
+              label="Rows"
+              rows={12}
+              details="One variant per line. Paste straight from a spreadsheet."
+            />
             <s-stack direction="inline" gap="base">
               <s-button
                 type="button"

--- a/app/routes/app.baselines.recapture.tsx
+++ b/app/routes/app.baselines.recapture.tsx
@@ -115,15 +115,20 @@ export default function Recapture() {
 
         <fetcher.Form method="get">
           <s-stack gap="base">
-            <label htmlFor="segment">Scope</label>
-            <select id="segment" name="segment" defaultValue={segmentId}>
-              <option value="">The whole catalogue</option>
+            <s-select name="segment" label="Scope">
+              <s-option value="" defaultSelected={!segmentId}>
+                The whole catalogue
+              </s-option>
               {segments.map((segment) => (
-                <option key={segment.id} value={segment.id}>
+                <s-option
+                  key={segment.id}
+                  value={segment.id}
+                  defaultSelected={segmentId === segment.id}
+                >
                   {segment.name} ({segment.kind === "DYNAMIC" ? "dynamic" : "frozen"})
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
             <s-button type="submit">Check this scope</s-button>
           </s-stack>
         </fetcher.Form>

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -8,7 +8,7 @@ import { facets, previewMatches, type FilterAst } from "../services/segments.ser
 import { createCampaign } from "../services/campaigns/index.server";
 import type { AdjustmentRule, CompareAtPolicy } from "../lib/pricing/types";
 import { money } from "../lib/money/money";
-import { localInputToUtc, type Schedule } from "../lib/scheduling/window";
+import { joinDateAndTime, localInputToUtc, type Schedule } from "../lib/scheduling/window";
 import { presetStartFor } from "../lib/scheduling/calendar";
 import { describeAdjustment } from "../lib/markets/describe";
 import {
@@ -160,8 +160,16 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
         ? { kind: "clear" }
         : { kind: "leave" };
 
-  const startLocal = String(form.get("startAt") ?? "").trim();
-  const endLocal = String(form.get("endAt") ?? "").trim();
+  const startLocal = joinDateAndTime(
+    String(form.get("startDate") ?? ""),
+    String(form.get("startTime") ?? ""),
+    "09:00",
+  );
+  const endLocal = joinDateAndTime(
+    String(form.get("endDate") ?? ""),
+    String(form.get("endTime") ?? ""),
+    "23:59",
+  );
   const startUtc = startLocal ? localInputToUtc(startLocal, shop.timezone) : null;
 
   // A schedule needs a valid start. Anything else stays manual rather than being
@@ -253,15 +261,20 @@ export default function NewCampaign() {
         </s-paragraph>
         <FilterForm fields={SCOPE_FIELDS}>
           <s-stack gap="base">
-            <label htmlFor="segment">Saved segment</label>
-            <select id="segment" name="segment" defaultValue={selected.segment}>
-              <option value="">Build a filter below instead</option>
+            <s-select name="segment" label="Saved segment">
+              <s-option value="" defaultSelected={!selected.segment}>
+                Build a filter below instead
+              </s-option>
               {segments.map((segment) => (
-                <option key={segment.id} value={segment.id}>
+                <s-option
+                  key={segment.id}
+                  value={segment.id}
+                  defaultSelected={selected.segment === segment.id}
+                >
                   {segment.name} ({segment.kind === "DYNAMIC" ? "dynamic" : "frozen"})
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
             {usingSegment ? (
               <s-banner tone="info">
@@ -275,33 +288,36 @@ export default function NewCampaign() {
               </s-banner>
             ) : null}
 
-            <label htmlFor="collection">Collection</label>
-            <select id="collection" name="collection" defaultValue={selected.collection}>
-              <option value="">Any collection</option>
+            <s-select name="collection" label="Collection">
+              <s-option value="" defaultSelected={!selected.collection}>
+                Any collection
+              </s-option>
               {available.collections.map((c) => (
-                <option key={c} value={c}>
+                <s-option key={c} value={c} defaultSelected={selected.collection === c}>
                   {c}
-                </option>
+                </s-option>
               ))}
-            </select>
-            <label htmlFor="vendor">Vendor</label>
-            <select id="vendor" name="vendor" defaultValue={selected.vendor}>
-              <option value="">Any vendor</option>
+            </s-select>
+            <s-select name="vendor" label="Vendor">
+              <s-option value="" defaultSelected={!selected.vendor}>
+                Any vendor
+              </s-option>
               {available.vendors.map((v) => (
-                <option key={v} value={v}>
+                <s-option key={v} value={v} defaultSelected={selected.vendor === v}>
                   {v}
-                </option>
+                </s-option>
               ))}
-            </select>
-            <label htmlFor="tag">Tag</label>
-            <select id="tag" name="tag" defaultValue={selected.tag}>
-              <option value="">Any tag</option>
+            </s-select>
+            <s-select name="tag" label="Tag">
+              <s-option value="" defaultSelected={!selected.tag}>
+                Any tag
+              </s-option>
               {available.tags.map((t) => (
-                <option key={t} value={t}>
+                <s-option key={t} value={t} defaultSelected={selected.tag === t}>
                   {t}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
             <s-text-field name="title" label="Title contains" defaultValue={selected.title} />
             <s-button type="submit">Update match count</s-button>
           </s-stack>
@@ -335,12 +351,13 @@ export default function NewCampaign() {
           <s-stack gap="base">
             <s-text-field name="name" label="Campaign name" defaultValue="Sale" required />
 
-            <label htmlFor="ruleKind">Adjustment</label>
-            <select id="ruleKind" name="ruleKind" defaultValue="percent-change">
-              <option value="percent-change">Percent change from baseline</option>
-              <option value="fixed-change">Fixed change from baseline</option>
-              <option value="set-exact">Set an exact price</option>
-            </select>
+            <s-select name="ruleKind" label="Adjustment">
+              <s-option value="percent-change" defaultSelected>
+                Percent change from baseline
+              </s-option>
+              <s-option value="fixed-change">Fixed change from baseline</s-option>
+              <s-option value="set-exact">Set an exact price</s-option>
+            </s-select>
 
             <s-number-field
               name="ruleValue"
@@ -349,27 +366,25 @@ export default function NewCampaign() {
               details="Negative discounts. -20 means 20% off the baseline."
             />
 
-            <label htmlFor="compareAt">Compare-at price</label>
-            <select id="compareAt" name="compareAt" defaultValue="set-to-baseline">
-              <option value="set-to-baseline">
+            <s-select name="compareAt" label="Compare-at price">
+              <s-option value="set-to-baseline" defaultSelected>
                 Set to baseline (shows a strike-through)
-              </option>
-              <option value="leave">Leave unchanged</option>
-              <option value="clear">Clear it</option>
-            </select>
+              </s-option>
+              <s-option value="leave">Leave unchanged</s-option>
+              <s-option value="clear">Clear it</s-option>
+            </s-select>
 
-            <label htmlFor="rounding.default">Rounding</label>
-            <select
-              id="rounding.default"
-              name="rounding.default"
-              defaultValue={storeRounding.default}
-            >
+            <s-select name="rounding.default" label="Rounding">
               {roundingOptions.map((option) => (
-                <option key={option.value} value={option.value}>
+                <s-option
+                  key={option.value}
+                  value={option.value}
+                  defaultSelected={option.value === storeRounding.default}
+                >
                   {option.label}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
             <s-paragraph>
               <s-text>
                 Starts from your store setting. Change it here to round this campaign
@@ -436,24 +451,24 @@ export default function NewCampaign() {
                 </s-paragraph>
 
                 {currencies.map((code) => (
-                  <s-stack key={code} gap="small">
-                    <label htmlFor={`rounding.${code}`}>Rounding for {code}</label>
-                    <select
-                      id={`rounding.${code}`}
-                      name={`rounding.${code}`}
-                      defaultValue={storeRounding.byCurrency[code] ?? "inherit"}
+                  <s-select key={code} name={`rounding.${code}`} label={`Rounding for ${code}`}>
+                    <s-option
+                      value="inherit"
+                      defaultSelected={!storeRounding.byCurrency[code]}
                     >
-                      <option value="inherit">
-                        Same as this campaign&rsquo;s rounding (
-                        {ROUNDING_LABELS[profileNameFor(storeRounding, code)].toLowerCase()})
-                      </option>
-                      {roundingOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </s-stack>
+                      Same as this campaign&rsquo;s rounding (
+                      {ROUNDING_LABELS[profileNameFor(storeRounding, code)].toLowerCase()})
+                    </s-option>
+                    {roundingOptions.map((option) => (
+                      <s-option
+                        key={option.value}
+                        value={option.value}
+                        defaultSelected={storeRounding.byCurrency[code] === option.value}
+                      >
+                        {option.label}
+                      </s-option>
+                    ))}
+                  </s-select>
                 ))}
               </>
             ) : null}
@@ -468,16 +483,34 @@ export default function NewCampaign() {
               </s-text>
             </s-paragraph>
 
-            <label htmlFor="startAt">Start</label>
-            <input
-              id="startAt"
-              type="datetime-local"
-              name="startAt"
-              defaultValue={presetStart}
-            />
+            {/* Date and time as two fields, because Polaris has no datetime component:
+                `s-date-field` is date-only. Two Polaris fields beat one native
+                datetime-local that would style itself differently from everything
+                around it, and the two are recombined server-side. */}
+            <s-stack direction="inline" gap="base">
+              <s-date-field
+                name="startDate"
+                label="Start"
+                defaultValue={presetStart.slice(0, 10)}
+              />
+              <s-text-field
+                name="startTime"
+                label="Start time"
+                placeholder="09:00"
+                defaultValue={presetStart.slice(11)}
+                details="24-hour, in your store's zone."
+              />
+            </s-stack>
 
-            <label htmlFor="endAt">End (optional)</label>
-            <input id="endAt" type="datetime-local" name="endAt" />
+            <s-stack direction="inline" gap="base">
+              <s-date-field name="endDate" label="End (optional)" />
+              <s-text-field
+                name="endTime"
+                label="End time"
+                placeholder="23:59"
+                details="Defaults to the end of that day."
+              />
+            </s-stack>
 
             <s-number-field
               name="revertBuffer"

--- a/app/routes/app.segments.tsx
+++ b/app/routes/app.segments.tsx
@@ -220,41 +220,47 @@ export default function Segments() {
           <s-stack gap="base">
             <s-text-field name="name" label="Name" placeholder="Summer collection" required />
 
-            <label htmlFor="collection">Collection</label>
-            <select id="collection" name="collection" defaultValue="">
-              <option value="">Any collection</option>
+            <s-select name="collection" label="Collection">
+              <s-option value="" defaultSelected>
+                Any collection
+              </s-option>
               {available.collections.map((c) => (
-                <option key={c} value={c}>
+                <s-option key={c} value={c}>
                   {c}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
-            <label htmlFor="tag">Tag</label>
-            <select id="tag" name="tag" defaultValue="">
-              <option value="">Any tag</option>
+            <s-select name="tag" label="Tag">
+              <s-option value="" defaultSelected>
+                Any tag
+              </s-option>
               {available.tags.map((t) => (
-                <option key={t} value={t}>
+                <s-option key={t} value={t}>
                   {t}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
-            <label htmlFor="vendor">Vendor</label>
-            <select id="vendor" name="vendor" defaultValue="">
-              <option value="">Any vendor</option>
+            <s-select name="vendor" label="Vendor">
+              <s-option value="" defaultSelected>
+                Any vendor
+              </s-option>
               {available.vendors.map((v) => (
-                <option key={v} value={v}>
+                <s-option key={v} value={v}>
                   {v}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
-            <label htmlFor="kind">How it should behave</label>
-            <select id="kind" name="kind" defaultValue="DYNAMIC">
-              <option value="DYNAMIC">Dynamic — re-check the filter every time</option>
-              <option value="FROZEN">Frozen — pin the products it matches right now</option>
-            </select>
+            <s-select name="kind" label="How it should behave">
+              <s-option value="DYNAMIC" defaultSelected>
+                Dynamic &mdash; re-check the filter every time
+              </s-option>
+              <s-option value="FROZEN">
+                Frozen &mdash; pin the products it matches right now
+              </s-option>
+            </s-select>
 
             <s-button type="submit" variant="primary" loading={busy || undefined}>
               Create segment
@@ -275,14 +281,12 @@ export default function Segments() {
           <input type="hidden" name="intent" value="create-from-csv" />
           <s-stack gap="base">
             <s-text-field name="name" label="Name" placeholder="Clearance list" required />
-            {/* Native, like the selects above it — a plain element that is certain
-                to serialise a pasted list into the form. */}
-            <label htmlFor="segment-csv">SKUs, barcodes or IDs</label>
-            <textarea
-              id="segment-csv"
+            <s-text-area
               name="csv"
+              label="SKUs, barcodes or IDs"
               rows={8}
-              style={{ width: "100%", fontFamily: "monospace" }}
+              placeholder={"SKU-1\nSKU-2\n9781234567897"}
+              details="One per line. Anything we cannot match is reported rather than skipped."
             />
             <s-button type="submit" variant="primary" loading={busy || undefined}>
               Match and create

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -159,14 +159,11 @@ export default function Settings() {
 
         <fetcher.Form method="post">
           <s-stack gap="base">
-            <label>
-              <input
-                type="checkbox"
-                name="neverBelowCost"
-                defaultChecked={settings.neverBelowCost}
-              />{" "}
-              Never price at or below cost
-            </label>
+            <s-checkbox
+              name="neverBelowCost"
+              label="Never price at or below cost"
+              defaultChecked={settings.neverBelowCost || undefined}
+            />
 
             <s-number-field
               name="minMarginPercent"
@@ -182,28 +179,29 @@ export default function Settings() {
               details="An absolute floor, whatever the rule computes. Leave blank for none."
             />
 
-            <label htmlFor="violationPolicy">When a price would breach a floor</label>
-            <select
-              id="violationPolicy"
-              name="violationPolicy"
-              defaultValue={settings.violationPolicy}
-            >
-              <option value="clamp">Clamp it to the floor and carry on</option>
-              <option value="skip">Skip that variant, price the rest</option>
-              <option value="block">Block the whole campaign</option>
-            </select>
+            <s-select name="violationPolicy" label="When a price would breach a floor">
+              <s-option value="clamp" defaultSelected={settings.violationPolicy === "clamp"}>
+                Clamp it to the floor and carry on
+              </s-option>
+              <s-option value="skip" defaultSelected={settings.violationPolicy === "skip"}>
+                Skip that variant, price the rest
+              </s-option>
+              <s-option value="block" defaultSelected={settings.violationPolicy === "block"}>
+                Block the whole campaign
+              </s-option>
+            </s-select>
 
-            <label htmlFor="missingCostPolicy">
-              When a cost-based floor meets a variant with no cost
-            </label>
-            <select
-              id="missingCostPolicy"
+            <s-select
               name="missingCostPolicy"
-              defaultValue={settings.missingCostPolicy}
+              label="When a cost-based floor meets a variant with no cost"
             >
-              <option value="skip">Skip that variant</option>
-              <option value="error">Fail the campaign</option>
-            </select>
+              <s-option value="skip" defaultSelected={settings.missingCostPolicy === "skip"}>
+                Skip that variant
+              </s-option>
+              <s-option value="error" defaultSelected={settings.missingCostPolicy === "error"}>
+                Fail the campaign
+              </s-option>
+            </s-select>
 
             <s-button type="submit" variant="primary" loading={busy || undefined}>
               Save guardrails
@@ -224,18 +222,17 @@ export default function Settings() {
           <input type="hidden" name="intent" value="rounding" />
 
           <s-stack gap="base">
-            <label htmlFor="rounding.default">Everywhere, unless overridden</label>
-            <select
-              id="rounding.default"
-              name="rounding.default"
-              defaultValue={settings.rounding.default}
-            >
+            <s-select name="rounding.default" label="Everywhere, unless overridden">
               {roundingOptions.map((option) => (
-                <option key={option.value} value={option.value}>
+                <s-option
+                  key={option.value}
+                  value={option.value}
+                  defaultSelected={option.value === settings.rounding.default}
+                >
                   {option.label}
-                </option>
+                </s-option>
               ))}
-            </select>
+            </s-select>
 
             {currencies.length > 1 ? (
               <>
@@ -253,26 +250,27 @@ export default function Settings() {
                   const effective = profileNameFor(settings.rounding, code);
 
                   return (
-                    <s-stack key={code} gap="small">
-                      <label htmlFor={`rounding.${code}`}>
-                        {code}
-                        {code === currency ? " (your store's currency)" : ""}
-                      </label>
-                      <select
-                        id={`rounding.${code}`}
-                        name={`rounding.${code}`}
-                        defaultValue={settings.rounding.byCurrency[code] ?? "inherit"}
+                    <s-select
+                      key={code}
+                      name={`rounding.${code}`}
+                      label={`${code}${code === currency ? " (your store's currency)" : ""}`}
+                    >
+                      <s-option
+                        value="inherit"
+                        defaultSelected={!settings.rounding.byCurrency[code]}
                       >
-                        <option value="inherit">
-                          Use the setting above ({ROUNDING_LABELS[effective].toLowerCase()})
-                        </option>
-                        {roundingOptions.map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
-                    </s-stack>
+                        Use the setting above ({ROUNDING_LABELS[effective].toLowerCase()})
+                      </s-option>
+                      {roundingOptions.map((option) => (
+                        <s-option
+                          key={option.value}
+                          value={option.value}
+                          defaultSelected={settings.rounding.byCurrency[code] === option.value}
+                        >
+                          {option.label}
+                        </s-option>
+                      ))}
+                    </s-select>
                   );
                 })}
               </>


### PR DESCRIPTION
Native `<select>`, `<label>`, `<textarea>`, `<input type="date">` and `<input type="checkbox">` had accumulated across seven routes *alongside* the Polaris components they sit next to. They render with the browser's styling rather than Shopify admin's, so the same form carried two visual languages — and any Polaris restyling would leave them behind.

**Converted:** 21 selects, both textareas, the date filters, the loose checkboxes and every bare `<label>`. Selects became `s-select`/`s-option`; the rest went to their `s-` equivalents. The only native elements left are hidden inputs, which carry intent through a form and have no Polaris counterpart.

## The one API difference worth knowing

`s-select` takes the initial value **on the option** (`defaultSelected`), not on the select. Easy to get silently wrong: the control renders fine either way and just shows the first option.

## Verified in the app, both directions

Not assumed:

1. Seeded the store's guardrails to non-default values (`block` / `error`) and reloaded → the selects rendered those values. That proves `defaultSelected`.
2. Saved the form → those same values were written back. That proves submission: had the component not submitted, the action's fallbacks would have written `clamp` and `skip`.

## Dates and times

Polaris has no datetime component — `s-date-field` is date-only — so campaign start/end are now **a date field plus a time field**, recombined server-side by `joinDateAndTime`. Two Polaris fields beat one native input that styles itself unlike everything around it.

- A date with no time takes a sensible default rather than failing — the merchant said which day and left the hour to us.
- A time with no date is nothing at all, because an hour on no particular day cannot be scheduled.

## The calendar is a real grid

`s-grid` with seven equal columns, instead of rows of boxes that sized themselves to their contents — which put a busy Tuesday under Wednesday's heading.

## Tests

5 for the date/time join, falsified by removing the date guard and by accepting a malformed time.

Full suite: 556 unit tests, 50 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)