### PR TITLE
P5.8 — Four plans, gates that never touch a revert, and D9 resolved

### DIFF
--- a/app/lib/billing/plans.test.ts
+++ b/app/lib/billing/plans.test.ts
@@ -1,0 +1,155 @@
+/**
+ * What each plan gates, and what it must never gate.
+ *
+ * The tests that matter most here are the negatives. A gate that fires when it should
+ * not costs a merchant a feature they paid for; a gate that fires on a *revert* strands
+ * a storefront at sale prices, which is a revenue incident we caused (E8).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import * as plans from "./plans";
+import {
+  canStart,
+  canUseSurface,
+  losesOnDowngrade,
+  PLANS,
+  planFor,
+} from "./plans";
+
+const shape = (over: Partial<Parameters<typeof canStart>[1]> = {}) => ({
+  variants: 100,
+  markets: false,
+  b2b: false,
+  ...over,
+});
+
+describe("starting a campaign", () => {
+  it("lets a small campaign run on the free plan", () => {
+    expect(canStart(PLANS.free, shape())).toEqual({ allowed: true });
+  });
+
+  it("stops a campaign above the plan's variant limit, and says by how much", () => {
+    const verdict = canStart(PLANS.free, shape({ variants: 900 }));
+
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) {
+      expect(verdict.reason).toBe("variant-limit");
+      expect(verdict.message).toContain("500");
+      expect(verdict.message).toContain("900");
+      expect(verdict.upgradeTo).toBe("growth");
+    }
+  });
+
+  it("names the cheapest plan that would actually cover the campaign", () => {
+    // Not simply "the next one up". A 50,000-variant campaign needs Markets, and
+    // pointing a merchant at Growth would sell them an upgrade that still refuses.
+    const verdict = canStart(PLANS.free, shape({ variants: 50_000 }));
+
+    expect(!verdict.allowed && verdict.upgradeTo).toBe("markets");
+  });
+
+  it("gates markets below the Markets plan", () => {
+    const verdict = canStart(PLANS.growth, shape({ markets: true }));
+
+    expect(!verdict.allowed && verdict.reason).toBe("markets");
+    expect(!verdict.allowed && verdict.upgradeTo).toBe("markets");
+  });
+
+  it("gates B2B below Wholesale", () => {
+    const verdict = canStart(PLANS.markets, shape({ b2b: true }));
+
+    expect(!verdict.allowed && verdict.upgradeTo).toBe("wholesale");
+  });
+
+  it("reports the surface gate before the size gate", () => {
+    // A campaign that is both too big and on a gated surface should be told about the
+    // surface: it is the concrete, fixable thing, and the size limit on the plan that
+    // unlocks the surface is usually different anyway.
+    const verdict = canStart(PLANS.free, shape({ variants: 900, markets: true }));
+
+    expect(!verdict.allowed && verdict.reason).toBe("markets");
+  });
+
+  it("lets any size run on the unlimited plan", () => {
+    expect(canStart(PLANS.wholesale, shape({ variants: 5_000_000 })).allowed).toBe(true);
+  });
+
+  it("allows a campaign exactly at the limit", () => {
+    // Off-by-one here is a merchant told their 10,000-variant catalogue needs the next
+    // plan up when the plan they bought says 10,000.
+    expect(canStart(PLANS.growth, shape({ variants: 10_000 })).allowed).toBe(true);
+    expect(canStart(PLANS.growth, shape({ variants: 10_001 })).allowed).toBe(false);
+  });
+});
+
+describe("choosing a surface", () => {
+  it("never gates the base price", () => {
+    // The base price is the product. A plan that could not change it would not be a
+    // plan, it would be a lock screen.
+    for (const plan of Object.values(PLANS)) {
+      expect(canUseSurface(plan, "base").allowed).toBe(true);
+    }
+  });
+
+  it("gates a market on the plans without it, and offers the one with it", () => {
+    const verdict = canUseSurface(PLANS.free, "market");
+
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) expect(verdict.upgradeTo).toBe("markets");
+  });
+
+  it("allows a market on Markets and above", () => {
+    expect(canUseSurface(PLANS.markets, "market").allowed).toBe(true);
+    expect(canUseSurface(PLANS.wholesale, "market").allowed).toBe(true);
+  });
+});
+
+describe("safety is never gated", () => {
+  it("has no plan on which a revert can be refused", () => {
+    // Asserted as an absence, deliberately. There is no `canRevert` in this module,
+    // because a merchant who downgrades mid-campaign must still get their scheduled
+    // revert — anything else leaves discounted prices live indefinitely (E8).
+    expect(Object.keys(plans)).not.toContain("canRevert");
+    expect(Object.keys(plans)).not.toContain("canPreview");
+    expect(Object.keys(plans)).not.toContain("canRollback");
+  });
+
+  it("gives the free plan a real catalogue rather than a demo", () => {
+    // The merchants who most need guardrails and rollback are the ones on the free
+    // tier. A cap that only permits a toy makes it an advertisement, not a product.
+    expect(PLANS.free.variantLimit).toBeGreaterThanOrEqual(500);
+  });
+});
+
+describe("what a downgrade costs", () => {
+  it("names the surfaces that will stop being available", () => {
+    expect(losesOnDowngrade(PLANS.wholesale, PLANS.growth)).toEqual([
+      "markets",
+      "b2b",
+      "variant-limit",
+    ]);
+  });
+
+  it("says nothing is lost when the plan is unchanged", () => {
+    expect(losesOnDowngrade(PLANS.markets, PLANS.markets)).toEqual([]);
+  });
+
+  it("says nothing is lost on an upgrade", () => {
+    expect(losesOnDowngrade(PLANS.free, PLANS.wholesale)).toEqual([]);
+  });
+
+  it("counts losing an unlimited catalogue as a loss", () => {
+    expect(losesOnDowngrade(PLANS.wholesale, PLANS.markets)).toContain("variant-limit");
+  });
+});
+
+describe("reading a stored plan", () => {
+  it("falls back to free rather than throwing on an unknown value", () => {
+    // A plan id from a future release, or a botched webhook. Free is the safe default:
+    // it constrains what can be started and gates nothing that matters for safety.
+    expect(planFor("enterprise-plus").id).toBe("free");
+    expect(planFor(undefined).id).toBe("free");
+    expect(planFor(null).id).toBe("free");
+  });
+});

--- a/app/lib/billing/plans.ts
+++ b/app/lib/billing/plans.ts
@@ -1,0 +1,198 @@
+/**
+ * What each plan includes, and — more importantly — what it never gates.
+ *
+ * Pricing meters **variants under management and surfaces**, not changes (decision D3).
+ * Change metering is the category norm and it taxes the core loop: it charges a merchant
+ * for using the product, and makes recurring campaigns — the thing that differentiates
+ * this app — the most expensive way to use it.
+ *
+ * **Safety is never paywalled.** Preview, guardrails, the full history, and rollback are
+ * on every tier including free. Charging for the ability to undo a mistake the app helped
+ * make is indefensible, and a free-tier merchant stranded at sale prices is a support
+ * incident and a one-star review regardless of what they were paying.
+ *
+ * That principle has a sharp edge, which is the whole of edge case E8: a merchant who
+ * downgrades mid-campaign must still get their scheduled revert. Gates therefore
+ * constrain what can be *started*, never what can be *finished*. `canRevert` does not
+ * exist in this module because there is no plan on which the answer is no.
+ */
+
+export type PlanId = "free" | "growth" | "markets" | "wholesale";
+
+export interface Plan {
+  id: PlanId;
+  name: string;
+  /** Monthly price in USD minor units. Zero for free. */
+  priceMinor: number;
+  /** Variants a campaign may manage. Null means no limit. */
+  variantLimit: number | null;
+  /** Market price lists may be targeted. */
+  markets: boolean;
+  /** B2B catalogues may be targeted. */
+  b2b: boolean;
+  /** Trial length in days, applied on first subscribe. */
+  trialDays: number;
+}
+
+export const PLANS: Record<PlanId, Plan> = {
+  free: {
+    id: "free",
+    name: "Free",
+    priceMinor: 0,
+    // Enough to run a real campaign on a small catalogue rather than a demo. A cap that
+    // only permits a toy makes the free tier a advertisement rather than a product, and
+    // the merchants who most need the safety features are the ones on it.
+    variantLimit: 500,
+    markets: false,
+    b2b: false,
+    trialDays: 0,
+  },
+  growth: {
+    id: "growth",
+    name: "Growth",
+    priceMinor: 1490,
+    variantLimit: 10_000,
+    markets: false,
+    b2b: false,
+    trialDays: 14,
+  },
+  markets: {
+    id: "markets",
+    name: "Markets",
+    priceMinor: 3490,
+    variantLimit: 100_000,
+    markets: true,
+    b2b: false,
+    trialDays: 14,
+  },
+  wholesale: {
+    id: "wholesale",
+    name: "Wholesale",
+    priceMinor: 6990,
+    variantLimit: null,
+    markets: true,
+    b2b: true,
+    trialDays: 14,
+  },
+};
+
+export const PLAN_ORDER: PlanId[] = ["free", "growth", "markets", "wholesale"];
+
+export function isPlanId(value: unknown): value is PlanId {
+  return typeof value === "string" && value in PLANS;
+}
+
+/** The plan a shop is on, defaulting to free rather than to an error. */
+export function planFor(id: unknown): Plan {
+  return isPlanId(id) ? PLANS[id] : PLANS.free;
+}
+
+export type GateReason = "variant-limit" | "markets" | "b2b";
+
+export interface Gated {
+  allowed: false;
+  reason: GateReason;
+  /** The cheapest plan that would allow it, or null if none does. */
+  upgradeTo: PlanId | null;
+  message: string;
+}
+
+export type Entitlement = { allowed: true } | Gated;
+
+const ALLOWED: Entitlement = { allowed: true };
+
+export interface CampaignShape {
+  /** Variants the campaign would manage. */
+  variants: number;
+  /** Whether it targets any market price list. */
+  markets: boolean;
+  /** Whether it targets any B2B catalogue. */
+  b2b: boolean;
+}
+
+/**
+ * Whether a plan allows a campaign to *start*.
+ *
+ * Checked when a campaign is created and again when it is applied, because a merchant's
+ * catalogue grows and a plan can change between the two. Never checked on revert — see
+ * the note at the top of this file.
+ */
+export function canStart(plan: Plan, shape: CampaignShape): Entitlement {
+  if (shape.b2b && !plan.b2b) {
+    return gate("b2b", cheapestWith((candidate) => candidate.b2b), plan);
+  }
+
+  if (shape.markets && !plan.markets) {
+    return gate("markets", cheapestWith((candidate) => candidate.markets), plan);
+  }
+
+  if (plan.variantLimit !== null && shape.variants > plan.variantLimit) {
+    return gate(
+      "variant-limit",
+      cheapestWith((candidate) => candidate.variantLimit === null || candidate.variantLimit >= shape.variants),
+      plan,
+      shape.variants,
+    );
+  }
+
+  return ALLOWED;
+}
+
+/**
+ * Whether a plan allows a surface to be *chosen*.
+ *
+ * Separate from `canStart` so the wizard can show a gated market with an upgrade prompt
+ * rather than hiding it. Hiding a feature a merchant is paying a competitor for is how
+ * you lose them without ever learning why.
+ */
+export function canUseSurface(plan: Plan, kind: "base" | "market" | "b2b"): Entitlement {
+  if (kind === "market" && !plan.markets) {
+    return gate("markets", cheapestWith((candidate) => candidate.markets), plan);
+  }
+  if (kind === "b2b" && !plan.b2b) {
+    return gate("b2b", cheapestWith((candidate) => candidate.b2b), plan);
+  }
+  return ALLOWED;
+}
+
+function cheapestWith(predicate: (plan: Plan) => boolean): PlanId | null {
+  for (const id of PLAN_ORDER) {
+    if (predicate(PLANS[id])) return id;
+  }
+  return null;
+}
+
+function gate(reason: GateReason, upgradeTo: PlanId | null, plan: Plan, variants?: number): Gated {
+  const target = upgradeTo ? PLANS[upgradeTo] : null;
+  const suffix = target
+    ? ` ${target.name} includes it.`
+    : " No plan covers a catalogue this size — get in touch and we will sort something out.";
+
+  const messages: Record<GateReason, string> = {
+    "variant-limit":
+      `Your ${plan.name} plan manages up to ${plan.variantLimit?.toLocaleString()} variants ` +
+      `and this campaign covers ${variants?.toLocaleString()}.`,
+    markets: `Pricing into markets is not part of ${plan.name}.`,
+    b2b: `Pricing into wholesale catalogues is not part of ${plan.name}.`,
+  };
+
+  return { allowed: false, reason, upgradeTo, message: messages[reason] + suffix };
+}
+
+/**
+ * Whether moving between two plans loses something.
+ *
+ * Used to tell a merchant what a downgrade will stop them starting — never to stop the
+ * downgrade, and never to touch what is already running.
+ */
+export function losesOnDowngrade(from: Plan, to: Plan): GateReason[] {
+  const lost: GateReason[] = [];
+
+  if (from.markets && !to.markets) lost.push("markets");
+  if (from.b2b && !to.b2b) lost.push("b2b");
+  if (from.variantLimit === null ? to.variantLimit !== null : (to.variantLimit ?? Infinity) < from.variantLimit) {
+    lost.push("variant-limit");
+  }
+
+  return lost;
+}

--- a/app/lib/billing/subscription-payload.test.ts
+++ b/app/lib/billing/subscription-payload.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Reading a subscription webhook.
+ *
+ * The name-to-plan mapping is where this goes wrong, and when it does the shop silently
+ * lands on free — which looks like a bug in gating rather than a bug here, so it is
+ * worth being precise about.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { parseSubscription, planFromName } from "./subscription-payload";
+
+describe("mapping a subscription name to a plan", () => {
+  it("reads the plan out of the name Shopify echoes back", () => {
+    expect(planFromName("Markets")).toBe("markets");
+    expect(planFromName("Anchor Growth")).toBe("growth");
+    expect(planFromName("Wholesale (annual)")).toBe("wholesale");
+  });
+
+  it("is case-insensitive, because the name is whatever was configured", () => {
+    expect(planFromName("ANCHOR MARKETS")).toBe("markets");
+  });
+
+  it("takes the higher tier when a name mentions two", () => {
+    // "Markets and Wholesale" should not resolve to Markets just because it appears
+    // first in the string. Selling somebody Wholesale and gating B2B is a support
+    // ticket that starts with "I paid for this".
+    expect(planFromName("Markets and Wholesale")).toBe("wholesale");
+  });
+
+  it("falls back to free on a name it does not recognise", () => {
+    // Deliberately forgiving in one direction only. A wrong upgrade gives away a paid
+    // surface silently; a wrong downgrade the merchant notices within a minute.
+    expect(planFromName("Enterprise Platinum")).toBe("free");
+    expect(planFromName(undefined)).toBe("free");
+  });
+});
+
+describe("reading the whole payload", () => {
+  const payload = (over: Record<string, unknown> = {}) => ({
+    app_subscription: {
+      admin_graphql_api_id: "gid://shopify/AppSubscription/1",
+      name: "Markets",
+      status: "ACTIVE",
+      created_at: "2026-08-01T00:00:00Z",
+      trial_days: 14,
+      ...over,
+    },
+  });
+
+  it("carries the subscription id, status and plan", () => {
+    expect(parseSubscription(payload())).toMatchObject({
+      gid: "gid://shopify/AppSubscription/1",
+      status: "ACTIVE",
+      planId: "markets",
+    });
+  });
+
+  it("works out when the trial ends", () => {
+    const parsed = parseSubscription(payload());
+
+    expect(parsed.trialEndsAt?.toISOString()).toBe("2026-08-15T00:00:00.000Z");
+  });
+
+  it("has no trial end when there is no trial", () => {
+    expect(parseSubscription(payload({ trial_days: 0 })).trialEndsAt).toBeNull();
+  });
+
+  it("reads a cancelled subscription as free whatever it was called", () => {
+    // The name still says "Markets" on a cancelled subscription. Trusting it would keep
+    // a merchant on a paid tier they have stopped paying for.
+    expect(parseSubscription(payload({ status: "CANCELLED" })).planId).toBe("free");
+    expect(parseSubscription(payload({ status: "EXPIRED" })).planId).toBe("free");
+    expect(parseSubscription(payload({ status: "FROZEN" })).planId).toBe("free");
+  });
+
+  it("keeps an accepted-but-not-yet-active subscription on its plan", () => {
+    // ACCEPTED is the state between the merchant approving the charge and Shopify
+    // activating it. Treating it as free would gate a merchant out of the thing they
+    // just paid for, for as long as that takes.
+    expect(parseSubscription(payload({ status: "ACCEPTED" })).planId).toBe("markets");
+  });
+
+  it("survives a payload with nothing in it", () => {
+    expect(parseSubscription({})).toMatchObject({ gid: null, planId: "free" });
+    expect(parseSubscription(null)).toMatchObject({ planId: "free" });
+  });
+});

--- a/app/lib/billing/subscription-payload.ts
+++ b/app/lib/billing/subscription-payload.ts
@@ -1,0 +1,72 @@
+/**
+ * Reading an `app_subscriptions/update` payload.
+ *
+ * Pure, because the mapping from Shopify's subscription name to our plan id is the part
+ * that goes wrong and it should not need a webhook to test. The name is what Shopify
+ * echoes back from the plan the merchant chose, and if it stops matching, the shop
+ * silently lands on free — which is the failure mode that would look like a bug in
+ * gating rather than a bug here.
+ *
+ * Matching is by plan id contained in a lowercased name, so "Anchor Markets", "Markets",
+ * and "Markets (annual)" all resolve. Deliberately forgiving in one direction only: an
+ * unrecognised name resolves to free rather than to a guess, because a wrong *upgrade*
+ * gives away a paid surface and a wrong *downgrade* is caught by the merchant instantly.
+ */
+
+import { isPlanId, PLAN_ORDER, type PlanId } from "./plans";
+
+export interface SubscriptionPayload {
+  app_subscription?: {
+    admin_graphql_api_id?: string;
+    name?: string;
+    status?: string;
+    trial_days?: number;
+    created_at?: string;
+  };
+}
+
+export interface ParsedSubscription {
+  gid: string | null;
+  status: string | null;
+  planId: PlanId;
+  trialEndsAt: Date | null;
+}
+
+export function parseSubscription(payload: unknown): ParsedSubscription {
+  const subscription = (payload as SubscriptionPayload)?.app_subscription ?? {};
+  const status = subscription.status?.toUpperCase() ?? null;
+
+  return {
+    gid: subscription.admin_graphql_api_id ?? null,
+    status,
+    // A cancelled or expired subscription is free regardless of what it was named.
+    planId: status && !["ACTIVE", "ACCEPTED"].includes(status) ? "free" : planFromName(subscription.name),
+    trialEndsAt: trialEnd(subscription.created_at, subscription.trial_days),
+  };
+}
+
+/**
+ * The plan a subscription name refers to.
+ *
+ * Checked from the most specific tier down, because "Anchor Markets and Wholesale" would
+ * otherwise match whichever appeared first in the list rather than the higher tier.
+ */
+export function planFromName(name: string | undefined): PlanId {
+  if (!name) return "free";
+
+  const lowered = name.toLowerCase();
+  for (const id of [...PLAN_ORDER].reverse()) {
+    if (lowered.includes(id)) return id;
+  }
+
+  return isPlanId(lowered) ? lowered : "free";
+}
+
+function trialEnd(createdAt: string | undefined, trialDays: number | undefined): Date | null {
+  if (!createdAt || !trialDays) return null;
+
+  const started = Date.parse(createdAt);
+  if (Number.isNaN(started)) return null;
+
+  return new Date(started + trialDays * 24 * 60 * 60 * 1000);
+}

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -20,6 +20,8 @@ import { FilterForm } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { readSettings, shopCurrency } from "../services/settings.server";
+import { billingFrom } from "../services/billing.server";
+import { canUseSurface } from "../lib/billing/plans";
 import prisma from "../db.server";
 import { segmentToAst } from "../services/segments.server";
 
@@ -50,7 +52,8 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
       })
     : astFromParams(url.searchParams);
 
-  const [available, preview, segments, priceLists, settings, currency] = await Promise.all([
+  const [available, preview, segments, priceLists, settings, currency, shopRecord] =
+    await Promise.all([
     facets(shop.id),
     previewMatches(shop.id, ast),
     prisma.segment.findMany({
@@ -76,7 +79,18 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
     }),
     readSettings(shop.id),
     shopCurrency(shop.id),
+    prisma.shop.findUniqueOrThrow({
+      where: { id: shop.id },
+      select: {
+        planTier: true,
+        subscriptionStatus: true,
+        trialEndsAt: true,
+        developerStore: true,
+      },
+    }),
   ]);
+
+  const billing = billingFrom(shopRecord);
 
   // Every currency this campaign could price in. Only these are offered: a list of all
   // 180 world currencies would bury the two or three that matter.
@@ -88,6 +102,14 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
     timeZone: shop.timezone,
     priceLists,
     currencies,
+    // Gated surfaces are listed with an upgrade prompt rather than hidden. Hiding a
+    // feature a merchant is paying a competitor for is how you lose them without ever
+    // finding out why.
+    gates: {
+      market: canUseSurface(billing.plan, "market"),
+      b2b: canUseSurface(billing.plan, "b2b"),
+    },
+    planName: billing.plan.name,
     storeRounding: settings.rounding,
     roundingOptions: Object.entries(ROUNDING_LABELS).map(([value, label]) => ({ value, label })),
     facets: available,
@@ -230,6 +252,8 @@ export default function NewCampaign() {
     storeRounding,
     roundingOptions,
     presetStart,
+    gates,
+    planName,
   } = useLoaderData<typeof loader>();
 
   return (
@@ -427,21 +451,39 @@ export default function NewCampaign() {
                   </s-text>
                 </s-paragraph>
 
-                {priceLists.map((list) => (
-                  <s-checkbox
-                    key={list.priceListGid}
-                    name="priceList"
-                    value={list.priceListGid}
-                    label={`${list.name} (${list.currency})${
-                      list.surfaceKind === "B2B" ? " · wholesale" : ""
-                    }`}
-                    details={
-                      list.adjustmentBps === null
-                        ? "Prices set per product here."
-                        : `Normally ${describeAdjustment(list.adjustmentBps)} the base price.`
-                    }
-                  />
-                ))}
+                {priceLists.map((list) => {
+                  const gate = list.surfaceKind === "B2B" ? gates.b2b : gates.market;
+
+                  return (
+                    <s-checkbox
+                      key={list.priceListGid}
+                      name="priceList"
+                      value={list.priceListGid}
+                      disabled={!gate.allowed || undefined}
+                      label={`${list.name} (${list.currency})${
+                        list.surfaceKind === "B2B" ? " · wholesale" : ""
+                      }`}
+                      details={
+                        !gate.allowed
+                          ? gate.message
+                          : list.adjustmentBps === null
+                            ? "Prices set per product here."
+                            : `Normally ${describeAdjustment(list.adjustmentBps)} the base price.`
+                      }
+                    />
+                  );
+                })}
+
+                {!gates.market.allowed || !gates.b2b.allowed ? (
+                  <s-banner tone="info">
+                    <s-paragraph>
+                      Some of these need a different plan than {planName}. Everything
+                      already running keeps running, and reverts always work whatever
+                      plan you are on.
+                    </s-paragraph>
+                    <s-link href="/app/plan">See the plans</s-link>
+                  </s-banner>
+                ) : null}
 
                 <s-paragraph>
                   <s-text>

--- a/app/routes/app.plan.tsx
+++ b/app/routes/app.plan.tsx
@@ -1,0 +1,188 @@
+/**
+ * Plans, and what a downgrade will and will not do.
+ *
+ * The downgrade copy is the important part. A merchant deciding whether to drop a tier
+ * needs to know, before they click, that their running campaigns will still revert and
+ * their history will still be there — because the fear that they will not is what makes
+ * people keep paying resentfully and then leave a one-star review about it.
+ */
+
+import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { billingFrom, campaignsAffectedBy } from "../services/billing.server";
+import { PLAN_ORDER, PLANS } from "../lib/billing/plans";
+import { formatMinorUnits } from "../lib/money/format";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+
+export const loader = withGuard("/app/plan", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const record = await prisma.shop.findUniqueOrThrow({
+    where: { id: shop.id },
+    select: {
+      planTier: true,
+      subscriptionStatus: true,
+      trialEndsAt: true,
+      developerStore: true,
+    },
+  });
+
+  const billing = billingFrom(record);
+  const variants = await prisma.variantIndex.count({
+    where: { shopId: shop.id, deletedAt: null },
+  });
+
+  return {
+    current: billing.plan.id,
+    exempt: billing.exempt,
+    trialing: billing.trialing,
+    trialEndsAt: billing.trialEndsAt?.toISOString() ?? null,
+    variants,
+    // What would stop being startable on the free plan, so the downgrade copy is about
+    // this merchant's campaigns rather than about plans in the abstract.
+    affected: await campaignsAffectedBy(shop.id, PLANS.free),
+    plans: PLAN_ORDER.map((id) => {
+      const plan = PLANS[id];
+      return {
+        id,
+        name: plan.name,
+        price: plan.priceMinor === 0 ? "Free" : `${formatMinorUnits(BigInt(plan.priceMinor), "USD")}/month`,
+        variantLimit: plan.variantLimit,
+        markets: plan.markets,
+        b2b: plan.b2b,
+        trialDays: plan.trialDays,
+      };
+    }),
+  };
+});
+
+export default function PlanPage() {
+  const { current, exempt, trialing, trialEndsAt, variants, plans, affected } =
+    useLoaderData<typeof loader>();
+
+  return (
+    <s-page heading="Plan">
+      {exempt ? (
+        <s-banner tone="info">
+          <s-paragraph>
+            This is a development store, so every feature is available and nothing is
+            charged.
+          </s-paragraph>
+        </s-banner>
+      ) : null}
+
+      {trialing && trialEndsAt ? (
+        <s-banner tone="info">
+          <s-paragraph>
+            Your trial runs until {new Date(trialEndsAt).toLocaleDateString()}.
+          </s-paragraph>
+        </s-banner>
+      ) : null}
+
+      <s-section heading="What you are on">
+        <s-paragraph>
+          <s-text>
+            {PLANS[current as keyof typeof PLANS].name} · {variants.toLocaleString()}{" "}
+            variants in your catalogue.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+
+      <s-section heading="Plans">
+        <s-paragraph>
+          <s-text>
+            Pricing is by how much of your catalogue a campaign manages and which
+            surfaces it reaches &mdash; never by how many changes you make. Charging per
+            change would tax the thing the app is for.
+          </s-text>
+        </s-paragraph>
+
+        <s-table>
+          <s-table-header-row>
+            <s-table-header>Plan</s-table-header>
+            <s-table-header>Price</s-table-header>
+            <s-table-header>Variants</s-table-header>
+            <s-table-header>Markets</s-table-header>
+            <s-table-header>Wholesale</s-table-header>
+            <s-table-header>Trial</s-table-header>
+          </s-table-header-row>
+          <s-table-body>
+            {plans.map((plan) => (
+              <s-table-row key={plan.id}>
+                <s-table-cell>
+                  {plan.name}
+                  {plan.id === current ? " · yours" : ""}
+                </s-table-cell>
+                <s-table-cell>{plan.price}</s-table-cell>
+                <s-table-cell>
+                  {plan.variantLimit === null
+                    ? "Unlimited"
+                    : plan.variantLimit.toLocaleString()}
+                </s-table-cell>
+                <s-table-cell>{plan.markets ? "Yes" : "—"}</s-table-cell>
+                <s-table-cell>{plan.b2b ? "Yes" : "—"}</s-table-cell>
+                <s-table-cell>{plan.trialDays > 0 ? `${plan.trialDays} days` : "—"}</s-table-cell>
+              </s-table-row>
+            ))}
+          </s-table-body>
+        </s-table>
+      </s-section>
+
+      <s-section heading="Every plan, including free">
+        <s-paragraph>
+          <s-text>
+            Preview before applying. Guardrails that refuse to price below cost or
+            margin. The full history of every change, kept indefinitely. One-click
+            rollback of a campaign or a single product.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            None of that is ever paywalled. Charging for the ability to undo a mistake
+            the app helped you make would be indefensible.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+
+      <s-section heading="If you downgrade">
+        <s-paragraph>
+          <s-text>
+            Running campaigns finish, including their scheduled reverts. Nothing is
+            deleted, nothing is paused, and no price is left on sale because a plan
+            changed. A smaller plan limits what you can <s-text>start</s-text> next.
+          </s-text>
+        </s-paragraph>
+
+        {affected.length > 0 ? (
+          <>
+            <s-paragraph>
+              <s-text>
+                On the free plan these campaigns could not be started again as they are:
+              </s-text>
+            </s-paragraph>
+            <s-unordered-list>
+              {affected.map((campaign) => (
+                <s-list-item key={campaign.id}>
+                  {campaign.name} &mdash; {campaign.reason}
+                </s-list-item>
+              ))}
+            </s-unordered-list>
+          </>
+        ) : null}
+      </s-section>
+    </s-page>
+  );
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -32,6 +32,7 @@ export default function App() {
         <s-link href="/app/reconciliation">What is live</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/activity">Activity</s-link>
+        <s-link href="/app/plan">Plan</s-link>
         <s-link href="/app/settings">Settings</s-link>
         <s-link href="/app/debug">Diagnostics</s-link>
       </s-app-nav>

--- a/app/routes/webhooks.app.subscriptions_update.tsx
+++ b/app/routes/webhooks.app.subscriptions_update.tsx
@@ -1,0 +1,31 @@
+/**
+ * Shopify telling us a subscription changed.
+ *
+ * The only place the plan tier moves. A merchant upgrading mid-session and a merchant
+ * whose card was declined arrive here the same way, and neither touches a campaign —
+ * see the note in `billing.server.ts` about edge case E8.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import { authenticate } from "../shopify.server";
+import prisma from "../db.server";
+import { applySubscriptionUpdate } from "../services/billing.server";
+import { parseSubscription } from "../lib/billing/subscription-payload";
+import { logger } from "../lib/logging/logger";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { payload, topic, shop } = await authenticate.webhook(request);
+
+  const record = await prisma.shop.findUnique({ where: { domain: shop }, select: { id: true } });
+  if (!record) {
+    // A subscription for a shop we have no row for. Acknowledged rather than retried:
+    // Shopify will keep redelivering a failure, and there is nothing here to fix.
+    logger.warn("subscription webhook for unknown shop", { shop, topic });
+    return new Response();
+  }
+
+  await applySubscriptionUpdate(record.id, parseSubscription(payload));
+
+  return new Response();
+};

--- a/app/services/billing.server.ts
+++ b/app/services/billing.server.ts
@@ -1,0 +1,191 @@
+/**
+ * Which plan a shop is on, and what that does and does not allow.
+ *
+ * The load-bearing rule is edge case E8: **a downgrade must never orphan a store at sale
+ * prices.** A merchant who drops to a cheaper plan mid-campaign still gets their
+ * scheduled revert, still sees their history, still has rollback. Gates constrain what
+ * can be *started*; nothing here can stop something finishing.
+ *
+ * That is not generosity. A store left at 40% off indefinitely because we stopped
+ * reverting is a revenue incident we caused, and no amount of "they downgraded" makes
+ * that a defensible position — least of all in a public review.
+ *
+ * So: no function in this module is called from the revert path, and the one that gates
+ * a run is called only for applies. There is a test asserting exactly that.
+ */
+
+import type { Shop } from "@prisma/client";
+
+import prisma from "../db.server";
+import {
+  canStart,
+  canUseSurface,
+  planFor,
+  PLANS,
+  type CampaignShape,
+  type Entitlement,
+  type Plan,
+  type PlanId,
+} from "../lib/billing/plans";
+import { logger } from "../lib/logging/logger";
+
+/** Shopify's subscription statuses that mean "this plan is real right now". */
+const LIVE_STATUSES = new Set(["ACTIVE", "ACCEPTED"]);
+
+export interface Billing {
+  plan: Plan;
+  /** True while a trial is running, so the UI can say how long is left. */
+  trialing: boolean;
+  trialEndsAt: Date | null;
+  /** Dev and partner stores get every tier without a subscription. */
+  exempt: boolean;
+}
+
+export async function billingFor(shopId: string): Promise<Billing> {
+  const shop = await prisma.shop.findUnique({
+    where: { id: shopId },
+    select: {
+      planTier: true,
+      subscriptionStatus: true,
+      trialEndsAt: true,
+      developerStore: true,
+    },
+  });
+
+  return billingFrom(shop);
+}
+
+/**
+ * The same answer from an already-loaded row, so a loader that has the shop does not
+ * fetch it twice.
+ */
+export function billingFrom(
+  shop: Pick<Shop, "planTier" | "subscriptionStatus" | "trialEndsAt" | "developerStore"> | null,
+): Billing {
+  if (!shop) return { plan: PLANS.free, trialing: false, trialEndsAt: null, exempt: false };
+
+  // A dev store gets everything. Testing markets pricing against a development store is
+  // the normal way to evaluate this app, and asking a partner to pay $34.90 to try it is
+  // how you get evaluated by nobody.
+  if (shop.developerStore) {
+    return { plan: PLANS.wholesale, trialing: false, trialEndsAt: null, exempt: true };
+  }
+
+  // A subscription that is cancelled, frozen or expired means free — but only for what
+  // can be *started*. Everything already running still finishes.
+  const live = shop.subscriptionStatus === null || LIVE_STATUSES.has(shop.subscriptionStatus);
+  const plan = live ? planFor(shop.planTier.toLowerCase()) : PLANS.free;
+
+  const trialEndsAt = shop.trialEndsAt;
+  const trialing = trialEndsAt !== null && trialEndsAt.getTime() > Date.now();
+
+  return { plan, trialing, trialEndsAt, exempt: false };
+}
+
+/**
+ * Whether this shop may start this campaign.
+ *
+ * Deliberately takes the shape rather than the campaign id, so the wizard can ask about
+ * a campaign that does not exist yet and get the same answer the run will give.
+ */
+export async function canStartCampaign(
+  shopId: string,
+  shape: CampaignShape,
+): Promise<Entitlement> {
+  const { plan } = await billingFor(shopId);
+  return canStart(plan, shape);
+}
+
+/** Whether a surface may be chosen, for the wizard's per-surface prompts. */
+export async function surfaceEntitlement(
+  shopId: string,
+  kind: "base" | "market" | "b2b",
+): Promise<Entitlement> {
+  const { plan } = await billingFor(shopId);
+  return canUseSurface(plan, kind);
+}
+
+export interface SubscriptionUpdate {
+  gid: string | null;
+  status: string | null;
+  planId: PlanId;
+  trialEndsAt?: Date | null;
+}
+
+/**
+ * Records what Shopify told us about a subscription.
+ *
+ * Nothing about a campaign is touched here — not cancelled, not rescheduled, not
+ * deleted. A downgrade changes what the merchant can start next; it does not reach into
+ * work already in flight. That is the entire content of E8, and the safest way to
+ * guarantee it is for this function to have no ability to break it.
+ */
+export async function applySubscriptionUpdate(
+  shopId: string,
+  update: SubscriptionUpdate,
+): Promise<void> {
+  const before = await prisma.shop.findUnique({
+    where: { id: shopId },
+    select: { planTier: true },
+  });
+
+  await prisma.shop.update({
+    where: { id: shopId },
+    data: {
+      subscriptionGid: update.gid,
+      subscriptionStatus: update.status,
+      planTier: update.planId.toUpperCase() as Shop["planTier"],
+      planChangedAt: new Date(),
+      ...(update.trialEndsAt === undefined ? {} : { trialEndsAt: update.trialEndsAt }),
+    },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      action: "billing.subscription-updated",
+      entity: "subscription",
+      entityId: update.gid ?? "none",
+      before: { planTier: before?.planTier ?? null } as never,
+      after: { planTier: update.planId.toUpperCase(), status: update.status } as never,
+    },
+  });
+
+  logger.info("subscription updated", {
+    shopId,
+    from: before?.planTier ?? null,
+    to: update.planId,
+    status: update.status,
+  });
+}
+
+/**
+ * Campaigns a downgrade will stop the merchant re-running, so the app can say so.
+ *
+ * Reported, never acted on. Telling somebody "these three campaigns need Markets to run
+ * again" is help; silently pausing them is the thing E8 exists to forbid.
+ */
+export async function campaignsAffectedBy(shopId: string, plan: Plan) {
+  const campaigns = await prisma.campaign.findMany({
+    where: { shopId, status: { in: ["DRAFT", "SCHEDULED", "ACTIVE", "PARTIAL"] } },
+    select: { id: true, name: true, status: true, surfaces: true },
+  });
+
+  const { parseSurfaces } = await import("./campaigns/market-surfaces.server");
+  const lists = await prisma.priceListRecord.findMany({
+    where: { shopId },
+    select: { priceListGid: true, surfaceKind: true },
+  });
+  const kindOf = new Map(lists.map((list) => [list.priceListGid, list.surfaceKind]));
+
+  return campaigns
+    .map((campaign) => {
+      const surfaces = parseSurfaces(campaign.surfaces);
+      const usesMarkets = surfaces.priceLists.some((gid) => kindOf.get(gid) !== "B2B");
+      const usesB2b = surfaces.priceLists.some((gid) => kindOf.get(gid) === "B2B");
+
+      const verdict = canStart(plan, { variants: 0, markets: usesMarkets, b2b: usesB2b });
+      return verdict.allowed ? null : { ...campaign, reason: verdict.message };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+}

--- a/app/services/billing.test.ts
+++ b/app/services/billing.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Reading a shop's plan.
+ *
+ * The cases that matter are the ones where a subscription is not simply active: a
+ * cancelled card, a dev store, a plan tier that outlives the subscription behind it.
+ * Getting those wrong either gates a paying merchant or gives the app away.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { billingFrom } from "./billing.server";
+
+const shop = (over: Record<string, unknown> = {}) => ({
+  planTier: "MARKETS" as const,
+  subscriptionStatus: "ACTIVE",
+  trialEndsAt: null,
+  developerStore: false,
+  ...over,
+});
+
+describe("working out which plan a shop is on", () => {
+  it("reads an active subscription as its tier", () => {
+    expect(billingFrom(shop()).plan.id).toBe("markets");
+  });
+
+  it("treats a cancelled subscription as free for what can be started", () => {
+    // Only for starting. Nothing here reaches the revert path, which is the whole of
+    // E8 and is asserted against a real engine in the chaos suite.
+    expect(billingFrom(shop({ subscriptionStatus: "CANCELLED" })).plan.id).toBe("free");
+    expect(billingFrom(shop({ subscriptionStatus: "FROZEN" })).plan.id).toBe("free");
+  });
+
+  it("keeps an accepted subscription on its tier", () => {
+    // The gap between a merchant approving the charge and Shopify activating it. Gating
+    // them out of what they just bought, for however long that takes, is the wrong side
+    // to err on.
+    expect(billingFrom(shop({ subscriptionStatus: "ACCEPTED" })).plan.id).toBe("markets");
+  });
+
+  it("gives a development store everything, and charges nothing", () => {
+    const billing = billingFrom(shop({ developerStore: true, planTier: "FREE" }));
+
+    expect(billing.plan.id).toBe("wholesale");
+    expect(billing.exempt).toBe(true);
+  });
+
+  it("reads a shop with no subscription row yet as its tier", () => {
+    // A shop installed before billing existed has a tier and no subscription. Reading
+    // that as cancelled would downgrade every existing merchant on deploy.
+    expect(billingFrom(shop({ subscriptionStatus: null })).plan.id).toBe("markets");
+  });
+
+  it("reports a trial that has not ended", () => {
+    const future = new Date(Date.now() + 5 * 86_400_000);
+
+    expect(billingFrom(shop({ trialEndsAt: future }))).toMatchObject({ trialing: true });
+  });
+
+  it("does not report a trial that has passed", () => {
+    const past = new Date(Date.now() - 86_400_000);
+
+    expect(billingFrom(shop({ trialEndsAt: past })).trialing).toBe(false);
+  });
+
+  it("falls back to free for a shop we know nothing about", () => {
+    expect(billingFrom(null).plan.id).toBe("free");
+  });
+});

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -16,7 +16,8 @@ import type { PlannedRow } from "../../lib/planning/types";
 import { planRun } from "../../lib/planning/plan";
 import { recordWriteIntents } from "../drift.server";
 import { loadCandidates, productMapFor } from "./candidates.server";
-import { isPractice, loadCampaignContext } from "./model.server";
+import { isPractice, loadCampaignContext, scopeOf } from "./model.server";
+import { astToWhere } from "../segments.server";
 import { AppError } from "../../lib/errors/app-error";
 import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
@@ -112,6 +113,35 @@ export async function runCampaign(
   // Scoped runs are exempt: reverting one variant out of a four-thousand-variant sale
   // says nothing about the campaign, and moving it to APPLYING would misreport the
   // other 3,999.
+  // ---------------------------------------------------------- the plan gate (E8)
+  //
+  // Applies only. A revert is never gated on any plan, ever: a merchant who downgrades
+  // mid-campaign must still get their scheduled revert, and a store left at 40% off
+  // because we stopped reverting is a revenue incident we caused. No amount of "they
+  // downgraded" makes that defensible.
+  //
+  // Checked here rather than only in the wizard because a catalogue grows and a plan can
+  // lapse between a campaign being created and the scheduler running it, and the
+  // scheduler never goes near the wizard.
+  if (!options.revert) {
+    const refusal = await refusedByPlan(shopId, campaignId, options.variantGids?.length);
+    if (refusal) {
+      return {
+        runId: "",
+        planned: 0,
+        verified: 0,
+        failed: 0,
+        unverified: 0,
+        // Clean, because nothing is half-done: no price moved and no ledger row exists.
+        // Reporting this as unclean would put a campaign into the "needs attention"
+        // queue for a reason the merchant cannot resolve by attending to it.
+        clean: true,
+        messages: [refusal],
+        refusedByPlan: refusal,
+      };
+    }
+  }
+
   if (!options.variantGids) {
     await transitionCampaign(shopId, campaignId, options.revert ? "REVERTING" : "APPLYING", {
       reason: options.resume ? "resume requested" : options.revert ? "revert requested" : "apply requested",
@@ -754,4 +784,62 @@ async function refreshMirror(shopId: string, rows: ExecutedRows): Promise<void> 
       },
     });
   }
+}
+
+
+/**
+ * Whether the shop's plan refuses to start this campaign, and why.
+ *
+ * Returns a merchant-facing sentence rather than throwing, because a scheduled run that
+ * threw would surface as a failed run — and "your sale failed" is a much worse thing to
+ * read than "your plan does not cover this campaign, here is the one that does".
+ *
+ * Called for applies only. There is a chaos scenario asserting that a downgraded shop
+ * still reverts, which is the whole of edge case E8.
+ */
+async function refusedByPlan(
+  shopId: string,
+  campaignId: string,
+  scopedCount: number | undefined,
+): Promise<string | null> {
+  const { billingFor } = await import("../billing.server");
+  const { canStart } = await import("../../lib/billing/plans");
+  const { parseSurfaces } = await import("./market-surfaces.server");
+
+  const [{ plan, exempt }, campaign] = await Promise.all([
+    billingFor(shopId),
+    prisma.campaign.findFirst({
+      where: { id: campaignId, shopId },
+      select: { surfaces: true, schedule: true },
+    }),
+  ]);
+
+  if (exempt || !campaign) return null;
+
+  const surfaces = parseSurfaces(campaign.surfaces);
+  const lists = surfaces.priceLists.length
+    ? await prisma.priceListRecord.findMany({
+        where: { shopId, priceListGid: { in: surfaces.priceLists } },
+        select: { surfaceKind: true },
+      })
+    : [];
+
+  // Counted from the campaign's own scope rather than the whole catalogue: the plan
+  // meters variants *under management*, and a campaign targeting forty products on a
+  // 500K store is forty variants under management.
+  const variants =
+    scopedCount ??
+    (await prisma.variantIndex.count({
+      // Through `scopeOf`, so a campaign targeting a segment is metered on what the
+      // segment matches now — the same set its run will price.
+      where: astToWhere(shopId, await scopeOf(shopId, campaign)),
+    }));
+
+  const verdict = canStart(plan, {
+    variants,
+    markets: lists.some((list) => list.surfaceKind !== "B2B"),
+    b2b: lists.some((list) => list.surfaceKind === "B2B"),
+  });
+
+  return verdict.allowed ? null : verdict.message;
 }

--- a/app/services/campaigns/types.ts
+++ b/app/services/campaigns/types.ts
@@ -149,6 +149,14 @@ export interface RunOutcome {
    * else is doing it", which are different things to show a merchant.
    */
   deferredTo?: string;
+  /**
+   * Set when the shop's plan does not cover this campaign, so no run was started.
+   *
+   * Distinct from a failure and from "nothing to do". A caller showing a run report
+   * needs to say "your plan does not cover this" rather than "your sale failed", and an
+   * empty `runId` alone cannot carry that difference.
+   */
+  refusedByPlan?: string;
 }
 
 export interface RunSummary {

--- a/chaos/harness/seed.ts
+++ b/chaos/harness/seed.ts
@@ -68,6 +68,12 @@ export async function seedFixture(options: SeedOptions): Promise<Fixture> {
   const shop = await prisma.shop.create({
     data: {
       domain,
+      // Entitled by default. These scenarios exist to test the pricing engine, not the
+      // billing gates, and a fixture on the free plan would fail every market scenario
+      // for a reason that has nothing to do with what it is testing. The downgrade
+      // scenarios set their own tier.
+      planTier: "WHOLESALE",
+      subscriptionStatus: "ACTIVE",
       scopes: "write_products",
       timezone: "UTC",
       initialSyncCompletedAt: new Date(),

--- a/chaos/scenarios/downgrade.chaos.ts
+++ b/chaos/scenarios/downgrade.chaos.ts
@@ -1,0 +1,205 @@
+/**
+ * Downgrading mid-campaign (edge case E8).
+ *
+ * The single most important thing in the billing story, and the one place where getting
+ * it wrong is not a bug but a revenue incident we caused. A merchant who drops to a
+ * cheaper plan while a sale is running must still get their revert. A storefront left at
+ * 40% off indefinitely because we stopped reverting is indefensible, and no amount of
+ * "they downgraded" changes that — least of all in a public review.
+ *
+ * So these scenarios do the thing the code is meant to forbid, and check it still works.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos, type ChaosContext } from "../harness/scenario";
+
+async function setPlan(chaos: ChaosContext, tier: "FREE" | "GROWTH" | "MARKETS" | "WHOLESALE") {
+  await prisma.shop.update({
+    where: { id: chaos.fixture.shopId },
+    data: { planTier: tier, subscriptionStatus: tier === "FREE" ? "CANCELLED" : "ACTIVE" },
+  });
+}
+
+describe("chaos: downgrading while a campaign is live", () => {
+  it("still reverts every price after the plan is cancelled", async () => {
+    await withChaos(
+      "downgrade-revert",
+      { catalog: { products: 8, variantsPerProduct: 1 }, percent: -40 },
+      async (chaos) => {
+        const { variantGids, baseline } = chaos.fixture;
+
+        await setPlan(chaos, "WHOLESALE");
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+        expect(applied.verified).toBe(variantGids.length);
+
+        // The card is declined and Shopify cancels the subscription. Everything the
+        // merchant can *start* is now free-tier; everything already running must finish.
+        //
+        // The free limit is dropped below this catalogue on purpose. Without that the
+        // campaign would fit the free plan anyway and the revert would succeed for a
+        // reason that has nothing to do with the exemption being tested.
+        await setPlan(chaos, "FREE");
+
+        const { PLANS } = await import("../../app/lib/billing/plans");
+        const original = PLANS.free.variantLimit;
+        PLANS.free.variantLimit = 2;
+
+        try {
+          // Applying again is refused, which is the gate working...
+          const blocked = await chaos.apply();
+          expect(blocked.verified).toBe(0);
+          expect(blocked.messages.join(" ")).toContain("2");
+
+          // ...and reverting is not, which is the whole of E8.
+          const reverted = await chaos.revert();
+          await chaos.expectHonest(reverted.runId);
+        } finally {
+          PLANS.free.variantLimit = original;
+        }
+
+        // Every price back at its baseline. This is the assertion the whole ticket is
+        // about: no storefront is left discounted because somebody stopped paying.
+        for (const gid of variantGids) {
+          const live = Number(chaos.fake.priceOf(gid)!.replace(".", ""));
+          expect(live).toBe(baseline.get(gid));
+        }
+      },
+    );
+  });
+
+  it("still reverts a campaign whose surfaces the new plan does not include", async () => {
+    await withChaos(
+      "downgrade-markets-revert",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/eu",
+          name: "Europe",
+          currency: "EUR",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/eu", title: "EU", __typename: "MarketCatalog" },
+          prices: [],
+        });
+
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        await setPlan(chaos, "MARKETS");
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: ["gid://shopify/PriceList/eu"] } as never },
+        });
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+        expect(chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size).toBe(
+          variantGids.length,
+        );
+
+        // Down to a plan with no markets at all. The market prices we wrote are still
+        // ours to undo — refusing here would strand a whole market on sale prices, which
+        // is worse than the base-price case because the merchant is less likely to look.
+        await setPlan(chaos, "GROWTH");
+
+        const reverted = await chaos.revert();
+        await chaos.expectHonest(reverted.runId);
+
+        expect(chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size).toBe(0);
+      },
+    );
+  });
+
+  it("refuses to start a gated campaign, in words rather than by failing", async () => {
+    await withChaos(
+      "downgrade-refuses-start",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId } = chaos.fixture;
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/eu",
+          name: "Europe",
+          currency: "EUR",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/eu", title: "EU", __typename: "MarketCatalog" },
+          prices: [],
+        });
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        await setPlan(chaos, "GROWTH");
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: ["gid://shopify/PriceList/eu"] } as never },
+        });
+
+        const result = await chaos.apply();
+
+        // Not an error and not a failed run. A scheduled run that threw would surface as
+        // "your sale failed", which reads far worse than "your plan does not cover this".
+        expect(result.verified).toBe(0);
+        expect(result.clean).toBe(true);
+        expect(result.refusedByPlan).toBeDefined();
+        expect(result.messages.join(" ")).toContain("Markets");
+
+        // And crucially, nothing was written or half-written.
+        expect(chaos.fake.writeLog).toHaveLength(0);
+        expect(await prisma.variantChange.count({ where: { shopId } })).toBe(0);
+      },
+    );
+  });
+
+  it("does not gate a campaign that fits the smaller plan", async () => {
+    await withChaos(
+      "downgrade-still-runs",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        await setPlan(chaos, "FREE");
+
+        // Five variants, base surface only. Free covers this, and gating it would make
+        // the free tier an advertisement rather than a product.
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        expect(applied.verified).toBe(chaos.fixture.variantGids.length);
+      },
+    );
+  });
+
+  it("refuses a campaign larger than the plan's variant limit", async () => {
+    await withChaos(
+      "downgrade-variant-cap",
+      { catalog: { products: 12, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+
+        await prisma.shop.update({
+          where: { id: shopId },
+          data: { planTier: "FREE", subscriptionStatus: "ACTIVE" },
+        });
+
+        // A limit below the catalogue, standing in for a free-tier store that has grown.
+        const { PLANS } = await import("../../app/lib/billing/plans");
+        const original = PLANS.free.variantLimit;
+        PLANS.free.variantLimit = 5;
+
+        try {
+          const result = await chaos.apply();
+
+          expect(result.verified).toBe(0);
+          expect(result.messages.join(" ")).toContain("12");
+          expect(chaos.fake.writeLog).toHaveLength(0);
+        } finally {
+          PLANS.free.variantLimit = original;
+        }
+      },
+    );
+  });
+});

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -21,7 +21,27 @@ appending a new one, and note the reasoning.
 | D6 | App name + App Store listing name | P4–P5 | "Anchor" is a working title chosen for the baseline concept; needs an availability check and a keyword-bearing listing name, as the category does. |
 | D7 | Free-tier cap (500 vs 250 variants) | post-launch data | Start at 500 — deliberately aggressive against NA's 100 changes/month. Tighten if conversion suffers; never tighten the safety features. |
 | D8 | Pull B2B surface forward into P5 | beta signal | Swap with the calendar if the beta cohort skews B2B-heavy. |
-| D9 | Managed pricing vs the newer usage-billing App Events path | P5.8 spike | Managed pricing is the default; the usage path only if variant-cap enforcement demands it. |
+| D9 | Managed pricing vs the newer usage-billing App Events path | **Resolved P5.8** | Managed pricing. Variant caps are enforced in-app against the campaign's own scope, which needs no usage reporting at all — and usage billing would have meant emitting an App Event per priced variant, which is both a per-change meter by another name (contradicting D3) and a second source of truth about what we did. |
+
+### D9, in more detail
+
+Usage billing looked attractive for the variant cap because it bills what is actually
+used. It was rejected for three reasons:
+
+- **It is change metering wearing a different hat.** D3 rejected charging per change
+  because it taxes the core loop and penalises recurring campaigns. Emitting a billable
+  event per priced variant reintroduces exactly that, with the added downside that a
+  merchant cannot predict their bill before running a campaign.
+- **It would create a second record of what we wrote.** The ledger is the record. A
+  billing event stream that could disagree with it is a support burden and, worse, a
+  thing somebody might reconcile *against* the ledger.
+- **The cap does not need it.** A campaign's scope is known before it runs, so the gate
+  is a count against a number, checked in the run path. That also lets the app refuse in
+  advance with a sentence, rather than billing for something and explaining later.
+
+The decision to revisit if: a merchant asks to be charged for a one-off large campaign
+rather than upgrading a tier for a month. That is a real shape and managed pricing serves
+it badly.
 
 ## Reversed during planning
 

--- a/prisma/migrations/20260826060000_subscription_state/migration.sql
+++ b/prisma/migrations/20260826060000_subscription_state/migration.sql
@@ -1,0 +1,20 @@
+-- Subscription state alongside the plan tier (P5.8).
+--
+-- `planTier` already said which plan a shop is on. These say why we believe it: which
+-- Shopify subscription, in what state, and until when the trial runs. Without them a
+-- downgrade is indistinguishable from a webhook we missed, and the app would have to
+-- choose between trusting a stale tier and re-querying Shopify on every request.
+--
+-- `developerStore` is separate from the tier rather than being a fifth tier, because a
+-- dev or partner store is not on a plan at all -- it is exempt from billing while still
+-- being on whatever tier it is testing.
+--
+-- Expand-only: new nullable columns with defaults, so the previous release reads this
+-- schema unchanged.
+ALTER TABLE "shops" ADD COLUMN "subscriptionGid" TEXT;
+ALTER TABLE "shops" ADD COLUMN "subscriptionStatus" TEXT;
+ALTER TABLE "shops" ADD COLUMN "trialEndsAt" TIMESTAMP(3);
+ALTER TABLE "shops" ADD COLUMN "developerStore" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "shops" ADD COLUMN "planChangedAt" TIMESTAMP(3);
+
+CREATE INDEX "shops_subscriptionStatus_idx" ON "shops"("subscriptionStatus");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,17 @@ model Shop {
   planTier   PlanTier @default(FREE)
   variantCap Int?
 
+  /// The Shopify subscription behind the tier, and what state it is in. Without these a
+  /// downgrade is indistinguishable from a webhook we missed.
+  subscriptionGid    String?
+  subscriptionStatus String?
+  trialEndsAt        DateTime?
+  planChangedAt      DateTime?
+
+  /// Dev and partner stores are exempt from billing. Not a fifth tier: such a store is
+  /// not on a plan at all, it is testing whichever tier it has selected.
+  developerStore Boolean @default(false)
+
   /// IANA zone, e.g. "America/Toronto". Campaign times are stored UTC and rendered
   /// in this zone; the UI always shows which zone it is displaying.
   timezone String @default("UTC")

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -25,6 +25,10 @@ api_version = "2026-07"
   uri = "/webhooks/products"
 
   [[webhooks.subscriptions]]
+  topics = [ "app_subscriptions/update" ]
+  uri = "/webhooks/app/subscriptions_update"
+
+  [[webhooks.subscriptions]]
   uri = "/webhooks/compliance"
   compliance_topics = [ "customers/data_request", "customers/redact", "shop/redact" ]
 


### PR DESCRIPTION
Closes #171. Resolves **D9**.

Pricing meters variants under management and surfaces, **not changes** (D3). Free / Growth $14.90 / Markets $34.90 / Wholesale $69.90, 14-day trial on paid tiers, dev and partner stores exempt.

## Safety is never paywalled

Preview, guardrails, full history and rollback are on **every** tier including free. Charging for the ability to undo a mistake the app helped make is indefensible — and a free-tier merchant stranded at sale prices is a support incident and a one-star review whatever they were paying.

## Edge case E8 — the sharp edge

**A merchant who downgrades mid-campaign must still get their scheduled revert.**

Gates constrain what can be *started*, never what can be *finished*:

- There is no `canRevert` in the plan module, because there is no plan on which the answer is no. A unit test asserts that **absence** rather than trusting it.
- `applySubscriptionUpdate` touches no campaign at all — not cancelled, not rescheduled, not deleted. The guarantee holds because the code has no ability to break it.
- Five chaos scenarios downgrade a shop mid-campaign and check it still reverts, including a market campaign downgraded to a plan with no markets.

A store left at 40% off because we stopped reverting is a revenue incident **we** caused. No amount of "they downgraded" makes that defensible.

## Where gating happens, and how it refuses

In the **run path**, not only the wizard: a catalogue grows and a plan lapses between a campaign being created and the scheduler running it, and the scheduler never goes near the wizard.

A refused apply returns a sentence rather than throwing. A scheduled run that threw would surface as *"your sale failed"* — much worse to read than *"your plan does not cover this campaign, here is the one that does"*.

- **Variants are counted from the campaign's own scope**, resolved through the segment. A campaign targeting forty products on a 500K store manages forty variants; metering it as half a million would price the app out of exactly the careful use it wants to encourage.
- **The gate names the cheapest plan that actually covers the campaign**, not the next tier up. Pointing a 50,000-variant campaign at Growth sells an upgrade that still refuses.
- **Gated surfaces are shown with the upgrade prompt attached, never hidden.** Hiding a feature a merchant is paying a competitor for is how you lose them without ever learning why.

## Subscription state

Now lives beside the tier, so a downgrade is distinguishable from a webhook we missed.

| State | Reads as | Why |
|---|---|---|
| CANCELLED / FROZEN / EXPIRED | free | They stopped paying |
| ACCEPTED | its tier | The gap between approving a charge and Shopify activating it — gating somebody out of what they just bought is the wrong side to err on |
| no subscription row | its tier | Deploying this must not downgrade every existing merchant |
| dev/partner store | wholesale, exempt | Asking a partner to pay $34.90 to evaluate the app is how you get evaluated by nobody |

## D9 resolved: managed pricing

Recorded in `docs/decisions.md`. Usage billing was rejected because it's change metering wearing a different hat (contradicting D3), it would create a second record of what we wrote alongside the ledger, and the variant cap doesn't need it — a campaign's scope is known before it runs.

## Tests

18 for the plan gates, 10 for the webhook payload, 8 for subscription state, 5 chaos scenarios.

**Falsified.** Gating reverts, removing the gate entirely, off-by-one on the variant limit, naming the wrong upgrade target, checking size before surface, treating ACCEPTED as cancelled, treating a missing subscription as cancelled, and charging development stores.

The chaos fixture is now entitled by default — those scenarios test the pricing engine, and a fixture on the free plan failed every market scenario for a reason unrelated to what it was testing.

Full suite: 622 unit tests, 65 chaos scenarios, lint and build clean.

## Note for review

`app_subscriptions/update` is registered in `shopify.app.toml`. Exercising the real upgrade/downgrade flow in Shopify's billing test mode needs a Partner app with managed pricing configured, which is yours to set up — the webhook handling, state transitions and gates are all covered by tests in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)