### PR TITLE
Fix: Polaris fields never showed their saved values

### DIFF
--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -91,8 +91,8 @@ export default function Activity() {
               ))}
             </s-select>
 
-            <s-date-field name="from" label="From" defaultValue={filters.from ?? ""} />
-            <s-date-field name="to" label="To" defaultValue={filters.to ?? ""} />
+            <s-date-field name="from" label="From" value={filters.from ?? ""} />
+            <s-date-field name="to" label="To" value={filters.to ?? ""} />
 
             <s-button type="submit">Filter</s-button>
           </s-stack>

--- a/app/routes/app.baselines._index.tsx
+++ b/app/routes/app.baselines._index.tsx
@@ -77,7 +77,7 @@ export default function Baselines() {
       <s-section>
         <FilterForm fields={FILTER_FIELDS}>
           <s-stack gap="base">
-            <s-text-field name="q" label="Title, SKU or variant ID" defaultValue={filters.q ?? ""} />
+            <s-text-field name="q" label="Title, SKU or variant ID" value={filters.q ?? ""} />
 
             <s-select name="vendor" label="Vendor">
               <s-option value="" defaultSelected={!filters.vendor}>
@@ -105,7 +105,7 @@ export default function Baselines() {
               name="diverged"
               value="1"
               label="Only variants whose live price differs from their baseline"
-              defaultChecked={filters.divergedOnly || undefined}
+              checked={filters.divergedOnly || undefined}
             />
 
             <s-button type="submit">Filter</s-button>

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -342,7 +342,7 @@ export default function NewCampaign() {
                 </s-option>
               ))}
             </s-select>
-            <s-text-field name="title" label="Title contains" defaultValue={selected.title} />
+            <s-text-field name="title" label="Title contains" value={selected.title} />
             <s-button type="submit">Update match count</s-button>
           </s-stack>
         </FilterForm>
@@ -373,7 +373,7 @@ export default function NewCampaign() {
           <input type="hidden" name="title" value={selected.title} />
 
           <s-stack gap="base">
-            <s-text-field name="name" label="Campaign name" defaultValue="Sale" required />
+            <s-text-field name="name" label="Campaign name" value="Sale" required />
 
             <s-select name="ruleKind" label="Adjustment">
               <s-option value="percent-change" defaultSelected>
@@ -386,7 +386,7 @@ export default function NewCampaign() {
             <s-number-field
               name="ruleValue"
               label="Value"
-              defaultValue="-20"
+              value="-20"
               details="Negative discounts. -20 means 20% off the baseline."
             />
 
@@ -419,7 +419,7 @@ export default function NewCampaign() {
             <s-number-field
               name="priority"
               label="Priority"
-              defaultValue="100"
+              value="100"
               details="Higher wins when two campaigns cover the same variant. They never stack."
             />
 
@@ -433,7 +433,7 @@ export default function NewCampaign() {
             <s-checkbox
               name="autoEnroll"
               label="Price products that join this campaign while it runs"
-              defaultChecked
+              checked
               details="A product you add to the sale later is priced from its own normal price, not the sale price."
             />
 
@@ -533,13 +533,13 @@ export default function NewCampaign() {
               <s-date-field
                 name="startDate"
                 label="Start"
-                defaultValue={presetStart.slice(0, 10)}
+                value={presetStart.slice(0, 10)}
               />
               <s-text-field
                 name="startTime"
                 label="Start time"
                 placeholder="09:00"
-                defaultValue={presetStart.slice(11)}
+                value={presetStart.slice(11)}
                 details="24-hour, in your store's zone."
               />
             </s-stack>
@@ -557,7 +557,7 @@ export default function NewCampaign() {
             <s-number-field
               name="revertBuffer"
               label="Revert this many minutes early"
-              defaultValue="5"
+              value="5"
               details="A busy bulk queue takes time; starting early means prices are back before the window closes."
             />
 

--- a/app/routes/app.catalog.tsx
+++ b/app/routes/app.catalog.tsx
@@ -109,7 +109,7 @@ export default function Catalog() {
               label="Search"
               labelAccessibilityVisibility="exclusive"
               placeholder="Search by title or SKU"
-              defaultValue={query}
+              value={query}
             />
             <s-button type="submit">Search</s-button>
           </s-stack>

--- a/app/routes/app.costs._index.tsx
+++ b/app/routes/app.costs._index.tsx
@@ -189,7 +189,7 @@ export default function Costs() {
             <s-number-field
               name="value"
               label={`Amount (percent, or ${currency})`}
-              defaultValue="4"
+              value="4"
               details="Products with no cost are skipped by the first two rules rather than treated as zero."
             />
 

--- a/app/routes/app.debug.tsx
+++ b/app/routes/app.debug.tsx
@@ -69,7 +69,7 @@ export default function Debug() {
 
         <Form method="get">
           <s-stack direction="inline" gap="base">
-            <s-text-field name="id" label="Reference" defaultValue={query} />
+            <s-text-field name="id" label="Reference" value={query} />
             <s-button type="submit" variant="primary">
               Find
             </s-button>

--- a/app/routes/app.prices.import.tsx
+++ b/app/routes/app.prices.import.tsx
@@ -134,7 +134,7 @@ export default function ImportPrices() {
         <fetcher.Form method="post" ref={form}>
           <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
           <s-stack gap="base">
-            <s-text-field name="name" label="Call this" defaultValue="Imported prices" />
+            <s-text-field name="name" label="Call this" value="Imported prices" />
             <s-text-area
               name="csv"
               label="Rows"

--- a/app/routes/app.reconciliation.tsx
+++ b/app/routes/app.reconciliation.tsx
@@ -106,7 +106,7 @@ export default function Reconciliation() {
 
         <FilterForm fields={RECONCILE_FIELDS}>
           <s-stack gap="base">
-            <s-text-field name="q" label="Title, SKU or variant ID" defaultValue={selected.q} />
+            <s-text-field name="q" label="Title, SKU or variant ID" value={selected.q} />
 
             <s-select name="surface" label="Surface">
               <s-option value="any" defaultSelected={selected.surface === "any"}>
@@ -177,7 +177,7 @@ export default function Reconciliation() {
         <fetcher.Form method="post">
           <input type="hidden" name="intent" value="spot-check" />
           <s-stack direction="inline" gap="base">
-            <s-number-field name="size" label="How many to check" defaultValue="100" />
+            <s-number-field name="size" label="How many to check" value="100" />
             <s-button type="submit" loading={busy || undefined}>
               Check now
             </s-button>

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -162,20 +162,20 @@ export default function Settings() {
             <s-checkbox
               name="neverBelowCost"
               label="Never price at or below cost"
-              defaultChecked={settings.neverBelowCost || undefined}
+              checked={settings.neverBelowCost || undefined}
             />
 
             <s-number-field
               name="minMarginPercent"
               label="Minimum margin (%)"
-              defaultValue={settings.minMarginPercent?.toString() ?? ""}
+              value={settings.minMarginPercent?.toString() ?? ""}
               details="Share of the selling price. 25 means a price of at least cost ÷ 0.75. Leave blank for none."
             />
 
             <s-number-field
               name="minPrice"
               label={`Minimum price (${currency})`}
-              defaultValue={settings.minPrice?.toString() ?? ""}
+              value={settings.minPrice?.toString() ?? ""}
               details="An absolute floor, whatever the rule computes. Leave blank for none."
             />
 
@@ -307,7 +307,7 @@ export default function Settings() {
               name="email"
               label="Send to"
               placeholder="ops@yourshop.com"
-              defaultValue={notifications.email ?? ""}
+              value={notifications.email ?? ""}
               details="Leave blank to turn notifications off entirely."
             />
 
@@ -315,29 +315,29 @@ export default function Settings() {
               name="onPartialOrFailure"
               label="A run did not finish cleanly"
               details="Something needs you: rows failed, or the run stopped early."
-              defaultChecked={notifications.onPartialOrFailure || undefined}
+              checked={notifications.onPartialOrFailure || undefined}
             />
             <s-checkbox
               name="onDrift"
               label="Someone changed a price outside the app"
               details="Those edits are held for your decision rather than overwritten."
-              defaultChecked={notifications.onDrift || undefined}
+              checked={notifications.onDrift || undefined}
             />
             <s-checkbox
               name="onRevert"
               label="A campaign was reverted"
-              defaultChecked={notifications.onRevert || undefined}
+              checked={notifications.onRevert || undefined}
             />
             <s-checkbox
               name="onCompletion"
               label="A run finished cleanly"
               details="Off by default. Being emailed about every success is how the one email that mattered gets skimmed past."
-              defaultChecked={notifications.onCompletion || undefined}
+              checked={notifications.onCompletion || undefined}
             />
             <s-checkbox
               name="weeklyDigest"
               label="Weekly summary"
-              defaultChecked={notifications.weeklyDigest || undefined}
+              checked={notifications.weeklyDigest || undefined}
             />
 
             <s-button type="submit" variant="primary" loading={busy || undefined}>

--- a/docs/polaris-notes.md
+++ b/docs/polaris-notes.md
@@ -1,0 +1,68 @@
+# Polaris web components: what actually works
+
+Notes from getting the app's forms to behave. Written down because each of these cost an
+afternoon and none of them fails loudly — the component renders, it just quietly does
+nothing.
+
+## `defaultValue` does not work. Use `value`.
+
+`s-text-field`, `s-number-field`, `s-date-field` and the rest all accept `defaultValue` in
+their TypeScript types, and it is inherited from a real base class, so it compiles and
+looks correct. It renders an empty field.
+
+Verified by putting three fields side by side on one page:
+
+| What was passed | What rendered |
+|---|---|
+| `defaultValue="camelCase"` | empty |
+| `defaultvalue="lowercase"` (forced attribute) | empty |
+| `value="valueProp"` | **the value** |
+
+Almost certainly React's special handling of `defaultValue` on form elements: it is
+intercepted rather than forwarded to the custom element, so the element never sees it.
+
+Because these forms are uncontrolled — no `onChange`, no state — setting `value` does not
+make the field read-only. React sets the property once on mount and the element manages
+its own state from there.
+
+This was app-wide and silent. Settings could not show a merchant their own saved
+guardrails, the wizard could not prefill a campaign name, and the calendar's
+create-from-slot passed a date that never appeared in the field.
+
+## `s-select` takes its initial value on the option
+
+Not on the select. `<s-option value="x" defaultSelected>` rather than
+`<s-select defaultValue="x">`. Easy to get wrong because it renders fine either way — it
+just always shows the first option.
+
+## `s-button` has no `name` or `value`
+
+So a form with two submit buttons cannot distinguish them the usual way. The pattern used
+throughout this app is a hidden input the buttons set before submitting:
+
+```tsx
+<input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
+<s-button type="button" onClick={() => submitWith("commit")}>…</s-button>
+```
+
+One form rather than two, because both actions read the same fields and duplicating them
+would let them drift apart.
+
+## `s-table` blanks the whole page past a few hundred cells
+
+Not the table — the page. No error, and no console message, because the app's console
+lives in a cross-origin iframe. Found by bisection: five rows fine, fifty-six not.
+
+Encoded as a cell budget in `app/lib/ui/table-budget.ts`, so a view that grows columns
+loses rows rather than losing the page.
+
+## A native `<form>` breaks the embedded session
+
+A plain `<form>` — GET or POST — does a full navigation that wipes App Bridge's `host`,
+`id_token` and `shop` parameters. The server then logs `shop: null` and the merchant sees
+a blank page. Use `FilterForm` for GET or React Router's `<Form>` for POST.
+
+## `*.server.ts` is stripped from the client bundle
+
+Calling something from one in a component gives `undefined` at click time with no build
+error. Hit three times before it stuck: rollback CSV, activity CSV, `describeActor`.


### PR DESCRIPTION
`defaultValue` and `defaultChecked` do nothing on Polaris web components. They're in the TypeScript types, inherited from real base classes, so they compile and read as correct — and render an empty field every time.

Almost certainly React's special handling of `defaultValue`/`defaultChecked` on form elements: intercepted rather than forwarded, so the custom element never sees them.

## Proved, not guessed

Three fields side by side on one page:

| Passed | Rendered |
|---|---|
| `defaultValue="camelCase"` | empty |
| `defaultvalue="lowercase"` (forced attribute) | empty |
| `value="valueProp"` | **the value** |

## What this was costing

App-wide and completely silent:

- **Settings couldn't show a merchant the guardrails they'd saved.** Margin and price floors rendered blank whatever was in the database, and *"never price at or below cost"* showed unticked while being on.
- **The wizard couldn't prefill** a campaign name or rule value.
- **The calendar's create-from-slot** passed a date that never appeared in the field — so the one thing that feature does looked broken.

Every one of those is a field a merchant would have typed into again, or worse, saved past — submitting a blank the action then reads as "not set".

## The fix

18 fields to `value`, 8 checkboxes to `checked`.

These forms are **uncontrolled** — no `onChange`, no state — so setting `value` doesn't make them read-only: React sets the property once on mount and the element manages itself after.

**Verified in the app against the real store, both directions.** Seeding a 25% margin and a 4.50 floor and reloading now shows `25` and `4.5` where it previously showed nothing, and the cost checkbox renders ticked.

## `docs/polaris-notes.md`

Added, because every one of these cost an afternoon and none fails loudly:

- the select whose initial value goes on the **option**, not the select
- the button with no `name` or `value`
- the table that blanks the **page** rather than itself
- the native `<form>` that wipes the embedded session
- `*.server.ts` vanishing from the client bundle

Full suite: 679 unit tests, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)