### PR TITLE
P4.6 — Built for Shopify pre-audit, as a test rather than a checklist

### DIFF
--- a/app/lib/compliance/built-for-shopify.test.ts
+++ b/app/lib/compliance/built-for-shopify.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Built for Shopify criteria, checked against the source rather than a checklist.
+ *
+ * Nine of fourteen direct competitors carry the badge, so it is an entry requirement
+ * rather than a nice-to-have — and certification measurably moves App Store search rank.
+ *
+ * A checklist somebody ticked once is worth very little: the interesting failures are the
+ * ones introduced afterwards by a change that looked unrelated. Everything here that can
+ * be verified mechanically is, and runs on every CI build. What cannot — colour contrast,
+ * keyboard traps, real admin performance — is listed in `docs/built-for-shopify.md` with
+ * how it was checked and by whom.
+ */
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+function sourceFiles(dir: string, match: RegExp): string[] {
+  const out: string[] = [];
+  const walk = (path: string) => {
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const full = join(path, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (match.test(entry.name)) out.push(full);
+    }
+  };
+  walk(join(ROOT, dir));
+  return out;
+}
+
+const routes = sourceFiles("app/routes", /\.tsx$/);
+const components = sourceFiles("app/components", /\.tsx$/);
+
+/**
+ * The embedded admin surface.
+ *
+ * `_index` is the app's public landing page — it renders outside Shopify's admin, where
+ * App Bridge is not loaded and Polaris web components therefore do not exist. The design
+ * criteria are about the embedded experience, so holding a plain login page to them would
+ * be checking the wrong thing.
+ */
+const ui = [
+  ...routes.filter((file) => !file.includes("routes/_index")),
+  ...components,
+];
+
+describe("performance — no storefront impact", () => {
+  it("ships no theme app extension", () => {
+    // The criterion the app satisfies by construction: campaign-scoped tags are the
+    // storefront hook, and a theme a merchant's own developer maintains is not something
+    // this app should be adding to.
+    const extensions = existsSync(join(ROOT, "extensions"))
+      ? readdirSync(join(ROOT, "extensions"))
+      : [];
+
+    for (const name of extensions) {
+      const toml = join(ROOT, "extensions", name, "shopify.extension.toml");
+      if (!existsSync(toml)) continue;
+
+      const contents = readFileSync(toml, "utf8");
+      expect(contents, `${name} is a theme extension`).not.toMatch(
+        /type\s*=\s*"theme(_app_extension)?"/,
+      );
+    }
+  });
+});
+
+describe("design — Polaris and App Bridge", () => {
+  it("uses no native form outside the App Bridge-safe wrapper", () => {
+    // A native form does a full navigation that wipes App Bridge's host, id_token and
+    // shop parameters. The server then sees no shop and the merchant gets a blank page —
+    // which is both a broken app and a design-criterion failure for full page reloads.
+    for (const file of ui) {
+      if (file.endsWith("FilterForm.tsx")) continue;
+      const source = readFileSync(file, "utf8");
+
+      expect(source, `${file} uses a native <form>`).not.toMatch(/<form[\s>]/);
+    }
+  });
+
+  it("labels every form field", () => {
+    // WCAG AA, and also simply usable. A field whose only description is placeholder
+    // text is unreadable to a screen reader and invisible once somebody starts typing.
+    const FIELDS = [
+      "s-text-field",
+      "s-number-field",
+      "s-select",
+      "s-checkbox",
+      "s-text-area",
+      "s-date-field",
+      "s-money-field",
+      "s-email-field",
+    ];
+
+    for (const file of ui) {
+      const source = readFileSync(file, "utf8");
+
+      for (const field of FIELDS) {
+        // Each opening tag with everything up to its closing bracket, so a label on a
+        // later line counts — which is how most of them are written.
+        const pattern = new RegExp(`<${field}\\b[^>]*>`, "gs");
+        for (const match of source.matchAll(pattern)) {
+          expect(
+            /\blabel=|\baccessibilityLabel=/.test(match[0]),
+            `${file}: a <${field}> has no label`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("never renders a raw HTML input other than a hidden one", () => {
+    // Hidden inputs carry intent through a form and have no Polaris equivalent. Anything
+    // visible should be a Polaris component, or the app has two visual languages in it.
+    for (const file of ui) {
+      const source = readFileSync(file, "utf8");
+
+      for (const match of source.matchAll(/<input\b[^>]*>/gs)) {
+        expect(
+          /type="hidden"/.test(match[0]),
+          `${file}: a visible <input> should be a Polaris field`,
+        ).toBe(true);
+      }
+    }
+  });
+});
+
+describe("integration — API, auth and webhooks", () => {
+  it("pins one API version, with no environment override", () => {
+    // A worker and a web process on different versions is a class of bug that only ever
+    // shows up in production, and only sometimes.
+    const source = readFileSync(join(ROOT, "app/lib/shopify/api-version.ts"), "utf8");
+
+    expect(source).toMatch(/export const API_VERSION\s*=\s*ApiVersion\./);
+    expect(source, "the API version must not be overridable by env").not.toMatch(
+      /process\.env\.\w*API_VERSION/,
+    );
+  });
+
+  it("authenticates every webhook route", () => {
+    // The HMAC check lives inside authenticate.webhook. A route without it accepts
+    // anything anyone sends.
+    const webhooks = routes.filter((file) => file.includes("/webhooks."));
+
+    expect(webhooks.length).toBeGreaterThan(0);
+    for (const file of webhooks) {
+      expect(readFileSync(file, "utf8"), `${file} does not authenticate`).toMatch(
+        /authenticate\.webhook\(/,
+      );
+    }
+  });
+
+  it("authenticates every embedded route", () => {
+    const embedded = routes.filter(
+      (file) => /\/app\./.test(file) && !file.includes("webhooks") && !file.endsWith("app.tsx"),
+    );
+
+    for (const file of embedded) {
+      const source = readFileSync(file, "utf8");
+      if (!/export const (loader|action)/.test(source)) continue;
+
+      expect(source, `${file} has a loader or action that does not authenticate`).toMatch(
+        /authenticate\.(admin|flow)\(/,
+      );
+    }
+  });
+
+  it("registers all three mandatory GDPR topics", () => {
+    const toml = readFileSync(join(ROOT, "shopify.app.toml"), "utf8");
+
+    for (const topic of ["customers/data_request", "customers/redact", "shop/redact"]) {
+      expect(toml, `${topic} is not registered`).toContain(topic);
+    }
+  });
+
+  it("keeps requested scopes to the ones the app demonstrably uses", () => {
+    // Every extra scope is a reason a merchant declines the install, and a question at
+    // review. These three were each established empirically in P0.2.
+    const toml = readFileSync(join(ROOT, "shopify.app.toml"), "utf8");
+    const match = /scopes\s*=\s*"([^"]*)"/.exec(toml);
+
+    expect(match).not.toBeNull();
+    const scopes = (match?.[1] ?? "").split(",").map((scope) => scope.trim()).filter(Boolean);
+
+    expect(scopes.sort()).toEqual(["read_markets", "write_markets", "write_products"]);
+  });
+});

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -27,10 +27,20 @@ export default function App() {
         </p>
         {showForm && (
           <Form className={styles.form} method="post" action="/auth/login">
-            <label className={styles.label}>
+            <label className={styles.label} htmlFor="shop">
               <span>Shop domain</span>
-              <input className={styles.input} type="text" name="shop" />
-              <span>e.g: my-shop-domain.myshopify.com</span>
+              {/* Explicitly associated rather than relying on the wrapping label alone:
+                  some screen readers announce a wrapped input without its hint, and this
+                  page is the first thing a merchant installing the app ever sees. */}
+              <input
+                id="shop"
+                className={styles.input}
+                type="text"
+                name="shop"
+                autoComplete="off"
+                aria-describedby="shop-hint"
+              />
+              <span id="shop-hint">e.g: my-shop-domain.myshopify.com</span>
             </label>
             <button className={styles.button} type="submit">
               Log in

--- a/docs/built-for-shopify.md
+++ b/docs/built-for-shopify.md
@@ -1,0 +1,70 @@
+# Built for Shopify — pre-submission audit
+
+Nine of fourteen direct competitors carry the badge, which makes it an entry requirement
+rather than a differentiator, and certification measurably moves App Store search rank.
+
+Everything below that can be verified mechanically **is**, in
+`app/lib/compliance/built-for-shopify.test.ts`, and runs on every CI build. A checklist
+somebody ticked once is worth very little — the interesting failures are the ones
+introduced later by a change that looked unrelated.
+
+What follows records the rest: the criteria a test cannot check, how each was checked, and
+the gaps that remain open with the reason.
+
+---
+
+## Performance
+
+| Criterion | State | Evidence |
+|---|---|---|
+| No storefront speed impact | **Met by construction** | The app ships no theme app extension and no script tag. Campaign-scoped product tags are the storefront hook, so a merchant's theme reads a tag it already supports. Asserted by test. |
+| Admin performance | **Partly measured** | Every list view narrows in SQL and pages at the database, never in memory — the reconciliation, baseline and activity views all do. Real thresholds need the 100K-variant store (#50), which is not yet seeded. |
+
+The `s-table` cell budget (`app/lib/ui/table-budget.ts`) exists because the widget blanks
+the page past a few hundred cells; it also keeps every table view small enough to render
+quickly by construction.
+
+---
+
+## Design
+
+| Criterion | State | Evidence |
+|---|---|---|
+| Polaris web components throughout | **Met** | Every visible control is a Polaris component. Only hidden inputs are native, and they have no Polaris equivalent. Asserted by test. |
+| App Bridge embedding | **Met** | All admin routes authenticate through `authenticate.admin`, which is what makes the session token flow work. Asserted by test. |
+| No full page reloads | **Met** | No native `<form>` anywhere in the embedded surface; navigation is React Router's `Link` and `Form`. Asserted by test. A native form would also break the app outright, since it wipes App Bridge's parameters. |
+| WCAG AA | **Partly met — see below** | Every field is labelled, asserted by test. Colour contrast and keyboard navigation come from Polaris itself. |
+
+**WCAG gaps, open:**
+
+- **Colour contrast** is inherited from Polaris and has not been independently measured. Polaris meets AA by design; this app adds no custom colours, so the risk is low and the check is still owed.
+- **Keyboard navigation and screen-reader flow** have not been tested by a person. This needs somebody using the app with a keyboard and a screen reader for half an hour, and it is not something automation substitutes for.
+- **Focus management on route change** is React Router's default. Worth a pass before submission.
+
+---
+
+## Integration
+
+| Criterion | State | Evidence |
+|---|---|---|
+| Latest supported API version | **Met** | One `API_VERSION` constant, `2025-10`, with no environment override — a worker and a web process on different versions is a class of bug that only shows up in production. Asserted by test. |
+| Session-token authentication | **Met** | Every embedded route authenticates. Asserted by test. |
+| Webhook HMAC verification | **Met** | Every webhook route goes through `authenticate.webhook`, which performs the check. Asserted by test. |
+| Mandatory GDPR topics answered | **Met** | `customers/data_request`, `customers/redact` and `shop/redact` are registered and handled. Asserted by test. |
+| Minimal scopes | **Met** | `write_products`, `read_markets`, `write_markets`. Each was established empirically in P0.2 rather than requested speculatively; the test fails if a fourth appears. |
+
+---
+
+## Still open before submission
+
+These need a person, an account, or a deployed environment, and none of them can be closed
+from the codebase:
+
+- [ ] **Accessibility pass by a human** — keyboard-only and screen-reader, half an hour. The one gap above that automation cannot substitute for.
+- [ ] **Admin performance against real thresholds** — needs the 100K-variant store (#50, #66).
+- [ ] **Listing assets and copy** (#172) and **review submission** (#173).
+- [ ] **Staging drills with alerting live** (#161, #92) — confirming each alert fires and reaches a human.
+
+## Deliberately not doing
+
+- **A theme app extension.** The app's whole storefront contract is a tag. Adding theme code would create the storefront performance risk this section exists to avoid, and put us in the merchant's theme, which is the one place a pricing app has no business being.


### PR DESCRIPTION
Addresses #163. Nine of fourteen direct competitors carry the badge — an entry requirement, not a differentiator.

## A checklist somebody ticked once is worth very little

The interesting failures are the ones introduced *afterwards* by a change that looked unrelated: a native form added for convenience, a fourth scope requested speculatively, a field shipped without a label.

So everything checkable is a test that runs on every CI build:

| Check | Why it matters |
|---|---|
| No theme app extension | How the storefront-performance criterion is satisfied by construction — the app's entire storefront contract is a product tag |
| No native `<form>` in the embedded surface | Doubly load-bearing: a full-page-reload failure *and* it breaks the app, since a native form wipes App Bridge's `host`/`id_token` |
| Every Polaris field labelled | WCAG AA, and unreadable to a screen reader otherwise |
| Every visible control is Polaris | Hidden inputs the only exception — they have no equivalent |
| One pinned API version, no env override | A worker and web process on different versions only fails in production |
| Every webhook through `authenticate.webhook` | That's where the HMAC check lives |
| Every embedded route through `authenticate.admin` | Session-token auth |
| All three GDPR topics | Mandatory |
| Exactly three scopes | The ones P0.2 established empirically. **The test fails if a fourth appears** |

## The landing page is deliberately excluded

`_index` renders *outside* Shopify's admin, where App Bridge isn't loaded and Polaris web components don't exist. Holding a plain login page to the embedded criteria would be checking the wrong thing.

Its one input got a proper label association anyway — it's the first thing a merchant installing the app ever sees.

## What's still open

`docs/built-for-shopify.md` records each criterion's state, how it was checked, and what remains. Nothing that needs a person or an account is marked done:

- **Accessibility pass by a human** — keyboard-only and screen-reader. The one gap automation can't substitute for.
- **Admin performance against real thresholds** — needs the 100K store (#50, #66).
- **Listing and review submission** (#172, #173).
- **Staging drills with alerting live** (#161, #92).

Also recorded: what we're deliberately *not* doing, and why. No theme app extension — it would create the exact storefront risk the performance section exists to avoid, and put us in the merchant's theme, which is the one place a pricing app has no business being.

**Falsified.** Removing a field's label, adding a fourth scope, and an embedded route that stops authenticating each fail the check.

Full suite: 694 unit tests, 94 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)