### PR TITLE
P0.6.1 — Sentry in web and worker, and nothing leaves without being scrubbed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,14 @@ REDIS_URL=redis://localhost:6379
 
 # --- Observability (RFC-001 B11) ---------------------------------------------
 # Optional locally; required in staging/prod.
+# Sentry. Absent means error reporting is local only — every failure still lands in
+# error_events with an id a merchant can quote, and nothing leaves the process.
 SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+# The deployed commit. Without it a stack trace points at a line in a file that has moved,
+# which is worse than no trace because it looks authoritative.
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=0.05
 OTEL_EXPORTER_OTLP_ENDPOINT=
 LOG_LEVEL=debug
 
@@ -39,3 +46,4 @@ BULK_PATH_ROW_THRESHOLD=1000
 # Any string; it is hashed to a 256-bit key. Changing it invalidates every stored
 # session, which signs merchants out rather than losing anything.
 TOKEN_ENCRYPTION_KEY=
+

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -5,6 +5,12 @@ import { createReadableStreamFromReadable } from "@react-router/node";
 import { type EntryContext } from "react-router";
 import { isbot } from "isbot";
 import { addDocumentResponseHeaders } from "./shopify.server";
+import { initSentry } from "./lib/observability/sentry.server";
+
+// Once per process, at import time, before any request is handled. Initialising lazily
+// on the first error would miss the errors that happen during startup, which are the ones
+// most likely to be about configuration.
+initSentry({ process: "web" });
 
 export const streamTimeout = 5000;
 

--- a/app/lib/observability/sentry.server.ts
+++ b/app/lib/observability/sentry.server.ts
@@ -1,0 +1,162 @@
+/**
+ * Sentry, in both processes, and silent when it is not configured.
+ *
+ * The app already records every failure to `error_events` with an id a merchant can
+ * quote. Sentry is not a replacement for that — it is the thing that tells us a failure
+ * is happening *now*, across shops, before anybody opens a support ticket. The two answer
+ * different questions and both are worth having.
+ *
+ * **No price ever reaches Sentry.** Same rule as telemetry and Flow, and the same
+ * enforcement: everything attached as context goes through the redactor first, and the
+ * `beforeSend` hook is the last gate rather than a convention people remember. An
+ * exception message can contain a price — "cannot set price 19.99 on…" — so the message
+ * is scrubbed too, not only the structured context.
+ *
+ * Absent DSN means absent Sentry. A deployment without one runs normally and says so once
+ * at startup, because an app that refused to boot without an observability vendor would
+ * be an app that could not run locally.
+ */
+
+import * as Sentry from "@sentry/node";
+
+import { redact, redactText } from "../logging/redact";
+import { redactPrices } from "../telemetry/redact";
+import { logger } from "../logging/logger";
+
+let started = false;
+
+export interface SentryOptions {
+  /** Which process this is, so an alert says where it came from. */
+  process: "web" | "worker";
+  env?: NodeJS.ProcessEnv;
+}
+
+export function initSentry(options: SentryOptions): boolean {
+  const env = options.env ?? process.env;
+  const dsn = env.SENTRY_DSN;
+
+  if (!dsn) {
+    // Once, and at info. A deployment without Sentry is a normal state — every local
+    // development run is one — and warning about it every boot trains people to ignore
+    // the log.
+    if (!started) logger.info("no SENTRY_DSN; error reporting is local only");
+    started = true;
+    return false;
+  }
+
+  if (started) return true;
+  started = true;
+
+  Sentry.init({
+    dsn,
+    environment: env.SENTRY_ENVIRONMENT ?? env.NODE_ENV ?? "development",
+    // The deployed commit. Without it a stack trace points at a line number in a file
+    // that has moved, which is worse than no trace because it looks authoritative.
+    release: env.SENTRY_RELEASE ?? env.SOURCE_VERSION ?? undefined,
+
+    // Sampled, because a busy shop's campaign generates thousands of spans and none of
+    // them is individually interesting. Errors are always sent; traces are a sample.
+    tracesSampleRate: Number(env.SENTRY_TRACES_SAMPLE_RATE ?? 0.05),
+
+    // Off. Shopify's admin runs the app in an iframe and a session replay would record a
+    // merchant's catalogue, their prices and their customers' names.
+    integrations: (defaults) =>
+      defaults.filter((integration) => integration.name !== "LocalVariables"),
+
+    beforeSend(event) {
+      return scrub(event);
+    },
+  });
+
+  Sentry.setTag("process", options.process);
+
+  logger.info("sentry initialised", {
+    process: options.process,
+    environment: env.SENTRY_ENVIRONMENT ?? env.NODE_ENV ?? "development",
+  });
+
+  return true;
+}
+
+/**
+ * The last gate before anything leaves the process.
+ *
+ * A hook rather than a convention, because "remember to redact before you capture" is a
+ * rule that holds until the first person in a hurry. Exported so it can be tested without
+ * initialising the SDK.
+ */
+export function scrub(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+  if (event.message) event.message = redactText(redactPricesInText(event.message));
+
+  for (const exception of event.exception?.values ?? []) {
+    if (exception.value) exception.value = redactText(redactPricesInText(exception.value));
+  }
+
+  if (event.extra) {
+    event.extra = redact(redactPrices(event.extra)) as Record<string, unknown>;
+  }
+  if (event.contexts?.anchor) {
+    event.contexts.anchor = redact(redactPrices(event.contexts.anchor)) as Record<string, unknown>;
+  }
+
+  // Never. A stack frame's local variables are the single most likely place for a price
+  // to appear, and no amount of redaction on a structured field helps if the value is
+  // sitting in a captured scope.
+  delete event.extra?.__serialized__;
+
+  return event;
+}
+
+/**
+ * Money-shaped substrings inside free text.
+ *
+ * The structured redactor works on keys and values; an exception message is one string,
+ * and "cannot set price 19.99 on variant 12345" carries a price in the middle of a
+ * sentence. Numbers with exactly two decimals are the shape worth catching — variant ids
+ * and counts do not look like that.
+ *
+ * The lookbehind and lookahead are load-bearing rather than tidiness. Without them
+ * "API version 2025.10" matched its own tail as "5.10" and became "API version 2[price]",
+ * which is both a corrupted message and a false sense that something was protected. And
+ * without them the leading space was consumed, so every redaction ran the previous word
+ * into the placeholder.
+ *
+ * Over-matching costs more than it looks: a log full of unreadable messages is a log
+ * people stop reading, which is worse than the leak it was guarding against.
+ */
+export function redactPricesInText(text: string): string {
+  return text.replace(
+    /(?<![\d.])[$£€¥]?\d{1,3}(?:[,\s]\d{3})*\.\d{2}(?!\d)/g,
+    "[price]",
+  );
+}
+
+/** Attaches shop context. Never prices — see the note at the top. */
+export function setShopContext(shopId: string | null, shop?: string | null): void {
+  if (!started) return;
+
+  Sentry.setContext("anchor", {
+    shopId: shopId ?? null,
+    shop: shop ?? null,
+  });
+}
+
+/** Reports an error to Sentry, if it is configured. Never throws. */
+export function captureError(error: unknown, context: Record<string, unknown> = {}): void {
+  if (!started) return;
+
+  try {
+    Sentry.withScope((scope) => {
+      scope.setContext("anchor", redact(redactPrices(context)) as Record<string, unknown>);
+      Sentry.captureException(error);
+    });
+  } catch {
+    // An error inside the error handler replaces a useful message with a useless one and
+    // usually loses the original. Swallowed deliberately.
+  }
+}
+
+/** Test seam: forgets initialisation so a test can start from a known state. */
+export function resetSentryForTests(): void {
+  started = false;
+}

--- a/app/lib/observability/sentry.test.ts
+++ b/app/lib/observability/sentry.test.ts
@@ -1,0 +1,78 @@
+/**
+ * What is allowed to leave the process.
+ *
+ * Sentry is a third party. A price that reaches it has left the merchant's control and
+ * ours, and no amount of "we only send errors" makes that acceptable — so the scrubbing
+ * is a hook rather than a convention, and this is what proves it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { redactPricesInText, scrub } from "./sentry.server";
+
+describe("prices inside free text", () => {
+  it("removes a price from the middle of a sentence", () => {
+    // The realistic case. An exception message is one string, and the structured
+    // redactor works on keys and values.
+    expect(redactPricesInText("cannot set price 19.99 on variant 12345")).toBe(
+      "cannot set price [price] on variant 12345",
+    );
+  });
+
+  it("removes a formatted price with a symbol and separators", () => {
+    expect(redactPricesInText("expected $1,299.00 but got £15.50")).toBe(
+      "expected [price] but got [price]",
+    );
+  });
+
+  it("leaves variant ids and counts alone", () => {
+    // If this over-matched, every message would be unreadable and people would stop
+    // reading them — which costs more than the leak it prevents.
+    expect(redactPricesInText("412 of 1616 variants, gid://shopify/ProductVariant/12345"))
+      .toBe("412 of 1616 variants, gid://shopify/ProductVariant/12345");
+  });
+
+  it("leaves a version number alone", () => {
+    expect(redactPricesInText("API version 2025.10 is pinned")).toBe(
+      "API version 2025.10 is pinned",
+    );
+  });
+});
+
+describe("scrubbing an event before it is sent", () => {
+  it("scrubs the message", () => {
+    const event = scrub({ message: "failed writing 19.99" } as never);
+
+    expect(event.message).toBe("failed writing [price]");
+  });
+
+  it("scrubs an exception value", () => {
+    const event = scrub({
+      exception: { values: [{ type: "Error", value: "price 24.50 rejected" }] },
+    } as never);
+
+    expect(event.exception?.values?.[0].value).toBe("price [price] rejected");
+  });
+
+  it("redacts a price out of structured extra data", () => {
+    const event = scrub({ extra: { intendedPrice: 1999, shopId: "s1" } } as never);
+
+    expect(event.extra?.intendedPrice).not.toBe(1999);
+    // The shop id survives, because that is the thing that makes an alert actionable.
+    expect(event.extra?.shopId).toBe("s1");
+  });
+
+  it("redacts a token out of context", () => {
+    const event = scrub({
+      contexts: { anchor: { shopId: "s1", accessToken: "shpua_secret" } },
+    } as never);
+
+    expect(JSON.stringify(event.contexts?.anchor)).not.toContain("shpua_secret");
+  });
+
+  it("survives an event with nothing in it", () => {
+    // A scrubber that threw would take out the error handler, which is how an app loses
+    // the original error entirely.
+    expect(() => scrub({} as never)).not.toThrow();
+  });
+});

--- a/app/services/error-report.server.ts
+++ b/app/services/error-report.server.ts
@@ -16,6 +16,7 @@ import type { ReportedError } from "../lib/errors/report";
 import { newErrorId } from "../lib/errors/error-id";
 import { logger } from "../lib/logging/logger";
 import { redact, redactText } from "../lib/logging/redact";
+import { captureError, setShopContext } from "../lib/observability/sentry.server";
 
 export interface ReportContext {
   shopId?: string | null;
@@ -48,6 +49,18 @@ export async function reportError(
     retryable: appError.retryable,
     ...merged,
     error: appError.cause ?? appError,
+  });
+
+  // To Sentry as well as the table, and after the log for the same reason. The table
+  // answers "is this one merchant or all of them" as a query; Sentry answers "is this
+  // happening right now" without anybody asking. Different questions, both worth having,
+  // and neither is allowed to fail the other.
+  setShopContext(shopId ?? null, shop);
+  captureError(appError.cause ?? appError, {
+    errorId,
+    code: appError.code,
+    route,
+    ...merged,
   });
 
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-router/fs-routes": "^7.12.0",
         "@react-router/node": "^7.12.0",
         "@react-router/serve": "^7.12.0",
+        "@sentry/node": "^10.71.0",
         "@shopify/app-bridge-react": "^4.2.4",
         "@shopify/shopify-app-react-router": "^1.1.0",
         "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
@@ -53,6 +54,55 @@
         "packages": [
           "extensions/*"
         ]
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins/node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@ardatan/relay-compiler": {
@@ -2533,6 +2583,119 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
@@ -3400,6 +3563,120 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.71.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.71.0.tgz",
+      "integrity": "sha512-OIjT7rzcWJjUC6r3eBT3Td1j0afDBMkbbx9jTocSD+ZSfc25eEU7hoIPS0WvfeIOTIN3y8bfQnXavwMReaNVHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.71.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.71.0.tgz",
+      "integrity": "sha512-bw2M/xkMu2+ATo6QWFmtTZTYp5LV1krt9/DTtYqtt4GmhXmXgdFPXCv6783AJI3HUoEMx2BcehhNbKzGrFXo/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.71.0",
+        "@sentry/node-core": "10.71.0",
+        "@sentry/opentelemetry": "10.71.0",
+        "@sentry/server-utils": "10.71.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.71.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.71.0.tgz",
+      "integrity": "sha512-sxd0/ZW+Uda/17H0R7lB2Othm37VYcdwKdWdyHRizg872TfCX4UwTTPaoS2tMJAUjV2tVh83ZA0fsoC2q9SpjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.71.0",
+        "@sentry/opentelemetry": "10.71.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.71.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.71.0.tgz",
+      "integrity": "sha512-YgeL0xTObKma3MuOrt+/6M/f6mo/Z08LHh3OxPomzQpgpCgCLGyJ/739cDSSH1LRjqWdPQtoia5asl5ZRdhWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.71.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.71.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.71.0.tgz",
+      "integrity": "sha512-zdyShKNsghzPGVWVRzc7oybYTsRZdKgdPtq+dsksImo1b6n7ILlD7eYx1Q0eAOZoWkDqDmm+Ml6MQb76IT1eTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.71.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@shopify/admin-api-client": {
       "version": "1.1.2",
@@ -4852,6 +5129,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -5357,6 +5643,12 @@
       "dependencies": {
         "consola": "^3.2.3"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -6907,7 +7199,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -6933,7 +7224,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -8058,6 +8348,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -9261,7 +9571,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -9312,6 +9621,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/meros": {
@@ -9447,6 +9765,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/morgan": {
       "version": "1.11.0",
@@ -10626,6 +10950,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
@@ -10880,6 +11217,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@react-router/fs-routes": "^7.12.0",
     "@react-router/node": "^7.12.0",
     "@react-router/serve": "^7.12.0",
+    "@sentry/node": "^10.71.0",
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -12,6 +12,7 @@
 
 import Redis from "ioredis";
 
+import { initSentry } from "../app/lib/observability/sentry.server";
 import { tick } from "../app/services/scheduler.server";
 import { reportDepths, runtimeFor } from "../app/worker/queue-runtime.server";
 import { handleJob } from "../app/worker/handlers.server";
@@ -31,6 +32,8 @@ for (const key of ["DATABASE_URL"]) {
     process.exit(1);
   }
 }
+
+initSentry({ process: "worker" });
 
 const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
   maxRetriesPerRequest: 3,


### PR DESCRIPTION
Addresses #46 (the code half — the account and source-map upload stay open).

The app already records every failure to `error_events` with an id a merchant can quote. Sentry answers a **different question**: is this happening *now*, across shops, before anybody opens a support ticket.

Both are worth having, and neither is allowed to fail the other — the log line comes first, because if the database is what's broken, the log is all there will be.

## No price reaches Sentry

Enforced in `beforeSend`, not by convention. *"Remember to redact before you capture"* is a rule that holds until the first person in a hurry — and Sentry is a third party: a price that reaches it has left the merchant's control **and ours**.

Free text is scrubbed as well as structured fields, because an exception message is one string and `"cannot set price 19.99 on variant 12345"` carries a price mid-sentence.

**That pattern took two goes, and both failures are worth recording:**

- Consuming the leading space ran the previous word into the placeholder.
- Worse: `"API version 2025.10"` matched its own tail as `5.10` and became `"API version 2[price]"` — a corrupted message **and** a false sense that something had been protected.

A lookbehind fixes both. Over-matching costs more than it looks: a log full of unreadable messages is a log people stop reading, which is worse than the leak it guards against.

## Two things deliberately off

- **Session replay** — the admin runs in an iframe over a merchant's catalogue and customers.
- **Local-variable capture** — a stack frame's locals are the single most likely place for a price to appear, and no amount of redacting structured fields helps if the value is sitting in a captured scope.

## Absent DSN means absent Sentry

Said once at `info`, not warned about every boot. A deployment without it is a normal state — every local run is one — and an app that refused to start without an observability vendor would be an app that couldn't run locally.

Traces sampled at 5%; errors always send.

## Tests

9. **Falsified:** dropping the lookbehind, skipping the message scrub, skipping the structured redaction.

Full suite: 703 unit tests, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)