### PR TITLE
Import exact prices as a campaign, not a direct write

### DIFF
--- a/app/lib/planning/plan.ts
+++ b/app/lib/planning/plan.ts
@@ -99,6 +99,7 @@ export function planRun(input: PlanInput): PlanOutcome {
       campaigns: applicable,
       storeGuardrails,
       variantSegmentIds: candidate.segmentIds,
+      importedPrices: candidate.importedPrices,
     });
 
     // A blocking policy stops the whole run. Returning partial rows here would let

--- a/app/lib/planning/types.ts
+++ b/app/lib/planning/types.ts
@@ -34,6 +34,14 @@ export interface PlanCandidate {
   liveCompareAt?: Money;
   /** Segments this variant belongs to, for matching campaign rule rows. */
   segmentIds?: string[];
+  /**
+   * This variant's price in each import that names it, keyed by import id.
+   *
+   * Loaded by the caller, because the planner and resolver do no I/O — the same reason
+   * baselines and live prices are passed in. A `from-import` rule with nothing here
+   * prices nothing, which is correct for a variant the file did not mention.
+   */
+  importedPrices?: Record<string, Money>;
 }
 
 export type PlannedRowStatus = "pending" | "skipped" | "clamped";

--- a/app/lib/pricing/resolver.ts
+++ b/app/lib/pricing/resolver.ts
@@ -105,10 +105,15 @@ export function resolve(input: ResolveInput): Resolution {
 
   let unrounded: Money;
   try {
-    unrounded = applyRule(rule, baseline);
+    unrounded = applyRule(rule, baseline, { importedPrices: input.importedPrices });
   } catch (error) {
     if (error instanceof RuleNotApplicableError) {
-      const reason = error.reason === "invalid-margin" ? "invalid-margin" : "missing-cost";
+      const reason =
+        error.reason === "invalid-margin"
+          ? "invalid-margin"
+          : error.reason === "missing-import"
+            ? "missing-import"
+            : "missing-cost";
       return winner.guardrailViolationPolicy === "block"
         ? blocked(winner, reason, rule)
         : skipped(winner, reason, rule);

--- a/app/lib/pricing/rules.ts
+++ b/app/lib/pricing/rules.ts
@@ -14,9 +14,19 @@ import {
 } from "../money/money";
 import type { AdjustmentRule, Baseline, RuleRow } from "./types";
 
+/** Per-variant inputs a rule may need that the baseline does not carry. */
+export interface RuleContext {
+  importedPrices?: Record<string, Money>;
+}
+
 export class RuleNotApplicableError extends Error {
   constructor(
-    readonly reason: "missing-cost" | "missing-compare-at" | "invalid-margin",
+    readonly reason:
+      | "missing-cost"
+      | "missing-compare-at"
+      | "invalid-margin"
+      /** The imported file did not name this variant. */
+      | "missing-import",
     message: string,
   ) {
     super(message);
@@ -54,7 +64,12 @@ export function selectRule(
  * on a variant with no cost must never silently treat cost as zero — that would
  * price the item at nothing and report success.
  */
-export function applyRule(rule: AdjustmentRule, baseline: Baseline): Money {
+export function applyRule(
+  rule: AdjustmentRule,
+  baseline: Baseline,
+  /** Per-variant inputs a rule may need that the baseline does not carry. */
+  context: RuleContext = {},
+): Money {
   switch (rule.kind) {
     case "percent-change":
       return applyPercentChange(baseline.price, rule.percent);
@@ -64,6 +79,14 @@ export function applyRule(rule: AdjustmentRule, baseline: Baseline): Money {
 
     case "set-exact":
       return rule.amount;
+
+    case "from-import": {
+      const price = context.importedPrices?.[rule.importId];
+      // A variant the file did not mention. Not an error and not zero: this campaign
+      // simply does not price it, and reporting that is what the skipped count is for.
+      if (!price) throw new RuleNotApplicableError("missing-import", rule.kind);
+      return price;
+    }
 
     case "from-cost-multiplier": {
       const cost = requireCost(baseline, "from-cost-multiplier");

--- a/app/lib/pricing/types.ts
+++ b/app/lib/pricing/types.ts
@@ -48,6 +48,20 @@ export type AdjustmentRule =
    * Margin is a percentage of the *selling price*, the usual retail convention.
    */
   | { kind: "from-cost-margin"; marginPercent: number }
+  /**
+   * The price this variant was given in an imported file.
+   *
+   * A merchant setting prices from a spreadsheet is doing something a rule cannot
+   * express: forty thousand different answers, one per product. Rather than a side door
+   * that writes them directly, the import becomes a campaign whose rule says "look it
+   * up" — so it gets a preview, guardrails, rounding, blast-radius confirmation, per-
+   * market surfaces and a revert, exactly like every other campaign, and for free.
+   *
+   * The rule carries the import's id rather than the prices themselves. A rule row is
+   * stored as JSON on the campaign, and forty thousand prices in a JSON column would be
+   * a second copy of the file that can disagree with the first.
+   */
+  | { kind: "from-import"; importId: string }
   /** Percentage change from the baseline compare-at price. */
   | { kind: "percent-of-compare-at"; percent: number };
 
@@ -184,7 +198,14 @@ export type ResolutionReason =
   | "missing-cost"
   | "invalid-compare-at"
   | "invalid-margin"
-  | "non-positive-price";
+  | "non-positive-price"
+  /**
+   * A `from-import` campaign covers this variant but the file did not name it.
+   *
+   * Its own reason rather than folding into "missing-cost", because the fix is entirely
+   * different: add the row to the file, or narrow the campaign's scope to match it.
+   */
+  | "missing-import";
 
 export interface Resolution {
   /** The price to write. Absent when nothing should be written. */
@@ -207,4 +228,12 @@ export interface ResolveInput {
   storeGuardrails?: Guardrails;
   /** Segment ids this variant belongs to, for matching rule rows. */
   variantSegmentIds?: string[];
+  /**
+   * This variant's price in an imported file, keyed by import id.
+   *
+   * Passed in rather than looked up, because the resolver does no I/O — the same reason
+   * baselines are. A `from-import` rule with nothing here prices nothing, which is the
+   * correct outcome for a variant the file did not mention.
+   */
+  importedPrices?: Record<string, Money>;
 }

--- a/app/routes/app.prices.import.tsx
+++ b/app/routes/app.prices.import.tsx
@@ -1,0 +1,186 @@
+/**
+ * Importing exact prices.
+ *
+ * The file does not set prices — it creates a campaign that does. That is not ceremony:
+ * it is what gives an import a preview, guardrails, rounding, market surfaces and a
+ * revert, all of which a direct write would have had none of, on the one path where a
+ * merchant most needs them.
+ */
+
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useRef } from "react";
+import { redirect, useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { shopCurrency } from "../services/settings.server";
+import {
+  importedVariantGids,
+  importPrices,
+  type PriceImportResult,
+} from "../services/price-import.server";
+import { createCampaign } from "../services/campaigns/index.server";
+import { linesOf } from "../lib/reporting/lines";
+import { actorFor } from "../lib/audit/actor";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { withGuard } from "../lib/errors/guard.server";
+import prisma from "../db.server";
+
+export const loader = withGuard("/app/prices/import", async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  return { currency: await shopCurrency(shop.id) };
+});
+
+type ActionData = { ok: boolean; message: string; result?: PriceImportResult };
+
+export const action = withGuard("/app/prices/import", async ({ request }: ActionFunctionArgs) => {
+  const { session, sessionToken } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  const currency = await shopCurrency(shop.id);
+  const dryRun = String(form.get("intent")) !== "commit";
+  const name = String(form.get("name") ?? "Imported prices").trim() || "Imported prices";
+  const actor = actorFor(sessionToken, session.shop);
+
+  const result = await importPrices(
+    shop.id,
+    name,
+    linesOf(String(form.get("csv") ?? "")),
+    currency,
+    { dryRun, actor },
+  );
+
+  if (dryRun || !result.importId) {
+    return {
+      ok: true,
+      result,
+      message: `${result.ready} of ${result.total} rows matched a product. Nothing has been created yet.`,
+    };
+  }
+
+  // Frozen to exactly the variants the file named. A dynamic filter would let products
+  // added later fall into a campaign whose rule can say nothing about them.
+  const gids = await importedVariantGids(result.importId);
+  const segment = await prisma.segment.create({
+    data: {
+      shopId: shop.id,
+      name: `${name} (imported)`,
+      kind: "FROZEN",
+      filterAst: { groups: [] } as never,
+      frozenVariantGids: gids,
+    },
+  });
+
+  const campaign = await createCampaign(shop.id, {
+    name,
+    ast: { groups: [] },
+    segmentId: segment.id,
+    rule: { kind: "from-import", importId: result.importId },
+    compareAtPolicy: { kind: "leave" },
+    rounding: { default: "none", byCurrency: {} },
+  });
+
+  // Straight to the preview. The whole argument for routing an import through a campaign
+  // is that the merchant sees what it will do before it does it.
+  return redirect(`/app/campaigns/${campaign.id}`);
+});
+
+export default function ImportPrices() {
+  const { currency } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+  const busy = fetcher.state !== "idle";
+  const result = fetcher.data?.result;
+
+  const form = useRef<HTMLFormElement>(null);
+  const intent = useRef<HTMLInputElement>(null);
+
+  const submitWith = (value: string) => {
+    if (intent.current) intent.current.value = value;
+    form.current?.requestSubmit();
+  };
+
+  const problems = result
+    ? [...result.invalid, ...result.unmatched, ...result.ambiguous, ...result.duplicates]
+    : [];
+
+  return (
+    <s-page heading="Import prices">
+      {fetcher.data ? (
+        <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
+          <s-paragraph>{fetcher.data.message}</s-paragraph>
+        </s-banner>
+      ) : null}
+
+      <s-section heading="Set prices from a spreadsheet">
+        <s-paragraph>
+          <s-text>
+            This creates a campaign rather than changing prices straight away. You get a
+            preview of every product first, your guardrails still apply, and you can undo
+            the whole thing in one click &mdash; none of which a direct import would give
+            you.
+          </s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            One row per variant: a SKU, barcode or variant ID, then the price. Prices are
+            read in {currency} and must be plain numbers. A Matrixify export works as it
+            is.
+          </s-text>
+        </s-paragraph>
+
+        <fetcher.Form method="post" ref={form}>
+          <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
+          <s-stack gap="base">
+            <s-text-field name="name" label="Call this" defaultValue="Imported prices" />
+            <s-text-area
+              name="csv"
+              label="Rows"
+              rows={12}
+              placeholder={"Variant SKU,Variant Price\nCH-1,129.00\nCH-2,149.00"}
+              details="Paste straight from a spreadsheet."
+            />
+
+            <s-stack direction="inline" gap="base">
+              <s-button
+                type="button"
+                variant="primary"
+                loading={busy || undefined}
+                onClick={() => submitWith("dry-run")}
+              >
+                Check the file
+              </s-button>
+              <s-button
+                type="button"
+                loading={busy || undefined}
+                onClick={() => submitWith("commit")}
+              >
+                Create a campaign from it
+              </s-button>
+            </s-stack>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      {problems.length > 0 ? (
+        <s-section heading="Rows that need fixing">
+          <s-unordered-list>
+            {problems.slice(0, 25).map((problem) => (
+              <s-list-item key={`${problem.line}-${problem.identifier}`}>
+                Line {problem.line} ({problem.identifier || "no identifier"}): {problem.reason}
+              </s-list-item>
+            ))}
+          </s-unordered-list>
+        </s-section>
+      ) : null}
+    </s-page>
+  );
+}
+
+export const headers: HeadersFunction = (args) => boundary.headers(args);
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -27,6 +27,7 @@ export default function App() {
         <s-link href="/app/segments">Segments</s-link>
         <s-link href="/app/catalog">Catalogue</s-link>
         <s-link href="/app/baselines">Baselines</s-link>
+        <s-link href="/app/prices/import">Import prices</s-link>
         <s-link href="/app/baselines/import">Import baselines</s-link>
         <s-link href="/app/costs">Costs</s-link>
         <s-link href="/app/reconciliation">What is live</s-link>

--- a/app/services/campaigns/candidates.server.ts
+++ b/app/services/campaigns/candidates.server.ts
@@ -60,6 +60,14 @@ export async function loadCandidates(
    * the campaign's scope must not be pulled into a run just because a caller named it.
    */
   onlyVariantGids?: string[],
+  /**
+   * Imports whose prices these candidates may need.
+   *
+   * Passed in rather than discovered, because only the caller knows which campaigns are
+   * in play — and loading every import a shop has ever done would be a table scan for
+   * the many campaigns that use none.
+   */
+  importIds: readonly string[] = [],
 ): Promise<PlanCandidate[]> {
   if (onlyVariantGids?.length === 0) return [];
 
@@ -73,6 +81,8 @@ export async function loadCandidates(
   if (variants.length === 0) return [];
 
   const gids = variants.map((v) => v.variantGid);
+
+  const imported = await importedPricesByVariant(importIds, gids);
 
   const [baselines, entries] = await Promise.all([
     prisma.baseline.findMany({
@@ -109,8 +119,54 @@ export async function loadCandidates(
       baseline: base,
       livePrice: asMoney(entry?.livePrice),
       liveCompareAt: asMoney(entry?.liveCompareAt),
+      ...(imported.size > 0
+        ? { importedPrices: pricesFor(imported, variant.variantGid, currency) }
+        : {}),
     });
   }
 
   return candidates;
+}
+
+
+/**
+ * Imported prices for these variants, from these imports.
+ *
+ * Keyed variant → import → price, because a variant can appear in more than one import
+ * and the rule names which one it means. Two campaigns from two files pricing the same
+ * product is exactly the overlap the resolver exists to settle, and it can only do that
+ * if both prices are available to it.
+ */
+async function importedPricesByVariant(
+  importIds: readonly string[],
+  variantGids: readonly string[],
+): Promise<Map<string, Map<string, bigint>>> {
+  if (importIds.length === 0 || variantGids.length === 0) return new Map();
+
+  const rows = await prisma.priceImportRow.findMany({
+    where: { importId: { in: [...importIds] }, variantGid: { in: [...variantGids] } },
+    select: { importId: true, variantGid: true, price: true },
+  });
+
+  const byVariant = new Map<string, Map<string, bigint>>();
+  for (const row of rows) {
+    const forVariant = byVariant.get(row.variantGid) ?? new Map<string, bigint>();
+    forVariant.set(row.importId, row.price);
+    byVariant.set(row.variantGid, forVariant);
+  }
+
+  return byVariant;
+}
+
+function pricesFor(
+  imported: Map<string, Map<string, bigint>>,
+  variantGid: string,
+  currency: string,
+): Record<string, Money> {
+  const forVariant = imported.get(variantGid);
+  if (!forVariant) return {};
+
+  return Object.fromEntries(
+    [...forVariant].map(([importId, price]) => [importId, money(Number(price), currency)]),
+  );
 }

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -187,3 +187,23 @@ export async function loadCampaignContext(shopId: string, campaignId: string) {
     ast: await scopeOf(shopId, campaign),
   };
 }
+
+
+/**
+ * Import ids any of these campaigns price from.
+ *
+ * Collected from the rules rather than stored separately, so a campaign whose rule
+ * changes cannot end up loading prices for an import it no longer uses — or, worse,
+ * failing to load the one it now does.
+ */
+export function importIdsOf(campaigns: readonly ResolvableCampaign[]): string[] {
+  const ids = new Set<string>();
+
+  for (const campaign of campaigns) {
+    for (const row of campaign.ruleRows) {
+      if (row.rule.kind === "from-import") ids.add(row.rule.importId);
+    }
+  }
+
+  return [...ids];
+}

--- a/app/services/campaigns/preview.server.ts
+++ b/app/services/campaigns/preview.server.ts
@@ -10,7 +10,7 @@ import { money, type Money } from "../../lib/money/money";
 import { planRun } from "../../lib/planning/plan";
 import { selectWritePath } from "../../lib/planning/write-path";
 import { loadCandidates, titleMapFor } from "./candidates.server";
-import { loadCampaignContext } from "./model.server";
+import { loadCampaignContext, importIdsOf} from "./model.server";
 import { guardrailsFor, readSettings } from "../settings.server";
 import { describeImpact, marginImpact } from "../../lib/pricing/margin";
 import { decideMarketPath, describePath, planMarket } from "./market-plan.server";
@@ -49,7 +49,7 @@ export async function previewCampaign(
 ): Promise<CampaignPreview> {
   const { campaign, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
   const [candidates, storeGuardrails] = await Promise.all([
-    loadCandidates(shopId, ast),
+    loadCandidates(shopId, ast, undefined, importIdsOf(resolvable)),
     guardrailsFor(shopId),
   ]);
 

--- a/app/services/campaigns/rollback-report.server.ts
+++ b/app/services/campaigns/rollback-report.server.ts
@@ -23,7 +23,7 @@ import { format } from "../../lib/money/format";
 import { money } from "../../lib/money/money";
 import { planRun } from "../../lib/planning/plan";
 import { loadCandidates, titleMapFor } from "./candidates.server";
-import { loadCampaignContext } from "./model.server";
+import { loadCampaignContext, importIdsOf} from "./model.server";
 import { guardrailsFor } from "../settings.server";
 import {
   classifyRollbackRow,
@@ -47,7 +47,7 @@ export async function rollbackReport(
   const { campaign, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
 
   const [candidates, storeGuardrails, applied] = await Promise.all([
-    loadCandidates(shopId, ast),
+    loadCandidates(shopId, ast, undefined, importIdsOf(resolvable)),
     guardrailsFor(shopId),
     appliedValues(campaignId),
   ]);

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -16,7 +16,7 @@ import type { PlannedRow } from "../../lib/planning/types";
 import { planRun } from "../../lib/planning/plan";
 import { recordWriteIntents } from "../drift.server";
 import { loadCandidates, productMapFor } from "./candidates.server";
-import { isPractice, loadCampaignContext, scopeOf } from "./model.server";
+import { isPractice, loadCampaignContext, scopeOf, importIdsOf} from "./model.server";
 import { astToWhere } from "../segments.server";
 import { AppError } from "../../lib/errors/app-error";
 import { guardrailsFor } from "../settings.server";
@@ -152,7 +152,7 @@ export async function runCampaign(
   const { campaign: campaignRecord, resolvable, ast } = await loadCampaignContext(shopId, campaignId);
   const campaignName = campaignRecord.name;
   const [candidates, storeGuardrails] = await Promise.all([
-    loadCandidates(shopId, ast, options.variantGids),
+    loadCandidates(shopId, ast, options.variantGids, importIdsOf(resolvable)),
     guardrailsFor(shopId),
   ]);
 
@@ -433,9 +433,47 @@ export async function runCampaign(
               ".",
           ]
         : []),
+      // Rows the plan decided not to write, grouped by why. Previously only *resume*
+      // skips were reported, so a campaign that skipped four hundred products for a
+      // nameable reason — no cost, below a floor, not in the imported file — handed the
+      // merchant a smaller number than they expected and no explanation for it. The
+      // count was in the database; it was just never said out loud.
+      ...describeSkips(outcome.rows),
       ...messages.slice(0, 5),
     ],
   };
+}
+
+/** Why the plan left rows alone, in the merchant's terms. */
+const SKIP_REASONS: Record<string, string> = {
+  "missing-cost": "have no cost recorded, and a cost-based guardrail applies",
+  "missing-import": "were not in the imported file",
+  "below-floor": "would have priced below a guardrail floor",
+  "invalid-margin": "have a margin target that cannot be satisfied",
+  "invalid-compare-at": "would have had a compare-at price below their price",
+  "non-positive-price": "would have priced at or below zero",
+};
+
+function describeSkips(rows: readonly PlannedRow[]): string[] {
+  const byReason = new Map<string, number>();
+
+  for (const row of rows) {
+    if (row.status !== "skipped") continue;
+    const reason = row.reason ?? "unknown";
+    byReason.set(reason, (byReason.get(reason) ?? 0) + 1);
+  }
+
+  // Largest group first: a merchant reading one line wants the one that explains most of
+  // the difference between what they expected and what happened.
+  return [...byReason]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([reason, count]) => {
+      const what = SKIP_REASONS[reason];
+      return what
+        ? `${count} ${count === 1 ? "product was" : "products were"} skipped: they ${what}.`
+        : `${count} ${count === 1 ? "product was" : "products were"} skipped (${reason}).`;
+    });
 }
 
 /**

--- a/app/services/price-import.server.ts
+++ b/app/services/price-import.server.ts
@@ -1,0 +1,206 @@
+/**
+ * Importing exact prices, as a campaign.
+ *
+ * The obvious implementation — read the file, write the prices — breaks two architectural
+ * rules at once: the web process never writes prices, and nothing changes without a ledger
+ * row a revert can recompute from. It would also be the one path in the app with no
+ * preview, no guardrails and no undo, which is the path a merchant most needs those on.
+ *
+ * So an import produces rows and a campaign whose rule is "look them up". Everything
+ * downstream is unchanged, and gets there by being ordinary rather than by special
+ * handling: preview, blast-radius confirmation, cost floors, rounding, market surfaces and
+ * revert all work because a `from-import` rule is just another rule.
+ *
+ * Same reader, matcher, dry run and error file as the baseline and cost imports. Three
+ * importers that decided "SKU-1 matches two variants" differently would be three chances
+ * to be inconsistent about the thing that matters most.
+ */
+
+import prisma from "../db.server";
+import { readRows } from "../lib/baselines/csv-rows";
+import { isValid, validateRow } from "../lib/baselines/csv-rows";
+import { buildMatchIndex, matchIdentifiers, type CsvRow } from "../lib/segments/csv-import";
+import { logger } from "../lib/logging/logger";
+
+export interface PriceImportProblem {
+  line: number;
+  identifier: string;
+  reason: string;
+}
+
+export interface PriceImportResult {
+  importId: string | null;
+  total: number;
+  ready: number;
+  invalid: PriceImportProblem[];
+  unmatched: PriceImportProblem[];
+  ambiguous: PriceImportProblem[];
+  /** A variant the file named twice. Refused rather than letting the last row win. */
+  duplicates: PriceImportProblem[];
+  dryRun: boolean;
+}
+
+const MAX_PROBLEMS = 500;
+const BATCH = 1_000;
+
+export async function importPrices(
+  shopId: string,
+  name: string,
+  lines: AsyncIterable<string>,
+  shopCurrency: string,
+  options: { dryRun?: boolean; actor?: string } = {},
+): Promise<PriceImportResult> {
+  const result: PriceImportResult = {
+    importId: null,
+    total: 0,
+    ready: 0,
+    invalid: [],
+    unmatched: [],
+    ambiguous: [],
+    duplicates: [],
+    dryRun: options.dryRun === true,
+  };
+
+  const variants = await prisma.variantIndex.findMany({
+    where: { shopId, deletedAt: null },
+    select: { variantGid: true, productGid: true, sku: true, barcode: true },
+  });
+  const index = buildMatchIndex(variants);
+
+  // Created up front so rows can be written in batches rather than held. On a dry run
+  // nothing is created at all, which is what makes the dry run a real dry run rather
+  // than a create-and-delete.
+  const record = result.dryRun
+    ? null
+    : await prisma.priceImport.create({
+        data: { shopId, name, currency: shopCurrency, createdBy: options.actor ?? null },
+      });
+  result.importId = record?.id ?? null;
+
+  const seen = new Set<string>();
+  let batch: Array<{ importId: string; variantGid: string; price: bigint; compareAt: bigint | null }> = [];
+
+  const flush = async () => {
+    if (batch.length === 0 || !record) return;
+    const pending = batch;
+    batch = [];
+    await prisma.priceImportRow.createMany({ data: pending, skipDuplicates: true });
+  };
+
+  for await (const raw of readRows(lines)) {
+    result.total++;
+
+    const validated = validateRow(raw, shopCurrency);
+    if (!isValid(validated)) {
+      push(result.invalid, { line: raw.line, identifier: raw.identifier, reason: validated.reason });
+      continue;
+    }
+
+    const csvRow: CsvRow = { line: raw.line, value: raw.identifier };
+    const outcome = matchIdentifiers([csvRow], index);
+
+    if (outcome.ambiguous.length > 0) {
+      push(result.ambiguous, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason:
+          `Matches ${outcome.ambiguous[0].candidates.length} variants. ` +
+          `Use a variant ID, or make the SKU unique.`,
+      });
+      continue;
+    }
+
+    const variantGid = outcome.matched[0];
+    if (!variantGid) {
+      push(result.unmatched, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason: "No variant in this shop has that SKU, barcode or ID.",
+      });
+      continue;
+    }
+
+    // A file naming a variant twice is a question, not two instructions. Letting the
+    // last row win would set a price the merchant may not have meant, silently.
+    if (seen.has(variantGid)) {
+      push(result.duplicates, {
+        line: raw.line,
+        identifier: raw.identifier,
+        reason: "This variant already has a price earlier in the file. Remove one of the rows.",
+      });
+      continue;
+    }
+    seen.add(variantGid);
+
+    result.ready++;
+    if (record) {
+      batch.push({
+        importId: record.id,
+        variantGid,
+        price: BigInt(validated.parsedPrice.amount),
+        compareAt:
+          validated.parsedCompareAt === null ? null : BigInt(validated.parsedCompareAt.amount),
+      });
+      if (batch.length >= BATCH) await flush();
+    }
+  }
+
+  await flush();
+
+  if (record) {
+    await prisma.priceImport.update({
+      where: { id: record.id },
+      data: { rowsRead: result.total, rowsMatched: result.ready },
+    });
+  }
+
+  logger.info("prices imported", {
+    shopId,
+    importId: result.importId,
+    total: result.total,
+    ready: result.ready,
+    problems:
+      result.invalid.length +
+      result.unmatched.length +
+      result.ambiguous.length +
+      result.duplicates.length,
+    dryRun: result.dryRun,
+  });
+
+  return result;
+}
+
+/**
+ * The imported prices for a set of variants, keyed for the resolver.
+ *
+ * Loaded by the planner and passed in, because the resolver does no I/O. A variant the
+ * import did not name is simply absent, and the rule reports it as skipped rather than
+ * pricing it at nothing.
+ */
+export async function importedPricesFor(
+  importId: string,
+  variantGids: readonly string[],
+): Promise<Map<string, { price: bigint; compareAt: bigint | null }>> {
+  if (variantGids.length === 0) return new Map();
+
+  const rows = await prisma.priceImportRow.findMany({
+    where: { importId, variantGid: { in: [...variantGids] } },
+    select: { variantGid: true, price: true, compareAt: true },
+  });
+
+  return new Map(rows.map((row) => [row.variantGid, { price: row.price, compareAt: row.compareAt }]));
+}
+
+/** Every variant an import names, so a campaign can be scoped to exactly them. */
+export async function importedVariantGids(importId: string): Promise<string[]> {
+  const rows = await prisma.priceImportRow.findMany({
+    where: { importId },
+    select: { variantGid: true },
+  });
+
+  return rows.map((row) => row.variantGid);
+}
+
+function push(list: PriceImportProblem[], problem: PriceImportProblem): void {
+  if (list.length < MAX_PROBLEMS) list.push(problem);
+}

--- a/chaos/scenarios/price-import.chaos.ts
+++ b/chaos/scenarios/price-import.chaos.ts
@@ -1,0 +1,247 @@
+/**
+ * Importing exact prices, as a campaign.
+ *
+ * The point of doing it this way rather than writing the prices directly is that
+ * everything else comes for free — preview, guardrails, rounding, markets, revert. So the
+ * tests are mostly "does an imported campaign behave like any other campaign", because if
+ * it does not, the architecture bought nothing.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos, type ChaosContext } from "../harness/scenario";
+
+async function* linesOf(text: string): AsyncGenerator<string> {
+  for (const line of text.split("\n")) yield line;
+}
+
+/** SKUs, because that is what a merchant's spreadsheet has. */
+async function giveSkus(chaos: ChaosContext) {
+  const { shopId, variantGids } = chaos.fixture;
+  await Promise.all(
+    variantGids.map((gid, i) =>
+      prisma.variantIndex.updateMany({
+        where: { shopId, variantGid: gid },
+        data: { sku: `SKU-${i}` },
+      }),
+    ),
+  );
+}
+
+/** Points the fixture's campaign at an import rather than a percentage. */
+async function useImport(campaignId: string, importId: string) {
+  await prisma.campaign.update({
+    where: { id: campaignId },
+    data: { ruleRows: [{ segmentIds: [], rule: { kind: "from-import", importId } }] as never },
+  });
+}
+
+describe("chaos: importing exact prices", () => {
+  it("writes each product the price its row named", async () => {
+    await withChaos(
+      "price-import",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+        await giveSkus(chaos);
+
+        const { importPrices } = await import("../../app/services/price-import.server");
+        const file = [
+          "Variant SKU,Variant Price",
+          ...variantGids.map((_, i) => `SKU-${i},${(10 + i).toFixed(2)}`),
+        ].join("\n");
+
+        const imported = await importPrices(shopId, "Spring list", linesOf(file), "USD");
+        expect(imported.ready).toBe(variantGids.length);
+
+        await useImport(campaignId, imported.importId!);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // One answer per product, which is the thing a rule cannot express.
+        variantGids.forEach((gid, i) => {
+          expect(chaos.fake.priceOf(gid)).toBe((10 + i).toFixed(2));
+        });
+      },
+    );
+  });
+
+  it("skips a product the file did not name, and says why", async () => {
+    await withChaos(
+      "price-import-partial-file",
+      { catalog: { products: 5, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids, baseline } = chaos.fixture;
+        await giveSkus(chaos);
+
+        const { importPrices } = await import("../../app/services/price-import.server");
+        // Only three of five.
+        const file = ["Variant SKU,Variant Price", "SKU-0,10.00", "SKU-1,11.00", "SKU-2,12.00"]
+          .join("\n");
+
+        const imported = await importPrices(shopId, "Partial", linesOf(file), "USD");
+        await useImport(campaignId, imported.importId!);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // The two the file missed keep their prices rather than being set to nothing.
+        // Skipped, with a reason — not an error, and certainly not zero.
+        for (const gid of variantGids.slice(3)) {
+          const live = Number(chaos.fake.priceOf(gid)!.replace(".", ""));
+          expect(live).toBe(baseline.get(gid));
+        }
+
+        // Counted on the run rather than ledgered. A skipped row was never going to be
+        // written, so giving it a ledger entry would put two rows in the record of "what
+        // we did to this storefront" that describe nothing having been done.
+        const run = await prisma.campaignRun.findUniqueOrThrow({ where: { id: applied.runId } });
+        expect(run.skippedRows).toBe(2);
+
+        // And the merchant is told, rather than left to notice two products missing.
+        expect(applied.messages.join(" ")).toContain("skipped");
+      },
+    );
+  });
+
+  it("is still subject to guardrails, like any other campaign", async () => {
+    await withChaos(
+      "price-import-guardrail",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+        await giveSkus(chaos);
+
+        // Costs at $20, and a file that prices everything at $5.
+        const { importCosts } = await import("../../app/services/cost-import.server");
+        await importCosts(
+          shopId,
+          linesOf(["Variant SKU,Variant Cost", ...variantGids.map((_, i) => `SKU-${i},20.00`)].join("\n")),
+          "USD",
+        );
+
+        const shop = await prisma.shop.findUniqueOrThrow({ where: { id: shopId } });
+        await prisma.shop.update({
+          where: { id: shopId },
+          data: {
+            settings: {
+              ...((shop.settings ?? {}) as object),
+              neverBelowCost: true,
+              violationPolicy: "clamp",
+              missingCostPolicy: "skip",
+            } as never,
+          },
+        });
+
+        const { importPrices } = await import("../../app/services/price-import.server");
+        const imported = await importPrices(
+          shopId,
+          "Too cheap",
+          linesOf(["Variant SKU,Variant Price", ...variantGids.map((_, i) => `SKU-${i},5.00`)].join("\n")),
+          "USD",
+        );
+        await useImport(campaignId, imported.importId!);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Clamped to cost, not written at $5. This is the whole argument for routing an
+        // import through a campaign: a direct write would have been the one path in the
+        // app with no floor under it.
+        for (const gid of variantGids) {
+          expect(chaos.fake.priceOf(gid)).toBe("20.00");
+        }
+      },
+    );
+  });
+
+  it("reverts by recomputing, like any other campaign", async () => {
+    await withChaos(
+      "price-import-revert",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids, baseline } = chaos.fixture;
+        await giveSkus(chaos);
+
+        const { importPrices } = await import("../../app/services/price-import.server");
+        const imported = await importPrices(
+          shopId,
+          "Spring",
+          linesOf(["Variant SKU,Variant Price", ...variantGids.map((_, i) => `SKU-${i},7.00`)].join("\n")),
+          "USD",
+        );
+        await useImport(campaignId, imported.importId!);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        const reverted = await chaos.revert();
+        await chaos.expectHonest(reverted.runId);
+
+        for (const gid of variantGids) {
+          const live = Number(chaos.fake.priceOf(gid)!.replace(".", ""));
+          expect(live).toBe(baseline.get(gid));
+        }
+      },
+    );
+  });
+
+  it("refuses a file that names one variant twice", async () => {
+    await withChaos(
+      "price-import-duplicate",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        await giveSkus(chaos);
+
+        const { importPrices } = await import("../../app/services/price-import.server");
+        const result = await importPrices(
+          shopId,
+          "Conflicting",
+          linesOf(["Variant SKU,Variant Price", "SKU-0,10.00", "SKU-1,11.00", "SKU-0,99.00"].join("\n")),
+          "USD",
+        );
+
+        // A file naming a variant twice is a question, not two instructions. Letting the
+        // last row win would set a price the merchant may not have meant, silently.
+        expect(result.ready).toBe(2);
+        expect(result.duplicates).toHaveLength(1);
+        expect(result.duplicates[0].line).toBe(4);
+
+        const stored = await prisma.priceImportRow.findMany({
+          where: { importId: result.importId! },
+        });
+        expect(stored).toHaveLength(2);
+        // The first row won, and the merchant was told about the second.
+        expect(stored.find((row) => Number(row.price) === 9_900)).toBeUndefined();
+      },
+    );
+  });
+
+  it("writes nothing on a dry run, not even the import", async () => {
+    await withChaos(
+      "price-import-dry",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        await giveSkus(chaos);
+
+        const { importPrices } = await import("../../app/services/price-import.server");
+        const result = await importPrices(
+          shopId,
+          "Preview only",
+          linesOf(["Variant SKU,Variant Price", "SKU-0,10.00"].join("\n")),
+          "USD",
+          { dryRun: true },
+        );
+
+        expect(result.ready).toBe(1);
+        expect(result.importId).toBeNull();
+        // A dry run that created and deleted an import would not be a dry run.
+        expect(await prisma.priceImport.count({ where: { shopId } })).toBe(0);
+      },
+    );
+  });
+});

--- a/prisma/migrations/20260826120000_price_imports/migration.sql
+++ b/prisma/migrations/20260826120000_price_imports/migration.sql
@@ -1,0 +1,55 @@
+-- Prices imported from a file, to be applied as a campaign (#228).
+--
+-- A merchant setting prices from a spreadsheet is doing something a rule cannot express:
+-- forty thousand different answers, one per product. The obvious implementation -- read
+-- the file, write the prices -- breaks two architectural rules at once: the web process
+-- never writes prices, and no price changes without a ledger row a revert can recompute
+-- from.
+--
+-- So the import becomes a campaign whose rule says "look it up here". Everything
+-- downstream is unchanged: preview, guardrails, rounding, blast-radius confirmation,
+-- per-market surfaces and revert all work, because the rule is just another rule.
+--
+-- The rows live here rather than in the campaign's JSON because a rule row is stored as
+-- JSON on the campaign, and forty thousand prices in a JSON column would be a second copy
+-- of the file that can disagree with the first.
+--
+-- Expand-only: two new tables and their indexes.
+CREATE TABLE "price_imports" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+
+    "name" TEXT NOT NULL,
+    "currency" TEXT NOT NULL,
+
+    -- Rows read and matched. Kept so the campaign can say where it came from.
+    "rowsRead" INTEGER NOT NULL DEFAULT 0,
+    "rowsMatched" INTEGER NOT NULL DEFAULT 0,
+
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "price_imports_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "price_import_rows" (
+    "id" TEXT NOT NULL,
+    "importId" TEXT NOT NULL,
+
+    "variantGid" TEXT NOT NULL,
+    "price" BIGINT NOT NULL,
+    "compareAt" BIGINT,
+
+    CONSTRAINT "price_import_rows_pkey" PRIMARY KEY ("id")
+);
+
+-- One price per variant per import. A file naming a variant twice is a question, not two
+-- instructions, and the importer refuses it rather than letting the last row win.
+CREATE UNIQUE INDEX "price_import_rows_importId_variantGid_key"
+  ON "price_import_rows"("importId", "variantGid");
+CREATE INDEX "price_imports_shopId_createdAt_idx" ON "price_imports"("shopId", "createdAt");
+
+ALTER TABLE "price_imports" ADD CONSTRAINT "price_imports_shopId_fkey"
+  FOREIGN KEY ("shopId") REFERENCES "shops"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "price_import_rows" ADD CONSTRAINT "price_import_rows_importId_fkey"
+  FOREIGN KEY ("importId") REFERENCES "price_imports"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,7 @@ model Shop {
   priceListChanges PriceListChange[]
   topologyNotices  TopologyNotice[]
   feedback         Feedback[]
+  priceImports     PriceImport[]
   writeIntents     WriteIntent[]
   driftEvents      DriftEvent[]
   roundingProfiles RoundingProfileRecord[]
@@ -733,6 +734,53 @@ model Feedback {
   @@index([shopId, createdAt])
   @@index([status])
   @@map("feedback")
+}
+
+/// A file of exact prices, applied as a campaign rather than written directly.
+///
+/// Setting prices from a spreadsheet is something a rule cannot express: one answer per
+/// product. Writing them directly would break two rules at once -- the web process never
+/// writes prices, and nothing changes without a ledger row a revert can recompute from.
+/// So the import becomes a campaign whose rule says "look it up here", and preview,
+/// guardrails, rounding, markets and revert all work unchanged.
+model PriceImport {
+  id String @id @default(cuid())
+
+  shopId   String
+  name     String
+  currency String
+
+  rowsRead    Int @default(0)
+  rowsMatched Int @default(0)
+
+  createdBy String?
+  createdAt DateTime @default(now())
+
+  shop Shop               @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  rows PriceImportRow[]
+
+  @@index([shopId, createdAt])
+  @@map("price_imports")
+}
+
+/// One variant's price in an imported file.
+///
+/// Separate rows rather than JSON on the campaign: forty thousand prices in a JSON column
+/// would be a second copy of the file that can disagree with the first.
+model PriceImportRow {
+  id String @id @default(cuid())
+
+  importId   String
+  variantGid String
+
+  price     BigInt
+  compareAt BigInt?
+
+  priceImport PriceImport @relation(fields: [importId], references: [id], onDelete: Cascade)
+
+  /// A file naming a variant twice is a question, not two instructions.
+  @@unique([importId, variantGid])
+  @@map("price_import_rows")
 }
 
 model RoundingProfileRecord {


### PR DESCRIPTION
Closes #228.

Setting prices from a spreadsheet is something a rule cannot express: forty thousand different answers, one per product.

The obvious implementation — read the file, write the prices — breaks two architectural rules at once (*the web process never writes prices*; *nothing changes without a ledger row a revert can recompute from*). It would also be **the one path in the app with no preview, no guardrails and no undo** — which is the path a merchant most needs those on.

## So an import creates a campaign

Rows go in a table; the campaign's rule is `from-import`. Everything downstream then works by being **ordinary** rather than by special handling: preview, blast radius, cost floors, rounding, market surfaces and revert all apply because it's just another rule.

The chaos scenarios test exactly that — an imported campaign **clamped to cost by a guardrail**, and **reverting by recomputation** — because if it didn't behave like every other campaign, the architecture bought nothing.

## Details worth knowing

- **The rule carries the import's id, not the prices.** A rule row is JSON on the campaign, and forty thousand prices in a JSON column would be a second copy of the file that can disagree with the first. Prices are loaded by the caller and passed in, like baselines, because the resolver does no I/O.
- **A variant the file didn't name gets its own skip reason**, not folded into "missing cost" — the fix is entirely different: add the row, or narrow the scope.
- **The campaign is scoped to a frozen segment** of exactly the named variants, so a product added later can't fall into a campaign whose rule can say nothing about it.
- **A file naming a variant twice is refused**, rather than letting the last row win and setting a price the merchant may not have meant.

## A gap this surfaced

The run reported **resume**-time skips but never **plan**-time ones. A campaign that skipped four hundred products for a nameable reason — no cost, below a floor, not in the file — handed the merchant a smaller number than they expected with no explanation.

The count was in the database. It was simply never said out loud. Skips are now grouped by reason and reported largest first, since a merchant reading one line wants the one explaining most of the difference.

## Tests

6 chaos scenarios.

**Falsified.** Pricing an unnamed variant at its baseline instead of skipping it, letting a duplicate row through, and dropping the skip message.

Full suite: 679 unit tests, 87 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)