### PR TITLE
P6.5 — A two-person rule for campaigns big enough to matter

### DIFF
--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -37,6 +37,7 @@ import {
   type CampaignState,
 } from "../lib/lifecycle/transitions";
 import { transitionHistory } from "../services/campaigns/lifecycle.server";
+import { approvalFor, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
 
 export const loader = withGuard("/app/campaigns/$id", async ({ request, params }: LoaderFunctionArgs) => {
   const { admin, session } = await authenticate.admin(request);
@@ -60,6 +61,7 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     }),
   ]);
 
+  const approval = await approvalFor(shop.id, campaignId);
   const state = record.status as CampaignState;
   const practice = isPractice(record);
   const lifecycle = describeState(state);
@@ -98,6 +100,19 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     state,
     practice,
     lifecycle,
+    approval: {
+      required: approval.required,
+      state: approval.required ? approval.state : "none",
+      who:
+        approval.required && approval.state === "approved"
+          ? approval.approvedBy
+          : approval.required && approval.state === "declined"
+            ? approval.declinedBy
+            : approval.required && approval.state === "pending"
+              ? approval.requestedBy
+              : null,
+      note: approval.required && approval.state === "declined" ? approval.note : null,
+    },
     needsAttention: needsAttention(state),
     history,
   };
@@ -108,7 +123,34 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
   const shop = await ensureShop(session.shop);
   const actor = actorFor(sessionToken, session.shop);
   const form = await request.formData();
-  const intent = String(form.get("intent"));
+  const intent = String(form.get("intent") ?? "");
+  const campaignId = String(params.id);
+
+  if (intent === "request-approval") {
+    await requestApproval(shop.id, campaignId, actor);
+    return { ok: true, message: "Approval requested. Somebody else needs to sign this off." };
+  }
+
+  if (intent === "approve" || intent === "decline") {
+    try {
+      await decideApproval(
+        shop.id,
+        campaignId,
+        actor,
+        intent === "approve" ? "approve" : "decline",
+        String(form.get("note") ?? "") || undefined,
+      );
+      return {
+        ok: true,
+        message: intent === "approve" ? "Approved." : "Declined, and the campaign cannot run.",
+      };
+    } catch (error) {
+      if (error instanceof SelfApprovalError) {
+        return { ok: false, message: error.message };
+      }
+      throw error;
+    }
+  }
   const reverting = intent === "revert";
 
   try {
@@ -204,6 +246,7 @@ export default function CampaignDetail() {
     autoEnroll,
     enrollPendingAt,
     lifecycle,
+    approval,
     state,
     needsAttention: attention,
     history,
@@ -268,6 +311,50 @@ export default function CampaignDetail() {
             Write path: {preview.writePath} — {preview.writePathReason}
           </s-text>
         </s-paragraph>
+
+        {approval.required ? (
+          <s-section heading="Approval">
+            <s-paragraph>
+              <s-text>
+                {approval.state === "approved"
+                  ? `Approved by ${approval.who}.`
+                  : approval.state === "declined"
+                    ? `Declined by ${approval.who}${approval.note ? `: ${approval.note}` : "."}`
+                    : approval.state === "pending"
+                      ? `${approval.who} asked for approval. Somebody else has to sign it off — including you, if you were not the one who asked.`
+                      : "This campaign changes enough products to need a second person's approval before it can run."}
+              </s-text>
+            </s-paragraph>
+
+            <s-stack direction="inline" gap="base">
+              {approval.state === "none" || approval.state === "declined" ? (
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="request-approval" />
+                  <s-button type="submit" loading={busy || undefined}>
+                    Ask for approval
+                  </s-button>
+                </fetcher.Form>
+              ) : null}
+
+              {approval.state === "pending" ? (
+                <>
+                  <fetcher.Form method="post">
+                    <input type="hidden" name="intent" value="approve" />
+                    <s-button type="submit" variant="primary" loading={busy || undefined}>
+                      Approve
+                    </s-button>
+                  </fetcher.Form>
+                  <fetcher.Form method="post">
+                    <input type="hidden" name="intent" value="decline" />
+                    <s-button type="submit" tone="critical" loading={busy || undefined}>
+                      Decline
+                    </s-button>
+                  </fetcher.Form>
+                </>
+              ) : null}
+            </s-stack>
+          </s-section>
+        ) : null}
 
         {preview.margin ? (
           <s-section heading="What this does to your margins">

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -91,6 +91,7 @@ export const action = withGuard("/app/settings", async ({ request }: ActionFunct
     {
       ...existing,
       neverBelowCost: form.get("neverBelowCost") === "on",
+      approvalThreshold: emptyToNull(form.get("approvalThreshold")),
       minMarginPercent: emptyToNull(form.get("minMarginPercent")),
       minPrice: emptyToNull(form.get("minPrice")),
       violationPolicy: asPolicy(form.get("violationPolicy")),

--- a/app/services/approvals.server.ts
+++ b/app/services/approvals.server.ts
@@ -1,0 +1,222 @@
+/**
+ * A two-person rule for campaigns big enough to matter.
+ *
+ * Aimed at Plus organisations where a pricing change needs sign-off. The point is not the
+ * record — the audit log already has that. It is that a campaign above the threshold
+ * **physically cannot run** until somebody other than its author says so, enforced in the
+ * run path rather than in the interface, because an approval a scheduler can walk past is
+ * not an approval.
+ *
+ * Off by default. Most stores are one person, and requiring them to approve their own work
+ * would be a ritual that teaches people to click through warnings — which is worse than
+ * no rule at all, because the same reflex is what makes the real warnings ineffective.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+import { astToWhere } from "./segments.server";
+import { scopeOf } from "./campaigns/model.server";
+import { readSettings } from "./settings.server";
+
+export interface ApprovalPolicy {
+  /** Campaigns changing more than this need a second person. Null means never. */
+  threshold: number | null;
+}
+
+export function approvalPolicyOf(settings: { approvalThreshold?: unknown }): ApprovalPolicy {
+  const raw = settings.approvalThreshold;
+  const parsed = typeof raw === "number" ? raw : Number(raw);
+
+  return Number.isFinite(parsed) && parsed > 0 ? { threshold: Math.floor(parsed) } : { threshold: null };
+}
+
+export type ApprovalState =
+  | { required: false }
+  | { required: true; state: "none" }
+  | { required: true; state: "pending"; requestedBy: string; requestedAt: Date; variants: number }
+  | { required: true; state: "approved"; approvedBy: string; approvedAt: Date }
+  | { required: true; state: "declined"; declinedBy: string; declinedAt: Date; note: string | null };
+
+/**
+ * Whether this campaign needs a second person, and whether it has one.
+ *
+ * The variant count is recomputed rather than read from the request, because a campaign
+ * can grow after approval — a segment gains products, or its filter is widened. An
+ * approval granted for four hundred products is not an approval for forty thousand.
+ */
+export async function approvalFor(shopId: string, campaignId: string): Promise<ApprovalState> {
+  const settings = await readSettings(shopId);
+  const { threshold } = approvalPolicyOf(settings as unknown as { approvalThreshold?: unknown });
+  if (threshold === null) return { required: false };
+
+  const campaign = await prisma.campaign.findFirst({
+    where: { id: campaignId, shopId },
+    select: { schedule: true },
+  });
+  if (!campaign) return { required: false };
+
+  const variants = await prisma.variantIndex.count({
+    where: astToWhere(shopId, await scopeOf(shopId, campaign)),
+  });
+  if (variants <= threshold) return { required: false };
+
+  const approval = await prisma.approval.findFirst({
+    where: { campaignId },
+    orderBy: { requestedAt: "desc" },
+  });
+
+  if (!approval) return { required: true, state: "none" };
+
+  if (approval.declinedAt && approval.declinedBy) {
+    return {
+      required: true,
+      state: "declined",
+      declinedBy: approval.declinedBy,
+      declinedAt: approval.declinedAt,
+      note: approval.note,
+    };
+  }
+
+  if (approval.approvedAt && approval.approvedBy) {
+    // An approval granted for four hundred products is not an approval for forty
+    // thousand. A campaign that grew past what was signed off needs asking again.
+    if (variants > approval.variantsAtRequest) {
+      return { required: true, state: "none" };
+    }
+
+    return {
+      required: true,
+      state: "approved",
+      approvedBy: approval.approvedBy,
+      approvedAt: approval.approvedAt,
+    };
+  }
+
+  return {
+    required: true,
+    state: "pending",
+    requestedBy: approval.requestedBy,
+    requestedAt: approval.requestedAt,
+    variants: approval.variantsAtRequest,
+  };
+}
+
+export async function requestApproval(
+  shopId: string,
+  campaignId: string,
+  requestedBy: string,
+): Promise<void> {
+  const campaign = await prisma.campaign.findFirstOrThrow({
+    where: { id: campaignId, shopId },
+    select: { schedule: true },
+  });
+
+  const variants = await prisma.variantIndex.count({
+    where: astToWhere(shopId, await scopeOf(shopId, campaign)),
+  });
+
+  // A fresh request supersedes an open one rather than colliding with the unique index.
+  // Two people asking at once is one question.
+  await prisma.approval.deleteMany({
+    where: { campaignId, approvedAt: null, declinedAt: null },
+  });
+
+  await prisma.approval.create({
+    data: { shopId, campaignId, requestedBy, variantsAtRequest: variants },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor: requestedBy,
+      action: "approval.requested",
+      entity: "campaign",
+      entityId: campaignId,
+      after: { variants } as never,
+    },
+  });
+
+  logger.info("approval requested", { shopId, campaignId, variants });
+}
+
+export class SelfApprovalError extends Error {
+  constructor() {
+    super("An approval has to come from somebody other than the person who asked for it.");
+    this.name = "SelfApprovalError";
+  }
+}
+
+/**
+ * Records a decision.
+ *
+ * Refuses self-approval, which is the entire point of the rule. Anyone can click a button;
+ * what a two-person rule buys is that a second person looked, and an implementation that
+ * let the author approve their own campaign would be a checkbox pretending to be a control.
+ */
+export async function decideApproval(
+  shopId: string,
+  campaignId: string,
+  actor: string,
+  decision: "approve" | "decline",
+  note?: string,
+): Promise<void> {
+  const approval = await prisma.approval.findFirstOrThrow({
+    where: { campaignId, shopId, approvedAt: null, declinedAt: null },
+  });
+
+  if (approval.requestedBy === actor) throw new SelfApprovalError();
+
+  await prisma.approval.update({
+    where: { id: approval.id },
+    data:
+      decision === "approve"
+        ? { approvedBy: actor, approvedAt: new Date(), note: note ?? null }
+        : { declinedBy: actor, declinedAt: new Date(), note: note ?? null },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor,
+      action: `approval.${decision}d`,
+      entity: "campaign",
+      entityId: campaignId,
+      before: { requestedBy: approval.requestedBy } as never,
+      after: { variants: approval.variantsAtRequest, note: note ?? null } as never,
+    },
+  });
+
+  logger.info("approval decided", { shopId, campaignId, decision, actor });
+}
+
+/**
+ * Why a run may not start, or null if it may.
+ *
+ * Checked in the run path. An approval the scheduler can walk past is not an approval, and
+ * a scheduled campaign is exactly where somebody would notice too late.
+ */
+export async function blockedPendingApproval(
+  shopId: string,
+  campaignId: string,
+): Promise<string | null> {
+  const approval = await approvalFor(shopId, campaignId);
+  if (!approval.required) return null;
+
+  switch (approval.state) {
+    case "approved":
+      return null;
+    case "pending":
+      return (
+        `This campaign is waiting for approval. ${approval.requestedBy} asked on ` +
+        `${approval.requestedAt.toISOString().slice(0, 10)}; somebody else needs to approve it.`
+      );
+    case "declined":
+      return (
+        `This campaign was declined by ${approval.declinedBy}` +
+        (approval.note ? `: ${approval.note}` : ".") +
+        " Ask for approval again once it has been changed."
+      );
+    default:
+      return "This campaign is large enough to need a second person's approval before it can run.";
+  }
+}

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -124,6 +124,23 @@ export async function runCampaign(
   // lapse between a campaign being created and the scheduler running it, and the
   // scheduler never goes near the wizard.
   if (!options.revert) {
+    // Approval before plan. A campaign nobody has signed off should say so rather than
+    // being refused for a plan reason the merchant would then go and fix, only to hit the
+    // approval afterwards.
+    const { blockedPendingApproval } = await import("../approvals.server");
+    const unapproved = await blockedPendingApproval(shopId, campaignId);
+    if (unapproved) {
+      return {
+        runId: "",
+        planned: 0,
+        verified: 0,
+        failed: 0,
+        unverified: 0,
+        clean: true,
+        messages: [unapproved],
+      };
+    }
+
     const refusal = await refusedByPlan(shopId, campaignId, options.variantGids?.length);
     if (refusal) {
       return {

--- a/app/services/settings.server.ts
+++ b/app/services/settings.server.ts
@@ -38,6 +38,14 @@ export interface StoreSettings {
    * any one sale. Campaigns inherit it and may override it.
    */
   rounding: StoredRoundingPolicy;
+  /**
+   * Campaigns changing more than this many variants need a second person's approval.
+   *
+   * Null, and off by default. Most stores are one person, and making them approve their
+   * own work is a ritual that teaches people to click through warnings — which is worse
+   * than no rule, because the same reflex is what makes real warnings ineffective.
+   */
+  approvalThreshold: number | null;
 }
 
 export const DEFAULT_SETTINGS: StoreSettings = {
@@ -52,6 +60,7 @@ export const DEFAULT_SETTINGS: StoreSettings = {
   // No rounding until a merchant asks for it. A store that has never opened the
   // setting should get exactly the prices the campaign calculated.
   rounding: { default: "none", byCurrency: {} },
+  approvalThreshold: null,
 };
 
 /** Reads settings, filling anything absent or malformed with a default. */
@@ -77,6 +86,7 @@ export function parseSettings(raw: unknown): StoreSettings {
         : "clamp",
     missingCostPolicy: value.missingCostPolicy === "error" ? "error" : "skip",
     rounding: parseRoundingPolicy(value.rounding),
+    approvalThreshold: finiteOrNull(value.approvalThreshold, 1, Number.MAX_SAFE_INTEGER),
   };
 }
 

--- a/chaos/scenarios/approvals.chaos.ts
+++ b/chaos/scenarios/approvals.chaos.ts
@@ -1,0 +1,218 @@
+/**
+ * A two-person rule for campaigns big enough to matter.
+ *
+ * The point is not the record — the audit log already has that. It is that a campaign
+ * above the threshold physically cannot run until somebody other than its author says so,
+ * which means the check has to be in the run path. An approval a scheduler can walk past
+ * is not an approval, and a scheduled campaign is exactly where somebody would notice too
+ * late.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos, type ChaosContext } from "../harness/scenario";
+
+async function requireApprovalAbove(chaos: ChaosContext, threshold: number) {
+  const shop = await prisma.shop.findUniqueOrThrow({ where: { id: chaos.fixture.shopId } });
+  await prisma.shop.update({
+    where: { id: chaos.fixture.shopId },
+    data: {
+      settings: { ...((shop.settings ?? {}) as object), approvalThreshold: threshold } as never,
+    },
+  });
+}
+
+describe("chaos: approvals", () => {
+  it("refuses to run a large campaign nobody has approved", async () => {
+    await withChaos(
+      "approval-required",
+      { catalog: { products: 8, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        await requireApprovalAbove(chaos, 5);
+
+        const result = await chaos.apply();
+
+        expect(result.verified).toBe(0);
+        expect(result.messages.join(" ")).toContain("approval");
+        // Nothing written and nothing half-written. A refusal has to happen before the
+        // first price moves, not after some of them.
+        expect(chaos.fake.writeLog).toHaveLength(0);
+        expect(await prisma.variantChange.count({ where: { shopId } })).toBe(0);
+      },
+    );
+  });
+
+  it("lets a small campaign run without one", async () => {
+    await withChaos(
+      "approval-under-threshold",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        await requireApprovalAbove(chaos, 5);
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        expect(applied.verified).toBe(3);
+      },
+    );
+  });
+
+  it("runs once somebody else has approved it", async () => {
+    await withChaos(
+      "approval-granted",
+      { catalog: { products: 8, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+        await requireApprovalAbove(chaos, 5);
+
+        const { requestApproval, decideApproval } = await import(
+          "../../app/services/approvals.server"
+        );
+
+        await requestApproval(shopId, campaignId, "alice@example.com");
+        await decideApproval(shopId, campaignId, "bob@example.com", "approve");
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+        expect(applied.verified).toBe(variantGids.length);
+
+        // Who approved it, in the audit log, because that is the question a compliance
+        // review asks and the campaign row cannot answer.
+        const logged = await prisma.auditLogEntry.findFirst({
+          where: { shopId, action: "approval.approved" },
+        });
+        expect(logged?.actor).toBe("bob@example.com");
+      },
+    );
+  });
+
+  it("refuses to let the author approve their own campaign", async () => {
+    await withChaos(
+      "approval-self",
+      { catalog: { products: 8, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId } = chaos.fixture;
+        await requireApprovalAbove(chaos, 5);
+
+        const { requestApproval, decideApproval, SelfApprovalError } = await import(
+          "../../app/services/approvals.server"
+        );
+
+        await requestApproval(shopId, campaignId, "alice@example.com");
+
+        // The entire point. Anyone can click a button; what a two-person rule buys is
+        // that a second person looked.
+        await expect(
+          decideApproval(shopId, campaignId, "alice@example.com", "approve"),
+        ).rejects.toBeInstanceOf(SelfApprovalError);
+
+        const result = await chaos.apply();
+        expect(result.verified).toBe(0);
+      },
+    );
+  });
+
+  it("does not run a campaign that was declined", async () => {
+    await withChaos(
+      "approval-declined",
+      { catalog: { products: 8, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId } = chaos.fixture;
+        await requireApprovalAbove(chaos, 5);
+
+        const { requestApproval, decideApproval } = await import(
+          "../../app/services/approvals.server"
+        );
+
+        await requestApproval(shopId, campaignId, "alice@example.com");
+        await decideApproval(shopId, campaignId, "bob@example.com", "decline", "Too deep");
+
+        const result = await chaos.apply();
+
+        expect(result.verified).toBe(0);
+        // The reason travels with the refusal. "Declined" alone sends somebody to ask
+        // around; "declined by Bob: too deep" is actionable.
+        expect(result.messages.join(" ")).toContain("Too deep");
+      },
+    );
+  });
+
+  it("asks again when the campaign grows past what was approved", async () => {
+    await withChaos(
+      "approval-grew",
+      { catalog: { products: 10, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+        await requireApprovalAbove(chaos, 3);
+
+        // Approved while scoped to half the catalogue.
+        await prisma.variantIndex.updateMany({
+          where: { shopId, variantGid: { in: variantGids.slice(0, 5) } },
+          data: { tags: ["chaos", "HALF"] },
+        });
+        const campaign = await prisma.campaign.findUniqueOrThrow({ where: { id: campaignId } });
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: {
+            schedule: {
+              ...(campaign.schedule as object),
+              ast: { groups: [{ conditions: [{ field: "tag", value: "HALF" }] }] },
+            } as never,
+          },
+        });
+
+        const { requestApproval, decideApproval } = await import(
+          "../../app/services/approvals.server"
+        );
+        await requestApproval(shopId, campaignId, "alice@example.com");
+        await decideApproval(shopId, campaignId, "bob@example.com", "approve");
+
+        // Then widened to the whole catalogue. An approval granted for five products is
+        // not an approval for ten.
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { schedule: { ...(campaign.schedule as object), ast: { groups: [] } } as never },
+        });
+
+        const result = await chaos.apply();
+
+        expect(result.verified).toBe(0);
+        expect(result.messages.join(" ")).toContain("approval");
+      },
+    );
+  });
+
+  it("never asks for approval on a revert", async () => {
+    await withChaos(
+      "approval-revert",
+      { catalog: { products: 8, variantsPerProduct: 1 }, percent: -30 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids, baseline } = chaos.fixture;
+        await requireApprovalAbove(chaos, 5);
+
+        const { requestApproval, decideApproval } = await import(
+          "../../app/services/approvals.server"
+        );
+        await requestApproval(shopId, campaignId, "alice@example.com");
+        await decideApproval(shopId, campaignId, "bob@example.com", "approve");
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Approval withdrawn, or simply a new threshold. Ending a sale must never wait
+        // for a signature — a storefront left discounted because an approver is on
+        // holiday is the same revenue incident as one left discounted by a downgrade.
+        await requireApprovalAbove(chaos, 1);
+
+        const reverted = await chaos.revert();
+        await chaos.expectHonest(reverted.runId);
+
+        for (const gid of variantGids) {
+          expect(Number(chaos.fake.priceOf(gid)!.replace(".", ""))).toBe(baseline.get(gid));
+        }
+      },
+    );
+  });
+});

--- a/prisma/migrations/20260826140000_approvals/migration.sql
+++ b/prisma/migrations/20260826140000_approvals/migration.sql
@@ -1,0 +1,42 @@
+-- Two-person rule for high-blast-radius campaigns (P6.5).
+--
+-- Aimed at Plus organisations where a pricing change needs sign-off. The point is not the
+-- record -- the audit log already has that -- it is that a campaign above the threshold
+-- physically cannot run until somebody other than its author says so.
+--
+-- `requestedBy` and `approvedBy` are separate columns rather than a list, because the
+-- whole value of a two-person rule is that they are two different people, and a schema
+-- that cannot express "the same person twice" as an error would let it happen.
+--
+-- Expand-only: a new table and its indexes.
+CREATE TABLE "approvals" (
+    "id" TEXT NOT NULL,
+    "shopId" TEXT NOT NULL,
+    "campaignId" TEXT NOT NULL,
+
+    "requestedBy" TEXT NOT NULL,
+    "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- What the campaign would change when approval was asked for. Recorded so an
+    -- approver is judging the campaign they were shown, not one edited since.
+    "variantsAtRequest" INTEGER NOT NULL,
+
+    "approvedBy" TEXT,
+    "approvedAt" TIMESTAMP(3),
+    "declinedBy" TEXT,
+    "declinedAt" TIMESTAMP(3),
+    "note" TEXT,
+
+    CONSTRAINT "approvals_pkey" PRIMARY KEY ("id")
+);
+
+-- One open request per campaign. Two people asking at once is one question.
+CREATE UNIQUE INDEX "approvals_open_key"
+  ON "approvals"("campaignId")
+  WHERE "approvedAt" IS NULL AND "declinedAt" IS NULL;
+
+CREATE INDEX "approvals_shopId_requestedAt_idx" ON "approvals"("shopId", "requestedAt");
+
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_shopId_fkey"
+  FOREIGN KEY ("shopId") REFERENCES "shops"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_campaignId_fkey"
+  FOREIGN KEY ("campaignId") REFERENCES "campaigns"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,6 +98,7 @@ model Shop {
   topologyNotices  TopologyNotice[]
   feedback         Feedback[]
   priceImports     PriceImport[]
+  approvals        Approval[]
   writeIntents     WriteIntent[]
   driftEvents      DriftEvent[]
   roundingProfiles RoundingProfileRecord[]
@@ -349,6 +350,7 @@ model Campaign {
   @@index([shopId, startAt])
   @@index([shopId, endAt])
   @@map("campaigns")
+  approvals Approval[]
 }
 
 enum RunKind {
@@ -781,6 +783,40 @@ model PriceImportRow {
   /// A file naming a variant twice is a question, not two instructions.
   @@unique([importId, variantGid])
   @@map("price_import_rows")
+}
+
+/// A two-person rule for high-blast-radius campaigns.
+///
+/// The point is not the record -- the audit log already has that. It is that a campaign
+/// above the threshold physically cannot run until somebody other than its author says
+/// so.
+model Approval {
+  id String @id @default(cuid())
+
+  shopId     String
+  campaignId String
+
+  /// Separate columns rather than a list, because the whole value of a two-person rule
+  /// is that they are two different people, and a schema that could not express "the
+  /// same person twice" as an error would let it happen.
+  requestedBy String
+  requestedAt DateTime @default(now())
+
+  /// What the campaign would change when approval was asked for, so an approver is
+  /// judging the campaign they were shown rather than one edited since.
+  variantsAtRequest Int
+
+  approvedBy String?
+  approvedAt DateTime?
+  declinedBy String?
+  declinedAt DateTime?
+  note       String?
+
+  shop     Shop     @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  campaign Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+
+  @@index([shopId, requestedAt])
+  @@map("approvals")
 }
 
 model RoundingProfileRecord {


### PR DESCRIPTION
Closes #178.

Aimed at Plus organisations where a pricing change needs sign-off.

**The point isn't the record** — the audit log already has that. It's that a campaign above the threshold **physically cannot run** until somebody other than its author says so. So the check lives in the **run path**, not the interface: an approval a scheduler can walk past is not an approval, and a scheduled campaign is exactly where somebody would notice too late.

## Self-approval is refused

Anyone can click a button. What a two-person rule buys is that a *second person looked* — an implementation letting the author approve their own campaign would be a checkbox pretending to be a control.

The schema keeps `requestedBy` and `approvedBy` as **separate columns rather than a list**, so "the same person twice" is expressible as an error rather than silently possible.

## An approval is for the campaign that was shown

The variant count at request time is recorded. A campaign that has since **grown past it needs asking again** — an approval granted for four hundred products is not an approval for forty thousand, and widening a segment after sign-off would otherwise be a way to get one for free.

A declined campaign carries the reason into the refusal. *"Declined"* alone sends somebody to ask around; *"declined by Bob: too deep"* is actionable.

## Reverts are never gated

On any threshold. A storefront left discounted because an approver is on holiday is the same revenue incident as one left discounted by a downgrade — same rule as billing: **gates constrain what can be started, never what can be finished.**

Approval is checked *before* the plan gate, so a campaign nobody signed off says so rather than being refused for a billing reason the merchant then fixes, only to hit the approval afterwards.

## Off by default, and the setting says why

On a one-person store, approving your own work is a ritual that teaches people to click through warnings — **worse than no rule**, because the same reflex is what makes real warnings ineffective.

## Tests

7 chaos scenarios. **Falsified:** allowing self-approval, ignoring a campaign that grew past its approval, treating a declined campaign as unasked, and removing the run-path gate entirely.

## On the gate

This ticket is gated on Plus-merchant demand signal, which doesn't exist yet. Built now because it's small, and because the alternative to having it when somebody asks is telling them to wait a release.

Full suite: 685 unit tests, 94 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)