### PR TITLE
P5.7 — Matrixify-compatible imports, a cost import, and the missing exports

### DIFF
--- a/app/lib/baselines/cost-rows.test.ts
+++ b/app/lib/baselines/cost-rows.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Validating imported costs.
+ *
+ * A cost is not a price: importing one changes nothing on the storefront, it changes
+ * what the app will refuse to do. That makes the failure mode different — a wrong cost
+ * is a wrong floor, not a wrong price — and this validates accordingly.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isValidCost, validateCostRow } from "./cost-rows";
+
+const row = (over: Record<string, string> = {}) => ({
+  line: 2,
+  identifier: "SKU-1",
+  price: "",
+  cost: "12.50",
+  ...over,
+});
+
+describe("reading a cost from a row", () => {
+  it("parses a plain number in the shop's currency", () => {
+    const result = validateCostRow(row(), "USD");
+
+    expect(isValidCost(result)).toBe(true);
+    if (isValidCost(result)) expect(result.parsedCost.amount).toBe(1250);
+  });
+
+  it("uses the row's own currency when it names one", () => {
+    // Precision is currency-specific. "1250" is ¥1,250 and $12.50, and taking the
+    // shop's currency for a row that named another is off by a factor of a hundred.
+    const result = validateCostRow(row({ cost: "1250", currency: "JPY" }), "USD");
+
+    expect(isValidCost(result) && result.parsedCost.amount).toBe(1250);
+  });
+
+  it("accepts a cost of zero", () => {
+    // Unlike a zero baseline, which makes every percentage campaign compute to zero.
+    // A sample or a giveaway genuinely costs nothing, and refusing it would force the
+    // merchant to drop the row and lose the fact that the cost is known.
+    const result = validateCostRow(row({ cost: "0" }), "USD");
+
+    expect(isValidCost(result)).toBe(true);
+  });
+
+  it("refuses a negative cost", () => {
+    expect(isValidCost(validateCostRow(row({ cost: "-1" }), "USD"))).toBe(false);
+  });
+
+  it("refuses a cost with a currency symbol, and says how to fix it", () => {
+    const result = validateCostRow(row({ cost: "$12.50" }), "USD");
+
+    expect(isValidCost(result)).toBe(false);
+    if (!isValidCost(result)) expect(result.reason).toContain("12.50, not $12.50");
+  });
+
+  it("refuses a row with no identifier to match on", () => {
+    expect(isValidCost(validateCostRow(row({ identifier: "" }), "USD"))).toBe(false);
+  });
+
+  it("treats a blank cost as a row to leave out, not a zero", () => {
+    // Reading blank as zero would set a floor of nothing on every product whose cost
+    // the merchant simply had not filled in — turning the guardrail off silently.
+    const result = validateCostRow(row({ cost: "" }), "USD");
+
+    expect(isValidCost(result)).toBe(false);
+    if (!isValidCost(result)) expect(result.problem).toBe("no-cost");
+  });
+
+  it("refuses a fractional minor unit in a zero-decimal currency", () => {
+    // ¥12.50 is not a cost that exists.
+    expect(isValidCost(validateCostRow(row({ cost: "12.50", currency: "JPY" }), "USD")))
+      .toBe(false);
+  });
+});

--- a/app/lib/baselines/cost-rows.ts
+++ b/app/lib/baselines/cost-rows.ts
@@ -1,0 +1,73 @@
+/**
+ * Reading unit costs from a spreadsheet.
+ *
+ * Cost is what the margin guardrails compute against, and most catalogues arrive with it
+ * missing — Shopify does not require it, and a store built by importing a supplier feed
+ * usually has it in the supplier's spreadsheet rather than in Shopify. Until it is here,
+ * "never price below cost" is a setting a merchant can switch on and get nothing from,
+ * because every variant without a cost is skipped.
+ *
+ * Deliberately not a price. Importing a cost changes no storefront value and needs no
+ * write to Shopify; it changes what the app will *refuse* to do. That makes it the one
+ * import that can be applied directly rather than through a campaign — and it also means
+ * a wrong cost is not a wrong price, only a wrong floor, which is why this validates
+ * less severely than the baseline importer.
+ */
+
+import { parseMoney, type Money } from "../money/money";
+import type { RawRow } from "./csv-rows";
+
+export interface ValidCostRow extends RawRow {
+  parsedCost: Money;
+}
+
+export type CostProblem = "no-identifier" | "no-cost" | "cost-unparseable" | "cost-negative";
+
+export interface InvalidCostRow extends RawRow {
+  problem: CostProblem;
+  reason: string;
+}
+
+const REASONS: Record<CostProblem, string> = {
+  "no-identifier": "No SKU, barcode or variant ID in this row — nothing to match on.",
+  "no-cost": "No cost given. Leave the row out rather than leaving the cost blank.",
+  "cost-unparseable":
+    "Cost is not a plain number. Remove currency symbols and thousands separators — 12.50, not $12.50.",
+  "cost-negative": "Cost cannot be negative.",
+};
+
+export function validateCostRow(
+  row: RawRow,
+  shopCurrency: string,
+): ValidCostRow | InvalidCostRow {
+  const fail = (problem: CostProblem): InvalidCostRow => ({
+    ...row,
+    problem,
+    reason: REASONS[problem],
+  });
+
+  if (!row.identifier.trim()) return fail("no-identifier");
+
+  const raw = (row.cost ?? "").trim();
+  if (!raw) return fail("no-cost");
+
+  const currency = (row.currency || shopCurrency).toUpperCase();
+
+  let parsedCost: Money;
+  try {
+    parsedCost = parseMoney(raw, currency);
+  } catch {
+    return fail("cost-unparseable");
+  }
+
+  // Zero is allowed, unlike a zero baseline. A genuinely free item — a sample, a
+  // giveaway — has a cost of nothing, and refusing it would force the merchant to leave
+  // the row out and lose the fact that its cost is known to be zero.
+  if (parsedCost.amount < 0) return fail("cost-negative");
+
+  return { ...row, parsedCost };
+}
+
+export function isValidCost(row: ValidCostRow | InvalidCostRow): row is ValidCostRow {
+  return "parsedCost" in row;
+}

--- a/app/lib/baselines/csv-rows.test.ts
+++ b/app/lib/baselines/csv-rows.test.ts
@@ -108,7 +108,38 @@ describe("mapColumns", () => {
       price: 1,
       compareAt: 2,
       currency: null,
+      cost: null,
     });
+  });
+
+  it("reads a Matrixify export untouched", () => {
+    // Matrixify is how a large share of Shopify merchants already move catalogue data.
+    // Its headers are title-case and multi-word, which lowercase to strings none of the
+    // single-word aliases matched — so a merchant with a working spreadsheet workflow
+    // hit "unrecognised header" and went back to doing it by hand.
+    expect(
+      mapColumns([
+        "Handle",
+        "Variant SKU",
+        "Variant Price",
+        "Variant Compare At Price",
+        "Variant Cost",
+      ]),
+      // Identifier is the SKU at index 1, not the Handle at index 0. Matrixify puts
+      // Handle first, and a handle names a product where a SKU names a variant.
+    ).toEqual({ identifier: 1, price: 2, compareAt: 3, currency: null, cost: 4 });
+  });
+
+  it("prefers the SKU column over a handle, whichever comes first", () => {
+    // Both orderings, because the bug this replaces was "whichever column appeared
+    // first wins" and it only shows up when the handle is on the left.
+    expect(mapColumns(["Variant SKU", "Handle", "Variant Price"])?.identifier).toBe(0);
+    expect(mapColumns(["Handle", "Variant SKU", "Variant Price"])?.identifier).toBe(1);
+  });
+
+  it("still accepts a handle when that is the only identifier there is", () => {
+    // Preferring a SKU must not mean refusing a file that has none.
+    expect(mapColumns(["Handle", "Variant Price"])?.identifier).toBe(0);
   });
 
   it("returns null when it cannot tell which column is the price", () => {

--- a/app/lib/baselines/csv-rows.ts
+++ b/app/lib/baselines/csv-rows.ts
@@ -26,6 +26,7 @@ export interface RawRow {
   price: string;
   compareAt?: string;
   currency?: string;
+  cost?: string;
 }
 
 export interface ValidRow extends RawRow {
@@ -104,18 +105,60 @@ export function isValid(row: ValidRow | InvalidRow): row is ValidRow {
 }
 
 /** Header names understood for each column, so a merchant's export mostly just works. */
-const HEADERS: Record<"identifier" | "price" | "compareAt" | "currency", string[]> = {
-  identifier: ["sku", "barcode", "variant", "variant_id", "variantid", "gid", "id", "handle", "product"],
-  price: ["price", "baseline", "baseline_price", "msrp", "list_price", "list price", "rrp"],
-  compareAt: ["compare_at", "compare at", "compareatprice", "compare_at_price", "was", "was_price"],
+/**
+ * Header names we recognise, including Matrixify's.
+ *
+ * Matrixify is how a large share of Shopify merchants already move catalogue data, so a
+ * file exported from it should import here untouched. Its columns are title-case and
+ * multi-word — "Variant SKU", "Variant Price" — which lowercase to strings none of the
+ * original single-word aliases matched. A merchant with a working spreadsheet workflow
+ * would have hit "unrecognised header" and gone back to doing it by hand.
+ */
+const HEADERS: Record<"identifier" | "price" | "compareAt" | "currency" | "cost", string[]> = {
+  // Most specific first, and the order matters. A Matrixify export carries both
+  // "Handle" and "Variant SKU", with Handle in the first column — and a handle names a
+  // *product* while a SKU names a *variant*. Taking whichever appeared first would match
+  // a variant-level price row on a product-level identifier, which is how one row
+  // silently reprices every size of a shirt.
+  identifier: [
+    "variant id", "variant_id", "variantid", "gid",
+    "sku", "variant sku",
+    "barcode", "variant barcode",
+    "variant", "id",
+    "handle", "product handle", "product",
+  ],
+  price: [
+    "price", "baseline", "baseline_price", "msrp", "list_price", "list price", "rrp",
+    // Matrixify
+    "variant price",
+  ],
+  compareAt: [
+    "compare_at", "compare at", "compareatprice", "compare_at_price", "was", "was_price",
+    // Matrixify
+    "variant compare at price",
+  ],
   currency: ["currency", "currency_code", "currencycode"],
+  cost: [
+    "cost", "unit_cost", "unit cost", "cost_per_item",
+    // Matrixify
+    "variant cost", "cost per item",
+  ],
 };
 
 export interface ColumnMap {
   identifier: number;
-  price: number;
+  /**
+   * Null when the file has no price column at all.
+   *
+   * A cost file legitimately has none — "Variant SKU, Variant Cost" is a complete and
+   * ordinary spreadsheet. Requiring a price here meant the header went unrecognised, the
+   * reader fell back to *positions*, and every row then read its cost from a column that
+   * was not there. The file imported nothing and said every row had no cost.
+   */
+  price: number | null;
   compareAt: number | null;
   currency: number | null;
+  cost: number | null;
 }
 
 /**
@@ -128,21 +171,33 @@ export interface ColumnMap {
  * caller falls back to positional columns it can describe to the merchant.
  */
 export function mapColumns(header: readonly string[]): ColumnMap | null {
-  const find = (names: string[]) =>
-    header.findIndex((cell) => names.includes(cell.trim().toLowerCase()));
+  // Searched in the order the aliases are listed, not the order the columns appear, so
+  // a file carrying several usable identifiers is matched on the most specific one.
+  const find = (names: string[]) => {
+    for (const name of names) {
+      const at = header.findIndex((cell) => cell.trim().toLowerCase() === name);
+      if (at !== -1) return at;
+    }
+    return -1;
+  };
 
   const identifier = find(HEADERS.identifier);
   const price = find(HEADERS.price);
-  if (identifier === -1 || price === -1) return null;
+  const cost = find(HEADERS.cost);
+
+  // An identifier and at least one value worth importing. Neither alone is a file: a
+  // column of SKUs says nothing, and a column of prices names nothing.
+  if (identifier === -1 || (price === -1 && cost === -1)) return null;
 
   const compareAt = find(HEADERS.compareAt);
   const currency = find(HEADERS.currency);
 
   return {
     identifier,
-    price,
+    price: price === -1 ? null : price,
     compareAt: compareAt === -1 ? null : compareAt,
     currency: currency === -1 ? null : currency,
+    cost: cost === -1 ? null : cost,
   };
 }
 
@@ -189,7 +244,7 @@ export function splitCsvLine(line: string): string[] {
  */
 export async function* readRows(
   lines: AsyncIterable<string>,
-  fallback: ColumnMap = { identifier: 0, price: 1, compareAt: 2, currency: 3 },
+  fallback: ColumnMap = { identifier: 0, price: 1, compareAt: 2, currency: 3, cost: null },
 ): AsyncGenerator<RawRow> {
   let columns: ColumnMap | null = null;
   let lineNumber = 0;
@@ -214,9 +269,10 @@ export async function* readRows(
     yield {
       line: lineNumber,
       identifier: cells[columns.identifier] ?? "",
-      price: cells[columns.price] ?? "",
+      price: columns.price === null ? "" : (cells[columns.price] ?? ""),
       compareAt: columns.compareAt === null ? undefined : cells[columns.compareAt],
       currency: columns.currency === null ? undefined : cells[columns.currency],
+      cost: columns.cost === null ? undefined : cells[columns.cost],
     };
   }
 }

--- a/app/lib/reporting/baselines-csv.ts
+++ b/app/lib/reporting/baselines-csv.ts
@@ -1,0 +1,51 @@
+/**
+ * The baseline browser as a file, in a shape it can be re-imported from.
+ *
+ * The round trip is the point: export, edit in Excel, import. So the headers are the
+ * ones the importer recognises rather than the ones that read best on screen, and the
+ * prices are plain numbers — a merchant who exported "$1,299.00" and imported it again
+ * would get a row-level error on every line, which makes the export useless for the one
+ * job it has.
+ */
+
+import type { BaselineRow } from "../../services/baseline-browser.server";
+import { toCsv } from "./csv";
+
+export function baselinesCsv(rows: readonly BaselineRow[]): string {
+  // "Variant SKU" and "Variant Price" rather than "SKU" and "Baseline": Matrixify's
+  // names, so the same file opens in the workflow a merchant already has.
+  const header = [
+    "Variant SKU",
+    "Variant ID",
+    "Title",
+    "Vendor",
+    "Variant Price",
+    "Live price",
+    "Source",
+    "Captured at",
+  ];
+
+  const body = rows.map((row) => [
+    row.sku ?? "",
+    row.variantGid,
+    row.title,
+    row.vendor ?? "",
+    plain(row.baseline),
+    plain(row.live),
+    row.source ?? "",
+    row.capturedAt ?? "",
+  ]);
+
+  return toCsv(header, body);
+}
+
+/**
+ * A formatted price back to a plain number.
+ *
+ * The screen wants "$1,299.00"; the importer wants "1299.00" and rejects anything else.
+ * Exporting the display form would make every round trip fail on every row.
+ */
+export function plain(formatted: string | null): string {
+  if (!formatted) return "";
+  return formatted.replace(/[^\d.-]/g, "");
+}

--- a/app/lib/reporting/cost-errors.ts
+++ b/app/lib/reporting/cost-errors.ts
@@ -1,0 +1,30 @@
+/**
+ * The rows a cost import could not use, as a file to fix and re-upload.
+ *
+ * The line number is the point. "37 rows failed" sends a merchant scrolling through a
+ * spreadsheet; "line 412, SKU-9931, cost is not a plain number" is something they can
+ * act on in seconds.
+ */
+
+import type { CostImportResult } from "../../services/cost-import.server";
+import { toCsv } from "./csv";
+
+export function costErrorCsv(result: CostImportResult): string {
+  const rows = [
+    ...result.invalid.map((problem) => ["invalid", problem] as const),
+    ...result.unmatched.map((problem) => ["unmatched", problem] as const),
+    ...result.ambiguous.map((problem) => ["ambiguous", problem] as const),
+  ];
+
+  return toCsv(
+    ["Line", "Identifier", "Problem", "What to do"],
+    rows
+      .sort((a, b) => a[1].line - b[1].line)
+      .map(([kind, problem]) => [
+        String(problem.line),
+        problem.identifier,
+        kind,
+        problem.reason,
+      ]),
+  );
+}

--- a/app/lib/reporting/ledger-csv.ts
+++ b/app/lib/reporting/ledger-csv.ts
@@ -1,0 +1,30 @@
+/**
+ * A run's ledger as a file.
+ *
+ * This is the record of what the app did to a merchant's storefront: every variant it
+ * intended to change, what it wrote, and whether Shopify confirmed. It is what gets
+ * attached to a support ticket, and what a merchant's finance team asks for when a price
+ * on an invoice does not match what they expected.
+ *
+ * So a failed row keeps its reason in the file. An export that dropped the failures
+ * would show a clean run that was not clean, which is the specific dishonesty this whole
+ * product is built against.
+ */
+
+import type { LedgerRow } from "../../services/campaigns/types";
+import { toCsv } from "./csv";
+
+export function ledgerCsv(rows: readonly LedgerRow[]): string {
+  const header = ["Variant", "Title", "Before", "We wrote", "Status", "Why not"];
+
+  const body = rows.map((row) => [
+    row.variantGid,
+    row.title,
+    row.before ?? "",
+    row.intended ?? "",
+    row.status,
+    row.failureReason ?? "",
+  ]);
+
+  return toCsv(header, body);
+}

--- a/app/lib/reporting/lines.ts
+++ b/app/lib/reporting/lines.ts
@@ -1,0 +1,19 @@
+/**
+ * Splits pasted text into lines without holding a second copy of the whole file.
+ *
+ * A generator rather than `text.split("\n")` because the importers are written to stream:
+ * splitting would double the memory for a 500K-row paste at exactly the moment it is
+ * already large. Shared by both importers so they cannot drift on how a line ends.
+ */
+export async function* linesOf(text: string): AsyncGenerator<string> {
+  let start = 0;
+  for (;;) {
+    const next = text.indexOf("\n", start);
+    if (next === -1) break;
+    // Trailing carriage return, because a spreadsheet saved on Windows ends every line
+    // with one and it would otherwise become part of the last column's value.
+    yield text.slice(start, next).replace(/\r$/, "");
+    start = next + 1;
+  }
+  if (start < text.length) yield text.slice(start);
+}

--- a/app/lib/reporting/round-trip.test.ts
+++ b/app/lib/reporting/round-trip.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Export, edit, import.
+ *
+ * The acceptance criterion for the data I/O story is a round trip that survives a
+ * spreadsheet. That is not a formality: the obvious export prints "$1,299.00" because
+ * that is what reads well on screen, and the importer refuses it because a price with a
+ * currency symbol is exactly the row that silently becomes the wrong number. An export
+ * that cannot be re-imported is a feature that only appears to exist.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { BaselineRow } from "../../services/baseline-browser.server";
+import { baselinesCsv, plain } from "./baselines-csv";
+import { mapColumns, splitCsvLine, validateRow } from "../baselines/csv-rows";
+
+const row = (over: Partial<BaselineRow> = {}): BaselineRow => ({
+  variantGid: "gid://shopify/ProductVariant/1",
+  productGid: "gid://shopify/Product/1",
+  title: "Chair",
+  sku: "CH-1",
+  vendor: "Acme",
+  baseline: "$1,299.00",
+  live: "$999.00",
+  source: "INSTALL_CAPTURE",
+  capturedAt: "2026-08-01T00:00:00.000Z",
+  diverged: true,
+  adminUrl: "https://example.myshopify.com/admin/products/1",
+  ...over,
+});
+
+describe("stripping display formatting for re-import", () => {
+  it("turns a formatted price into a plain number", () => {
+    expect(plain("$1,299.00")).toBe("1299.00");
+    expect(plain("€64,00")).toBe("6400");
+    expect(plain("¥9,480")).toBe("9480");
+  });
+
+  it("keeps a negative sign", () => {
+    expect(plain("-$5.00")).toBe("-5.00");
+  });
+
+  it("leaves a missing price missing rather than writing zero", () => {
+    // "0" would import as a baseline of nothing, which makes every percentage campaign
+    // on that variant compute to zero.
+    expect(plain(null)).toBe("");
+  });
+});
+
+describe("the round trip", () => {
+  it("exports headers the importer recognises", () => {
+    const header = splitCsvLine(baselinesCsv([row()]).split("\n")[0]);
+    const map = mapColumns(header);
+
+    expect(map).not.toBeNull();
+    // The variant ID, not the SKU — and that is the right answer. A gid names exactly
+    // one variant for ever; a SKU is whatever the merchant typed and may name two. The
+    // importer is right to prefer the one that cannot be ambiguous, and the export
+    // carries both so a merchant editing by hand still has the SKU to read.
+    expect(header[map!.identifier]).toBe("Variant ID");
+    expect(map!.price).not.toBeNull();
+    expect(header[map!.price!]).toBe("Variant Price");
+    expect(header).toContain("Variant SKU");
+  });
+
+  it("round-trips on the SKU when the ID column is removed, as a spreadsheet edit might", () => {
+    // Merchants delete columns they do not recognise. Losing the gid must degrade to
+    // matching on SKU rather than failing the file.
+    const header = ["Variant SKU", "Title", "Variant Price"];
+    const map = mapColumns(header);
+
+    expect(map).not.toBeNull();
+    expect(header[map!.identifier]).toBe("Variant SKU");
+  });
+
+  it("exports prices the importer accepts", () => {
+    const line = baselinesCsv([row()]).split("\n")[1];
+    const cells = splitCsvLine(line);
+    const header = splitCsvLine(baselinesCsv([row()]).split("\n")[0]);
+    const map = mapColumns(header)!;
+
+    const validated = validateRow(
+      {
+        line: 2,
+        identifier: cells[map.identifier],
+        price: cells[map.price!],
+      },
+      "USD",
+    );
+
+    expect("parsedPrice" in validated).toBe(true);
+    if ("parsedPrice" in validated) expect(validated.parsedPrice.amount).toBe(129_900);
+  });
+
+  it("survives a title containing a comma and a quote", () => {
+    // Ordinary catalogue data, and the thing that breaks a naive round trip.
+    const csv = baselinesCsv([row({ title: 'Monitor, 24"', sku: "M,24" })]);
+    const cells = splitCsvLine(csv.split("\n")[1]);
+
+    expect(cells[0]).toBe("M,24");
+    expect(cells[2]).toBe('Monitor, 24"');
+  });
+});

--- a/app/routes/app.baselines._index.tsx
+++ b/app/routes/app.baselines._index.tsx
@@ -24,6 +24,8 @@ import { ensureShop } from "../services/shop.server";
 import { baselineHistory, browseBaselines } from "../services/baseline-browser.server";
 import { BaselineTable } from "../components/BaselineTable";
 import { FilterForm } from "../components/FilterForm";
+import { baselinesCsv } from "../lib/reporting/baselines-csv";
+import { downloadCsv } from "../lib/reporting/csv";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 
@@ -122,6 +124,17 @@ export default function Baselines() {
                 {total} variants · showing {rows.length}
               </s-text>
             </s-paragraph>
+
+            {/* Exports what the filters currently show, not the whole catalogue. A
+                merchant who narrowed to one vendor means that vendor, and handing them
+                500K rows instead is not being generous. */}
+            <s-button
+              type="button"
+              variant="tertiary"
+              onClick={() => downloadCsv("anchor-baselines.csv", baselinesCsv(rows))}
+            >
+              Export these baselines (CSV)
+            </s-button>
 
             <BaselineTable rows={rows} onShowHistory={show} />
 

--- a/app/routes/app.baselines.import.tsx
+++ b/app/routes/app.baselines.import.tsx
@@ -21,6 +21,7 @@ import { shopCurrency } from "../services/settings.server";
 import { importBaselines, type BaselineImportResult } from "../services/baseline-import.server";
 import { importErrorCsv } from "../lib/reporting/baseline-errors";
 import { downloadCsv } from "../lib/reporting/csv";
+import { linesOf } from "../lib/reporting/lines";
 import { actorFor } from "../lib/audit/actor";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
@@ -67,18 +68,6 @@ export const action = withGuard("/app/baselines/import", async ({ request }: Act
     return { ok: false, message: reported.userMessage, errorId: reported.errorId };
   }
 });
-
-/** Splits pasted text into lines without holding a second copy of the whole file. */
-async function* linesOf(text: string): AsyncGenerator<string> {
-  let start = 0;
-  for (;;) {
-    const next = text.indexOf("\n", start);
-    if (next === -1) break;
-    yield text.slice(start, next).replace(/\r$/, "");
-    start = next + 1;
-  }
-  if (start < text.length) yield text.slice(start);
-}
 
 export default function ImportBaselines() {
   const { currency } = useLoaderData<typeof loader>();

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -23,6 +23,7 @@ import { downloadCsv, filenameSlug } from "../lib/reporting/csv";
 import { rollbackReportCsv } from "../lib/reporting/rollback";
 import { PreviewTable } from "../components/PreviewTable";
 import { RunHistoryTable } from "../components/RunHistoryTable";
+import { ledgerCsv } from "../lib/reporting/ledger-csv";
 import { previewCsv } from "../lib/reporting/preview-csv";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { reportError } from "../services/error-report.server";
@@ -378,6 +379,19 @@ export default function CampaignDetail() {
               its price without it.
             </s-text>
           </s-paragraph>
+          <s-button
+            type="button"
+            variant="tertiary"
+            onClick={() =>
+              downloadCsv(
+                `ledger-${filenameSlug(preview.name) || "campaign"}.csv`,
+                ledgerCsv(ledger),
+              )
+            }
+          >
+            Export this ledger (CSV)
+          </s-button>
+
           <LedgerTable
             rows={ledger}
             renderAction={(row) =>

--- a/app/routes/app.costs.import.tsx
+++ b/app/routes/app.costs.import.tsx
@@ -1,0 +1,204 @@
+/**
+ * Importing unit costs.
+ *
+ * The margin guardrail is the safety feature merchants ask for most, and on most
+ * catalogues it protects nothing: Shopify does not require a cost, and a store built from
+ * a supplier feed keeps costs in the supplier's spreadsheet. "Never price below cost"
+ * then quietly skips every variant — switched on, reassuring, and inert. This is how a
+ * merchant makes it real.
+ *
+ * Dry run is the default here as it is for baselines, though the stakes are different: a
+ * wrong cost is a wrong floor rather than a wrong price. It stays the default anyway,
+ * because a merchant who has just imported ten thousand costs should get to look before
+ * the guardrail starts refusing to price things.
+ */
+
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useRef } from "react";
+import { useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { shopCurrency } from "../services/settings.server";
+import { importCosts, type CostImportResult } from "../services/cost-import.server";
+import { costErrorCsv } from "../lib/reporting/cost-errors";
+import { downloadCsv } from "../lib/reporting/csv";
+import { actorFor } from "../lib/audit/actor";
+import { linesOf } from "../lib/reporting/lines";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+import { reportError } from "../services/error-report.server";
+
+export const loader = withGuard("/app/costs/import", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const [currency, withCost, variants] = await Promise.all([
+    shopCurrency(shop.id),
+    prisma.variantIndex.count({ where: { shopId: shop.id, cost: { not: null }, deletedAt: null } }),
+    prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } }),
+  ]);
+
+  return { currency, withCost, variants };
+});
+
+type ActionData = { ok: boolean; message: string; result?: CostImportResult; errorId?: string };
+
+export const action = withGuard("/app/costs/import", async ({ request }: ActionFunctionArgs) => {
+  const { session, sessionToken } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  const csv = String(form.get("csv") ?? "");
+  const dryRun = String(form.get("intent")) !== "commit";
+
+  try {
+    const result = await importCosts(shop.id, linesOf(csv), await shopCurrency(shop.id), {
+      dryRun,
+      actor: actorFor(sessionToken, session.shop),
+    });
+
+    return {
+      ok: true,
+      result,
+      message: dryRun
+        ? `${result.ready} of ${result.total} rows would be imported. Nothing has been written.`
+        : `Imported ${result.written} costs.` +
+          (result.unchanged > 0
+            ? ` ${result.unchanged} already matched and were left alone.`
+            : ""),
+    };
+  } catch (error) {
+    const reported = await reportError(error, {
+      shopId: shop.id,
+      shop: session.shop,
+      route: "/app/costs/import",
+    });
+    return { ok: false, message: reported.userMessage, errorId: reported.errorId };
+  }
+});
+
+export default function ImportCosts() {
+  const { currency, withCost, variants } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const busy = fetcher.state !== "idle";
+  const data = fetcher.data;
+  const result = data?.result;
+
+  const form = useRef<HTMLFormElement>(null);
+  const intent = useRef<HTMLInputElement>(null);
+
+  const submitWith = (value: string) => {
+    if (intent.current) intent.current.value = value;
+    form.current?.requestSubmit();
+  };
+
+  const coverage = variants === 0 ? 0 : Math.round((withCost / variants) * 100);
+  const problems = result
+    ? [...result.invalid, ...result.unmatched, ...result.ambiguous]
+    : [];
+
+  return (
+    <s-page heading="Import costs">
+      {data ? (
+        <s-banner tone={data.ok ? "success" : "critical"}>
+          <s-paragraph>{data.message}</s-paragraph>
+          {data.errorId ? <s-paragraph>Reference {data.errorId}</s-paragraph> : null}
+        </s-banner>
+      ) : null}
+
+      <s-section heading="What your cost floors can protect">
+        <s-paragraph>
+          <s-text>
+            {withCost} of {variants} variants have a cost ({coverage}%). Cost-based
+            guardrails only constrain variants that have one — the rest are skipped, so
+            a low number here means &ldquo;never price below cost&rdquo; is doing less
+            than it looks.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            One row per variant: a SKU, barcode or variant ID, then the cost. Costs are
+            read in {currency} unless a row says otherwise, and must be plain numbers —
+            12.50, not $12.50. A file exported from Matrixify works as it is.
+          </s-text>
+        </s-paragraph>
+
+        <fetcher.Form method="post" ref={form}>
+          {/* `s-button` takes no name/value, so the intent rides in a hidden field the
+              buttons set before submitting. One form, because both actions read the same
+              rows and duplicating the field would let them drift apart. */}
+          <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
+          <s-stack gap="base">
+            <s-text-area
+              name="csv"
+              label="Rows"
+              rows={12}
+              placeholder={"Variant SKU,Variant Cost\nCH-1,12.50\nCH-2,14.00"}
+              details="Paste straight from a spreadsheet. A header row is read if there is one."
+            />
+
+            <s-stack direction="inline" gap="base">
+              <s-button
+                type="button"
+                variant="primary"
+                loading={busy || undefined}
+                onClick={() => submitWith("dry-run")}
+              >
+                Check without importing
+              </s-button>
+              <s-button
+                type="button"
+                tone="critical"
+                loading={busy || undefined}
+                onClick={() => submitWith("commit")}
+              >
+                Import these costs
+              </s-button>
+            </s-stack>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      {result ? (
+        <s-section heading="What happened">
+          <s-paragraph>
+            <s-text>
+              {result.total} rows read · {result.ready} ready · {result.written} written ·{" "}
+              {result.unchanged} unchanged · {problems.length} need attention
+            </s-text>
+          </s-paragraph>
+
+          {problems.length > 0 ? (
+            <>
+              <s-button
+                type="button"
+                variant="tertiary"
+                onClick={() => downloadCsv("cost-import-errors.csv", costErrorCsv(result))}
+              >
+                Download the rows that need fixing (CSV)
+              </s-button>
+
+              <s-unordered-list>
+                {problems.slice(0, 25).map((problem) => (
+                  <s-list-item key={`${problem.line}-${problem.identifier}`}>
+                    Line {problem.line} ({problem.identifier || "no identifier"}):{" "}
+                    {problem.reason}
+                  </s-list-item>
+                ))}
+              </s-unordered-list>
+            </>
+          ) : null}
+        </s-section>
+      ) : null}
+    </s-page>
+  );
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -28,6 +28,7 @@ export default function App() {
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/baselines">Baselines</s-link>
         <s-link href="/app/baselines/import">Import baselines</s-link>
+        <s-link href="/app/costs/import">Import costs</s-link>
         <s-link href="/app/reconciliation">What is live</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/activity">Activity</s-link>

--- a/app/services/cost-import.server.ts
+++ b/app/services/cost-import.server.ts
@@ -1,0 +1,181 @@
+/**
+ * Importing unit costs.
+ *
+ * The margin guardrail is the safety net merchants say they want most, and on most
+ * catalogues it does nothing, because Shopify does not require a cost and a store built
+ * from a supplier feed keeps its costs in the supplier's spreadsheet. "Never price below
+ * cost" then silently skips every variant, which is the worst possible shape for a safety
+ * feature: switched on, reassuring, and inert.
+ *
+ * Structurally the same as the baseline import, deliberately. Same row reader, same
+ * matcher, same dry run, same row-level error file — so "SKU-1 matches two variants"
+ * means one thing in this app rather than being decided twice, differently.
+ *
+ * Costs are written to the catalogue mirror and to the current baseline. The baseline is
+ * what the guardrail reads at resolve time; the mirror is what the settings page counts
+ * to tell a merchant how much of their catalogue the guardrail can actually protect.
+ */
+
+import prisma from "../db.server";
+import {
+  buildMatchIndex,
+  matchIdentifiers,
+  type CsvRow,
+} from "../lib/segments/csv-import";
+import { readRows } from "../lib/baselines/csv-rows";
+import { isValidCost, validateCostRow, type ValidCostRow } from "../lib/baselines/cost-rows";
+import { logger } from "../lib/logging/logger";
+
+export interface CostImportProblem {
+  line: number;
+  identifier: string;
+  reason: string;
+}
+
+export interface CostImportResult {
+  total: number;
+  ready: number;
+  written: number;
+  /** Rows whose cost already equals the one on file. */
+  unchanged: number;
+  invalid: CostImportProblem[];
+  unmatched: CostImportProblem[];
+  ambiguous: CostImportProblem[];
+  dryRun: boolean;
+}
+
+/** Rows per write. Large enough to be quick, small enough not to hold the file. */
+const BATCH = 500;
+
+export async function importCosts(
+  shopId: string,
+  lines: AsyncIterable<string>,
+  shopCurrency: string,
+  options: { dryRun?: boolean; actor?: string } = {},
+): Promise<CostImportResult> {
+  const result: CostImportResult = {
+    total: 0,
+    ready: 0,
+    written: 0,
+    unchanged: 0,
+    invalid: [],
+    unmatched: [],
+    ambiguous: [],
+    dryRun: options.dryRun === true,
+  };
+
+  const variants = await prisma.variantIndex.findMany({
+    where: { shopId, deletedAt: null },
+    select: { variantGid: true, productGid: true, sku: true, barcode: true, cost: true },
+  });
+  const index = buildMatchIndex(variants);
+  const currentCost = new Map(variants.map((row) => [row.variantGid, row.cost]));
+
+  let batch: Array<{ row: ValidCostRow; variantGid: string }> = [];
+
+  const flush = async () => {
+    if (batch.length === 0) return;
+    const pending = batch;
+    batch = [];
+    if (result.dryRun) return;
+
+    await writeCosts(shopId, pending);
+    result.written += pending.length;
+  };
+
+  // Streamed. The file is consumed a line at a time and never assembled, so a 500K-row
+  // import costs one batch of memory rather than the whole spreadsheet.
+  for await (const raw of readRows(lines)) {
+    result.total++;
+
+    const validated = validateCostRow(raw, shopCurrency);
+    if (!isValidCost(validated)) {
+      push(result.invalid, { line: raw.line, identifier: raw.identifier, reason: validated.reason });
+      continue;
+    }
+
+    const csvRow: CsvRow = { line: raw.line, value: raw.identifier };
+    const outcome = matchIdentifiers([csvRow], index);
+
+    if (outcome.ambiguous.length > 0) {
+      push(result.ambiguous, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason:
+          `Matches ${outcome.ambiguous[0].candidates.length} variants. ` +
+          `Use a variant ID, or make the SKU unique.`,
+      });
+      continue;
+    }
+
+    const variantGid = outcome.matched[0];
+    if (!variantGid) {
+      push(result.unmatched, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason: "No variant in this shop has that SKU, barcode or ID.",
+      });
+      continue;
+    }
+
+    // Unchanged is a real answer, not a write. Rewriting an identical cost would churn
+    // the mirror's syncedAt and make the audit look like something moved.
+    const existing = currentCost.get(variantGid);
+    if (existing !== null && existing !== undefined && Number(existing) === validated.parsedCost.amount) {
+      result.unchanged++;
+      continue;
+    }
+
+    result.ready++;
+    batch.push({ row: validated, variantGid });
+    if (batch.length >= BATCH) await flush();
+  }
+
+  await flush();
+
+  logger.info("costs imported", {
+    shopId,
+    total: result.total,
+    ready: result.ready,
+    written: result.written,
+    unchanged: result.unchanged,
+    problems: result.invalid.length + result.unmatched.length + result.ambiguous.length,
+    dryRun: result.dryRun,
+  });
+
+  return result;
+}
+
+async function writeCosts(
+  shopId: string,
+  rows: ReadonlyArray<{ row: ValidCostRow; variantGid: string }>,
+): Promise<void> {
+  await prisma.$transaction(
+    rows.flatMap(({ row, variantGid }) => [
+      prisma.variantIndex.updateMany({
+        where: { shopId, variantGid },
+        data: { cost: BigInt(row.parsedCost.amount) },
+      }),
+      // The baseline is what the guardrail actually reads at resolve time. Updating the
+      // mirror alone would leave "never price below cost" using whatever cost was known
+      // when the baseline was captured, which is usually none.
+      prisma.baseline.updateMany({
+        where: { shopId, variantGid, supersededAt: null },
+        data: { cost: BigInt(row.parsedCost.amount) },
+      }),
+    ]),
+  );
+}
+
+/**
+ * Keeps a bounded number of problems.
+ *
+ * A file that is wrong in five hundred thousand ways should produce a usable error list
+ * and a count, not an out-of-memory. The first few hundred are enough to see the shape
+ * of what went wrong, which is what the merchant needs in order to fix the spreadsheet.
+ */
+const MAX_PROBLEMS = 500;
+
+function push(list: CostImportProblem[], problem: CostImportProblem): void {
+  if (list.length < MAX_PROBLEMS) list.push(problem);
+}

--- a/chaos/scenarios/cost-import.chaos.ts
+++ b/chaos/scenarios/cost-import.chaos.ts
@@ -1,0 +1,209 @@
+/**
+ * Importing costs, and the round trip through a spreadsheet.
+ *
+ * The margin guardrail is the safety feature merchants ask for most, and on most
+ * catalogues it protects nothing because Shopify does not require a cost. This is what
+ * makes it real — so the thing worth testing is that an imported cost actually reaches
+ * the guardrail, not merely that a row was written somewhere.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos } from "../harness/scenario";
+
+/** The pasted-file shape both importers consume. */
+async function* linesOf(text: string): AsyncGenerator<string> {
+  for (const line of text.split("\n")) yield line;
+}
+
+describe("chaos: importing costs", () => {
+  it("writes costs the margin guardrail can actually use", async () => {
+    await withChaos(
+      "cost-import",
+      { catalog: { products: 6, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+
+        // SKUs, because that is what a merchant's spreadsheet has.
+        await Promise.all(
+          variantGids.map((gid, i) =>
+            prisma.variantIndex.updateMany({
+              where: { shopId, variantGid: gid },
+              data: { sku: `SKU-${i}` },
+            }),
+          ),
+        );
+
+        const { importCosts } = await import("../../app/services/cost-import.server");
+        const file = ["Variant SKU,Variant Cost", ...variantGids.map((_, i) => `SKU-${i},10.00`)]
+          .join("\n");
+
+        // Dry run writes nothing. Not a nicety: it is the same code path with the write
+        // skipped, so what the merchant reviews is what happens.
+        const preview = await importCosts(shopId, linesOf(file), "USD", { dryRun: true });
+        expect(preview.ready).toBe(variantGids.length);
+        expect(preview.written).toBe(0);
+        expect(
+          await prisma.variantIndex.count({ where: { shopId, cost: { not: null } } }),
+        ).toBe(0);
+
+        const real = await importCosts(shopId, linesOf(file), "USD");
+        expect(real.written).toBe(variantGids.length);
+
+        // Both places, because the guardrail reads the baseline at resolve time and the
+        // settings page counts the mirror. Writing one and not the other would show a
+        // merchant "100% cost coverage" over a guardrail still skipping everything.
+        expect(
+          await prisma.variantIndex.count({ where: { shopId, cost: BigInt(1000) } }),
+        ).toBe(variantGids.length);
+        expect(
+          await prisma.baseline.count({
+            where: { shopId, supersededAt: null, cost: BigInt(1000) },
+          }),
+        ).toBe(variantGids.length);
+      },
+    );
+  });
+
+  it("stops a campaign pricing below an imported cost", async () => {
+    await withChaos(
+      "cost-import-guardrail",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -90 },
+      async (chaos) => {
+        const { shopId, variantGids, baseline } = chaos.fixture;
+
+        await Promise.all(
+          variantGids.map((gid, i) =>
+            prisma.variantIndex.updateMany({
+              where: { shopId, variantGid: gid },
+              data: { sku: `SKU-${i}` },
+            }),
+          ),
+        );
+
+        // A cost just under each baseline, so a 90% discount is plainly below it.
+        const { importCosts } = await import("../../app/services/cost-import.server");
+        const file = [
+          "Variant SKU,Variant Cost",
+          ...variantGids.map((gid, i) => `SKU-${i},${((baseline.get(gid)! * 0.9) / 100).toFixed(2)}`),
+        ].join("\n");
+
+        await importCosts(shopId, linesOf(file), "USD");
+
+        // Switch the guardrail on. Before the import this setting did nothing at all,
+        // because every variant was skipped for having no cost.
+        const shop = await prisma.shop.findUniqueOrThrow({ where: { id: shopId } });
+        await prisma.shop.update({
+          where: { id: shopId },
+          data: {
+            settings: {
+              ...((shop.settings ?? {}) as object),
+              neverBelowCost: true,
+              violationPolicy: "clamp",
+              missingCostPolicy: "skip",
+            } as never,
+          },
+        });
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Every price clamped up to the cost floor rather than landing at 10% of
+        // baseline. Asserted against the imported cost itself, not against a fraction of
+        // the baseline: the claim is "no campaign priced below cost", and only the cost
+        // can test that.
+        for (const gid of variantGids) {
+          const floor = Math.round(baseline.get(gid)! * 0.9);
+          const live = Number(chaos.fake.priceOf(gid)!.replace(".", ""));
+
+          expect(live).toBeGreaterThanOrEqual(floor);
+          // And it really was clamped rather than left alone — a 90% discount would
+          // have landed far below this.
+          expect(live).toBeLessThan(baseline.get(gid)!);
+        }
+
+        const clamped = await prisma.variantChange.count({
+          where: { runId: applied.runId, status: "VERIFIED" },
+        });
+        expect(clamped).toBe(variantGids.length);
+      },
+    );
+  });
+
+  it("reports a bad row without failing the file", async () => {
+    await withChaos(
+      "cost-import-errors",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+
+        await Promise.all(
+          variantGids.map((gid, i) =>
+            prisma.variantIndex.updateMany({
+              where: { shopId, variantGid: gid },
+              data: { sku: `SKU-${i}` },
+            }),
+          ),
+        );
+
+        const { importCosts } = await import("../../app/services/cost-import.server");
+        const file = [
+          "Variant SKU,Variant Cost",
+          "SKU-0,10.00",
+          "SKU-1,$12.50",      // currency symbol
+          "NOPE-9,10.00",      // matches nothing
+          "SKU-2,10.00",
+        ].join("\n");
+
+        const result = await importCosts(shopId, linesOf(file), "USD");
+
+        // One malformed row must not reject the file. A merchant who has to find the
+        // single bad line before anything happens is a merchant who gives up.
+        expect(result.written).toBe(2);
+        expect(result.invalid).toHaveLength(1);
+        expect(result.unmatched).toHaveLength(1);
+        expect(result.invalid[0].line).toBe(3);
+        expect(result.unmatched[0].identifier).toBe("NOPE-9");
+      },
+    );
+  });
+
+  it("survives a 50,000-row file without assembling it", async () => {
+    await withChaos(
+      "cost-import-scale",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+
+        await prisma.variantIndex.updateMany({
+          where: { shopId, variantGid: variantGids[0] },
+          data: { sku: "SKU-REAL" },
+        });
+
+        // Generated lazily, so the test itself never holds the file either — which is
+        // the property being asserted. Most rows match nothing, which is the realistic
+        // shape of a merchant pasting their whole ERP export at a partial catalogue.
+        async function* rows(): AsyncGenerator<string> {
+          yield "Variant SKU,Variant Cost";
+          yield "SKU-REAL,10.00";
+          for (let i = 0; i < 50_000; i++) yield `SKU-MISSING-${i},10.00`;
+        }
+
+        const { importCosts } = await import("../../app/services/cost-import.server");
+        const before = process.memoryUsage().heapUsed;
+        const result = await importCosts(shopId, rows(), "USD");
+        const growth = process.memoryUsage().heapUsed - before;
+
+        expect(result.total).toBe(50_001);
+        expect(result.written).toBe(1);
+
+        // Problems are capped rather than accumulated. Fifty thousand unmatched rows
+        // must produce a usable list and a count, not an out-of-memory.
+        expect(result.unmatched.length).toBeLessThanOrEqual(500);
+        // Well under what holding 50K rows plus 50K problem objects would cost.
+        expect(growth).toBeLessThan(120 * 1024 * 1024);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Closes #170 (except exact-price import — see below).

## Matrixify files now import untouched

Matrixify is how a large share of Shopify merchants already move catalogue data. Its headers are title-case and multi-word — `Variant SKU`, `Variant Price` — which lowercase to strings none of the single-word aliases matched. A merchant with a working spreadsheet workflow hit "unrecognised header" and went back to doing it by hand.

**Identifier columns are now searched by specificity, not by position.** A Matrixify export carries both `Handle` and `Variant SKU`, with Handle *first* — and a handle names a **product** where a SKU names a **variant**. Taking whichever came first would match a variant-level price row on a product-level identifier: one row silently repricing every size of a shirt.

My own first test encoded that bug before the second one caught it.

## A cost import

Structurally identical to the baseline import on purpose — same row reader, same matcher, same dry run, same row-level error file — so "SKU-1 matches two variants" means one thing in this app rather than being decided twice, differently.

It exists because **the margin guardrail is the safety feature merchants ask for most and on most catalogues it protects nothing.** Shopify doesn't require a cost, so "never price below cost" quietly skips every variant: switched on, reassuring, and inert.

Costs write to **both** the catalogue mirror and the current baseline. The baseline is what the guardrail reads at resolve time; the mirror is what the settings page counts. Writing one and not the other would show a merchant "100% cost coverage" over a guardrail still skipping everything.

**A bug this surfaced:** the header mapper required a price column, so an ordinary `Variant SKU, Variant Cost` file went unrecognised, fell back to *positional* columns, and read every cost from a column that wasn't there — importing nothing while reporting that every row had no cost. A map now needs an identifier and at least one value column.

## Exports added

The run **ledger** and the **baseline browser**, both respecting the filters currently applied. A merchant who narrowed to one vendor means that vendor; handing them 500K rows instead isn't generosity.

The baseline export is written **to be re-imported**: Matrixify header names, prices as plain numbers. The obvious export prints `$1,299.00` because that reads well on screen — and the importer refuses it. An export that can't be re-imported is a feature that only appears to exist. There's a round-trip test asserting the export's own headers and values pass the importer's own parser.

## Not included

**Importing exact prices.** Every price write goes through the worker and is ledgered and revertible, so a price import has to become a campaign — and campaign rules are per *segment*, not per variant. Doing it properly needs a new rule kind backed by the imported rows, which is its own ticket rather than a corner of this one.

## Tests

8 for cost validation, 7 for the round trip, 4 chaos scenarios including a **50,000-row file asserted for bounded memory** (problems are capped, so a file wrong in 50K ways gives a usable list and a count, not an OOM).

**Falsified.** Requiring a price column, updating only the mirror and not the baseline, letting the problem list grow unbounded, matching first-column-wins, and dropping Matrixify's aliases.

Full suite: 586 unit tests, 60 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)