### PR TITLE
P5.6 — What is live, and why

### DIFF
--- a/app/components/ReconciliationTable.tsx
+++ b/app/components/ReconciliationTable.tsx
@@ -1,0 +1,64 @@
+import { Link } from "react-router";
+
+import type { ReconciliationRow } from "../services/reconciliation.server";
+import { describeState } from "../lib/reporting/reconciliation-csv";
+
+/**
+ * Every price, next to the reason it is that price.
+ *
+ * The controlling campaign is a link rather than a name because the next question is
+ * always "and what does that campaign do?", and the answer is one click away.
+ *
+ * Rows are variant × surface. A variant selling in four markets is four rows, which
+ * looks repetitive until the day the base price reverted and the Japanese one did not —
+ * the case a collapsed view could not show at all.
+ */
+export function ReconciliationTable({ rows }: { rows: ReconciliationRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <s-paragraph>
+        Nothing matches these filters. If you were looking for drifted prices, that is
+        good news.
+      </s-paragraph>
+    );
+  }
+
+  return (
+    <s-table>
+      <s-table-header-row>
+        <s-table-header>Product</s-table-header>
+        <s-table-header>Surface</s-table-header>
+        <s-table-header>Live</s-table-header>
+        <s-table-header>Baseline</s-table-header>
+        <s-table-header>Because of</s-table-header>
+        <s-table-header>State</s-table-header>
+      </s-table-header-row>
+      <s-table-body>
+        {rows.map((row) => (
+          <s-table-row key={`${row.variantGid}-${row.priceListGid}`}>
+            <s-table-cell>
+              <s-link href={row.adminUrl} target="_blank">
+                {row.title}
+              </s-link>
+            </s-table-cell>
+            <s-table-cell>{row.surface}</s-table-cell>
+            <s-table-cell>{row.live ?? "—"}</s-table-cell>
+            <s-table-cell>{row.baseline ?? "—"}</s-table-cell>
+            <s-table-cell>
+              {row.campaignId ? (
+                <Link to={`/app/campaigns/${row.campaignId}`}>{row.campaignName}</Link>
+              ) : (
+                "—"
+              )}
+            </s-table-cell>
+            <s-table-cell>
+              <s-badge tone={row.drifted ? "critical" : row.offBaseline ? "info" : "success"}>
+                {describeState(row)}
+              </s-badge>
+            </s-table-cell>
+          </s-table-row>
+        ))}
+      </s-table-body>
+    </s-table>
+  );
+}

--- a/app/lib/reporting/reconciliation-csv.test.ts
+++ b/app/lib/reporting/reconciliation-csv.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Exporting the reconciliation view.
+ *
+ * This is the file a merchant forwards to whoever asked whether the prices are right, so
+ * every column has to stand on its own.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ReconciliationRow } from "../../services/reconciliation.server";
+import { describeState, reconciliationCsv } from "./reconciliation-csv";
+
+const row = (over: Partial<ReconciliationRow> = {}): ReconciliationRow => ({
+  variantGid: "gid://shopify/ProductVariant/1",
+  title: "Chair",
+  sku: "CH-1",
+  priceListGid: "",
+  surface: "Base price",
+  currency: "USD",
+  live: "$80.00",
+  baseline: "$100.00",
+  campaignId: "c1",
+  campaignName: "Summer sale",
+  intended: "$80.00",
+  drifted: false,
+  offBaseline: true,
+  adminUrl: "https://example.myshopify.com/admin/products/1",
+  ...over,
+});
+
+describe("describing what is going on with a price", () => {
+  it("puts drift first, because it is the only one to act on", () => {
+    // A drifted row is also off baseline. Reporting "on sale" there would bury the one
+    // fact the merchant needs.
+    expect(describeState(row({ drifted: true, offBaseline: true })))
+      .toContain("drifted");
+  });
+
+  it("reads a campaign price as a sale rather than a problem", () => {
+    // Being off baseline is what a sale *is*. Calling it a warning would make every
+    // running campaign look broken.
+    expect(describeState(row())).toBe("on sale, as written");
+  });
+
+  it("flags a price that is off baseline with nothing controlling it", () => {
+    expect(describeState(row({ campaignName: null, campaignId: null })))
+      .toContain("no campaign controls it");
+  });
+
+  it("says so plainly when a price is exactly its baseline", () => {
+    expect(describeState(row({ offBaseline: false }))).toBe("at baseline");
+  });
+});
+
+describe("the exported file", () => {
+  it("names every column a reader needs to check a price", () => {
+    expect(reconciliationCsv([row()]).split("\n")[0]).toBe(
+      '"Variant","Title","SKU","Surface","Currency","Live price","Baseline",' +
+        '"Controlled by","We wrote","State"',
+    );
+  });
+
+  it("says in words when there is no campaign or no baseline", () => {
+    // An empty cell in a spreadsheet reads as missing data, and the merchant cannot
+    // tell that apart from a broken export.
+    const csv = reconciliationCsv([
+      row({ campaignName: null, baseline: null, intended: null }),
+    ]);
+
+    expect(csv).toContain('"no baseline"');
+    expect(csv).toContain('"no campaign"');
+    expect(csv).toContain('"nothing written"');
+  });
+
+  it("keeps each market on its own row", () => {
+    const csv = reconciliationCsv([
+      row({ surface: "Base price", live: "$80.00" }),
+      row({ surface: "Europe", currency: "EUR", live: "€64.00" }),
+    ]);
+
+    expect(csv.trim().split("\n")).toHaveLength(3);
+    expect(csv).toContain('"Europe"');
+  });
+
+  it("quotes a title containing a comma", () => {
+    expect(reconciliationCsv([row({ title: 'Monitor, 24"' })])).toContain('"Monitor, 24"""');
+  });
+});

--- a/app/lib/reporting/reconciliation-csv.ts
+++ b/app/lib/reporting/reconciliation-csv.ts
@@ -1,0 +1,58 @@
+/**
+ * The reconciliation view as a file.
+ *
+ * On screen it is a page at a time; here it is the whole picture, which is what a
+ * merchant sends to whoever asked "are the prices right?". So the columns have to stand
+ * alone: a cell saying "drifted" means nothing without the two numbers that disagree.
+ *
+ * Blank is never used for a fact. A variant no campaign controls says so in words,
+ * because an empty cell in a spreadsheet reads as missing data, and the merchant cannot
+ * tell that apart from a bug in the export.
+ */
+
+import type { ReconciliationRow } from "../../services/reconciliation.server";
+import { toCsv } from "./csv";
+
+export function reconciliationCsv(rows: readonly ReconciliationRow[]): string {
+  const header = [
+    "Variant",
+    "Title",
+    "SKU",
+    "Surface",
+    "Currency",
+    "Live price",
+    "Baseline",
+    "Controlled by",
+    "We wrote",
+    "State",
+  ];
+
+  const body = rows.map((row) => [
+    row.variantGid,
+    row.title,
+    row.sku ?? "",
+    row.surface,
+    row.currency,
+    row.live ?? "no price",
+    row.baseline ?? "no baseline",
+    row.campaignName ?? "no campaign",
+    row.intended ?? "nothing written",
+    describeState(row),
+  ]);
+
+  return toCsv(header, body);
+}
+
+/**
+ * One cell that says what is going on, in the order that matters.
+ *
+ * Drift first: it is the only one of these a merchant has to act on. Being off baseline
+ * is what a sale *is*, and reading it as a warning would make every running campaign
+ * look broken.
+ */
+export function describeState(row: ReconciliationRow): string {
+  if (row.drifted) return "drifted — live price is not what we wrote";
+  if (row.campaignName && row.offBaseline) return "on sale, as written";
+  if (row.offBaseline) return "off baseline, no campaign controls it";
+  return "at baseline";
+}

--- a/app/routes/app.reconciliation.tsx
+++ b/app/routes/app.reconciliation.tsx
@@ -1,0 +1,207 @@
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { reconcile } from "../services/reconciliation.server";
+import { auditMirror } from "../services/mirror-audit.server";
+import { toAdminClient } from "../services/admin-client.server";
+import { reconciliationCsv } from "../lib/reporting/reconciliation-csv";
+import { downloadCsv } from "../lib/reporting/csv";
+import { ReconciliationTable } from "../components/ReconciliationTable";
+import { FilterForm } from "../components/FilterForm";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+
+/** Filters that ride in the query string, so a merchant can bookmark a view. */
+export const RECONCILE_FIELDS = ["q", "surface", "campaign", "state"] as const;
+
+export const loader = withGuard("/app/reconciliation", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const url = new URL(request.url);
+  const state = url.searchParams.get("state") ?? "";
+
+  const page = await reconcile(
+    shop.id,
+    shop.domain,
+    {
+      q: url.searchParams.get("q") ?? undefined,
+      priceListGid: url.searchParams.get("surface") ?? undefined,
+      campaignId: url.searchParams.get("campaign") || undefined,
+      driftedOnly: state === "drifted",
+      offBaselineOnly: state === "off-baseline",
+    },
+    Number(url.searchParams.get("page") ?? 1) || 1,
+  );
+
+  return {
+    ...page,
+    selected: {
+      q: url.searchParams.get("q") ?? "",
+      surface: url.searchParams.get("surface") ?? "any",
+      campaign: url.searchParams.get("campaign") ?? "",
+      state,
+    },
+  };
+});
+
+export const action = withGuard("/app/reconciliation", async ({ request }: ActionFunctionArgs) => {
+  const { admin, session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  if (String(form.get("intent")) !== "spot-check") return { ok: false, message: "" };
+
+  // The same audit the nightly sweep runs, at a size the merchant chose. Reusing it
+  // rather than writing a second comparison is the point: a spot check that could
+  // disagree with the nightly audit would undermine both.
+  const size = Math.min(1000, Math.max(1, Number(form.get("size") ?? 100) || 100));
+  const result = await auditMirror(toAdminClient(admin), shop.id, { size });
+
+  return {
+    ok: true,
+    message:
+      result.diverged === 0
+        ? `Checked ${result.checked} prices against Shopify just now. Every one matched.`
+        : `Checked ${result.checked} prices against Shopify just now. ${result.diverged} ` +
+          `disagreed and have been corrected here — the storefront was always right.`,
+  };
+});
+
+export default function Reconciliation() {
+  const { rows, total, surfaces, campaigns, counts, selected } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<{ ok: boolean; message: string }>();
+  const busy = fetcher.state !== "idle";
+
+  return (
+    <s-page heading="What is live, and why">
+      <s-section>
+        <s-paragraph>
+          <s-text>
+            Every price on every surface, next to the baseline it was computed from and
+            the campaign that put it there. {total} rows.
+          </s-text>
+        </s-paragraph>
+
+        {counts.drifted > 0 ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              {counts.drifted} {counts.drifted === 1 ? "price is" : "prices are"} not what
+              we wrote. Something changed them outside this app.
+            </s-paragraph>
+          </s-banner>
+        ) : (
+          <s-banner tone="success">
+            <s-paragraph>
+              Every price we have written is still exactly what we wrote.
+              {counts.offBaseline > 0
+                ? ` ${counts.offBaseline} are away from their baseline, which is what a running campaign looks like.`
+                : ""}
+            </s-paragraph>
+          </s-banner>
+        )}
+
+        <FilterForm fields={RECONCILE_FIELDS}>
+          <s-stack gap="base">
+            <s-text-field name="q" label="Title, SKU or variant ID" defaultValue={selected.q} />
+
+            <s-select name="surface" label="Surface">
+              <s-option value="any" defaultSelected={selected.surface === "any"}>
+                Every surface
+              </s-option>
+              {surfaces.map((surface) => (
+                <s-option
+                  key={surface.priceListGid || "base"}
+                  value={surface.priceListGid}
+                  defaultSelected={selected.surface === surface.priceListGid}
+                >
+                  {surface.name}
+                  {surface.currency ? ` (${surface.currency})` : ""}
+                </s-option>
+              ))}
+            </s-select>
+
+            <s-select name="campaign" label="Controlled by">
+              <s-option value="" defaultSelected={!selected.campaign}>
+                Any campaign
+              </s-option>
+              {campaigns.map((campaign) => (
+                <s-option
+                  key={campaign.id}
+                  value={campaign.id}
+                  defaultSelected={selected.campaign === campaign.id}
+                >
+                  {campaign.name}
+                </s-option>
+              ))}
+            </s-select>
+
+            <s-select name="state" label="Show">
+              <s-option value="" defaultSelected={!selected.state}>
+                Everything
+              </s-option>
+              <s-option value="drifted" defaultSelected={selected.state === "drifted"}>
+                Only prices that are not what we wrote
+              </s-option>
+              <s-option
+                value="off-baseline"
+                defaultSelected={selected.state === "off-baseline"}
+              >
+                Only prices away from their baseline
+              </s-option>
+            </s-select>
+
+            <s-button type="submit">Filter</s-button>
+          </s-stack>
+        </FilterForm>
+      </s-section>
+
+      <s-section heading="Check against Shopify right now">
+        <s-paragraph>
+          <s-text>
+            Reads a sample of prices straight from Shopify and compares them with what
+            this page shows. Anything that disagrees is corrected here — the storefront
+            is always the truth.
+          </s-text>
+        </s-paragraph>
+
+        {fetcher.data?.message ? (
+          <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
+            <s-paragraph>{fetcher.data.message}</s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="spot-check" />
+          <s-stack direction="inline" gap="base">
+            <s-number-field name="size" label="How many to check" defaultValue="100" />
+            <s-button type="submit" loading={busy || undefined}>
+              Check now
+            </s-button>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      <s-section heading="Prices">
+        <ReconciliationTable rows={rows} />
+
+        <s-button
+          type="button"
+          variant="tertiary"
+          onClick={() => downloadCsv("anchor-reconciliation.csv", reconciliationCsv(rows))}
+        >
+          Export this page (CSV)
+        </s-button>
+      </s-section>
+    </s-page>
+  );
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -28,6 +28,7 @@ export default function App() {
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/baselines">Baselines</s-link>
         <s-link href="/app/baselines/import">Import baselines</s-link>
+        <s-link href="/app/reconciliation">What is live</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/activity">Activity</s-link>
         <s-link href="/app/settings">Settings</s-link>

--- a/app/services/admin-client.server.ts
+++ b/app/services/admin-client.server.ts
@@ -10,6 +10,8 @@
 import type { QueryCost } from "../lib/shopify/budget";
 import type { AdminClient } from "../lib/execution/sync-executor";
 import { API_VERSION_STRING } from "../lib/shopify/api-version";
+import { decryptToken, isEncrypted } from "../lib/crypto/secrets";
+import { logger } from "../lib/logging/logger";
 
 export interface ShopifyAdminContext {
   graphql(
@@ -98,6 +100,22 @@ export async function adminClientForShop(shopDomain: string): Promise<AdminClien
   });
   if (!session?.accessToken) return null;
 
+  // Decrypted here, because this path never goes through the session storage that
+  // encrypted it. The web process gets its token from Shopify's session machinery, which
+  // wraps `EncryptedSessionStorage`; the worker reads the row directly and would
+  // otherwise send ciphertext as a bearer token. Shopify answers that with "Invalid API
+  // key or access token", which reads like a misconfigured app and sends you looking
+  // anywhere but here — it broke every scheduled run, the nightly mirror audit and the
+  // reconciliation spot check at once, and all three failed the same misleading way.
+  //
+  // Plaintext falls through unchanged so a shop installed before encryption keeps
+  // working until its token is next rewritten.
+  const accessToken = decryptedToken(session.accessToken);
+  if (!accessToken) {
+    logger.error("stored token could not be decrypted", { shop: shopDomain });
+    return null;
+  }
+
   // The same version the web process speaks. This used to read an environment variable
   // with a different default, so a scheduled run hit a different Admin API than the
   // identical run started by hand — invisible in the code, and only ever failing
@@ -110,11 +128,28 @@ export async function adminClientForShop(shopDomain: string): Promise<AdminClien
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Shopify-Access-Token": session.accessToken,
+          "X-Shopify-Access-Token": accessToken,
         },
         body: JSON.stringify({ query, variables: options?.variables ?? {} }),
       });
       return { json: () => response.json() };
     },
   });
+}
+
+
+/**
+ * A stored token, whichever form it is in.
+ *
+ * Returns null only when a token that *is* encrypted cannot be read — a wrong or missing
+ * key. Failing loudly there is right: the alternative is sending ciphertext to Shopify
+ * and reporting its authentication error, which blames the wrong thing.
+ */
+export function decryptedToken(stored: string): string | null {
+  if (!isEncrypted(stored)) return stored;
+
+  const secret = process.env.TOKEN_ENCRYPTION_KEY;
+  if (!secret) return null;
+
+  return decryptToken(stored, secret);
 }

--- a/app/services/admin-client.test.ts
+++ b/app/services/admin-client.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The worker's route to an access token.
+ *
+ * This path never goes through the session storage that encrypts tokens — the web
+ * process gets its token from Shopify's session machinery, the worker reads the row
+ * directly. Which is exactly how it came to send ciphertext as a bearer token, breaking
+ * every scheduled run, the nightly mirror audit and the reconciliation spot check at
+ * once, all with the same misleading "Invalid API key or access token".
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { encryptToken } from "../lib/crypto/secrets";
+import { decryptedToken } from "./admin-client.server";
+
+const KEY = "a-test-key-for-this-file-only";
+
+describe("reading a stored token", () => {
+  it("decrypts a token that was stored encrypted", () => {
+    process.env.TOKEN_ENCRYPTION_KEY = KEY;
+    const stored = encryptToken("shpua_EXAMPLE_NOT_A_REAL_TOKEN_0000000", KEY);
+
+    expect(decryptedToken(stored)).toBe("shpua_EXAMPLE_NOT_A_REAL_TOKEN_0000000");
+  });
+
+  it("passes a plaintext token through unchanged", () => {
+    // A shop installed before encryption keeps working until its token is next
+    // rewritten. Roll-forward, not a migration.
+    process.env.TOKEN_ENCRYPTION_KEY = KEY;
+
+    expect(decryptedToken("shpua_EXAMPLE_NOT_A_REAL_TOKEN_0000000")).toBe(
+      "shpua_EXAMPLE_NOT_A_REAL_TOKEN_0000000",
+    );
+  });
+
+  it("refuses an encrypted token when there is no key, rather than sending ciphertext", () => {
+    const stored = encryptToken("shpua_EXAMPLE_NOT_A_REAL_TOKEN_0000000", KEY);
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+
+    // Null, so the caller reports "no session" — which points at this app. Sending the
+    // ciphertext makes Shopify report an authentication failure, which points at the
+    // API credentials and wastes the afternoon.
+    expect(decryptedToken(stored)).toBeNull();
+  });
+
+  it("refuses an encrypted token when the key is wrong", () => {
+    const stored = encryptToken("shpua_EXAMPLE_NOT_A_REAL_TOKEN_0000000", KEY);
+    process.env.TOKEN_ENCRYPTION_KEY = "a-different-key-entirely";
+
+    expect(decryptedToken(stored)).toBeNull();
+  });
+});

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -706,6 +706,14 @@ async function recordResults(
  *
  * Without this the dashboard's "not at baseline" count stays stale until the next
  * sync, which makes the app look wrong immediately after it did the right thing.
+ *
+ * *Both* copies of the base live price, which is the part that was missing. The catalogue
+ * index carries it for search and filtering; `price_surface_entries` carries it as one
+ * uniform "live value on surface X" the resolver can read the same way for every surface.
+ * Updating only the second left the first stale after every campaign — and the nightly
+ * mirror audit compares against the first. A merchant who ran a sale over their whole
+ * catalogue would have woken up to an alert saying the pipeline was systematically
+ * broken, on the morning after it worked perfectly.
  */
 async function refreshMirror(shopId: string, rows: ExecutedRows): Promise<void> {
   for (const executed of rows) {
@@ -723,6 +731,21 @@ async function refreshMirror(shopId: string, rows: ExecutedRows): Promise<void> 
         ...(executed.row.intendedCompareAtSet
           ? {
               liveCompareAt: executed.row.intendedCompareAt
+                ? BigInt(executed.row.intendedCompareAt.amount)
+                : null,
+            }
+          : {}),
+        syncedAt: new Date(),
+      },
+    });
+
+    await prisma.variantIndex.updateMany({
+      where: { shopId, variantGid: executed.row.ref.variantGid },
+      data: {
+        price: BigInt(executed.row.intendedPrice.amount),
+        ...(executed.row.intendedCompareAtSet
+          ? {
+              compareAt: executed.row.intendedCompareAt
                 ? BigInt(executed.row.intendedCompareAt.amount)
                 : null,
             }

--- a/app/services/mirror-audit.server.ts
+++ b/app/services/mirror-audit.server.ts
@@ -52,13 +52,16 @@ const BATCH = 100;
 export async function auditMirror(
   client: AdminClient,
   shopId: string,
-  options: { threshold?: number; now?: Date } = {},
+  options: { threshold?: number; now?: Date; size?: number } = {},
 ): Promise<AuditResult> {
   const threshold = options.threshold ?? ALERT_THRESHOLD;
   const now = options.now ?? new Date();
 
   const total = await prisma.variantIndex.count({ where: { shopId, deletedAt: null } });
-  const size = sampleSize(total);
+  // The nightly sweep sizes its own sample; a merchant asking "check this now" from the
+  // reconciliation view names a number instead. Same code either way, because a spot
+  // check that could disagree with the nightly audit would be worse than no spot check.
+  const size = Math.min(total, options.size ?? sampleSize(total));
 
   if (size === 0) {
     return { shopId, checked: 0, diverged: 0, rate: 0, divergences: [], alert: false, healed: 0, tombstoned: 0 };

--- a/app/services/reconciliation.server.ts
+++ b/app/services/reconciliation.server.ts
@@ -1,0 +1,317 @@
+/**
+ * What is live, on every surface, and why.
+ *
+ * The trust view. A merchant who has just run a sale across four markets wants one page
+ * that says: this variant is £15.99 in the UK because Summer Sale controls it, its normal
+ * price is £19.99, and nobody has touched it since we wrote it. No competitor offers
+ * that, because none of them keeps a ledger that could answer it.
+ *
+ * Three decisions carry the design.
+ *
+ * **Rows are variant × surface, not variant.** A variant is not "at" one price; it is at
+ * a price per market, and a reconciliation view that collapsed them would be unable to
+ * show the case that actually goes wrong — the base price reverted, the Japanese one
+ * still on sale.
+ *
+ * **"Which campaign controls this" is read from the ledger, not recomputed.** Re-running
+ * the resolver store-wide would be both slow and a second opinion: it would say which
+ * campaign *should* control the price, and this page exists to say which one *did*. When
+ * those disagree, the ledger is the evidence and the resolver is the hypothesis.
+ *
+ * **Everything narrows in SQL.** Filtering fetched rows would mean page 1 of 25 reporting
+ * "nothing matches" while the matches sit on page 9, and on a 500K-variant catalogue that
+ * is the difference between a feature and a timeout.
+ */
+
+import prisma from "../db.server";
+import { formatMinorUnits } from "../lib/money/format";
+
+const PAGE_SIZE = 25;
+
+export interface ReconciliationFilters {
+  q?: string;
+  /** "" for the base surface, a price list gid for a market. */
+  priceListGid?: string;
+  campaignId?: string;
+  /** Live price differs from what the ledger says we wrote. */
+  driftedOnly?: boolean;
+  /** Live price differs from the baseline — normal during a sale, not otherwise. */
+  offBaselineOnly?: boolean;
+}
+
+export interface ReconciliationRow {
+  variantGid: string;
+  title: string;
+  sku: string | null;
+  /** Empty for the base price; a price list gid for a market. */
+  priceListGid: string;
+  surface: string;
+  currency: string;
+  live: string | null;
+  baseline: string | null;
+  /** The campaign whose write is the most recent verified one for this cell. */
+  campaignId: string | null;
+  campaignName: string | null;
+  /** What that campaign's ledger says it wrote. */
+  intended: string | null;
+  /**
+   * Live disagrees with the ledger.
+   *
+   * Distinct from being off baseline: off baseline is what a sale *is*, and drift is
+   * somebody having changed the price behind us.
+   */
+  drifted: boolean;
+  /** Live differs from the baseline. Expected while a campaign runs. */
+  offBaseline: boolean;
+  adminUrl: string;
+}
+
+export interface ReconciliationPage {
+  rows: ReconciliationRow[];
+  total: number;
+  surfaces: Array<{ priceListGid: string; name: string; currency: string }>;
+  campaigns: Array<{ id: string; name: string }>;
+  counts: { drifted: number; offBaseline: number };
+}
+
+export async function reconcile(
+  shopId: string,
+  shopDomain: string,
+  filters: ReconciliationFilters = {},
+  page = 1,
+): Promise<ReconciliationPage> {
+  const [lists, campaigns] = await Promise.all([
+    prisma.priceListRecord.findMany({
+      where: { shopId },
+      select: { priceListGid: true, name: true, currency: true },
+      orderBy: { name: "asc" },
+    }),
+    prisma.campaign.findMany({
+      where: { shopId },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+      take: 100,
+    }),
+  ]);
+
+  const surfaces = [
+    { priceListGid: "", name: "Base price", currency: "" },
+    ...lists,
+  ];
+
+  // The surface rows themselves. `price_surface_entries` is the one uniform record of
+  // "the live value on surface X", which is exactly why base rows were put in it rather
+  // than being read from `variant_index`.
+  const where: Record<string, unknown> = { shopId };
+  if (filters.priceListGid !== undefined && filters.priceListGid !== "any") {
+    where.priceListGid = filters.priceListGid;
+  }
+
+  if (filters.q) {
+    const matching = await prisma.variantIndex.findMany({
+      where: {
+        shopId,
+        deletedAt: null,
+        OR: [
+          { title: { contains: filters.q, mode: "insensitive" } },
+          { sku: { contains: filters.q, mode: "insensitive" } },
+          { variantGid: { contains: filters.q } },
+        ],
+      },
+      select: { variantGid: true },
+      take: 500,
+    });
+    where.variantGid = { in: matching.map((row) => row.variantGid) };
+  }
+
+  // Drift and off-baseline both compare two tables' values for the same cell, which
+  // Prisma cannot express, so they go through raw SQL rather than through the fetched
+  // page. Filtering after paging would report "nothing matches" on page 1 while the
+  // matches sat on page 9 — and on a 500K-variant catalogue the whole point is that the
+  // database does the narrowing.
+  if (filters.driftedOnly || filters.offBaselineOnly) {
+    const cells = filters.driftedOnly
+      ? await driftedCells(shopId)
+      : await offBaselineCells(shopId);
+
+    if (cells.length === 0) {
+      return { rows: [], total: 0, surfaces, campaigns, counts: await counts(shopId) };
+    }
+    where.OR = cells.map((cell) => ({
+      variantGid: cell.variantGid,
+      priceListGid: cell.priceListGid,
+    }));
+  }
+
+  // Narrowed in SQL, not after paging, for the same reason.
+  if (filters.campaignId) {
+    const controlled = await prisma.variantChange.findMany({
+      where: { shopId, status: "VERIFIED", run: { campaignId: filters.campaignId } },
+      select: { variantGid: true },
+      distinct: ["variantGid"],
+      take: 5_000,
+    });
+    const gids = controlled.map((row) => row.variantGid);
+    where.variantGid = where.variantGid
+      ? { in: intersect((where.variantGid as { in: string[] }).in, gids) }
+      : { in: gids };
+  }
+
+  const [entries, total] = await Promise.all([
+    prisma.priceSurfaceEntry.findMany({
+      where,
+      orderBy: [{ variantGid: "asc" }, { priceListGid: "asc" }],
+      skip: (Math.max(1, page) - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+    }),
+    prisma.priceSurfaceEntry.count({ where }),
+  ]);
+
+  const gids = [...new Set(entries.map((entry) => entry.variantGid))];
+
+  const [variants, baselines, ledger] = await Promise.all([
+    prisma.variantIndex.findMany({
+      where: { shopId, variantGid: { in: gids } },
+      select: { variantGid: true, productGid: true, title: true, sku: true },
+    }),
+    prisma.baseline.findMany({
+      where: { shopId, variantGid: { in: gids }, supersededAt: null },
+      select: { variantGid: true, priceListGid: true, basePrice: true, currency: true },
+    }),
+    // The most recent verified write per cell. Ordered so the first row seen for a cell
+    // is the newest, which is the one that explains the price now.
+    prisma.variantChange.findMany({
+      where: { shopId, variantGid: { in: gids }, status: "VERIFIED" },
+      orderBy: { verifiedAt: "desc" },
+      select: {
+        variantGid: true,
+        priceListGid: true,
+        intendedPrice: true,
+        currency: true,
+        run: { select: { campaignId: true, campaign: { select: { name: true } } } },
+      },
+    }),
+  ]);
+
+  const variantBy = new Map(variants.map((row) => [row.variantGid, row]));
+  const baselineBy = new Map(baselines.map((row) => [key(row.variantGid, row.priceListGid), row]));
+
+  const controllerBy = new Map<string, (typeof ledger)[number]>();
+  for (const row of ledger) {
+    const cell = key(row.variantGid, row.priceListGid);
+    if (!controllerBy.has(cell)) controllerBy.set(cell, row);
+  }
+
+  const listBy = new Map(lists.map((list) => [list.priceListGid, list]));
+
+  const rows: ReconciliationRow[] = entries.map((entry) => {
+    const cell = key(entry.variantGid, entry.priceListGid);
+    const variant = variantBy.get(entry.variantGid);
+    const baseline = baselineBy.get(cell);
+    const controller = controllerBy.get(cell);
+    const currency = entry.currency || baseline?.currency || "USD";
+
+    const live = entry.livePrice === null ? null : Number(entry.livePrice);
+    const base = baseline ? Number(baseline.basePrice) : null;
+    const intended = controller?.intendedPrice === null || controller?.intendedPrice === undefined
+      ? null
+      : Number(controller.intendedPrice);
+
+    return {
+      variantGid: entry.variantGid,
+      title: variant?.title ?? entry.variantGid,
+      sku: variant?.sku ?? null,
+      priceListGid: entry.priceListGid,
+      surface: entry.priceListGid
+        ? (listBy.get(entry.priceListGid)?.name ?? entry.priceListGid)
+        : "Base price",
+      currency,
+      live: formatMinorUnits(entry.livePrice, currency),
+      baseline: formatMinorUnits(baseline?.basePrice ?? null, currency),
+      campaignId: controller?.run.campaignId ?? null,
+      campaignName: controller?.run.campaign.name ?? null,
+      intended: formatMinorUnits(
+        controller?.intendedPrice ?? null,
+        controller?.currency || currency,
+      ),
+      // Only a claim when we actually made one. A variant no campaign has written is
+      // not "drifted" — nothing was promised about it.
+      drifted: intended !== null && live !== null && intended !== live,
+      offBaseline: base !== null && live !== null && base !== live,
+      adminUrl: variant
+        ? `https://${shopDomain}/admin/products/${variant.productGid.split("/").pop()}`
+        : `https://${shopDomain}/admin/products`,
+    };
+  });
+
+  return { rows, total, surfaces, campaigns, counts: await counts(shopId) };
+}
+
+/**
+ * Cells where the live price disagrees with what we last verified writing.
+ *
+ * This is drift in the strict sense: somebody changed the price behind us. A cell no
+ * campaign has ever written cannot drift, because nothing was promised about it — hence
+ * the join rather than a left join.
+ *
+ * `DISTINCT ON` picks the newest verified write per cell, which is the one that explains
+ * the price now. Postgres-specific and deliberately so: the alternative is a correlated
+ * subquery per row.
+ */
+async function driftedCells(shopId: string) {
+  return prisma.$queryRaw<Array<{ variantGid: string; priceListGid: string }>>`
+    SELECT e."variantGid", e."priceListGid"
+    FROM "price_surface_entries" e
+    JOIN (
+      SELECT DISTINCT ON (c."variantGid", c."priceListGid")
+             c."variantGid", c."priceListGid", c."intendedPrice"
+      FROM "variant_changes" c
+      WHERE c."shopId" = ${shopId} AND c."status" = 'VERIFIED'
+      ORDER BY c."variantGid", c."priceListGid", c."verifiedAt" DESC
+    ) w ON w."variantGid" = e."variantGid" AND w."priceListGid" = e."priceListGid"
+    WHERE e."shopId" = ${shopId}
+      AND e."livePrice" IS NOT NULL
+      AND w."intendedPrice" IS NOT NULL
+      AND e."livePrice" <> w."intendedPrice"
+    LIMIT 5000
+  `;
+}
+
+/** Cells whose live price differs from their baseline — what a sale looks like. */
+async function offBaselineCells(shopId: string) {
+  return prisma.$queryRaw<Array<{ variantGid: string; priceListGid: string }>>`
+    SELECT e."variantGid", e."priceListGid"
+    FROM "price_surface_entries" e
+    JOIN "baselines" b
+      ON b."variantGid" = e."variantGid"
+     AND b."priceListGid" = e."priceListGid"
+     AND b."shopId" = e."shopId"
+     AND b."supersededAt" IS NULL
+    WHERE e."shopId" = ${shopId}
+      AND e."livePrice" IS NOT NULL
+      AND e."livePrice" <> b."basePrice"
+    LIMIT 5000
+  `;
+}
+
+/**
+ * Store-wide totals, not page totals.
+ *
+ * "12 products have drifted" is the number a merchant needs; "0 on this page" tells them
+ * nothing and quietly implies everything is fine.
+ */
+async function counts(shopId: string) {
+  const [drifted, offBaseline] = await Promise.all([
+    driftedCells(shopId),
+    offBaselineCells(shopId),
+  ]);
+
+  return { drifted: drifted.length, offBaseline: offBaseline.length };
+}
+
+const key = (variantGid: string, priceListGid: string) => `${variantGid}@${priceListGid}`;
+
+function intersect(a: readonly string[], b: readonly string[]): string[] {
+  const set = new Set(b);
+  return a.filter((value) => set.has(value));
+}

--- a/chaos/scenarios/reconciliation.chaos.ts
+++ b/chaos/scenarios/reconciliation.chaos.ts
@@ -1,0 +1,197 @@
+/**
+ * The trust view, against a real engine.
+ *
+ * This is the page that answers "are my prices right?" — so the only thing worth testing
+ * is whether it tells the truth when they are not. A reconciliation view that showed
+ * everything green while a price had been changed behind us would be worse than having
+ * no such page, because a merchant would have checked and been reassured.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos, type ChaosContext } from "../harness/scenario";
+
+async function view(chaos: ChaosContext, filters = {}) {
+  const { reconcile } = await import("../../app/services/reconciliation.server");
+  const shop = await prisma.shop.findUniqueOrThrow({ where: { id: chaos.fixture.shopId } });
+  return reconcile(shop.id, shop.domain, filters, 1);
+}
+
+describe("chaos: the reconciliation view", () => {
+  it("names the campaign that put each price where it is", async () => {
+    await withChaos(
+      "reconcile-why",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const page = await view(chaos);
+        const priced = page.rows.filter((row) => row.campaignId !== null);
+
+        expect(priced.length).toBeGreaterThan(0);
+        for (const row of priced) {
+          expect(row.campaignId).toBe(chaos.fixture.campaignId);
+          // Off baseline is what a sale is. It must not read as a problem.
+          expect(row.offBaseline).toBe(true);
+          expect(row.drifted).toBe(false);
+        }
+        expect(page.counts.drifted).toBe(0);
+      },
+    );
+  });
+
+  it("catches a price somebody changed behind us, and says which", async () => {
+    await withChaos(
+      "reconcile-drift",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // A merchant edits one price by hand in Shopify admin, and the webhook updates
+        // the mirror. Our ledger still says what we wrote, and the two now disagree.
+        const meddled = variantGids[0];
+        await prisma.priceSurfaceEntry.updateMany({
+          where: { shopId, variantGid: meddled, priceListGid: "" },
+          data: { livePrice: BigInt(12_345) },
+        });
+
+        const page = await view(chaos, { driftedOnly: true });
+
+        expect(page.counts.drifted).toBe(1);
+        expect(page.rows).toHaveLength(1);
+        expect(page.rows[0].variantGid).toBe(meddled);
+        expect(page.rows[0].drifted).toBe(true);
+      },
+    );
+  });
+
+  it("does not call a variant drifted when nothing was ever promised about it", async () => {
+    await withChaos(
+      "reconcile-untouched",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        // No campaign has run. Every price is at its baseline and nothing was written,
+        // so nothing can have drifted — a page that flagged these would cry wolf on a
+        // brand-new install.
+        const page = await view(chaos);
+
+        expect(page.counts.drifted).toBe(0);
+        expect(page.rows.every((row) => row.drifted === false)).toBe(true);
+        expect(page.rows.every((row) => row.campaignId === null)).toBe(true);
+      },
+    );
+  });
+
+  it("keeps each market on its own row", async () => {
+    await withChaos(
+      "reconcile-markets",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/eu",
+          name: "Europe",
+          currency: "EUR",
+          adjustment: null,
+          catalog: { id: "gid://shopify/MarketCatalog/eu", title: "EU", __typename: "MarketCatalog" },
+          prices: variantGids.map((gid) => ({
+            variantGid: gid,
+            amount: "50.00",
+            compareAt: null,
+            originType: "FIXED" as const,
+          })),
+        });
+
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: ["gid://shopify/PriceList/eu"] } as never },
+        });
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const page = await view(chaos);
+        const surfaces = new Set(page.rows.map((row) => row.priceListGid));
+
+        // Both surfaces present. A view that collapsed them could not show the case
+        // that actually goes wrong: the base price reverted, the market's still on sale.
+        expect(surfaces.has("")).toBe(true);
+        expect(surfaces.has("gid://shopify/PriceList/eu")).toBe(true);
+
+        const eu = page.rows.find((row) => row.priceListGid === "gid://shopify/PriceList/eu");
+        expect(eu?.currency).toBe("EUR");
+        expect(eu?.surface).toBe("Europe");
+      },
+    );
+  });
+
+  it("narrows to one campaign in the database, not on the page", async () => {
+    await withChaos(
+      "reconcile-by-campaign",
+      { catalog: { products: 6, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { campaignId } = chaos.fixture;
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const mine = await view(chaos, { campaignId });
+        expect(mine.rows.length).toBeGreaterThan(0);
+        expect(mine.rows.every((row) => row.campaignId === campaignId)).toBe(true);
+
+        // A campaign that never ran controls nothing, and the count must say so rather
+        // than quietly showing page one of everything.
+        const other = await view(chaos, { campaignId: "does-not-exist" });
+        expect(other.rows).toHaveLength(0);
+      },
+    );
+  });
+
+  it("agrees with a fresh read from Shopify, and heals when it does not", async () => {
+    await withChaos(
+      "reconcile-spot-check",
+      { catalog: { products: 20, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const { auditMirror } = await import("../../app/services/mirror-audit.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        // Clean store, clean check.
+        const clean = await auditMirror(client, shopId, { size: 20 });
+        expect(clean.checked).toBe(20);
+        expect(clean.diverged).toBe(0);
+
+        // Now corrupt the mirror without touching the store — the shape a missed webhook
+        // takes. The spot check must find it, because the storefront is the truth and
+        // this page is only a claim about it.
+        await prisma.variantIndex.updateMany({
+          where: { shopId, variantGid: variantGids[0] },
+          data: { price: BigInt(999) },
+        });
+
+        const dirty = await auditMirror(client, shopId, { size: 20 });
+        expect(dirty.diverged).toBe(1);
+        expect(dirty.healed).toBe(1);
+
+        // Healed means healed: a third check finds nothing.
+        const after = await auditMirror(client, shopId, { size: 20 });
+        expect(after.diverged).toBe(0);
+      },
+    );
+  });
+});

--- a/scripts/test-spot-check.ts
+++ b/scripts/test-spot-check.ts
@@ -1,0 +1,51 @@
+/**
+ * Runs the reconciliation spot check against the real store.
+ *
+ * The acceptance criterion for P5.6 is that a large spot check agrees with fresh API
+ * reads, and the only way to know that is to ask Shopify. The chaos suite proves the
+ * logic against a fake; this proves the query, the batching and the id handling against
+ * the thing that actually answers.
+ *
+ *   npx tsx scripts/test-spot-check.ts [sampleSize]
+ */
+
+import prisma from "../app/db.server";
+import { adminClientForShop } from "../app/services/admin-client.server";
+import { auditMirror } from "../app/services/mirror-audit.server";
+
+async function main() {
+  const size = Number(process.argv[2] ?? 100) || 100;
+
+  const shop = await prisma.shop.findFirstOrThrow();
+  const client = await adminClientForShop(shop.domain);
+  if (!client) throw new Error(`No usable session for ${shop.domain}. Reinstall the app.`);
+
+  const total = await prisma.variantIndex.count({
+    where: { shopId: shop.id, deletedAt: null },
+  });
+  console.log(`${shop.domain}: ${total} variants mirrored, checking ${size}.`);
+
+  const started = Date.now();
+  const result = await auditMirror(client, shop.id, { size });
+  const elapsed = Date.now() - started;
+
+  console.log(
+    `checked ${result.checked} in ${elapsed}ms · diverged ${result.diverged} ` +
+      `(${(result.rate * 100).toFixed(2)}%) · healed ${result.healed} · ` +
+      `tombstoned ${result.tombstoned} · alert ${result.alert}`,
+  );
+
+  // Named, not counted. "3 diverged" is a number; "these three variants disagreed, by
+  // this much" is something a person can act on.
+  for (const divergence of result.divergences.slice(0, 10)) {
+    console.log(`  ${divergence.kind}: ${divergence.variantGid}`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await prisma.$disconnect();
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #169.

The trust view. A merchant who has just run a sale across four markets gets one page saying: *this variant is £15.99 in the UK because Summer Sale controls it, its normal price is £19.99, and nobody has touched it since we wrote it.* No competitor offers that, because none of them keeps a ledger that could answer it.

## Three decisions

**Rows are variant × surface, not variant.** A variant isn't "at" a price; it's at a price *per market*. A collapsed view couldn't show the case that actually goes wrong — the base price reverted, the Japanese one still on sale.

**"Which campaign controls this" is read from the ledger, never recomputed.** Re-running the resolver store-wide would be slow and, worse, a second opinion: it would say which campaign *should* control the price, and this page exists to say which one *did*. When those disagree, the ledger is the evidence and the resolver is the hypothesis.

**Drift ≠ off baseline.** Off baseline is what a sale *is*; drift is somebody changing the price behind us, and it's the only one of the two to act on. A cell no campaign has written cannot drift — nothing was promised about it — so a new install doesn't open to a wall of false warnings.

Every filter narrows in SQL. Drift and off-baseline compare two tables' values for the same cell, which Prisma can't express, so they go through raw queries with `DISTINCT ON`. Filtering the fetched page would report "nothing matches" on page one while the matches sat on page nine. Counts are store-wide: "12 prices have drifted" is the number that matters; "0 on this page" quietly implies all is well.

The spot check **reuses the nightly mirror audit** at a size the merchant picks, rather than being a second comparison free to disagree with it.

## Two real bugs found while testing this

Both mattered more than the feature.

**Every background path was sending ciphertext as an access token.** Token encryption (#213) landed at the session-storage layer, but the worker reads the session row *directly* and never goes through it. Shopify answers ciphertext with `Invalid API key or access token` — which reads like a misconfigured app. So scheduled runs, the nightly mirror audit, and this spot check were all broken, all failing the same misleading way, all pointing anywhere but at the cause. Plaintext still falls through unchanged, so a shop installed before encryption keeps working.

**A run updated only one of the two copies of the base live price.** The catalogue index carries it for search; `price_surface_entries` carries it as the uniform "live value on surface X". Only the second was refreshed — and the nightly audit compares against the first. A merchant who ran a sale across their catalogue would have woken to an alert saying the pipeline was systematically broken, the morning after it worked perfectly.

## Verified against the real store

```
boltify-apps.myshopify.com: 1616 variants mirrored, checking 1000.
checked 1000 in 4281ms · diverged 0 (0.00%) · healed 0 · alert false
```

That's the ticket's headline criterion — **1,000-variant spot check agrees with fresh API reads** — and it's also what proved the token fix end to end.

## Tests

8 for the export, 6 chaos scenarios, 4 for the token path.

**Falsified.** Dropping the second mirror update, ignoring what the ledger says we wrote, reordering the state labels so drift hides behind "on sale", blanking a cell instead of naming it, and passing an encrypted token through undecrypted.

Full suite: 568 unit tests, 56 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)