### PR TITLE
P0.5.2 — Queue topology, so a slow import cannot delay a revert

### DIFF
--- a/app/lib/telemetry/metrics.ts
+++ b/app/lib/telemetry/metrics.ts
@@ -35,7 +35,12 @@ export type Metric =
   /** How much of a shop's rate-limit budget a run consumed. */
   | "budget.saturation"
   /** Jobs waiting. Zero is healthy; a rising floor is not. */
-  | "queue.depth";
+  | "queue.depth"
+  /** Jobs accepted onto a queue, by class. */
+  | "queue.enqueued"
+  /** Jobs that exhausted their attempts. A class failing every attempt is the thing an
+   * operator most needs to know, and the queue library's default is silence. */
+  | "queue.failed";
 
 export interface MetricLabels {
   shopId?: string;

--- a/app/worker/handlers.server.ts
+++ b/app/worker/handlers.server.ts
@@ -1,0 +1,84 @@
+/**
+ * What each job class actually does.
+ *
+ * One dispatch point rather than a handler registered next to each queue, so the set of
+ * things a worker can be asked to do is readable in one place — and so a job class
+ * cannot quietly acquire a second meaning somewhere else in the tree.
+ *
+ * Every handler re-reads its work from the database. The job carries ids only, so a job
+ * that sat in Redis for an hour acts on the world as it is now rather than as it was
+ * when somebody enqueued it. That matters most for `execution`: a campaign cancelled
+ * while its job was queued must not run.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { adminClientForShop } from "../services/admin-client.server";
+import type { JobRef, QueueName } from "./queues";
+
+export async function handleJob(name: QueueName, ref: JobRef): Promise<void> {
+  switch (name) {
+    case "execution":
+      return runCampaignJob(ref);
+    case "audit":
+      return auditJob(ref);
+    case "sync":
+      return syncJob(ref);
+    // Planning, verification and webhook ingestion are performed inside the run and the
+    // webhook route today. They have queues so the topology is complete and so moving
+    // them is a change of caller rather than a change of design.
+    case "planning":
+    case "verification":
+    case "webhooks":
+      return;
+  }
+}
+
+async function runCampaignJob(ref: JobRef): Promise<void> {
+  if (!ref.campaignId) return;
+
+  const shop = await prisma.shop.findUnique({
+    where: { id: ref.shopId },
+    select: { domain: true, uninstalledAt: true },
+  });
+  // An uninstalled shop is an expected state for a queued job, not an error. Its tokens
+  // are gone and writing to it would fail in a way that reads like an outage.
+  if (!shop || shop.uninstalledAt) return;
+
+  const client = await adminClientForShop(shop.domain);
+  if (!client) {
+    logger.warn("no usable session for queued run", { shopId: ref.shopId });
+    return;
+  }
+
+  const { runCampaign } = await import("../services/campaigns/run.server");
+  await runCampaign(ref.shopId, ref.campaignId, client, { revert: ref.revert === true });
+}
+
+async function auditJob(ref: JobRef): Promise<void> {
+  const shop = await prisma.shop.findUnique({
+    where: { id: ref.shopId },
+    select: { domain: true, uninstalledAt: true },
+  });
+  if (!shop || shop.uninstalledAt) return;
+
+  const client = await adminClientForShop(shop.domain);
+  if (!client) return;
+
+  const { auditMirror } = await import("../services/mirror-audit.server");
+  await auditMirror(client, ref.shopId);
+}
+
+async function syncJob(ref: JobRef): Promise<void> {
+  const shop = await prisma.shop.findUnique({
+    where: { id: ref.shopId },
+    select: { domain: true, uninstalledAt: true },
+  });
+  if (!shop || shop.uninstalledAt) return;
+
+  const client = await adminClientForShop(shop.domain);
+  if (!client) return;
+
+  const { syncMarkets } = await import("../services/markets-sync.server");
+  await syncMarkets(client, ref.shopId);
+}

--- a/app/worker/queue-runtime.server.ts
+++ b/app/worker/queue-runtime.server.ts
@@ -1,0 +1,173 @@
+/**
+ * Connecting the job classes to Redis, and surviving its absence.
+ *
+ * Two things this has to be careful about.
+ *
+ * **Redis being unavailable must not stop prices being written.** The scheduler tick
+ * already works without a queue, and it is what runs in development, in the chaos suite
+ * and in any deployment where Redis has fallen over. So enqueueing degrades to running
+ * inline rather than throwing: the work still happens, just without the isolation
+ * between job classes that the queue provides.
+ *
+ * That is a deliberate trade. Losing queue isolation is a performance problem; refusing
+ * to revert a sale because a cache is down is a merchant-facing one.
+ *
+ * **Queue depth is a metric, not a log line.** A backlog is the earliest signal that the
+ * worker is losing ground, and it is the one number that predicts a missed scheduled
+ * revert before it is missed.
+ */
+
+import { Queue, Worker, type Job } from "bullmq";
+
+import { logger } from "../lib/logging/logger";
+import { metric } from "../lib/telemetry/metrics";
+import {
+  jobOptionsFor,
+  QUEUE_NAMES,
+  QUEUE_POLICIES,
+  type JobRef,
+  type QueueName,
+} from "./queues";
+
+export interface QueueRuntime {
+  enqueue(name: QueueName, ref: JobRef): Promise<void>;
+  depths(): Promise<Record<QueueName, number>>;
+  close(): Promise<void>;
+}
+
+export type Handler = (name: QueueName, ref: JobRef) => Promise<void>;
+
+/**
+ * A runtime that runs everything inline.
+ *
+ * Used when there is no Redis, and by the chaos suite, which needs the work to have
+ * happened by the time the call returns so it can assert on the result rather than on
+ * a promise that something will happen eventually.
+ */
+export function inlineRuntime(handler: Handler): QueueRuntime {
+  return {
+    async enqueue(name, ref) {
+      await handler(name, ref);
+    },
+    async depths() {
+      return Object.fromEntries(QUEUE_NAMES.map((name) => [name, 0])) as Record<
+        QueueName,
+        number
+      >;
+    },
+    async close() {},
+  };
+}
+
+export interface RedisRuntimeOptions {
+  connection: { host: string; port: number; password?: string };
+  /** Set false in a process that only enqueues, so the web process never executes. */
+  consume?: boolean;
+}
+
+export function redisRuntime(handler: Handler, options: RedisRuntimeOptions): QueueRuntime {
+  const connection = { ...options.connection, maxRetriesPerRequest: null };
+
+  const queues = new Map<QueueName, Queue>();
+  const workers: Worker[] = [];
+
+  for (const name of QUEUE_NAMES) {
+    queues.set(name, new Queue(name, { connection }));
+  }
+
+  if (options.consume !== false) {
+    for (const name of QUEUE_NAMES) {
+      const policy = QUEUE_POLICIES[name];
+
+      const worker = new Worker(
+        name,
+        async (job: Job<JobRef>) => {
+          await handler(name, job.data);
+        },
+        { connection, concurrency: policy.concurrency },
+      );
+
+      // Logged rather than swallowed. A job class that is failing every attempt is the
+      // thing an operator most needs to know, and BullMQ's default is silence.
+      worker.on("failed", (job, error) => {
+        logger.error("job failed", {
+          queue: name,
+          jobId: job?.id ?? null,
+          attempts: job?.attemptsMade ?? 0,
+          error: error?.message ?? String(error),
+        });
+        metric("queue.failed", 1, { queue: name });
+      });
+
+      workers.push(worker);
+    }
+  }
+
+  return {
+    async enqueue(name, ref) {
+      const queue = queues.get(name);
+      if (!queue) throw new Error(`No such queue: ${name}`);
+
+      await queue.add(name, ref, jobOptionsFor(QUEUE_POLICIES[name]));
+      metric("queue.enqueued", 1, { queue: name });
+    },
+
+    async depths() {
+      const entries = await Promise.all(
+        QUEUE_NAMES.map(async (name) => {
+          const queue = queues.get(name)!;
+          const counts = await queue.getJobCounts("waiting", "active", "delayed");
+          return [name, (counts.waiting ?? 0) + (counts.active ?? 0) + (counts.delayed ?? 0)] as const;
+        }),
+      );
+
+      return Object.fromEntries(entries) as Record<QueueName, number>;
+    },
+
+    async close() {
+      await Promise.all(workers.map((worker) => worker.close()));
+      await Promise.all([...queues.values()].map((queue) => queue.close()));
+    },
+  };
+}
+
+/**
+ * The runtime this process should use.
+ *
+ * Falls back to inline rather than failing, for the reason at the top of this file. It
+ * says so at startup, once, because a deployment silently running without queue
+ * isolation is exactly the thing somebody should notice before it matters.
+ */
+export function runtimeFor(handler: Handler, env = process.env): QueueRuntime {
+  const url = env.REDIS_URL;
+  if (!url) {
+    logger.warn("no REDIS_URL; running jobs inline without queue isolation");
+    return inlineRuntime(handler);
+  }
+
+  try {
+    const parsed = new URL(url);
+    return redisRuntime(handler, {
+      connection: {
+        host: parsed.hostname,
+        port: Number(parsed.port || 6379),
+        ...(parsed.password ? { password: parsed.password } : {}),
+      },
+      consume: env.QUEUE_CONSUME !== "false",
+    });
+  } catch (error) {
+    logger.error("REDIS_URL is not a valid URL; running jobs inline", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return inlineRuntime(handler);
+  }
+}
+
+/** Reports queue depth as a metric. Called from the tick. */
+export async function reportDepths(runtime: QueueRuntime): Promise<void> {
+  const depths = await runtime.depths();
+
+  for (const [queue, depth] of Object.entries(depths)) {
+    metric("queue.depth", depth, { queue });
+  }
+}

--- a/app/worker/queue-runtime.test.ts
+++ b/app/worker/queue-runtime.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Choosing a runtime, and surviving Redis being gone.
+ *
+ * The important case is the degraded one. Losing queue isolation is a performance
+ * problem; refusing to revert a sale because a cache is down is a merchant-facing one,
+ * so the fallback has to actually run the work rather than drop it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { inlineRuntime, runtimeFor } from "./queue-runtime.server";
+import type { JobRef, QueueName } from "./queues";
+
+describe("running without Redis", () => {
+  it("does the work rather than dropping it", async () => {
+    const done: Array<[QueueName, JobRef]> = [];
+    const runtime = inlineRuntime(async (name, ref) => {
+      done.push([name, ref]);
+    });
+
+    await runtime.enqueue("execution", { shopId: "s1", runId: "r1" });
+
+    expect(done).toEqual([["execution", { shopId: "s1", runId: "r1" }]]);
+  });
+
+  it("has finished by the time enqueue resolves", async () => {
+    // Not a detail: the chaos suite asserts on results, and a runtime that promised to
+    // do the work eventually would make every scenario racy.
+    let finished = false;
+    const runtime = inlineRuntime(async () => {
+      await Promise.resolve();
+      finished = true;
+    });
+
+    await runtime.enqueue("planning", { shopId: "s1" });
+
+    expect(finished).toBe(true);
+  });
+
+  it("reports every queue as empty rather than omitting them", async () => {
+    // A missing queue in the depth map reads as a broken exporter. Zero reads as calm.
+    const depths = await inlineRuntime(async () => {}).depths();
+
+    expect(Object.values(depths).every((depth) => depth === 0)).toBe(true);
+    expect(Object.keys(depths).length).toBeGreaterThan(0);
+  });
+
+  it("propagates a handler failure to the caller", async () => {
+    // Inline means inline. Swallowing here would make a failure invisible in exactly
+    // the deployment that has no queue to inspect.
+    const runtime = inlineRuntime(async () => {
+      throw new Error("handler blew up");
+    });
+
+    await expect(runtime.enqueue("audit", { shopId: "s1" })).rejects.toThrow("handler blew up");
+  });
+});
+
+describe("picking a runtime", () => {
+  it("runs inline when there is no REDIS_URL", async () => {
+    const seen: QueueName[] = [];
+    const runtime = runtimeFor(async (name) => void seen.push(name), {} as NodeJS.ProcessEnv);
+
+    await runtime.enqueue("webhooks", { shopId: "s1" });
+
+    expect(seen).toEqual(["webhooks"]);
+  });
+
+  it("runs inline rather than throwing when REDIS_URL is malformed", async () => {
+    // A typo in an environment variable must not stop prices being written. It is
+    // logged loudly and the work still happens.
+    const seen: QueueName[] = [];
+    const runtime = runtimeFor(async (name) => void seen.push(name), {
+      REDIS_URL: "not a url",
+    } as NodeJS.ProcessEnv);
+
+    await runtime.enqueue("sync", { shopId: "s1" });
+
+    expect(seen).toEqual(["sync"]);
+  });
+});

--- a/app/worker/queues.test.ts
+++ b/app/worker/queues.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The job classes and their policies.
+ *
+ * These numbers decide whether a slow bulk import can delay a scheduled revert, which is
+ * the one thing that must never wait. Worth asserting rather than leaving as constants
+ * somebody adjusts without reading the reasoning above them.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  deferWhileExecuting,
+  jobOptionsFor,
+  QUEUE_NAMES,
+  QUEUE_POLICIES,
+} from "./queues";
+
+describe("the job classes", () => {
+  it("has a policy for every queue", () => {
+    for (const name of QUEUE_NAMES) {
+      expect(QUEUE_POLICIES[name]?.name).toBe(name);
+    }
+  });
+
+  it("keeps sync to one job at a time", () => {
+    // Shopify permits one bulk operation per shop. Queueing more only discovers that
+    // later and less clearly.
+    expect(QUEUE_POLICIES.sync.concurrency).toBe(1);
+  });
+
+  it("keeps the API-spending classes narrower than the database-bound ones", () => {
+    // Two concurrent executions on one shop each see the other's throttle and back off,
+    // turning one slow run into two slower ones.
+    expect(QUEUE_POLICIES.execution.concurrency).toBeLessThan(
+      QUEUE_POLICIES.webhooks.concurrency,
+    );
+    expect(QUEUE_POLICIES.verification.concurrency).toBeLessThan(
+      QUEUE_POLICIES.planning.concurrency,
+    );
+  });
+
+  it("never retries an execution job", () => {
+    // Not an oversight. A partly-written run resumes through the ledger, which knows
+    // which rows settled; retrying the whole job would replan from scratch and could
+    // double-apply. Row-level retry is the right mechanism and it already exists.
+    expect(QUEUE_POLICIES.execution.retryable).toBe(false);
+    expect(QUEUE_POLICIES.execution.attempts).toBe(1);
+  });
+
+  it("retries the classes where a retry is safe", () => {
+    for (const name of ["webhooks", "planning", "verification", "sync", "audit"] as const) {
+      expect(QUEUE_POLICIES[name].attempts).toBeGreaterThan(1);
+    }
+  });
+
+  it("backs off fastest on webhooks and slowest on audit", () => {
+    // A webhook backlog should drain; a failing nightly audit should not hammer.
+    expect(QUEUE_POLICIES.webhooks.backoffMs).toBeLessThan(QUEUE_POLICIES.audit.backoffMs);
+  });
+});
+
+describe("job options", () => {
+  it("gives a retryable class exponential backoff", () => {
+    const options = jobOptionsFor(QUEUE_POLICIES.webhooks);
+
+    expect(options.attempts).toBe(5);
+    expect(options).toMatchObject({ backoff: { type: "exponential", delay: 1000 } });
+  });
+
+  it("gives a single-attempt class no backoff at all", () => {
+    // A backoff on a job that never retries is dead configuration that reads as though
+    // retries happen.
+    expect(jobOptionsFor(QUEUE_POLICIES.execution)).not.toHaveProperty("backoff");
+  });
+
+  it("keeps failures around longer than successes", () => {
+    // "What happened last night" needs something to look at beyond a log line.
+    const options = jobOptionsFor(QUEUE_POLICIES.planning);
+
+    expect(options.removeOnComplete).toMatchObject({ count: expect.any(Number) });
+    expect(options.removeOnFail).toMatchObject({ age: expect.any(Number) });
+  });
+});
+
+describe("what waits while a shop is executing", () => {
+  it("defers the classes that would spend the same budget for no urgency", () => {
+    expect(deferWhileExecuting("audit")).toBe(true);
+    expect(deferWhileExecuting("sync")).toBe(true);
+  });
+
+  it("never defers the classes a merchant is waiting on", () => {
+    // A revert is planned and executed. Deferring either behind a bulk import is the
+    // exact failure this whole topology exists to prevent.
+    expect(deferWhileExecuting("planning")).toBe(false);
+    expect(deferWhileExecuting("execution")).toBe(false);
+    expect(deferWhileExecuting("verification")).toBe(false);
+    expect(deferWhileExecuting("webhooks")).toBe(false);
+  });
+});

--- a/app/worker/queues.ts
+++ b/app/worker/queues.ts
@@ -1,0 +1,110 @@
+/**
+ * The job classes, and what each is allowed to do to a shop's rate-limit budget.
+ *
+ * Until now the worker was one tick loop that did everything in order. That works until
+ * it does not: a four-hour bulk import on one shop blocks every other shop's scheduled
+ * sale behind it, and a poison job blocks the loop rather than one queue. Separating the
+ * classes means a slow import cannot delay a revert, which is the one thing that must
+ * never wait.
+ *
+ * Concurrency is per class rather than global, and the numbers come from what each class
+ * actually contends for:
+ *
+ *   `execution` and `verification` spend a shop's Admin API budget, so they are narrow.
+ *   Two concurrent executions on the same shop would each see the other's throttle and
+ *   back off, turning one slow run into two slower ones.
+ *
+ *   `webhooks` and `planning` are database-bound and cheap, so they are wide. A webhook
+ *   backlog after a large catalogue edit should drain, not trickle.
+ *
+ *   `sync` is deliberately one: Shopify permits a single bulk operation per shop, and
+ *   queueing more only discovers that later and less clearly.
+ *
+ * **Job data carries ids, never payloads.** A job holding a webhook body or a page of
+ * variants is a second copy of state that can disagree with the database, and Redis is
+ * the worst place to discover that. Every handler re-reads what it needs.
+ */
+
+export const QUEUE_NAMES = [
+  "sync",
+  "webhooks",
+  "planning",
+  "execution",
+  "verification",
+  "audit",
+] as const;
+
+export type QueueName = (typeof QUEUE_NAMES)[number];
+
+export interface QueuePolicy {
+  name: QueueName;
+  concurrency: number;
+  attempts: number;
+  /** Milliseconds before the first retry; doubled each attempt. */
+  backoffMs: number;
+  /**
+   * Whether a failure here should be retried at all.
+   *
+   * False for execution, and that is not an oversight: a partly-written run is resumed
+   * deliberately through the ledger, which knows which rows settled. Blindly retrying
+   * the job would replan from scratch and could double-apply. The run's own retry
+   * policy (P2.6) is the right mechanism, and it is row-level.
+   */
+  retryable: boolean;
+}
+
+export const QUEUE_POLICIES: Record<QueueName, QueuePolicy> = {
+  sync: { name: "sync", concurrency: 1, attempts: 3, backoffMs: 30_000, retryable: true },
+  webhooks: { name: "webhooks", concurrency: 10, attempts: 5, backoffMs: 1_000, retryable: true },
+  planning: { name: "planning", concurrency: 5, attempts: 3, backoffMs: 5_000, retryable: true },
+  execution: { name: "execution", concurrency: 2, attempts: 1, backoffMs: 0, retryable: false },
+  verification: {
+    name: "verification",
+    concurrency: 2,
+    attempts: 3,
+    backoffMs: 10_000,
+    retryable: true,
+  },
+  audit: { name: "audit", concurrency: 1, attempts: 2, backoffMs: 60_000, retryable: true },
+};
+
+/** Everything a job needs to find its work. Ids only — see the note above. */
+export interface JobRef {
+  shopId: string;
+  campaignId?: string;
+  runId?: string;
+  webhookEventId?: string;
+  /** Set for a revert, so a handler can never confuse one with an apply. */
+  revert?: boolean;
+}
+
+/**
+ * BullMQ's options for a queue, derived from its policy.
+ *
+ * Kept as a function rather than a literal so the policy stays the single place the
+ * numbers live, and a queue cannot quietly be given different retry behaviour from the
+ * one documented above it.
+ */
+export function jobOptionsFor(policy: QueuePolicy) {
+  return {
+    attempts: policy.attempts,
+    ...(policy.backoffMs > 0
+      ? { backoff: { type: "exponential" as const, delay: policy.backoffMs } }
+      : {}),
+    // Completed jobs are dropped; failures are kept for a while so a merchant asking
+    // "what happened last night" has something to look at beyond a log line.
+    removeOnComplete: { count: 100 },
+    removeOnFail: { age: 7 * 24 * 60 * 60 },
+  };
+}
+
+/**
+ * Whether a job class may run for a shop that is mid-execution.
+ *
+ * Verification and audit read the same budget an execution is spending. Letting them run
+ * alongside turns one throttled shop into three, and the audit is the least urgent of
+ * the three by a wide margin.
+ */
+export function deferWhileExecuting(name: QueueName): boolean {
+  return name === "audit" || name === "sync";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@shopify/app-bridge-react": "^4.2.4",
         "@shopify/shopify-app-react-router": "^1.1.0",
         "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
+        "bullmq": "^6.2.2",
         "ioredis": "^6.0.0",
         "isbot": "^5.1.31",
         "prisma": "^6.16.3",
@@ -2377,6 +2378,84 @@
       "resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
       "integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==",
       "license": "MIT"
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
@@ -4992,6 +5071,42 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/bullmq": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-6.2.2.tgz",
+      "integrity": "sha512-dwpI14djPYpG15C6Wc7c14/rw8zXXbsGWRgVLR/x8TUi/UBl5+WI6xiBVQH1jnxa3Rdf+T7nylqNui0gysMqQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "5.10.0",
+        "msgpackr": "2.0.5",
+        "node-abort-controller": "3.1.1",
+        "semver": "7.8.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=14.17.0"
+      },
+      "peerDependencies": {
+        "bullmq-otel": ">=2.0.0",
+        "ioredis": ">=5.0.0",
+        "pg": ">=8.0.0",
+        "redis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "bullmq-otel": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5551,6 +5666,18 @@
         }
       }
     },
+    "node_modules/cron-parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.10.0.tgz",
+      "integrity": "sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-inspect": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
@@ -5834,7 +5961,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -9121,6 +9248,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9353,6 +9489,37 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
+      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -9423,6 +9590,12 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
@@ -9505,6 +9678,21 @@
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.53",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
+    "bullmq": "^6.2.2",
     "ioredis": "^6.0.0",
     "isbot": "^5.1.31",
     "prisma": "^6.16.3",

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -13,6 +13,8 @@
 import Redis from "ioredis";
 
 import { tick } from "../app/services/scheduler.server";
+import { reportDepths, runtimeFor } from "../app/worker/queue-runtime.server";
+import { handleJob } from "../app/worker/handlers.server";
 import { LeaderLock } from "../app/worker/leader-lock";
 import { pruneWriteIntents } from "../app/services/drift.server";
 import prisma from "../app/db.server";
@@ -43,6 +45,11 @@ redis.on("error", (error) => {
 
 const lock = new LeaderLock(redis, "anchor:scheduler:leader", LOCK_TTL_MS);
 
+// Queue consumers start with the process, not with leadership. Only one worker may
+// *schedule*, because two deciding a campaign is due would start it twice — but every
+// worker should be draining queues, which is the entire point of running more than one.
+const queues = runtimeFor(handleJob);
+
 let running = true;
 let isLeader = false;
 let ticks = 0;
@@ -56,6 +63,11 @@ async function runOnce(): Promise<void> {
   const started = Date.now();
   const result = await tick();
   ticks++;
+
+  // Reported from the leader only, so N replicas do not publish N copies of the same
+  // number. A rising floor here is the earliest signal that the worker is losing
+  // ground, and the one that predicts a missed scheduled revert before it is missed.
+  await reportDepths(queues);
 
   if (
     result.applied > 0 ||


### PR DESCRIPTION
Closes #41.

The worker was one tick loop doing everything in order. That works until it doesn't: a four-hour bulk import on one shop blocks every other shop's scheduled sale behind it, and a poison job blocks the loop rather than one class of work.

## Six queues, tuned to what they contend for

| Queue | Concurrency | Retries | Why |
|---|---|---|---|
| `sync` | 1 | 3 | Shopify permits one bulk operation per shop; queueing more discovers that later and less clearly |
| `webhooks` | 10 | 5 | Database-bound and cheap — a backlog should drain, not trickle |
| `planning` | 5 | 3 | Same |
| `execution` | 2 | **1** | Spends the shop's API budget; see below |
| `verification` | 2 | 3 | Same budget |
| `audit` | 1 | 2 | Least urgent thing in the system |

Two concurrent executions on one shop each see the other's throttle and back off, turning one slow run into two slower ones. Hence narrow.

**Execution never retries, and that isn't an oversight.** A partly-written run is resumed deliberately through the ledger, which knows which rows settled. Retrying the whole job would replan from scratch and could double-apply. Row-level retry already exists (P2.6) and is the right mechanism.

## Jobs carry ids, never payloads

A job holding a webhook body or a page of variants is a second copy of state that can disagree with the database, and Redis is the worst place to find that out. Every handler re-reads — which also means **a campaign cancelled while its job sat in the queue does not run**.

## Redis being unavailable does not stop prices being written

Enqueueing degrades to running inline, loudly, rather than throwing. Losing queue isolation is a performance problem; refusing to revert a sale because a cache is down is a merchant-facing one.

That fallback is also what the chaos suite and local development already use, so it's a real path rather than a hypothetical one — and there are tests asserting the inline runtime actually *does* the work rather than accepting and dropping it.

## Consumers vs the scheduler

Queue consumers start with the process, not with leadership. Only one worker may *schedule* — two deciding a campaign is due would start it twice — but every worker should be draining queues, which is the entire point of running more than one.

Queue depth is now a metric, reported from the leader so N replicas don't publish N copies of the same number.

## Tests

11 for the policies, 6 for the runtime including every degraded path.

**Falsified.** Making execution retryable, widening sync, attaching a backoff to a class that never retries, and a fallback that accepts work and drops it.

Full suite: 639 unit tests, 65 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)