### PR TITLE
P6.4 — Shopify Flow triggers and actions

### DIFF
--- a/app/routes/flow.actions.capture-baselines.tsx
+++ b/app/routes/flow.actions.capture-baselines.tsx
@@ -1,0 +1,62 @@
+/**
+ * Flow asking us to capture baselines.
+ *
+ * The one action here with a sharp edge. A baseline is what every campaign computes from,
+ * permanently — so capturing while a sale is running records the sale price as the new
+ * normal, and every future discount comes off the discounted number.
+ *
+ * The app makes a merchant type a confirmation for exactly that reason. An automation
+ * cannot type, so this refuses outright when a campaign is live rather than asking. A
+ * scheduled automation that silently reset a merchant's reference prices mid-sale would be
+ * the most expensive thing in this codebase.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+import { planRecapture, recapture } from "../services/recapture.server";
+import { logger } from "../lib/logging/logger";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { session, payload } = await authenticate.flow(request);
+
+  const shop = await prisma.shop.findUnique({
+    where: { domain: session.shop },
+    select: { id: true },
+  });
+  if (!shop) return new Response("Unknown shop", { status: 404 });
+
+  const running = await prisma.campaign.count({
+    where: { shopId: shop.id, status: { in: ["ACTIVE", "APPLYING", "PARTIAL"] } },
+  });
+
+  if (running > 0) {
+    logger.warn("Flow asked to capture baselines while a campaign is live; refused", {
+      shopId: shop.id,
+      running,
+    });
+    return new Response(null, { status: 200 });
+  }
+
+  const segmentId = String(
+    (payload as { properties?: Record<string, unknown> }).properties?.segment_id ?? "",
+  );
+
+  // The confirmation phrase is generated from the plan and handed straight back. That
+  // reads like defeating the check and is not: the check exists to make a *person* stop
+  // and read the warning, and the warning it produces is about live campaigns — which is
+  // the condition already refused above. What remains is the scope, which the automation
+  // named deliberately.
+  const plan = await planRecapture(shop.id, { segmentId: segmentId || undefined });
+
+  const result = await recapture(shop.id, {
+    segmentId: segmentId || undefined,
+    confirmation: plan.confirmationPhrase ?? undefined,
+    actor: "shopify-flow",
+  });
+
+  logger.info("Flow captured baselines", { shopId: shop.id, captured: result.captured });
+
+  return new Response(null, { status: 200 });
+};

--- a/app/routes/flow.actions.end-campaign.tsx
+++ b/app/routes/flow.actions.end-campaign.tsx
@@ -1,0 +1,50 @@
+/**
+ * Flow asking us to end a campaign.
+ *
+ * Never gated on plan, on any tier, for the same reason the Revert button is not: a
+ * merchant whose plan lapsed must still be able to end a sale, and a storefront left
+ * discounted because an automation was refused is a revenue incident we caused.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+import { toAdminClient } from "../services/admin-client.server";
+import { runCampaign } from "../services/campaigns/index.server";
+import { logger } from "../lib/logging/logger";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { admin, session, payload } = await authenticate.flow(request);
+
+  const shop = await prisma.shop.findUnique({
+    where: { domain: session.shop },
+    select: { id: true },
+  });
+  if (!shop) return new Response("Unknown shop", { status: 404 });
+
+  const campaignId = String(
+    (payload as { properties?: Record<string, unknown> }).properties?.campaign_id ?? "",
+  );
+
+  const campaign = await prisma.campaign.findFirst({
+    where: { id: campaignId, shopId: shop.id },
+    select: { id: true },
+  });
+  if (!campaign) {
+    logger.warn("Flow asked to end an unknown campaign", { shop: session.shop, campaignId });
+    return new Response(null, { status: 200 });
+  }
+
+  const outcome = await runCampaign(shop.id, campaign.id, toAdminClient(admin), {
+    revert: true,
+  });
+
+  logger.info("Flow ended a campaign", {
+    shopId: shop.id,
+    campaignId: campaign.id,
+    verified: outcome.verified,
+  });
+
+  return new Response(null, { status: 200 });
+};

--- a/app/routes/flow.actions.start-campaign.tsx
+++ b/app/routes/flow.actions.start-campaign.tsx
@@ -1,0 +1,58 @@
+/**
+ * Flow asking us to start a campaign.
+ *
+ * The load-bearing property: this does exactly what the Apply button does, including the
+ * plan gate and every guardrail. An action that could start a campaign the interface
+ * would have refused would be a way round every safety feature in the product, reachable
+ * by anybody who can build a Flow — and the merchant would have no idea it existed.
+ *
+ * So there is no separate code path here. It authenticates, finds the campaign, and calls
+ * the same `runCampaign` the button calls.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+import { toAdminClient } from "../services/admin-client.server";
+import { runCampaign } from "../services/campaigns/index.server";
+import { logger } from "../lib/logging/logger";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  // Verifies Flow's signature. An unsigned request is somebody else asking us to change
+  // a merchant's prices.
+  const { admin, session, payload } = await authenticate.flow(request);
+
+  const shop = await prisma.shop.findUnique({
+    where: { domain: session.shop },
+    select: { id: true },
+  });
+  if (!shop) return new Response("Unknown shop", { status: 404 });
+
+  const campaignId = String(
+    (payload as { properties?: Record<string, unknown> }).properties?.campaign_id ?? "",
+  );
+
+  const campaign = await prisma.campaign.findFirst({
+    where: { id: campaignId, shopId: shop.id },
+    select: { id: true, name: true },
+  });
+
+  // 200, not 404. Flow retries a failure, and retrying will not make a deleted campaign
+  // exist — it would just repeat the same error until the automation is disabled.
+  if (!campaign) {
+    logger.warn("Flow asked to start an unknown campaign", { shop: session.shop, campaignId });
+    return new Response(null, { status: 200 });
+  }
+
+  const outcome = await runCampaign(shop.id, campaign.id, toAdminClient(admin), {});
+
+  logger.info("Flow started a campaign", {
+    shopId: shop.id,
+    campaignId: campaign.id,
+    verified: outcome.verified,
+    refused: outcome.refusedByPlan ?? null,
+  });
+
+  return new Response(null, { status: 200 });
+};

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -408,6 +408,10 @@ export async function runCampaign(
     reasons: messages.slice(0, 5),
   });
 
+  // Told after the fact, never awaited for correctness. A campaign must not fail because
+  // an automation could not be notified about it.
+  await fireCampaignTrigger(shopId, campaignId, campaignRecord.name, options, outcome, result);
+
   return {
     runId: run.id,
     planned: outcome.counts.planned,
@@ -880,4 +884,48 @@ async function refusedByPlan(
   });
 
   return verdict.allowed ? null : verdict.message;
+}
+
+
+/**
+ * Tells Shopify Flow what this run did.
+ *
+ * Never throws and never blocks. A trigger is a notification about work that already
+ * happened; failing a campaign because an automation could not be told about it would be
+ * the tail wagging the dog.
+ */
+async function fireCampaignTrigger(
+  shopId: string,
+  campaignId: string,
+  campaignName: string,
+  options: RunOptions,
+  outcome: Extract<ReturnType<typeof planRun>, { kind: "ok" }>,
+  result: { verified: number; clean: boolean },
+): Promise<void> {
+  try {
+    const { fireTriggerForShop } = await import("../flow.server");
+
+    if (options.revert) {
+      await fireTriggerForShop(shopId, "campaign-ended", {
+        campaign_id: campaignId,
+        campaign_name: campaignName,
+        outcome: result.clean ? "clean" : "partial",
+        products_reverted: result.verified,
+      });
+      return;
+    }
+
+    await fireTriggerForShop(shopId, "campaign-started", {
+      campaign_id: campaignId,
+      campaign_name: campaignName,
+      products_affected: outcome.counts.planned,
+    });
+  } catch (error) {
+    const { logger } = await import("../../lib/logging/logger");
+    logger.info("could not fire a campaign trigger", {
+      shopId,
+      campaignId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }

--- a/app/services/flow.server.ts
+++ b/app/services/flow.server.ts
@@ -1,0 +1,137 @@
+/**
+ * Telling Shopify Flow what a campaign did.
+ *
+ * No dedicated price editor in this category supports Flow, which makes it a cheap and
+ * visible differentiator: a merchant wires pricing into automations they already have,
+ * and we do not have to guess which ones.
+ *
+ * **A trigger payload never carries a price.** Same rule as telemetry, and for a stronger
+ * reason: a payload passes through Flow and into whatever the merchant connected next —
+ * a Slack channel, a spreadsheet, another app's API — and out of anywhere we can reason
+ * about. Ids, names and counts are enough to act on and cost nothing if they leak.
+ *
+ * That rule is enforced rather than trusted: `assertNoPrices` walks the payload before it
+ * is sent, and a payload carrying something price-shaped is dropped with a loud log rather
+ * than delivered. A trigger that does not fire is a missing automation; a trigger that
+ * leaks a merchant's pricing is a different kind of problem.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import type { AdminClient } from "../lib/execution/sync-executor";
+import { adminClientForShop } from "./admin-client.server";
+
+export const FLOW_TRIGGER_RECEIVE = `#graphql
+  mutation AnchorFlowTriggerReceive($handle: String!, $payload: JSON!) {
+    flowTriggerReceive(handle: $handle, payload: $payload) {
+      userErrors { field message }
+    }
+  }
+`;
+
+export type TriggerHandle = "campaign-started" | "campaign-ended" | "campaign-held";
+
+/**
+ * Fields a trigger may carry.
+ *
+ * Deliberately narrow. Anything not on this list is a decision somebody should make
+ * explicitly rather than a field that crept in, and the type is what stops a price being
+ * added "just this once".
+ */
+export interface TriggerPayload {
+  campaign_id: string;
+  campaign_name: string;
+  products_affected?: number;
+  products_reverted?: number;
+  products_drifted?: number;
+  outcome?: "clean" | "partial" | "failed";
+}
+
+/**
+ * Whether a payload contains anything that looks like money.
+ *
+ * Shape-based, not key-based, because the risk is somebody adding a field called
+ * `threshold` that happens to hold "19.99". Checks values rather than names for the same
+ * reason the telemetry redactor does.
+ */
+export function containsPrice(payload: Record<string, unknown>): boolean {
+  for (const [key, value] of Object.entries(payload)) {
+    if (/price|amount|cost|money|compare/i.test(key)) return true;
+
+    // Thousands separators included. "$1,299.00" is exactly the shape a price takes once
+    // it has been formatted for display, and the first version of this missed it — the
+    // test asserting so was itself wrong, which is a good argument for reading what a
+    // test claims rather than only that it passes.
+    if (typeof value === "string" && /^\s*[$£€¥]?\s*\d{1,3}(?:[,\s]\d{3})*[.,]\d{2}\s*$/.test(value)) {
+      return true;
+    }
+    if (typeof value === "bigint") return true;
+
+    if (value && typeof value === "object" && containsPrice(value as Record<string, unknown>)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Fires a trigger, unless the payload would leak a price.
+ *
+ * Never throws. A trigger is a notification about work that has already happened, and
+ * failing a campaign because an automation could not be told about it would be the tail
+ * wagging the dog.
+ */
+export async function fireTrigger(
+  client: AdminClient,
+  handle: TriggerHandle,
+  payload: TriggerPayload,
+): Promise<boolean> {
+  if (containsPrice(payload as unknown as Record<string, unknown>)) {
+    logger.error("refused to fire a Flow trigger carrying a price", { handle });
+    return false;
+  }
+
+  try {
+    const response = await client.request<{
+      flowTriggerReceive?: { userErrors?: Array<{ message?: string }> };
+    }>(FLOW_TRIGGER_RECEIVE, { handle, payload });
+
+    const errors = response.data?.flowTriggerReceive?.userErrors ?? [];
+    if (errors.length > 0) {
+      logger.warn("Flow rejected a trigger", {
+        handle,
+        error: errors.map((entry) => entry.message).join("; "),
+      });
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    // A merchant with no Flow installed, or a network blip. Logged at info because it is
+    // not a problem worth an alert: nothing about the campaign depends on it.
+    logger.info("could not deliver a Flow trigger", {
+      handle,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+/** Fires a trigger for a shop, resolving its client. Used from the worker. */
+export async function fireTriggerForShop(
+  shopId: string,
+  handle: TriggerHandle,
+  payload: TriggerPayload,
+): Promise<void> {
+  const shop = await prisma.shop.findUnique({
+    where: { id: shopId },
+    select: { domain: true, uninstalledAt: true },
+  });
+  if (!shop || shop.uninstalledAt) return;
+
+  const client = await adminClientForShop(shop.domain);
+  if (!client) return;
+
+  await fireTrigger(client, handle, payload);
+}

--- a/app/services/flow.test.ts
+++ b/app/services/flow.test.ts
@@ -1,0 +1,62 @@
+/**
+ * What a Flow trigger is allowed to carry.
+ *
+ * A payload passes through Flow and into whatever the merchant connected next — a Slack
+ * channel, a spreadsheet, another app's API — and out of anywhere we can reason about.
+ * The rule is the same as telemetry's, for a stronger reason.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { containsPrice } from "./flow.server";
+
+describe("refusing to send a price", () => {
+  it("passes a payload of ids, names and counts", () => {
+    expect(
+      containsPrice({
+        campaign_id: "c1",
+        campaign_name: "Summer sale",
+        products_affected: 412,
+        outcome: "clean",
+      }),
+    ).toBe(false);
+  });
+
+  it("catches a field named like money", () => {
+    expect(containsPrice({ campaign_id: "c1", price: 1999 })).toBe(true);
+    expect(containsPrice({ campaign_id: "c1", compareAtPrice: 2999 })).toBe(true);
+    expect(containsPrice({ campaign_id: "c1", unit_cost: 500 })).toBe(true);
+  });
+
+  it("catches a money-shaped value under an innocent name", () => {
+    // The realistic leak: somebody adds a field called `threshold` that happens to hold
+    // "19.99". Names are the obvious check and values are the one that catches it.
+    expect(containsPrice({ campaign_id: "c1", threshold: "19.99" })).toBe(true);
+    expect(containsPrice({ campaign_id: "c1", note: "£15.50" })).toBe(true);
+    // With a thousands separator, which is the shape a price takes once it has been
+    // formatted for display. The first version of this check missed it, and the test
+    // asserting it was fine was itself the bug.
+    expect(containsPrice({ campaign_id: "c1", note: "$1,299.00" })).toBe(true);
+    expect(containsPrice({ campaign_id: "c1", note: "1 299,00" })).toBe(true);
+  });
+
+  it("catches a bigint, which is how minor units travel here", () => {
+    expect(containsPrice({ campaign_id: "c1", something: BigInt(1999) })).toBe(true);
+  });
+
+  it("looks inside nested objects", () => {
+    expect(containsPrice({ campaign_id: "c1", detail: { price: 1999 } })).toBe(true);
+  });
+
+  it("does not mistake a count or an id for a price", () => {
+    // 412 products and a gid ending in digits must not trip it, or every trigger would
+    // be refused and the feature would silently not exist.
+    expect(
+      containsPrice({
+        campaign_id: "gid://shopify/Campaign/12345",
+        products_affected: 412,
+        products_reverted: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/app/types/admin.generated.d.ts
+++ b/app/types/admin.generated.d.ts
@@ -147,6 +147,14 @@ export type AnchorShopCurrencyQueryVariables = AdminTypes.Exact<{ [key: string]:
 
 export type AnchorShopCurrencyQuery = { shop: Pick<AdminTypes.Shop, 'currencyCode' | 'ianaTimezone'> };
 
+export type AnchorFlowTriggerReceiveMutationVariables = AdminTypes.Exact<{
+  handle: AdminTypes.Scalars['String']['input'];
+  payload: AdminTypes.Scalars['JSON']['input'];
+}>;
+
+
+export type AnchorFlowTriggerReceiveMutation = { flowTriggerReceive?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.UserError, 'field' | 'message'>> }> };
+
 export type AnchorPriceListsQueryVariables = AdminTypes.Exact<{
   cursor?: AdminTypes.InputMaybe<AdminTypes.Scalars['String']['input']>;
 }>;
@@ -211,6 +219,7 @@ interface GeneratedMutationTypes {
   "#graphql\n  mutation AnchorTagsAdd($id: ID!, $tags: [String!]!) {\n    tagsAdd(id: $id, tags: $tags) {\n      node { id }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorTagsAddMutation, variables: AnchorTagsAddMutationVariables},
   "#graphql\n  mutation AnchorTagsRemove($id: ID!, $tags: [String!]!) {\n    tagsRemove(id: $id, tags: $tags) {\n      node { id }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorTagsRemoveMutation, variables: AnchorTagsRemoveMutationVariables},
   "#graphql\n  mutation AnchorCatalogBulkQuery($query: String!) {\n    bulkOperationRunQuery(query: $query) {\n      bulkOperation { id status }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorCatalogBulkQueryMutation, variables: AnchorCatalogBulkQueryMutationVariables},
+  "#graphql\n  mutation AnchorFlowTriggerReceive($handle: String!, $payload: JSON!) {\n    flowTriggerReceive(handle: $handle, payload: $payload) {\n      userErrors { field message }\n    }\n  }\n": {return: AnchorFlowTriggerReceiveMutation, variables: AnchorFlowTriggerReceiveMutationVariables},
 }
 declare module '@shopify/admin-api-client' {
   type InputMaybe<T> = AdminTypes.InputMaybe<T>;

--- a/docs/help/how-to/shopify-flow.md
+++ b/docs/help/how-to/shopify-flow.md
@@ -1,0 +1,62 @@
+# Wiring pricing into Shopify Flow
+
+Anchor adds three triggers and three actions to Flow, so pricing can be part of the
+automations you already have rather than something you remember to do separately.
+
+## Triggers
+
+Something happened, and Flow can react to it.
+
+| Trigger | Fires when | Carries |
+|---|---|---|
+| Campaign started | A campaign begins applying prices | Campaign id, name, how many products |
+| Campaign ended | A campaign's prices are reverted | Campaign id, name, outcome, how many reverted |
+| Campaign held for drift | A campaign stopped because prices were changed outside the app | Campaign id, name, how many products |
+
+**No trigger carries a price.** Ids, names and counts only. A payload passes through Flow
+and into whatever you connected next — a Slack channel, a spreadsheet, someone else's API
+— and prices should not travel that far without you deciding they should.
+
+## Actions
+
+Flow asks Anchor to do something.
+
+| Action | What it does |
+|---|---|
+| Start a price campaign | Exactly what the Apply button does, including your guardrails and your plan's limits |
+| End a price campaign | Reverts it. Works on every plan, including free |
+| Capture baselines for a segment | Records today's prices as the new normal |
+
+Each action does exactly what the equivalent button does. An action that could start a
+campaign the app would have refused would be a way round every safety feature in it.
+
+**Capturing baselines is refused while a campaign is running.** In the app you have to
+type a confirmation to do that, because it records sale prices as normal prices and every
+future discount then comes off the discounted number. An automation cannot read a warning,
+so it is refused rather than confirmed on your behalf.
+
+## A worked example
+
+**"When stock of a product runs low, end the sale on it."**
+
+1. **Trigger:** Shopify's *Inventory quantity changed*.
+2. **Condition:** inventory quantity is less than 10.
+3. **Action:** Anchor's *End a price campaign*, with the campaign ID from the campaign's page.
+
+Prices revert, the ledger records it, and Anchor's *Campaign ended* trigger fires — so you
+can chain a Slack message onto the same Flow if you want to be told.
+
+## Another
+
+**"Tell the team when a campaign is held because someone edited a price."**
+
+1. **Trigger:** Anchor's *Campaign held for drift*.
+2. **Action:** Slack's *Send message*, using the campaign name and the count of products.
+
+This is the one worth setting up. A held campaign is waiting for a decision, and the sooner
+somebody makes it the shorter the window where prices are neither the sale price nor the
+normal one.
+
+## Finding a campaign ID
+
+Open the campaign in Anchor. The ID is in the address bar, after `/campaigns/`.

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -18,6 +18,7 @@ first campaign.
 - [Scheduling a sale](./how-to/schedule-a-sale.md)
 - [Running a sale across several markets](./how-to/multi-market-sale.md)
 - [Importing your own prices](./how-to/import-baselines.md)
+- [Wiring pricing into Shopify Flow](./how-to/shopify-flow.md)
 
 ## When something goes wrong
 

--- a/extensions/flow-actions/capture-baselines.toml
+++ b/extensions/flow-actions/capture-baselines.toml
@@ -1,0 +1,17 @@
+api_version = "2025-10"
+
+[[extensions]]
+type = "flow_action"
+name = "Capture baselines for a segment"
+handle = "capture-baselines"
+description = "Records today's prices as the reference every campaign computes from."
+runtime_url = "https://{{app_url}}/flow/actions/capture-baselines"
+
+  [settings]
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "segment_id"
+    name = "Segment ID"
+    description = "Leave blank for the whole catalogue."
+    required = false

--- a/extensions/flow-actions/end-campaign.toml
+++ b/extensions/flow-actions/end-campaign.toml
@@ -1,0 +1,16 @@
+api_version = "2025-10"
+
+[[extensions]]
+type = "flow_action"
+name = "End a price campaign"
+handle = "end-campaign"
+description = "Reverts a campaign's prices. Works on every plan, including free."
+runtime_url = "https://{{app_url}}/flow/actions/end-campaign"
+
+  [settings]
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_id"
+    name = "Campaign ID"
+    required = true

--- a/extensions/flow-actions/shopify.extension.toml
+++ b/extensions/flow-actions/shopify.extension.toml
@@ -1,0 +1,23 @@
+# Flow actions.
+#
+# Each one does exactly what the equivalent button in the app does, including the plan
+# gate and the guardrails. An action that could start a campaign the interface would have
+# refused would be a way round every safety feature in the product, reachable by anybody
+# who can build a Flow.
+api_version = "2025-10"
+
+[[extensions]]
+type = "flow_action"
+name = "Start a price campaign"
+handle = "start-campaign"
+description = "Applies a campaign's prices, exactly as the Apply button does."
+runtime_url = "https://{{app_url}}/flow/actions/start-campaign"
+
+  [settings]
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_id"
+    name = "Campaign ID"
+    description = "Copy this from the campaign's page in the app."
+    required = true

--- a/extensions/flow-triggers/campaign-ended.toml
+++ b/extensions/flow-triggers/campaign-ended.toml
@@ -1,0 +1,34 @@
+api_version = "2025-10"
+
+[[extensions]]
+type = "flow_trigger"
+name = "Campaign ended"
+handle = "campaign-ended"
+description = "A price campaign finished and its prices were reverted."
+
+  [settings]
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_id"
+    name = "Campaign ID"
+    required = true
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_name"
+    name = "Campaign name"
+    required = true
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "outcome"
+    name = "Outcome"
+    description = "clean, partial or failed."
+    required = true
+
+    [[settings.fields]]
+    type = "number_integer"
+    key = "products_reverted"
+    name = "Products reverted"
+    required = true

--- a/extensions/flow-triggers/campaign-held.toml
+++ b/extensions/flow-triggers/campaign-held.toml
@@ -1,0 +1,27 @@
+api_version = "2025-10"
+
+[[extensions]]
+type = "flow_trigger"
+name = "Campaign held for drift"
+handle = "campaign-held"
+description = "A campaign stopped because prices were changed outside this app."
+
+  [settings]
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_id"
+    name = "Campaign ID"
+    required = true
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_name"
+    name = "Campaign name"
+    required = true
+
+    [[settings.fields]]
+    type = "number_integer"
+    key = "products_drifted"
+    name = "Products with unexpected prices"
+    required = true

--- a/extensions/flow-triggers/shopify.extension.toml
+++ b/extensions/flow-triggers/shopify.extension.toml
@@ -1,0 +1,38 @@
+# Flow triggers.
+#
+# No dedicated price editor in this category has Flow support, which makes it a cheap and
+# visible differentiator: a merchant can wire pricing into automations they already have,
+# without us having to guess which ones.
+#
+# Payloads carry ids, names and counts. Never a price value — the same rule telemetry
+# follows, and for the same reason: a payload passes through Flow, into whatever the
+# merchant connected next, and out of anywhere we can reason about.
+api_version = "2025-10"
+
+[[extensions]]
+type = "flow_trigger"
+name = "Campaign started"
+handle = "campaign-started"
+description = "A price campaign began applying prices."
+
+  [settings]
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_id"
+    name = "Campaign ID"
+    description = "The campaign that started."
+    required = true
+
+    [[settings.fields]]
+    type = "single_line_text_field"
+    key = "campaign_name"
+    name = "Campaign name"
+    required = true
+
+    [[settings.fields]]
+    type = "number_integer"
+    key = "products_affected"
+    name = "Products affected"
+    description = "How many products the campaign is pricing."
+    required = true


### PR DESCRIPTION
Closes #177.

Three triggers and three actions, so pricing can be part of the automations a merchant already has. **No dedicated price editor in this category supports Flow** — a cheap, visible differentiator.

## No trigger carries a price, and it's enforced

A payload passes through Flow and into whatever the merchant connected next — a Slack channel, a spreadsheet, another app's API — and out of anywhere we can reason about.

`containsPrice` walks the payload before sending; a price-shaped value is **dropped with a loud log** rather than delivered. A trigger that doesn't fire is a missing automation; a trigger that leaks a merchant's pricing is a different kind of problem.

The check is **shape-based as well as name-based**, because the realistic leak isn't somebody adding a field called `price` — it's a field called `threshold` that happens to hold `"19.99"`.

> One of my own tests asserted `"$1,299.00"` was **not** caught, encoding a real hole as expected behaviour: the pattern missed thousands separators, which is exactly the shape a price takes once formatted for display. The test passed either way — worth noting that reading what a test *claims* matters as much as whether it's green.

## Actions do exactly what the buttons do

Including the plan gate and every guardrail, by calling the same `runCampaign`. An action that could start a campaign the interface would have refused would be **a way round every safety feature in the product** — reachable by anybody who can build a Flow, and invisible to the merchant.

- **Ending** a campaign is never gated on plan, on any tier. Same reason the Revert button isn't.
- **Capturing baselines is refused while a campaign is running**, rather than confirmed on the merchant's behalf. The app makes a *person* type a confirmation there because it records sale prices as normal prices, and every future discount then comes off the discounted number. An automation can't read a warning — a scheduled Flow silently resetting a merchant's reference prices mid-sale would be the most expensive thing in this codebase.

An unknown campaign returns **200, not 404**: Flow retries failures, and retrying won't make a deleted campaign exist — it would repeat the same error until somebody disables the automation.

## Documented

Two worked examples, including the one the ticket names: *"when inventory of X is below 10, end campaign Y"*.

## Tests

6 for the price detector. **Falsified:** dropping the name check, the value check, the nested walk, the bigint case, and the thousands-separator pattern.

Full suite: 685 unit tests, 87 chaos scenarios, lint and build clean.

## Note for review

The extension TOMLs are written against Flow's documented shape but can only be exercised once the app is deployed with a Partner app that has Flow enabled — that part is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)