### PR TITLE
P4.4 + P4.5 — Runbooks, help docs, and every error linking to the page that explains it

### DIFF
--- a/app/components/ErrorScreen.tsx
+++ b/app/components/ErrorScreen.tsx
@@ -11,6 +11,8 @@
  * screen tells a merchant nothing and tells an attacker something.
  */
 
+import { helpLabelFor, helpUrlFor } from "../lib/errors/help-links";
+
 export interface ErrorScreenProps {
   errorId: string;
   userMessage: string;
@@ -44,6 +46,15 @@ export function ErrorScreen({
               campaign — its ledger shows exactly which variants were written before
               the failure, and resuming picks up from there.
             </s-text>
+          </s-paragraph>
+
+          {/* Every merchant-visible error links to the page that explains it. Somebody
+              hitting this at 9pm before a sale wants the sentence that says what to do,
+              one click from here — not a search box. */}
+          <s-paragraph>
+            <s-link href={helpUrlFor(code)} target="_blank">
+              {helpLabelFor(code)}
+            </s-link>
           </s-paragraph>
 
           <s-stack direction="inline" gap="base">

--- a/app/lib/errors/help-links.test.ts
+++ b/app/lib/errors/help-links.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Linking every error to the page that explains it.
+ *
+ * The acceptance criterion that makes a help centre real rather than a wiki nobody
+ * reads. A broken link under an error message is worse than no link at all: it confirms
+ * the merchant's suspicion that nobody is looking after this.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { helpLabelFor, helpUrlFor } from "./help-links";
+
+const CODES = [
+  "UNAUTHENTICATED",
+  "NO_SESSION",
+  "SHOPIFY_THROTTLED",
+  "SHOPIFY_UNAVAILABLE",
+  "SHOPIFY_REJECTED",
+  "GUARDRAIL_BLOCKED",
+  "NOT_FOUND",
+  "VALIDATION",
+  "DB_UNAVAILABLE",
+  "UNKNOWN",
+] as const;
+
+describe("help links", () => {
+  it("gives every error code a real path", () => {
+    for (const code of CODES) {
+      const url = helpUrlFor(code);
+
+      expect(url).not.toContain("undefined");
+      expect(url).toMatch(/^https?:\/\/.+\/.+/);
+    }
+  });
+
+  it("gives every error code a distinct page", () => {
+    // Sending four different failures to the same page would be a link that technically
+    // exists and answers nothing.
+    const urls = CODES.map(helpUrlFor);
+
+    expect(new Set(urls).size).toBe(CODES.length);
+  });
+
+  it("falls back to the general page for a code it does not know", () => {
+    // The code crosses a serialisation boundary as a plain string. A future or
+    // mistyped one must not produce ".../undefined".
+    expect(helpUrlFor("SOMETHING_NEW")).toBe(helpUrlFor("UNKNOWN"));
+    expect(helpUrlFor("")).not.toContain("undefined");
+  });
+
+  it("labels the link with what it explains, never with the URL", () => {
+    for (const code of CODES) {
+      const label = helpLabelFor(code);
+
+      expect(label.length).toBeGreaterThan(0);
+      expect(label.toLowerCase()).not.toContain("http");
+      expect(label.toLowerCase()).not.toContain("click here");
+    }
+  });
+});

--- a/app/lib/errors/help-links.ts
+++ b/app/lib/errors/help-links.ts
@@ -1,0 +1,65 @@
+/**
+ * Every merchant-visible error points at a page that explains it.
+ *
+ * This is the acceptance criterion that makes a help centre real rather than a wiki
+ * nobody reads. A merchant who hits "a guardrail stopped this run" at 9pm before a sale
+ * does not want a search box — they want the sentence that tells them which guardrail and
+ * what to do, one click from where they are.
+ *
+ * The mapping lives beside the error codes rather than in the docs, so adding a code
+ * without a doc is a type error rather than a broken link somebody finds later.
+ */
+
+import type { ErrorCode } from "./app-error";
+
+/** Where the published help lives. Overridable so staging can point at itself. */
+export const HELP_BASE = process.env.HELP_BASE_URL ?? "https://help.anchorpricing.app";
+
+/**
+ * The doc for each error.
+ *
+ * `Record` rather than a partial map on purpose: a new error code will not compile until
+ * somebody has decided what a merchant reading it should be sent to.
+ */
+const HELP_PATHS: Record<ErrorCode, string> = {
+  UNAUTHENTICATED: "/failures/session-expired",
+  NO_SESSION: "/failures/store-disconnected",
+  SHOPIFY_THROTTLED: "/concepts/rate-limits",
+  SHOPIFY_UNAVAILABLE: "/failures/shopify-unreachable",
+  SHOPIFY_REJECTED: "/failures/partial-runs",
+  GUARDRAIL_BLOCKED: "/failures/guardrail-blocks",
+  NOT_FOUND: "/failures/missing-record",
+  VALIDATION: "/failures/form-validation",
+  DB_UNAVAILABLE: "/failures/app-unavailable",
+  UNKNOWN: "/failures/unexpected",
+};
+
+/**
+ * Takes a plain string, not an `ErrorCode`.
+ *
+ * The boundary receives the code as a string across the serialisation boundary, and an
+ * unrecognised one must not produce `https://help…/undefined` — a broken link under an
+ * error message is worse than no link, because it confirms the merchant's suspicion that
+ * nobody is looking after this.
+ */
+export function helpUrlFor(code: string): string {
+  return `${HELP_BASE}${HELP_PATHS[code as ErrorCode] ?? HELP_PATHS.UNKNOWN}`;
+}
+
+/** What the link should say. Never "click here", and never the URL. */
+export function helpLabelFor(code: string): string {
+  const labels: Record<ErrorCode, string> = {
+    UNAUTHENTICATED: "Why sessions expire",
+    NO_SESSION: "Reconnecting your store",
+    SHOPIFY_THROTTLED: "How rate limits affect a run",
+    SHOPIFY_UNAVAILABLE: "When Shopify is unreachable",
+    SHOPIFY_REJECTED: "Understanding a partial run",
+    GUARDRAIL_BLOCKED: "How guardrails work",
+    NOT_FOUND: "Missing campaigns and records",
+    VALIDATION: "Fixing a form",
+    DB_UNAVAILABLE: "When the app is unavailable",
+    UNKNOWN: "What to do about an unexpected error",
+  };
+
+  return labels[code as ErrorCode] ?? labels.UNKNOWN;
+}

--- a/app/lib/errors/help-pages.test.ts
+++ b/app/lib/errors/help-pages.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The pages the app links to actually exist.
+ *
+ * Without this, the error-to-doc mapping and the docs drift apart silently: somebody
+ * renames a page, the link still compiles, and a merchant hitting an error at 9pm gets a
+ * 404 under the message telling them what went wrong. A broken link there is worse than
+ * no link, because it confirms nobody is looking after this.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { helpUrlFor, HELP_BASE } from "./help-links";
+
+const CODES = [
+  "UNAUTHENTICATED",
+  "NO_SESSION",
+  "SHOPIFY_THROTTLED",
+  "SHOPIFY_UNAVAILABLE",
+  "SHOPIFY_REJECTED",
+  "GUARDRAIL_BLOCKED",
+  "NOT_FOUND",
+  "VALIDATION",
+  "DB_UNAVAILABLE",
+  "UNKNOWN",
+] as const;
+
+/** The repo path a published help URL corresponds to. */
+function sourceFor(url: string): string {
+  const path = url.slice(HELP_BASE.length);
+  return join(process.cwd(), "docs/help", `${path}.md`);
+}
+
+describe("every error links to a page that exists", () => {
+  it.each(CODES)("%s", (code) => {
+    const file = sourceFor(helpUrlFor(code));
+
+    expect(existsSync(file), `${code} links to ${file}, which is not in the repo`).toBe(true);
+  });
+});

--- a/chaos/scenarios/b2b-surface.chaos.ts
+++ b/chaos/scenarios/b2b-surface.chaos.ts
@@ -1,0 +1,159 @@
+/**
+ * Pricing into a B2B catalogue.
+ *
+ * The Wholesale tier charges for this, so it had better work. Quantity price breaks —
+ * the genuinely B2B-specific part — are still gated behind beta signal (#174), but
+ * targeting a company-location catalogue as a campaign surface is available today and is
+ * what the plan gate actually sells.
+ *
+ * A B2B catalogue reaches Shopify through the same price-list mutations a market does,
+ * which is why it works at all: the surface abstraction was built to make this a
+ * configuration difference rather than a second code path.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos } from "../harness/scenario";
+
+const WHOLESALE = "gid://shopify/PriceList/wholesale";
+
+describe("chaos: pricing into a B2B catalogue", () => {
+  it("applies and reverts a wholesale price list like any other surface", async () => {
+    await withChaos(
+      "b2b-surface",
+      { catalog: { products: 6, variantsPerProduct: 1 }, percent: -25 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+
+        // A company-location catalogue. `surfaceKindOf` files a list with this catalog
+        // type as B2B, and one with no catalog at all as B2B too.
+        chaos.fake.addPriceList({
+          id: WHOLESALE,
+          name: "Trade partners",
+          currency: "USD",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 30 },
+          catalog: {
+            id: "gid://shopify/CompanyLocationCatalog/1",
+            title: "Trade",
+            __typename: "CompanyLocationCatalog",
+          },
+          prices: [],
+        });
+
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        // Mirrored as B2B, not as a market. The distinction is what the plan gate reads.
+        const record = await prisma.priceListRecord.findFirstOrThrow({
+          where: { shopId, priceListGid: WHOLESALE },
+        });
+        expect(record.surfaceKind).toBe("B2B");
+
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: [WHOLESALE] } as never },
+        });
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Asserted on what a trade buyer actually pays, not on how it was written. A
+        // uniform campaign over a whole catalogue takes the one-mutation path, so most
+        // variants have no per-product row at all — checking for fixed prices would be
+        // testing the write strategy rather than the price.
+        for (const gid of variantGids) {
+          expect(chaos.fake.priceOf(gid, WHOLESALE)).toBeDefined();
+        }
+
+        const rows = await prisma.variantChange.findMany({
+          where: { runId: applied.runId, surfaceKind: "MARKET", priceListGid: WHOLESALE },
+        });
+        expect(rows).toHaveLength(variantGids.length);
+        expect(rows.every((row) => row.status === "VERIFIED")).toBe(true);
+
+        await chaos.revert();
+
+        // Back to the list deriving from its own 30%, with no per-product prices left
+        // pinned to the sale.
+        expect(chaos.fake.fixedPricesOn(WHOLESALE).size).toBe(0);
+        const reverted = await prisma.variantChange.count({
+          where: { shopId, priceListGid: WHOLESALE, status: "REVERTED" },
+        });
+        expect(reverted).toBe(variantGids.length);
+      },
+    );
+  });
+
+  it("prices a market and a wholesale catalogue in the same campaign, independently", async () => {
+    await withChaos(
+      "b2b-and-market",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+
+        chaos.fake.addPriceList({
+          id: WHOLESALE,
+          name: "Trade partners",
+          currency: "USD",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 30 },
+          catalog: {
+            id: "gid://shopify/CompanyLocationCatalog/1",
+            title: "Trade",
+            __typename: "CompanyLocationCatalog",
+          },
+          prices: [],
+        });
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/eu",
+          name: "Europe",
+          currency: "EUR",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/eu", title: "EU", __typename: "MarketCatalog" },
+          prices: [],
+        });
+
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: {
+            surfaces: {
+              base: true,
+              priceLists: [WHOLESALE, "gid://shopify/PriceList/eu"],
+            } as never,
+          },
+        });
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Each surface priced from its own baseline in its own currency. The wholesale
+        // list is 30% below base in dollars; the European one is 10% below base in
+        // euros. Neither number is derived from the other.
+        for (const gid of variantGids) {
+          const trade = chaos.fake.priceOf(gid, WHOLESALE);
+          const eu = chaos.fake.priceOf(gid, "gid://shopify/PriceList/eu");
+
+          expect(trade).toBeDefined();
+          expect(eu).toBeDefined();
+          // Different numbers, because each came from its own baseline in its own
+          // currency rather than one being converted from the other.
+          expect(trade).not.toBe(eu);
+        }
+
+        // And both surfaces are ledgered separately, so support can answer "why is this
+        // that price for this buyer" per surface.
+        const bySurface = await prisma.variantChange.groupBy({
+          by: ["priceListGid"],
+          where: { runId: applied.runId, surfaceKind: "MARKET" },
+          _count: true,
+        });
+        expect(bySurface).toHaveLength(2);
+      },
+    );
+  });
+});

--- a/docs/help/concepts/baselines.md
+++ b/docs/help/concepts/baselines.md
@@ -1,0 +1,39 @@
+# What a baseline is
+
+A **baseline** is the price a product would be if no campaign were running. Every campaign
+computes from it — never from what the storefront happens to show right now.
+
+That one sentence is the whole product.
+
+## Why it matters
+
+Suppose a jacket normally sells for £100 and you run 20% off. It becomes £80.
+
+Now suppose next week you run another 20% off, because the first sale is still on and you
+forgot. An app that computes from the *current price* gives you £64. You have accidentally
+discounted 36%. Do it a third time and you are at £51.
+
+Anchor computes from the baseline, so the second campaign gives you £80 again. Running a
+campaign twice does nothing the second time. This is also what makes reverting exact: we
+know what £100 was, because we wrote it down before we touched anything.
+
+## Where baselines come from
+
+- **At install**, we capture whatever your storefront currently shows.
+- **You can import them**, if you keep a list price or MSRP somewhere else. This is the right move if your storefront prices are already discounted — otherwise "20% off" means 20% off a sale price.
+- **New products** get a baseline captured when they first enter a campaign's scope.
+
+## When to recapture
+
+Recapture when your *normal* prices have genuinely changed — a supplier price rise, a new
+season.
+
+Do **not** recapture while a campaign is running. You would be recording the sale price as
+the new normal, and every future discount would come off the discounted number. The app
+asks you to type a confirmation for exactly this reason, and tells you which campaigns are
+live at the time.
+
+## Related
+
+- [Why revert recomputes](./revert.md)
+- [Importing your own prices](../how-to/import-baselines.md)

--- a/docs/help/concepts/drift.md
+++ b/docs/help/concepts/drift.md
@@ -1,0 +1,37 @@
+# What drift means
+
+**Drift** is when a price on your storefront is not what this app last wrote.
+
+It is not an error, and it is usually not a problem. It means somebody or something else
+changed the price: you edited it in Shopify admin, another app touched it, or a bulk import
+ran.
+
+## Why we track it
+
+Because the alternative is worse. If we ignored manual edits, the next revert would
+overwrite them without asking — and a merchant who deliberately repriced one product would
+find the app had quietly undone it. If we overwrote silently in the other direction, the
+app's own ledger would be lying about what is live.
+
+So drift is surfaced and you decide.
+
+## What to do about it
+
+On the **What is live** page, anything drifted is flagged with both numbers: what we wrote
+and what is there now.
+
+- **Keep the change** — the app adopts the new price and stops flagging it.
+- **Put it back** — the app rewrites what the campaign says it should be.
+
+When you revert a campaign, drifted products are listed separately with a tick box, so
+ending a sale never silently discards a price you set on purpose.
+
+## Drift versus off baseline
+
+Different things, easily confused:
+
+- **Off baseline** means the price differs from its normal price. That is what a sale *is*. Expected.
+- **Drifted** means the price differs from what *we* wrote. That is somebody else's change.
+
+A product on sale is off baseline and not drifted. A product on sale that somebody then
+edited by hand is both.

--- a/docs/help/concepts/rate-limits.md
+++ b/docs/help/concepts/rate-limits.md
@@ -1,0 +1,31 @@
+# How rate limits affect a run
+
+Shopify limits how fast any app can talk to your store. When a campaign hits that limit,
+this app slows down rather than failing.
+
+## What you will see
+
+A run taking longer than you expected, with the ledger still filling in. That is the
+system working: the alternative is a run that fails halfway and leaves you to work out
+which products changed.
+
+## Why we do not just go faster
+
+The limit is a bucket that refills at a fixed rate. Sending more requests when it is empty
+gets them rejected, and repeatedly rejected requests make Shopify throttle the store
+harder — so pushing makes the whole thing slower, not faster.
+
+The app reads the remaining budget from Shopify's own response on every call rather than
+assuming a number, because the limits differ by Shopify plan.
+
+## Large catalogues
+
+Above a few thousand products the app switches to Shopify's bulk operation API, which is
+designed for exactly this and does not consume the same budget. You do not choose this —
+the app picks the path and the preview tells you which one it will use and why.
+
+## Nothing is lost
+
+A throttled run is not a failed run. Every price is recorded before it is written, so a
+run that is interrupted at any point is resumable and the ledger says exactly where it
+got to.

--- a/docs/help/concepts/resolver.md
+++ b/docs/help/concepts/resolver.md
@@ -1,0 +1,38 @@
+# How overlapping campaigns resolve
+
+Two campaigns can cover the same product. They never stack.
+
+## One winner per product
+
+For each product, exactly one campaign controls the price. The winner is:
+
+1. The campaign with the **highest priority**.
+2. If two have the same priority, the one that **started most recently**.
+
+Everything else is ignored for that product — not applied on top.
+
+## Why not stack?
+
+Because stacking is how merchants end up giving away 60% by accident. Two 20% campaigns
+and a 30% clearance are, stacked, a 55% discount that nobody chose. Every merchant who has
+lost money to a pricing app has lost it this way.
+
+If you *want* a deeper discount on some products, that is a campaign with a higher priority
+and a bigger number — a thing you decided, visible in one place.
+
+## Seeing it before it happens
+
+The preview on a campaign shows the price each product will get, having already resolved
+every other running campaign. What the preview says is what the run does; they share the
+same code path, so a preview that disagreed with the run would be a bug rather than an
+approximation.
+
+The **calendar** shows which campaigns overlap in time and how many products they share.
+
+## What happens when a campaign ends
+
+The winner is recomputed without it. If a lower-priority campaign still covers the product,
+its price applies. If none does, the product returns to its baseline.
+
+That is why reverting is a recomputation rather than a restore — see
+[Why revert recomputes](./revert.md).

--- a/docs/help/concepts/revert.md
+++ b/docs/help/concepts/revert.md
@@ -1,0 +1,34 @@
+# Why revert recomputes
+
+Reverting a campaign does not restore the prices that were there before. It works out what
+the price *should* be now, with that campaign removed, and writes that.
+
+## Why not just put the old prices back?
+
+Because the old price is often wrong by the time you revert.
+
+Say a jacket was £100, your summer sale made it £80, and while that ran you started a
+clearance campaign that made it £70. Now you end the summer sale. Restoring "what it was
+before summer" gives £100 — but clearance is still running, and that product should be £70.
+
+Recomputing gives £70. It is the only approach that survives overlapping campaigns,
+recurring campaigns, and campaigns that ended in a partial state.
+
+## What this means in practice
+
+- **Ending a sale is safe** even if other campaigns are running.
+- **Reverting a partial run** works: the ledger knows which products were actually written, so only those are touched.
+- **Reverting one product** out of a campaign takes it out for good, including future scheduled runs, and recomputes its price without it.
+
+## If someone changed a price by hand
+
+The revert notices. A product whose live price is not what we wrote is reported as
+**drifted**, and you choose: keep the manual edit, or bring it back in line. We never
+silently overwrite a price a person set — but we never silently ignore it either, because
+that would leave a product that no longer matches what the app believes.
+
+## Related
+
+- [What a baseline is](./baselines.md)
+- [What drift means](./drift.md)
+- [Understanding a partial run](../failures/partial-runs.md)

--- a/docs/help/failures/app-unavailable.md
+++ b/docs/help/failures/app-unavailable.md
@@ -1,0 +1,7 @@
+# The app is not responding
+
+This is our database, not your store. **No prices were changed.**
+
+Nothing you do in Shopify is affected while this is happening. Campaigns that were scheduled will run when the app recovers; scheduled reverts are not lost.
+
+Try again shortly. If it continues, the error reference on screen identifies exactly what happened.

--- a/docs/help/failures/form-validation.md
+++ b/docs/help/failures/form-validation.md
@@ -1,0 +1,5 @@
+# Some values need fixing
+
+The form is refusing to save because something on it would produce a price you would not want.
+
+Each field says what is wrong. The common ones: a percentage above 100, a compare-at price below the price it is compared to, or a date in the past on a schedule.

--- a/docs/help/failures/guardrail-blocks.md
+++ b/docs/help/failures/guardrail-blocks.md
@@ -1,0 +1,35 @@
+# A guardrail stopped the run
+
+A guardrail is a floor no campaign may price below. When one blocks a run, the app refused
+to write a price rather than writing one you would not have wanted.
+
+## The three floors
+
+- **Never price at or below cost** — needs a cost on the variant. Variants without one are skipped, which is why importing costs matters if you rely on this.
+- **Minimum margin** — a percentage of the selling price.
+- **Minimum price** — an absolute number, whatever the rule computes.
+
+## Why it stopped everything rather than skipping one product
+
+That is a setting: *when a price would breach a floor*.
+
+- **Clamp** raises the price to the floor and carries on. The default.
+- **Skip** leaves that product alone and prices the rest.
+- **Block** stops the whole campaign.
+
+Block exists for the case where one product breaching a floor means the rule itself is
+wrong — a misplaced decimal point in a percentage, say — and pricing the other forty
+thousand products would be the actual disaster.
+
+## Floors are checked after rounding
+
+A rounding rule can push an otherwise-legal price under the line. Checking before rounding
+would let that through, so the order is: compute, round, then check.
+
+## What to do
+
+The message names the product and the floor it breached. Either lower the floor in
+Settings, exclude that product from the campaign, or change the rule.
+
+If most of your catalogue has no cost, cost-based floors are protecting less than you
+think — the Settings page shows what percentage of your variants have one.

--- a/docs/help/failures/missing-record.md
+++ b/docs/help/failures/missing-record.md
@@ -1,0 +1,5 @@
+# That campaign or record no longer exists
+
+It was deleted, or the link is from an older session.
+
+Campaign history is kept indefinitely, so if you expected to find something here and it is gone, it was deleted deliberately rather than expired.

--- a/docs/help/failures/partial-runs.md
+++ b/docs/help/failures/partial-runs.md
@@ -1,0 +1,34 @@
+# Understanding a partial run
+
+A run is **partial** when some products were priced and some were not.
+
+This is a normal outcome, not a crash. Shopify rate-limits, a product gets deleted
+mid-run, a variant is rejected — on a large catalogue something eventually goes wrong, and
+the honest response is to say so rather than to report success and hope.
+
+## What partial guarantees
+
+- Every product that was written is recorded, with the price we wrote.
+- Every product that was not is recorded, with the reason.
+- Nothing is half-written. A price either changed and was read back and confirmed, or it did not change.
+
+## What to do
+
+Open the campaign and read the ledger. Each unfinished row says why.
+
+**Resume** picks up exactly where it stopped. It does not replan and it does not rewrite
+products that already succeeded, so resuming is safe however many times you do it.
+
+If the reason was a deleted product or a rejected variant, resuming will not help those
+rows — fix the product in Shopify first, or exclude it.
+
+## Why the campaign says "partial" rather than "active"
+
+Because it is. A campaign showing ACTIVE means every product it covers is at its campaign
+price. If some are not, saying ACTIVE would be a lie, and every decision you made on the
+strength of it would be built on that lie.
+
+## Related
+
+- [Why revert recomputes](../concepts/revert.md)
+- [When Shopify is unreachable](./shopify-unreachable.md)

--- a/docs/help/failures/session-expired.md
+++ b/docs/help/failures/session-expired.md
@@ -1,0 +1,5 @@
+# Your session expired
+
+Shopify signs you out of embedded apps periodically. Reload the page and you will be signed back in.
+
+Nothing was changed in your store. If a campaign was running, it is running in the background — it does not depend on your browser being open.

--- a/docs/help/failures/shopify-unreachable.md
+++ b/docs/help/failures/shopify-unreachable.md
@@ -1,0 +1,7 @@
+# Could not reach Shopify
+
+Usually brief. Shopify has planned maintenance and occasional incidents like anything else.
+
+Any run that had started is safe to resume: every price we wrote was recorded before we wrote it, so nothing is half-written and nothing is lost. Try again in a minute.
+
+If it persists, check [Shopify's status page](https://www.shopifystatus.com/).

--- a/docs/help/failures/store-disconnected.md
+++ b/docs/help/failures/store-disconnected.md
@@ -1,0 +1,5 @@
+# This store is no longer connected
+
+The app's access to your store has been revoked or has expired. This happens if the app was uninstalled, or if a token expired and was not refreshed.
+
+Reinstall the app from your Shopify admin. Your campaigns, baselines and history are all still here — they are keyed to the store, not to the connection.

--- a/docs/help/failures/stuck-runs.md
+++ b/docs/help/failures/stuck-runs.md
@@ -1,0 +1,31 @@
+# A run that seems stuck
+
+A run showing "Applying…" for a long time is usually one of three things.
+
+## It is genuinely still working
+
+A campaign over a large catalogue takes minutes, sometimes longer. Shopify rate-limits per
+store, and the app deliberately slows down rather than hammering — hammering gets the
+store throttled harder and takes longer overall.
+
+The ledger updates as it goes. If verified rows are still climbing, it is working.
+
+## Shopify is rate-limiting
+
+Normal on a big run. The app backs off and continues; nothing is lost and nothing is
+half-written. There is nothing to do.
+
+## The process running it stopped
+
+Rare, but it happens — a deploy, a restart, an out-of-memory. The app detects this: a run
+that stops reporting for five minutes is reclaimed automatically, marked **partial**, and
+becomes resumable.
+
+You do not need to do anything to trigger that, and you should not try to force it. A run
+that is merely slow, reclaimed early, would be two processes believing they own the same
+work.
+
+## What never happens
+
+A stuck run does not leave prices half-written in a way nobody can see. Every price we
+write is recorded before we write it, so however a run ends, the ledger says what is live.

--- a/docs/help/failures/unexpected.md
+++ b/docs/help/failures/unexpected.md
@@ -1,0 +1,5 @@
+# Something went wrong
+
+An error we did not anticipate. The reference on screen identifies it precisely — quote it if you get in touch.
+
+**Nothing was changed in your store** unless a run reported otherwise. If a campaign was running, open it: the ledger shows exactly which products were written before the failure, and resuming picks up from there.

--- a/docs/help/how-to/first-campaign.md
+++ b/docs/help/how-to/first-campaign.md
@@ -1,0 +1,45 @@
+# Your first campaign
+
+Fifteen minutes, and nothing touches your storefront until you say so.
+
+## 1. Check your baselines
+
+Open **Baselines**. These are the prices every campaign will compute from — captured when
+you installed the app.
+
+**If your storefront prices are currently discounted**, stop and
+[import your real prices](./import-baselines.md) first. Otherwise "20% off" will mean 20%
+off a sale price, permanently.
+
+## 2. Create a campaign
+
+**Campaigns → New campaign.**
+
+- **Scope** — leave everything blank to target the whole catalogue, or narrow by collection, vendor, tag or title.
+- **Rule** — "percent change from baseline", `-20` for 20% off.
+- **Compare-at** — "set to baseline" gives the strike-through shoppers expect.
+- **Rounding** — `.99` endings if you want them.
+
+## 3. Read the preview
+
+This is the step that matters. The preview shows the price every product will get, having
+already resolved any other campaign that covers it. What it shows is what the run does.
+
+Look at the counts: planned, already correct, skipped, clamped. A large skipped count
+usually means a guardrail is doing something you did not expect.
+
+## 4. Apply
+
+Prices are written and then read back and confirmed. When it finishes, the campaign says
+how many were verified.
+
+## 5. Reverting
+
+One button. It recomputes what each price should be with this campaign removed — which is
+not always the price it was before, and that is deliberate. See
+[why revert recomputes](../concepts/revert.md).
+
+## Try it without the risk
+
+A **practice campaign** does everything above and refuses to write anything, ever. If you
+have fifty thousand products and want to build confidence first, start there.

--- a/docs/help/how-to/import-baselines.md
+++ b/docs/help/how-to/import-baselines.md
@@ -1,0 +1,39 @@
+# Importing your own prices
+
+If you keep an MSRP, list price or RRP somewhere other than Shopify, import it. Every
+campaign will then compute from that number rather than from whatever your storefront
+happened to show the day you installed.
+
+## The file
+
+One row per variant. A SKU, barcode or variant ID, then the price.
+
+```
+Variant SKU,Variant Price
+CH-1,129.00
+CH-2,149.00
+```
+
+A file exported from **Matrixify** works as it is — its column names are recognised.
+
+Prices must be plain numbers: `1299.00`, not `$1,299.00`. Add a currency column if some
+rows are in a different currency from your store's.
+
+## Check before you commit
+
+**Check without importing** runs the whole thing and writes nothing. It reports how many
+rows matched, how many did not, and exactly which rows have problems — with line numbers.
+
+Fix those rows and re-upload. One bad row never rejects the file.
+
+## What "ambiguous" means
+
+A SKU that names two variants is a question, not a match. The app will not guess which one
+you meant, because guessing wrong sets a permanent wrong reference price on a product.
+
+Either make the SKU unique, or use variant IDs.
+
+## Costs
+
+Same shape, with a cost column instead — see **Import costs**. Worth doing if you use the
+"never price below cost" guardrail: without costs, that setting silently protects nothing.

--- a/docs/help/how-to/multi-market-sale.md
+++ b/docs/help/how-to/multi-market-sale.md
@@ -1,0 +1,36 @@
+# Running a sale across several markets
+
+A campaign can price into your markets alongside your base price, with a real
+strike-through in each market's own currency.
+
+## Each market is priced from its own normal price
+
+This is the part that is easy to get wrong and that most tools do get wrong.
+
+If your European market normally sits 10% below your base price, a 20% sale there means
+20% off the *European* price — not the euro equivalent of your base sale price. The two
+are different numbers, and the second one quietly changes your European margin every time
+your base price moves.
+
+The app computes each market from that market's own baseline, through the same rule.
+
+## Currencies round differently
+
+`.99` is what a shopper in dollars reads as a considered price. Yen has no sub-unit for a
+`.99` ending at all.
+
+Set rounding per currency in **Settings → Rounding**, or per campaign in the wizard. A
+currency with no decimal places gets sensible whole-number rounding rather than an ending
+it cannot express.
+
+## Reading the preview
+
+The preview shows one column per market, so you can see the base price, the euro price and
+the yen price for the same product side by side. That is the view that catches a market
+rounding to something strange.
+
+## Reverting
+
+Removes the campaign's prices from every market it touched. A market that normally derives
+its prices as a percentage goes back to doing that, rather than being pinned to numbers you
+never chose.

--- a/docs/help/how-to/schedule-a-sale.md
+++ b/docs/help/how-to/schedule-a-sale.md
@@ -1,0 +1,31 @@
+# Scheduling a sale
+
+Set a start, optionally an end, and the app runs it.
+
+## Times are your store's
+
+Everything is shown and entered in your store's timezone, which the app displays on every
+scheduling field so it is never a guess.
+
+## The revert buffer
+
+A sale ending at midnight starts reverting slightly *before* midnight — five minutes by
+default.
+
+That is deliberate. Writing prices across a large catalogue takes time, and starting the
+revert exactly at the advertised end leaves sale prices live for minutes after the sale is
+over. Merchants get complaints about that, and they are right to.
+
+Adjust the buffer per campaign if your catalogue is large enough to need longer.
+
+## What happens if the app is down at the moment it should start
+
+It starts when the app recovers. Scheduled runs are due-based, not moment-based: the
+scheduler asks "what should have started by now", not "what starts exactly now".
+
+The same applies to reverts, which is the more important half.
+
+## Seeing it in context
+
+The **calendar** shows every scheduled campaign, which ones overlap, and how many products
+they share. Clicking a day opens the wizard already dated to it.

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -1,0 +1,31 @@
+# Anchor help
+
+## Concepts
+
+Unfamiliar ideas that the rest of the product rests on. Worth ten minutes before your
+first campaign.
+
+- [What a baseline is](./concepts/baselines.md) — and why every campaign computes from it
+- [How overlapping campaigns resolve](./concepts/resolver.md) — one winner per product, never stacked
+- [Why revert recomputes](./concepts/revert.md) — rather than restoring old prices
+- [What drift means](./concepts/drift.md) — when somebody changes a price behind the app
+- [How rate limits affect a run](./concepts/rate-limits.md)
+- [How guardrails work](./failures/guardrail-blocks.md) — the floors no campaign may price below
+
+## How to
+
+- [Your first campaign](./how-to/first-campaign.md)
+- [Scheduling a sale](./how-to/schedule-a-sale.md)
+- [Running a sale across several markets](./how-to/multi-market-sale.md)
+- [Importing your own prices](./how-to/import-baselines.md)
+
+## When something goes wrong
+
+- [Understanding a partial run](./failures/partial-runs.md)
+- [A run that seems stuck](./failures/stuck-runs.md)
+- [A guardrail stopped the run](./failures/guardrail-blocks.md)
+- [When Shopify is unreachable](./failures/shopify-unreachable.md)
+- [This store is no longer connected](./failures/store-disconnected.md)
+- [Your session expired](./failures/session-expired.md)
+- [The app is not responding](./failures/app-unavailable.md)
+- [Something went wrong](./failures/unexpected.md)

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,145 @@
+# Runbooks
+
+One page per alert: what it means, how to tell what is actually happening, and what to do
+about it. Written to be read at 3am by somebody who did not build this.
+
+The first question in every incident here is the same one, so it is worth stating once:
+**the ledger is the record of what we did to a merchant's storefront.** `variant_changes`
+holds one row per variant per surface per run, written *before* the API call and settled
+after it. If you want to know what is live and why, that table and the reconciliation view
+over it are the answer — not the logs, and not a guess from the campaign's status.
+
+---
+
+## Alert: mirror divergence above 0.5%
+
+**Metric:** `mirror.divergence_rate`
+
+**What it means.** The nightly audit fresh-read a sample of variants from Shopify and more
+than one in two hundred disagreed with what we hold. Incidental divergence is expected —
+a webhook lost in flight, an edit during the sample. A rate this high is systematic: the
+pipeline is losing changes rather than dropping the occasional one.
+
+**Diagnose.**
+
+1. `SELECT * FROM error_events WHERE "createdAt" > now() - interval '24 hours' ORDER BY "createdAt" DESC LIMIT 50;` — a burst of `SHOPIFY_UNAVAILABLE` around the divergence explains it and needs no action beyond confirming it recovered.
+2. Check webhook delivery in the Partner dashboard. Sustained failures mean Shopify has been unable to reach us; the mirror will be stale until a full re-sync.
+3. `SELECT status, count(*) FROM webhook_events WHERE "receivedAt" > now() - interval '24 hours' GROUP BY status;` — a large PENDING count means we are accepting deliveries and not processing them, which is a worker problem rather than a Shopify one.
+
+**Remediate.** The audit heals what it samples, so the immediate divergence is already
+corrected. For the rest, trigger a catalogue re-sync from the dashboard. It is a bulk
+operation and takes minutes, not seconds, on a large store.
+
+**Do not** turn the alert threshold up. It is set where it is because a rate above it has
+always meant something real.
+
+---
+
+## Alert: scheduler tick stopped
+
+**Metric:** `scheduler.tick` absent for more than three intervals
+
+**What it means.** No worker is holding the leader lock and ticking. Scheduled campaigns
+are not starting and, more importantly, **scheduled reverts are not running** — every
+minute of this is a minute a sale runs past its end.
+
+**Diagnose.**
+
+1. Is the worker process alive? A crash loop shows as repeated startup lines with no ticks between.
+2. Is Redis reachable? The leader lock lives there. Without it no worker will consider itself leader, and the process stays up while doing nothing — which is why this alert exists rather than a process-liveness one.
+3. `SELECT id, status, "startedAt", "heartbeatAt" FROM campaign_runs WHERE status NOT IN ('COMPLETED','FAILED','PARTIAL');` — runs stuck in EXECUTING with an old heartbeat confirm the worker died mid-run.
+
+**Remediate.** Restart the worker. The reaper reclaims stale runs on the next tick and
+marks them PARTIAL, which is resumable and visible to the merchant. Nothing needs manual
+database editing.
+
+**Escalate** if the lock is held by a worker that is alive but not ticking — that is a bug
+worth waking somebody for, because the lock will not expire while it is being renewed.
+
+---
+
+## Alert: queue depth rising
+
+**Metric:** `queue.depth`, per queue
+
+**What it means.** Jobs are arriving faster than they are draining. Which queue matters
+enormously: `audit` backing up is cosmetic, `execution` backing up means merchant
+campaigns are late.
+
+**Diagnose.** Depth alone is not the signal — a bulk import legitimately enqueues a lot.
+Look at whether the floor is rising over hours. Compare against `queue.failed`: a queue
+that is failing every attempt looks like a backlog and is not one.
+
+**Remediate.** Add worker replicas; queue consumers start with the process, so a second
+worker drains immediately without any leadership change. If one queue is stuck behind a
+single poison job, its failure is in `error_events` with the job id.
+
+---
+
+## Alert: a shop's budget saturated
+
+**Metric:** `budget.saturation`
+
+**What it means.** A shop's Shopify rate-limit bucket is near empty and the executor is
+backing off. This is normal during a large campaign and is not by itself a problem — the
+budget manager exists to make it survivable.
+
+**It becomes a problem** when saturation is sustained while `run.duration_ms` climbs on a
+small campaign, which suggests we are competing with something else on that shop rather
+than simply being busy.
+
+**Remediate.** Nothing, usually. Do not raise concurrency to "get through it faster" —
+that makes it worse, because two workers on one shop each back off from the other.
+
+---
+
+## Stuck run recovery
+
+A run that will not finish is almost always one whose process died. The reaper handles
+this automatically after `RUN_STALE_AFTER_MS` (default five minutes), so **the first
+action is to wait one tick and look again.**
+
+If it is genuinely stuck:
+
+1. Find it: `SELECT id, "campaignId", status, "heartbeatAt" FROM campaign_runs WHERE status IN ('EXECUTING','VERIFYING') ORDER BY "startedAt";`
+2. Read what it actually did: the campaign page's ledger, or `SELECT status, count(*) FROM variant_changes WHERE "runId" = '<id>' GROUP BY status;`
+3. Let the reaper have it. Marking it PARTIAL by hand is the same thing the reaper does, and doing it manually risks marking a run that is merely slow.
+
+**Never** delete `variant_changes` rows to "clean up" a stuck run. Those rows are how a
+revert knows what to undo; deleting them strands the merchant's prices with no record of
+how they got there.
+
+**Resume** from the campaign page. A resumed run reads the ledger and continues from the
+rows that never settled — it does not replan.
+
+---
+
+## Data restore
+
+**Objective:** RPO ≤ 5 minutes, RTO ≤ 1 hour.
+
+What actually needs restoring, in order of how badly it hurts to lose:
+
+1. **`variant_changes` and `baselines`.** The ledger and the reference prices. Losing baselines means every campaign computes from the wrong number for ever after; losing the ledger means no revert can be trusted.
+2. **`campaigns` and `campaign_runs`.** Recoverable in principle from the ledger, painfully.
+3. **The mirror** (`variant_index`, `price_surface_entries`). Rebuildable from Shopify with a full sync. Slow but not lossy.
+4. **Sessions.** Rebuildable by reinstalling, at the cost of every merchant reinstalling.
+
+**Procedure.**
+
+1. Stop the worker first. A worker writing prices against a half-restored database is worse than an hour of downtime.
+2. Restore Postgres to the target point in time.
+3. `npm run setup` to apply any migrations the restored snapshot predates.
+4. Run the reconciliation spot check at a large sample *before* starting the worker. If the mirror disagrees with Shopify, sync before scheduling anything — a campaign planned against a stale mirror prices the wrong products.
+5. Start the worker. Reclaim happens on the first tick.
+
+**Rehearse this, do not assume it.** The numbers above are objectives until somebody has
+timed them against a real snapshot.
+
+---
+
+## On-call expectations
+
+- **Page-worthy:** scheduler tick stopped, execution queue depth rising for over an hour, mirror divergence above 0.5%. All three mean merchant prices are wrong or about to be.
+- **Next business day:** audit queue backlog, budget saturation, individual run failures. The app is designed so these are visible and resumable rather than urgent.
+- **Never page for:** a single failed variant, a guardrail block, a drift hold. Those are the product working.


### PR DESCRIPTION
Addresses #161 and #162 (the parts that don't need a deployed environment — see the bottom).

## The linkage is the feature

The criterion that makes a help centre real rather than a wiki nobody reads is that **every merchant-visible error links to the page explaining it**. So that part is code:

- `helpUrlFor` maps every error code to a page, as a `Record` rather than a partial map — adding a code without deciding where a merchant reading it should go is a **type error**.
- A test asserts every linked page exists in the repo. **It caught a broken link on its first run** (`GUARDRAIL_BLOCKED` pointed at a concepts page written under failures). Without it, somebody renames a page, the link still compiles, and a merchant hitting an error at 9pm gets a 404 under the message telling them what went wrong.
- The lookup takes a plain string and falls back, rather than being typed to `ErrorCode`: the code crosses a serialisation boundary into the error boundary, and a mistyped one must not render `https://help…/undefined`.

## Concept docs

The four ideas that are unfamiliar and that the product rests on. Each written around the specific misunderstanding that costs money:

| Doc | The mistake it prevents |
|---|---|
| What a baseline is | Discounts compounding — 20% off twice giving 36% off |
| How campaigns resolve | Expecting campaigns to stack, and giving away 55% |
| Why revert recomputes | Restoring a price that's wrong by the time you restore it |
| What drift means | Silently overwriting a price somebody set on purpose |

## How-tos

First campaign, scheduling, multi-market sale, importing prices. The multi-market one leads with what most tools get wrong: **each market is priced from its own normal price**, not converted from the base sale price.

## Runbooks

Per alert — mirror divergence, tick stopped, queue depth, budget saturation — plus stuck-run recovery, data restore, and on-call expectations.

Written to be read at 3am by somebody who didn't build this, and opinionated where vagueness costs time:

- **Don't** raise the divergence threshold. It's set where it is because a rate above it has always meant something real.
- **Don't** delete ledger rows to clean up a stuck run — those rows are how a revert knows what to undo.
- **Don't** raise concurrency to get through a throttle faster; two workers on one shop each back off from the other.

The restore procedure states its RPO/RTO as **objectives**, and says plainly they stay objectives until somebody has timed them against a real snapshot.

## Not included

Both tickets also ask for drills against a live staging environment with alerting wired up — confirming each alert actually fires and routes to a human. That needs the deployment from #45–#49, which isn't something I can do from here. The runbooks are written so those drills have something to test against.

Publishing the docs to a searchable public site is likewise yours; they're in `docs/help/` with an index, ready to point a static site at.

Full suite: 653 unit tests, 67 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)