### PR TITLE
P6.3 — Bulk cost editing, and noticing what it retroactively breaks

### DIFF
--- a/app/lib/pricing/cost-rules.test.ts
+++ b/app/lib/pricing/cost-rules.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Bulk cost rules.
+ *
+ * A cost is not a price and none of this writes to a storefront — it changes what the app
+ * will refuse to do. Which means the failure mode is a guardrail that quietly stops
+ * guarding, and that is what these test for.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { money } from "../money/money";
+import { applyCostRule, describeCostRule } from "./cost-rules";
+
+const input = (cost?: number) => ({
+  cost: cost === undefined ? undefined : money(cost, "USD"),
+  basePrice: money(10_000, "USD"),
+});
+
+describe("adjusting an existing cost", () => {
+  it("raises by a percentage", () => {
+    expect(applyCostRule({ kind: "percent-change", percent: 4 }, input(5_000))).toEqual({
+      kind: "set",
+      cost: money(5_200, "USD"),
+    });
+  });
+
+  it("adds a fixed amount", () => {
+    expect(
+      applyCostRule({ kind: "fixed-change", amount: money(250, "USD") }, input(5_000)),
+    ).toEqual({ kind: "set", cost: money(5_250, "USD") });
+  });
+
+  it("skips a variant with no cost rather than treating it as zero", () => {
+    // The important one. Reading "no cost" as zero and then raising it by 4% still
+    // gives zero — a floor of nothing on every product the merchant had not filled in,
+    // which turns the guardrail off exactly where it was most needed.
+    expect(applyCostRule({ kind: "percent-change", percent: 4 }, input())).toEqual({
+      kind: "skipped",
+      reason: "no-cost",
+    });
+  });
+
+  it("refuses a rule that would produce a negative cost", () => {
+    // A negative cost makes the margin floor negative, which silently disables the
+    // guardrail rather than tightening it.
+    expect(
+      applyCostRule({ kind: "fixed-change", amount: money(-9_000, "USD") }, input(5_000)),
+    ).toEqual({ kind: "skipped", reason: "not-positive" });
+  });
+});
+
+describe("setting a cost outright", () => {
+  it("sets an exact amount, whether or not there was a cost before", () => {
+    expect(applyCostRule({ kind: "set-exact", amount: money(4_200, "USD") }, input())).toEqual({
+      kind: "set",
+      cost: money(4_200, "USD"),
+    });
+  });
+
+  it("derives a cost from the baseline price", () => {
+    // For a merchant with no costs at all who knows the catalogue runs around 60%
+    // margin. Rough, and enormously better than a guardrail that protects nothing.
+    expect(applyCostRule({ kind: "share-of-price", percent: 40 }, input())).toEqual({
+      kind: "set",
+      cost: money(4_000, "USD"),
+    });
+  });
+
+  it("allows a cost of zero", () => {
+    // A sample or a giveaway genuinely costs nothing.
+    expect(applyCostRule({ kind: "set-exact", amount: money(0, "USD") }, input(5_000))).toEqual({
+      kind: "set",
+      cost: money(0, "USD"),
+    });
+  });
+
+  it("keeps the price's currency, not the rule's", () => {
+    const outcome = applyCostRule({ kind: "share-of-price", percent: 50 }, {
+      cost: undefined,
+      basePrice: money(1_980, "JPY"),
+    });
+
+    expect(outcome).toEqual({ kind: "set", cost: money(990, "JPY") });
+  });
+});
+
+describe("describing a rule", () => {
+  it("says which direction a percentage goes", () => {
+    expect(describeCostRule({ kind: "percent-change", percent: 4 })).toContain("Raise");
+    expect(describeCostRule({ kind: "percent-change", percent: -4 })).toContain("Lower");
+  });
+
+  it("says which direction a fixed change goes", () => {
+    expect(describeCostRule({ kind: "fixed-change", amount: money(250, "USD") })).toContain("Add");
+    expect(describeCostRule({ kind: "fixed-change", amount: money(-250, "USD") })).toContain(
+      "Subtract",
+    );
+  });
+});

--- a/app/lib/pricing/cost-rules.ts
+++ b/app/lib/pricing/cost-rules.ts
@@ -1,0 +1,95 @@
+/**
+ * Changing costs in bulk, by rule.
+ *
+ * The obvious use is a supplier price rise: every cost in one vendor goes up 4%. The less
+ * obvious one is a merchant who has never recorded costs at all and knows their catalogue
+ * runs at roughly a 60% margin — setting cost as a share of price gets the guardrails
+ * doing something useful today, and they can refine it later.
+ *
+ * A cost is not a price and none of this writes to a storefront. What it changes is what
+ * the app will *refuse* to do, which is why the interesting behaviour lives elsewhere:
+ * see `cost-edit.server.ts` for what happens to a campaign that was legal before the
+ * change and is not after it.
+ */
+
+import { money, type Money } from "../money/money";
+
+export type CostRule =
+  | { kind: "set-exact"; amount: Money }
+  | { kind: "percent-change"; percent: number }
+  | { kind: "fixed-change"; amount: Money }
+  /** Cost as a share of the baseline price — for a catalogue with no costs at all. */
+  | { kind: "share-of-price"; percent: number };
+
+export interface CostRuleInput {
+  /** The variant's current cost, if it has one. */
+  cost?: Money;
+  /** The variant's baseline price, for `share-of-price`. */
+  basePrice: Money;
+}
+
+export type CostOutcome =
+  | { kind: "set"; cost: Money }
+  /** Nothing to compute from — reported rather than guessed at. */
+  | { kind: "skipped"; reason: "no-cost" | "not-positive" };
+
+/**
+ * The new cost for one variant.
+ *
+ * A rule that needs an existing cost skips a variant that has none rather than treating
+ * it as zero. Zero is a real cost — a free sample — and inventing it here would set a
+ * floor of nothing on every product the merchant simply had not filled in, which turns
+ * the guardrail off precisely where it was most needed.
+ */
+export function applyCostRule(rule: CostRule, input: CostRuleInput): CostOutcome {
+  const currency = input.basePrice.currency;
+
+  switch (rule.kind) {
+    case "set-exact":
+      return positive(rule.amount);
+
+    case "share-of-price":
+      return positive(money(Math.round((input.basePrice.amount * rule.percent) / 100), currency));
+
+    case "percent-change": {
+      if (!input.cost) return { kind: "skipped", reason: "no-cost" };
+      return positive(
+        money(Math.round(input.cost.amount * (1 + rule.percent / 100)), currency),
+      );
+    }
+
+    case "fixed-change": {
+      if (!input.cost) return { kind: "skipped", reason: "no-cost" };
+      return positive(money(input.cost.amount + rule.amount.amount, currency));
+    }
+  }
+}
+
+/**
+ * A cost must not be negative.
+ *
+ * Zero is allowed — a giveaway genuinely costs nothing — but a negative cost would make
+ * `priceForMargin` produce a negative floor, which silently disables the guardrail rather
+ * than tightening it.
+ */
+function positive(cost: Money): CostOutcome {
+  return cost.amount < 0 ? { kind: "skipped", reason: "not-positive" } : { kind: "set", cost };
+}
+
+/** What the rule does, for the confirmation screen. */
+export function describeCostRule(rule: CostRule): string {
+  switch (rule.kind) {
+    case "set-exact":
+      return `Set every matching cost to ${(rule.amount.amount / 100).toFixed(2)}`;
+    case "percent-change":
+      return rule.percent >= 0
+        ? `Raise every matching cost by ${rule.percent}%`
+        : `Lower every matching cost by ${Math.abs(rule.percent)}%`;
+    case "fixed-change":
+      return rule.amount.amount >= 0
+        ? `Add ${(rule.amount.amount / 100).toFixed(2)} to every matching cost`
+        : `Subtract ${(Math.abs(rule.amount.amount) / 100).toFixed(2)} from every matching cost`;
+    case "share-of-price":
+      return `Set every matching cost to ${rule.percent}% of its normal price`;
+  }
+}

--- a/app/routes/app.costs._index.tsx
+++ b/app/routes/app.costs._index.tsx
@@ -1,0 +1,233 @@
+/**
+ * Editing costs in bulk, and the warning that follows.
+ *
+ * The editor is straightforward. The banner above it is the point: a cost change can put
+ * a campaign that is already running below its own floor, and nothing about the storefront
+ * changes to say so. No run fails, nothing alerts, and the merchant loses money on every
+ * sale until somebody notices.
+ *
+ * We report it and stop there. Repricing a live campaign because a cost moved would be the
+ * app changing prices on its own initiative — the one thing it must never do — and a
+ * merchant may well decide to honour the sale and take the margin hit.
+ */
+
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useRef } from "react";
+import { useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { shopCurrency } from "../services/settings.server";
+import { editCosts, newlyViolating, type CostEditResult } from "../services/cost-edit.server";
+import { describeCostRule, type CostRule } from "../lib/pricing/cost-rules";
+import { money } from "../lib/money/money";
+import { format } from "../lib/money/format";
+import { facets, type FilterAst } from "../services/segments.server";
+import { actorFor } from "../lib/audit/actor";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+
+export const loader = withGuard("/app/costs", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const [available, currency, withCost, variants, violations] = await Promise.all([
+    facets(shop.id),
+    shopCurrency(shop.id),
+    prisma.variantIndex.count({ where: { shopId: shop.id, cost: { not: null }, deletedAt: null } }),
+    prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } }),
+    newlyViolating(shop.id),
+  ]);
+
+  return {
+    currency,
+    withCost,
+    variants,
+    vendors: available.vendors,
+    violations: violations.slice(0, 25).map((violation) => ({
+      campaignId: violation.campaignId,
+      campaignName: violation.campaignName,
+      title: violation.title,
+      live: format(violation.live),
+      floor: format(violation.floor),
+    })),
+    violationCount: violations.length,
+  };
+});
+
+type ActionData = { ok: boolean; message: string; result?: CostEditResult };
+
+export const action = withGuard("/app/costs", async ({ request }: ActionFunctionArgs) => {
+  const { session, sessionToken } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  const currency = await shopCurrency(shop.id);
+  const amount = Number(form.get("value") ?? 0);
+  const kind = String(form.get("ruleKind") ?? "percent-change");
+
+  const rule: CostRule =
+    kind === "set-exact"
+      ? { kind: "set-exact", amount: money(Math.round(amount * 100), currency) }
+      : kind === "fixed-change"
+        ? { kind: "fixed-change", amount: money(Math.round(amount * 100), currency) }
+        : kind === "share-of-price"
+          ? { kind: "share-of-price", percent: amount }
+          : { kind: "percent-change", percent: amount };
+
+  const vendor = String(form.get("vendor") ?? "").trim();
+  const ast: FilterAst = vendor ? { groups: [{ conditions: [{ field: "vendor", value: vendor }] }] } : { groups: [] };
+
+  const dryRun = String(form.get("intent")) !== "commit";
+  const result = await editCosts(shop.id, ast, rule, {
+    dryRun,
+    actor: actorFor(sessionToken, session.shop),
+  });
+
+  return {
+    ok: true,
+    result,
+    message: dryRun
+      ? `${describeCostRule(rule)}: ${result.changed} of ${result.matched} would change. Nothing has been written.`
+      : `${result.changed} costs updated.`,
+  };
+});
+
+export default function Costs() {
+  const { currency, withCost, variants, vendors, violations, violationCount } =
+    useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const busy = fetcher.state !== "idle";
+
+  const form = useRef<HTMLFormElement>(null);
+  const intent = useRef<HTMLInputElement>(null);
+
+  const submitWith = (value: string) => {
+    if (intent.current) intent.current.value = value;
+    form.current?.requestSubmit();
+  };
+
+  const coverage = variants === 0 ? 0 : Math.round((withCost / variants) * 100);
+
+  return (
+    <s-page heading="Costs">
+      {violationCount > 0 ? (
+        <s-banner tone="critical">
+          <s-heading>A cost change has put live prices below your floor</s-heading>
+          <s-paragraph>
+            {violationCount} {violationCount === 1 ? "product is" : "products are"} selling
+            below what your guardrails allow. Nothing on your storefront changed — the cost
+            did, and these prices were set before it.
+          </s-paragraph>
+          <s-unordered-list>
+            {violations.map((violation) => (
+              <s-list-item key={`${violation.campaignId}-${violation.title}`}>
+                {violation.title} — selling at {violation.live}, floor is {violation.floor} (
+                {violation.campaignName})
+              </s-list-item>
+            ))}
+          </s-unordered-list>
+          <s-paragraph>
+            <s-text>
+              Re-preview the campaign to reprice these, or leave them if you would rather
+              honour the sale. We will not change them on our own.
+            </s-text>
+          </s-paragraph>
+        </s-banner>
+      ) : null}
+
+      <s-section heading="What your cost floors can protect">
+        <s-paragraph>
+          <s-text>
+            {withCost} of {variants} variants have a cost ({coverage}%). Cost-based
+            guardrails skip the rest entirely, so a low number here means &ldquo;never
+            price below cost&rdquo; is doing less than it looks.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-link href="/app/costs/import">Import costs from a spreadsheet</s-link>
+        </s-paragraph>
+      </s-section>
+
+      <s-section heading="Change costs in bulk">
+        {fetcher.data ? (
+          <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
+            <s-paragraph>{fetcher.data.message}</s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <fetcher.Form method="post" ref={form}>
+          {/* `s-button` takes no name/value, so the intent rides in a hidden field the
+              buttons set before submitting. One form, because both actions read the same
+              rule and duplicating the fields would let them drift apart. */}
+          <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
+          <s-stack gap="base">
+            <s-select name="vendor" label="Which products">
+              <s-option value="" defaultSelected>
+                Every product
+              </s-option>
+              {vendors.map((vendor) => (
+                <s-option key={vendor} value={vendor}>
+                  {vendor}
+                </s-option>
+              ))}
+            </s-select>
+
+            <s-select name="ruleKind" label="Change">
+              <s-option value="percent-change" defaultSelected>
+                Adjust the existing cost by a percentage
+              </s-option>
+              <s-option value="fixed-change">Add or subtract a fixed amount</s-option>
+              <s-option value="set-exact">Set an exact cost</s-option>
+              <s-option value="share-of-price">
+                Set cost to a percentage of the normal price
+              </s-option>
+            </s-select>
+
+            <s-number-field
+              name="value"
+              label={`Amount (percent, or ${currency})`}
+              defaultValue="4"
+              details="Products with no cost are skipped by the first two rules rather than treated as zero."
+            />
+
+            <s-stack direction="inline" gap="base">
+              <s-button
+                type="button"
+                variant="primary"
+                loading={busy || undefined}
+                onClick={() => submitWith("dry-run")}
+              >
+                Check without changing
+              </s-button>
+              <s-button
+                type="button"
+                tone="critical"
+                loading={busy || undefined}
+                onClick={() => submitWith("commit")}
+              >
+                Change these costs
+              </s-button>
+            </s-stack>
+          </s-stack>
+        </fetcher.Form>
+
+        {fetcher.data?.result && fetcher.data.result.skipped.length > 0 ? (
+          <s-unordered-list>
+            {fetcher.data.result.skipped.slice(0, 10).map((entry) => (
+              <s-list-item key={entry.variantGid}>{entry.reason}</s-list-item>
+            ))}
+          </s-unordered-list>
+        ) : null}
+      </s-section>
+    </s-page>
+  );
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -28,7 +28,7 @@ export default function App() {
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/baselines">Baselines</s-link>
         <s-link href="/app/baselines/import">Import baselines</s-link>
-        <s-link href="/app/costs/import">Import costs</s-link>
+        <s-link href="/app/costs">Costs</s-link>
         <s-link href="/app/reconciliation">What is live</s-link>
         <s-link href="/app/drift">Drift</s-link>
         <s-link href="/app/activity">Activity</s-link>

--- a/app/services/cost-edit.server.ts
+++ b/app/services/cost-edit.server.ts
@@ -1,0 +1,277 @@
+/**
+ * Editing costs in bulk, and noticing what that breaks.
+ *
+ * The bulk edit is the easy half. The half that matters is this: **changing a cost can
+ * retroactively invalidate a campaign that is already running.** A sale planned when a
+ * jacket cost £40 was comfortably above the margin floor; after the supplier raises it to
+ * £55, the live price is below cost and has been since the moment the cost changed.
+ *
+ * Nothing about the storefront changed, so nothing alerts, and no run failed. The
+ * merchant is losing money on every sale and the only thing that could tell them is the
+ * app that knows both numbers. That is what `newlyViolating` is for.
+ *
+ * It reports rather than acts. Automatically repricing a live campaign because a cost
+ * moved would be the app changing prices on its own initiative, which is the one thing it
+ * must never do — and the merchant may well want to honour the sale and eat the margin.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { computeFloor, MissingCostError } from "../lib/pricing/guardrails";
+import { applyCostRule, type CostRule } from "../lib/pricing/cost-rules";
+import { money, type Money } from "../lib/money/money";
+import { astToWhere, type FilterAst } from "./segments.server";
+import { guardrailsFor } from "./settings.server";
+
+export interface CostEditResult {
+  matched: number;
+  changed: number;
+  /** Variants the rule could not compute a cost for, with why. */
+  skipped: Array<{ variantGid: string; reason: string }>;
+  dryRun: boolean;
+}
+
+/**
+ * Applies a cost rule across a scope.
+ *
+ * Costs are written by superseding the current baseline rather than editing it, because
+ * baselines are append-only and "what did this cost in March" is a question somebody asks
+ * after a margin looks wrong. The price on the new row is copied unchanged: this is a
+ * cost edit, and quietly recapturing the price at the same time would be the single most
+ * destructive thing this function could do.
+ */
+export async function editCosts(
+  shopId: string,
+  ast: FilterAst,
+  rule: CostRule,
+  options: { dryRun?: boolean; actor?: string } = {},
+): Promise<CostEditResult> {
+  const result: CostEditResult = {
+    matched: 0,
+    changed: 0,
+    skipped: [],
+    dryRun: options.dryRun === true,
+  };
+
+  const variants = await prisma.variantIndex.findMany({
+    where: astToWhere(shopId, ast),
+    select: { variantGid: true },
+  });
+  result.matched = variants.length;
+  if (variants.length === 0) return result;
+
+  const gids = variants.map((row) => row.variantGid);
+
+  const baselines = await prisma.baseline.findMany({
+    where: {
+      shopId,
+      surfaceKind: "BASE",
+      priceListGid: "",
+      supersededAt: null,
+      variantGid: { in: gids },
+    },
+  });
+
+  const now = new Date();
+
+  for (const baseline of baselines) {
+    const currency = baseline.currency;
+    const outcome = applyCostRule(rule, {
+      cost: baseline.cost === null ? undefined : money(Number(baseline.cost), currency),
+      basePrice: money(Number(baseline.basePrice), currency),
+    });
+
+    if (outcome.kind === "skipped") {
+      result.skipped.push({
+        variantGid: baseline.variantGid,
+        reason:
+          outcome.reason === "no-cost"
+            ? "This rule adjusts an existing cost and this variant has none. Import a cost, or use a rule that sets one."
+            : "That rule produces a negative cost.",
+      });
+      continue;
+    }
+
+    // Unchanged is not a write. Superseding a baseline to store the number it already
+    // holds would add a version to its history that says nothing happened.
+    if (baseline.cost !== null && Number(baseline.cost) === outcome.cost.amount) continue;
+
+    result.changed += 1;
+    if (result.dryRun) continue;
+
+    await prisma.$transaction([
+      prisma.baseline.update({
+        where: { id: baseline.id },
+        data: { supersededAt: now },
+      }),
+      prisma.baseline.create({
+        data: {
+          shopId,
+          variantGid: baseline.variantGid,
+          surfaceKind: baseline.surfaceKind,
+          priceListGid: baseline.priceListGid,
+          currency,
+          // Copied unchanged. This is a cost edit; recapturing the price here would
+          // silently enshrine whatever the storefront currently shows as the new normal.
+          basePrice: baseline.basePrice,
+          baseCompareAt: baseline.baseCompareAt,
+          cost: BigInt(outcome.cost.amount),
+          source: baseline.source,
+          capturedBy: options.actor ?? null,
+        },
+      }),
+      prisma.variantIndex.updateMany({
+        where: { shopId, variantGid: baseline.variantGid },
+        data: { cost: BigInt(outcome.cost.amount) },
+      }),
+    ]);
+  }
+
+  if (!result.dryRun && result.changed > 0) {
+    await prisma.auditLogEntry.create({
+      data: {
+        shopId,
+        actor: options.actor ?? null,
+        action: "cost.bulk-edit",
+        entity: "cost",
+        after: { rule: rule.kind, matched: result.matched, changed: result.changed } as never,
+      },
+    });
+  }
+
+  logger.info("costs edited", {
+    shopId,
+    rule: rule.kind,
+    matched: result.matched,
+    changed: result.changed,
+    skipped: result.skipped.length,
+    dryRun: result.dryRun,
+  });
+
+  return result;
+}
+
+export interface FloorViolation {
+  campaignId: string;
+  campaignName: string;
+  variantGid: string;
+  title: string;
+  /** What the storefront charges right now. */
+  live: Money;
+  /** What the guardrail now says is the minimum. */
+  floor: Money;
+}
+
+/**
+ * Live prices that are now below a floor, because a cost moved.
+ *
+ * Checked against the *live* price rather than against what the campaign intended,
+ * because the intent was legal when it was planned. What matters is that the storefront
+ * is charging less than the merchant's own policy allows, right now.
+ *
+ * Keyed on the *ledger row* still being VERIFIED, not on the campaign's status. Those
+ * sound equivalent and are not: a reverted row is REVERTED and drops out by itself, but a
+ * campaign someone cancelled without reverting still has VERIFIED rows and still has
+ * discounted prices on the storefront. Filtering by campaign status would have hidden
+ * exactly that case — the merchant is losing money either way, and the campaign's label
+ * has no bearing on it.
+ */
+export async function newlyViolating(shopId: string): Promise<FloorViolation[]> {
+  const guardrails = await guardrailsFor(shopId);
+
+  // Nothing cost-dependent configured means a cost change cannot invalidate anything.
+  // `computeFloor` would reach the same conclusion per variant; this skips the queries
+  // entirely for the many shops that never set a cost floor.
+  if (!guardrails.neverBelowCost && guardrails.minMarginPercent === undefined) return [];
+
+  const written = await prisma.variantChange.findMany({
+    where: {
+      shopId,
+      status: "VERIFIED",
+      surfaceKind: "BASE",
+    },
+    select: {
+      variantGid: true,
+      run: { select: { campaignId: true, campaign: { select: { name: true } } } },
+    },
+    distinct: ["variantGid"],
+    take: 10_000,
+  });
+
+  if (written.length === 0) return [];
+
+  const gids = written.map((row) => row.variantGid);
+
+  const [baselines, entries, titles] = await Promise.all([
+    prisma.baseline.findMany({
+      where: {
+        shopId,
+        surfaceKind: "BASE",
+        priceListGid: "",
+        supersededAt: null,
+        variantGid: { in: gids },
+      },
+      select: { variantGid: true, basePrice: true, baseCompareAt: true, cost: true, currency: true },
+    }),
+    prisma.priceSurfaceEntry.findMany({
+      where: { shopId, surfaceKind: "BASE", priceListGid: "", variantGid: { in: gids } },
+      select: { variantGid: true, livePrice: true, currency: true },
+    }),
+    prisma.variantIndex.findMany({
+      where: { shopId, variantGid: { in: gids } },
+      select: { variantGid: true, title: true },
+    }),
+  ]);
+
+  const baselineBy = new Map(baselines.map((row) => [row.variantGid, row]));
+  const liveBy = new Map(entries.map((row) => [row.variantGid, row]));
+  const titleBy = new Map(titles.map((row) => [row.variantGid, row.title]));
+
+  const violations: FloorViolation[] = [];
+
+  for (const row of written) {
+    const baseline = baselineBy.get(row.variantGid);
+    const live = liveBy.get(row.variantGid);
+    if (!baseline || !live || live.livePrice === null) continue;
+
+    const currency = baseline.currency || live.currency || "USD";
+
+    let floor: Money | undefined;
+    try {
+      floor = computeFloor(
+        {
+          price: money(Number(baseline.basePrice), currency),
+          compareAtPrice: baseline.baseCompareAt === null
+            ? undefined
+            : money(Number(baseline.baseCompareAt), currency),
+          cost: baseline.cost === null ? undefined : money(Number(baseline.cost), currency),
+        },
+        guardrails,
+      );
+    } catch (error) {
+      // A variant with no cost under an "error" policy. Not a violation — it is a
+      // variant the guardrail cannot judge, and reporting it here would mix "this is
+      // losing money" with "we cannot tell", which are different problems.
+      if (error instanceof MissingCostError) continue;
+      throw error;
+    }
+
+    if (!floor) continue;
+
+    const livePrice = Number(live.livePrice);
+    if (livePrice >= floor.amount) continue;
+
+    violations.push({
+      campaignId: row.run.campaignId,
+      campaignName: row.run.campaign.name,
+      variantGid: row.variantGid,
+      title: titleBy.get(row.variantGid) ?? row.variantGid,
+      live: money(livePrice, currency),
+      floor,
+    });
+  }
+
+  // Worst first — the biggest gap between what is charged and what policy allows is the
+  // one costing the most per sale.
+  return violations.sort((a, b) => b.floor.amount - b.live.amount - (a.floor.amount - a.live.amount));
+}

--- a/chaos/scenarios/cost-edit.chaos.ts
+++ b/chaos/scenarios/cost-edit.chaos.ts
@@ -1,0 +1,221 @@
+/**
+ * Editing costs in bulk, and what that does to a campaign already running.
+ *
+ * The bulk edit is the easy half. The half that matters: a sale planned when a jacket
+ * cost £40 was comfortably above the margin floor. The supplier raises the cost to £55.
+ * Nothing about the storefront changed, no run failed, nothing alerts — and the merchant
+ * has been losing money on every sale since the moment the cost moved.
+ *
+ * The only thing that can tell them is the app that knows both numbers.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos, type ChaosContext } from "../harness/scenario";
+
+async function setCostFloor(chaos: ChaosContext) {
+  const shop = await prisma.shop.findUniqueOrThrow({ where: { id: chaos.fixture.shopId } });
+  await prisma.shop.update({
+    where: { id: chaos.fixture.shopId },
+    data: {
+      settings: {
+        ...((shop.settings ?? {}) as object),
+        neverBelowCost: true,
+        violationPolicy: "clamp",
+        missingCostPolicy: "skip",
+      } as never,
+    },
+  });
+}
+
+describe("chaos: editing costs in bulk", () => {
+  it("supersedes the baseline rather than editing it, keeping the price untouched", async () => {
+    await withChaos(
+      "cost-edit-history",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids, baseline } = chaos.fixture;
+
+        const { editCosts } = await import("../../app/services/cost-edit.server");
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 40 });
+
+        for (const gid of variantGids) {
+          const current = await prisma.baseline.findFirstOrThrow({
+            where: { shopId, variantGid: gid, supersededAt: null },
+          });
+
+          // The cost moved and the price did not. Quietly recapturing the price during a
+          // cost edit would enshrine whatever the storefront shows as the new normal,
+          // which is the single most destructive thing this could do.
+          expect(Number(current.cost)).toBe(Math.round(baseline.get(gid)! * 0.4));
+          expect(Number(current.basePrice)).toBe(baseline.get(gid));
+
+          // And the old version is still there, because "what did this cost in March" is
+          // a question somebody asks after a margin looks wrong.
+          const versions = await prisma.baseline.count({ where: { shopId, variantGid: gid } });
+          expect(versions).toBe(2);
+        }
+      },
+    );
+  });
+
+  it("does not write a version when the cost is unchanged", async () => {
+    await withChaos(
+      "cost-edit-noop",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        const { editCosts } = await import("../../app/services/cost-edit.server");
+
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 40 });
+        const after = await prisma.baseline.count({ where: { shopId } });
+
+        const again = await editCosts(shopId, { groups: [] }, {
+          kind: "share-of-price",
+          percent: 40,
+        });
+
+        // A version that says nothing happened is noise in exactly the history somebody
+        // reads when they are already confused.
+        expect(again.changed).toBe(0);
+        expect(await prisma.baseline.count({ where: { shopId } })).toBe(after);
+      },
+    );
+  });
+
+  it("writes nothing on a dry run", async () => {
+    await withChaos(
+      "cost-edit-dry",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        const { editCosts } = await import("../../app/services/cost-edit.server");
+
+        const preview = await editCosts(shopId, { groups: [] }, {
+          kind: "share-of-price",
+          percent: 40,
+        }, { dryRun: true });
+
+        expect(preview.changed).toBe(3);
+        expect(await prisma.baseline.count({ where: { shopId, cost: { not: null } } })).toBe(0);
+      },
+    );
+  });
+
+  it("flags a running campaign that a cost rise has put below its floor", async () => {
+    await withChaos(
+      "cost-edit-invalidates",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const { editCosts, newlyViolating } = await import(
+          "../../app/services/cost-edit.server"
+        );
+
+        // Cost at 50% of price. A 30% sale clears it comfortably.
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 50 });
+        await setCostFloor(chaos);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Nothing wrong yet.
+        expect(await newlyViolating(shopId)).toEqual([]);
+
+        // The supplier raises everything to 90% of the normal price. The live sale price
+        // is now below cost, and nothing about the storefront changed to say so.
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 90 });
+
+        const violations = await newlyViolating(shopId);
+
+        expect(violations).toHaveLength(variantGids.length);
+        expect(violations[0].campaignId).toBe(chaos.fixture.campaignId);
+        expect(violations[0].live.amount).toBeLessThan(violations[0].floor.amount);
+        // Named, so a merchant can decide per product whether to honour the sale.
+        expect(violations[0].title).toBeTruthy();
+      },
+    );
+  });
+
+  it("flags a cancelled campaign whose prices were never reverted", async () => {
+    await withChaos(
+      "cost-edit-cancelled",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId } = chaos.fixture;
+        const { editCosts, newlyViolating } = await import(
+          "../../app/services/cost-edit.server"
+        );
+
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 50 });
+        await setCostFloor(chaos);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Cancelled without reverting. The prices are still on the storefront.
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { status: "CANCELLED" },
+        });
+
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 90 });
+
+        // The merchant is losing money on every sale, and the campaign's label has no
+        // bearing on that.
+        expect((await newlyViolating(shopId)).length).toBeGreaterThan(0);
+      },
+    );
+  });
+
+  it("reports nothing when no cost-based guardrail is configured", async () => {
+    await withChaos(
+      "cost-edit-no-guardrail",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        const { editCosts, newlyViolating } = await import(
+          "../../app/services/cost-edit.server"
+        );
+
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 90 });
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // A merchant who has not asked for a cost floor has not been promised one.
+        // Flagging here would be the app inventing a policy and then reporting breaches
+        // of it.
+        expect(await newlyViolating(shopId)).toEqual([]);
+      },
+    );
+  });
+
+  it("does not flag prices that have been reverted", async () => {
+    await withChaos(
+      "cost-edit-completed",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        const { editCosts, newlyViolating } = await import(
+          "../../app/services/cost-edit.server"
+        );
+
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 50 });
+        await setCostFloor(chaos);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+        await chaos.revert();
+
+        await editCosts(shopId, { groups: [] }, { kind: "share-of-price", percent: 90 });
+
+        // The ledger rows are REVERTED, so the sale prices are not on the storefront to
+        // be below anything. Note this turns on the *row* status rather than the
+        // campaign's: a campaign cancelled without reverting still has live discounted
+        // prices, and hiding those would be the expensive kind of tidy.
+        expect(await newlyViolating(shopId)).toEqual([]);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Closes #176.

Bulk cost updates by rule, alongside the CSV import from #170. **Included here rather than gated at a top tier**, which is where both RUBIX and Platmart put it.

## The rules

Two real cases: a supplier price rise across a vendor, and a merchant who has never recorded costs but knows the catalogue runs at roughly 60% margin — setting cost as a share of price gets the guardrails doing something useful *today*.

A rule that adjusts an existing cost **skips** a variant that has none rather than treating it as zero. Reading "no cost" as zero and raising it 4% still gives zero: a floor of nothing on every product the merchant simply hadn't filled in — the guardrail switching itself off precisely where it was most needed.

Costs supersede the baseline rather than editing it, so *"what did this cost in March"* stays answerable. **The price is copied across unchanged** — quietly recapturing it during a cost edit would enshrine whatever the storefront currently shows as the new normal, which is the single most destructive thing this code could do.

## The half that matters

**Changing a cost can retroactively invalidate a campaign that's already running.**

A sale planned when a jacket cost £40 was comfortably above the margin floor. The supplier raises it to £55. The live price is now below cost and has been since the moment the cost changed.

Nothing about the storefront changed. No run failed. Nothing alerts. The merchant loses money on every sale — and the only thing that can tell them is the app that knows both numbers.

It **reports and stops there**. Repricing a live campaign because a cost moved would be the app changing prices on its own initiative, and a merchant may well decide to honour the sale and take the hit.

## Two things mutation testing corrected

Both were my code being wrong, not the tests being weak:

- **The violation check filtered on the campaign's status.** That sounds equivalent to filtering on the ledger row and isn't: a reverted row is `REVERTED` and drops out by itself, but a campaign somebody cancelled *without* reverting still has `VERIFIED` rows and still has discounted prices live. The campaign's label has no bearing on whether money is being lost. There's now a scenario for exactly that case.
- **The early return for shops with no cost guardrail** turned out to be an optimisation rather than a guard — `computeFloor` reaches the same conclusion per variant. The comment now says so instead of implying it's load-bearing.

## Tests

10 unit, 7 chaos scenarios.

**Falsified.** Recapturing the price during a cost edit, filtering by campaign status, treating a missing cost as zero, and accepting a negative cost.

Full suite: 679 unit tests, 81 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)