### PR TITLE
P0.6.2 — OpenTelemetry metrics and tracing

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,11 +6,15 @@ import { type EntryContext } from "react-router";
 import { isbot } from "isbot";
 import { addDocumentResponseHeaders } from "./shopify.server";
 import { initSentry } from "./lib/observability/sentry.server";
+import { initOtel } from "./lib/observability/otel.server";
 
 // Once per process, at import time, before any request is handled. Initialising lazily
 // on the first error would miss the errors that happen during startup, which are the ones
 // most likely to be about configuration.
 initSentry({ process: "web" });
+// Not awaited: the SDK starts in the background and metrics recorded before it is ready
+// fall through to the log sink, which is where they were going anyway.
+void initOtel({ process: "web" });
 
 export const streamTimeout = 5000;
 

--- a/app/lib/observability/otel.server.ts
+++ b/app/lib/observability/otel.server.ts
@@ -1,0 +1,238 @@
+/**
+ * OpenTelemetry: where the numbers go when there is somewhere to send them.
+ *
+ * Metrics already exist — `metric()` has been emitting them as structured log lines since
+ * P0.6. That is not a placeholder to be replaced; it is the fallback that keeps working
+ * when the collector is down, and it stays. This adds a second sink so the same numbers
+ * reach a dashboard that can alert on them.
+ *
+ * The instruments are created from the same `Metric` union the rest of the app uses, so a
+ * metric cannot be exported under a name nothing else knows about. A counter and a
+ * histogram behave differently and the distinction is not cosmetic: `run.duration_ms` as a
+ * counter would tell you total milliseconds spent, which is a number nobody wants, and
+ * `run.rows` as a histogram would lose the total, which is the only thing anybody wants.
+ *
+ * Absent endpoint means absent exporter, silently. Every local run is a deployment without
+ * a collector.
+ */
+
+import { metrics, trace, type Counter, type Histogram, type Span, type Tracer } from "@opentelemetry/api";
+
+import { logger } from "../logging/logger";
+import { redactPrices } from "../telemetry/redact";
+import { redact } from "../logging/redact";
+import type { Metric, MetricLabels } from "../telemetry/metrics";
+
+const SERVICE = "anchor";
+
+/**
+ * Which instrument each metric is.
+ *
+ * A counter sums; a histogram describes a distribution. Getting this wrong does not fail
+ * — it produces a panel that is quietly meaningless, which is worse than an empty one.
+ */
+export const INSTRUMENTS: Record<Metric, "counter" | "histogram" | "gauge"> = {
+  "run.verified_clean_rate": "gauge",
+  "run.duration_ms": "histogram",
+  "run.rows": "counter",
+  "webhook.lag_ms": "histogram",
+  "mirror.divergence_rate": "gauge",
+  "scheduler.tick": "counter",
+  "budget.saturation": "gauge",
+  "queue.depth": "gauge",
+  "queue.enqueued": "counter",
+  "queue.failed": "counter",
+};
+
+let enabled = false;
+let sdk: { shutdown(): Promise<void> } | null = null;
+
+const counters = new Map<string, Counter>();
+const histograms = new Map<string, Histogram>();
+const gauges = new Map<string, number>();
+
+export interface OtelOptions {
+  process: "web" | "worker";
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Starts the SDK when an endpoint is configured.
+ *
+ * Returns whether it started, so a caller can say so once rather than guessing. Never
+ * throws: a misconfigured collector must not stop the app writing prices.
+ */
+export async function initOtel(options: OtelOptions): Promise<boolean> {
+  const env = options.env ?? process.env;
+  const endpoint = env.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+  if (!endpoint) {
+    logger.info("no OTEL_EXPORTER_OTLP_ENDPOINT; metrics stay in the logs");
+    return false;
+  }
+
+  try {
+    const [{ NodeSDK }, { OTLPTraceExporter }, { OTLPMetricExporter }, { PeriodicExportingMetricReader }] =
+      await Promise.all([
+        import("@opentelemetry/sdk-node"),
+        import("@opentelemetry/exporter-trace-otlp-http"),
+        import("@opentelemetry/exporter-metrics-otlp-http"),
+        import("@opentelemetry/sdk-metrics"),
+      ]);
+
+    const instance = new NodeSDK({
+      serviceName: SERVICE,
+      traceExporter: new OTLPTraceExporter({ url: `${endpoint}/v1/traces` }),
+      metricReader: new PeriodicExportingMetricReader({
+        exporter: new OTLPMetricExporter({ url: `${endpoint}/v1/metrics` }),
+        exportIntervalMillis: Number(env.OTEL_EXPORT_INTERVAL_MS ?? 30_000),
+      }),
+    });
+
+    instance.start();
+    sdk = instance;
+    enabled = true;
+
+    logger.info("opentelemetry started", { process: options.process, endpoint });
+    return true;
+  } catch (error) {
+    // Logged, not thrown. An app that refused to start because a collector was
+    // unreachable would be an app that stops writing prices when a dashboard breaks.
+    logger.error("could not start opentelemetry; metrics stay in the logs", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+/**
+ * Records one measurement on the right kind of instrument.
+ *
+ * Labels are redacted on the way through. An attribute is exported verbatim to whoever is
+ * collecting, and the rule about prices does not change because the destination is a
+ * metrics backend rather than an error tracker.
+ */
+export function record(name: Metric, value: number, labels: MetricLabels = {}): void {
+  if (!enabled) return;
+
+  try {
+    const attributes = attributesFrom(labels);
+    const meter = metrics.getMeter(SERVICE);
+
+    switch (INSTRUMENTS[name]) {
+      case "counter": {
+        let counter = counters.get(name);
+        if (!counter) {
+          counter = meter.createCounter(name);
+          counters.set(name, counter);
+        }
+        counter.add(value, attributes);
+        return;
+      }
+
+      case "histogram": {
+        let histogram = histograms.get(name);
+        if (!histogram) {
+          histogram = meter.createHistogram(name);
+          histograms.set(name, histogram);
+        }
+        histogram.record(value, attributes);
+        return;
+      }
+
+      case "gauge": {
+        // Observed asynchronously by the SDK, so the value is held and read on export
+        // rather than pushed. A gauge pushed on every change would report whichever
+        // write happened to land last, which for queue depth is noise.
+        gauges.set(gaugeKey(name, attributes), value);
+        ensureGauge(name);
+        return;
+      }
+    }
+  } catch {
+    // A metric is a description of work that already happened. An exporter failing must
+    // not be able to change the work.
+  }
+}
+
+const observed = new Set<string>();
+
+function ensureGauge(name: Metric): void {
+  if (observed.has(name)) return;
+  observed.add(name);
+
+  const meter = metrics.getMeter(SERVICE);
+  const gauge = meter.createObservableGauge(name);
+
+  gauge.addCallback((result) => {
+    for (const [key, value] of gauges) {
+      if (!key.startsWith(`${name}|`)) continue;
+      result.observe(value, JSON.parse(key.slice(name.length + 1)) as Record<string, string>);
+    }
+  });
+}
+
+const gaugeKey = (name: Metric, attributes: Record<string, string | number | boolean>) =>
+  `${name}|${JSON.stringify(attributes)}`;
+
+/** Labels as OTel attributes, redacted, with undefined dropped rather than stringified. */
+export function attributesFrom(labels: MetricLabels): Record<string, string | number | boolean> {
+  const safe = redact(redactPrices(labels)) as Record<string, unknown>;
+  const out: Record<string, string | number | boolean> = {};
+
+  for (const [key, value] of Object.entries(safe)) {
+    if (value === undefined || value === null) continue;
+    out[key] =
+      typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+        ? value
+        : String(value);
+  }
+
+  return out;
+}
+
+/**
+ * Runs work inside a span.
+ *
+ * A no-op when tracing is off, and it returns the work's own value either way — so a call
+ * site reads the same whether or not anybody is collecting, and nobody is tempted to
+ * branch on it.
+ */
+export async function span<T>(
+  name: string,
+  attributes: Record<string, string | number | boolean>,
+  work: (span: Span | null) => Promise<T>,
+): Promise<T> {
+  if (!enabled) return work(null);
+
+  const tracer: Tracer = trace.getTracer(SERVICE);
+
+  return tracer.startActiveSpan(name, { attributes }, async (active) => {
+    try {
+      const result = await work(active);
+      active.end();
+      return result;
+    } catch (error) {
+      active.recordException(error as Error);
+      active.setStatus({ code: 2 });
+      active.end();
+      throw error;
+    }
+  });
+}
+
+export async function shutdownOtel(): Promise<void> {
+  if (!sdk) return;
+  try {
+    await sdk.shutdown();
+  } catch {
+    // Shutting down is best-effort by definition.
+  }
+  sdk = null;
+  enabled = false;
+}
+
+/** Test seam. */
+export function otelEnabledForTests(value: boolean): void {
+  enabled = value;
+}

--- a/app/lib/observability/otel.test.ts
+++ b/app/lib/observability/otel.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Choosing the right instrument, and not exporting a price as an attribute.
+ *
+ * The instrument choice does not fail loudly when it is wrong — it produces a panel that
+ * is quietly meaningless, which is worse than an empty one, because somebody builds an
+ * alert on it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { attributesFrom, INSTRUMENTS } from "./otel.server";
+
+describe("instrument choice", () => {
+  it("counts the things that are counts", () => {
+    // Rows written and jobs enqueued are totals. As histograms the total disappears,
+    // which is the only thing anybody wants from them.
+    expect(INSTRUMENTS["run.rows"]).toBe("counter");
+    expect(INSTRUMENTS["queue.enqueued"]).toBe("counter");
+    expect(INSTRUMENTS["queue.failed"]).toBe("counter");
+    expect(INSTRUMENTS["scheduler.tick"]).toBe("counter");
+  });
+
+  it("distributes the things that are durations", () => {
+    // As a counter, `run.duration_ms` would report total milliseconds ever spent, which
+    // is a number nobody wants. p95 is the question.
+    expect(INSTRUMENTS["run.duration_ms"]).toBe("histogram");
+    expect(INSTRUMENTS["webhook.lag_ms"]).toBe("histogram");
+  });
+
+  it("gauges the things that are levels", () => {
+    // Queue depth summed over a day is meaningless; queue depth right now is the alert.
+    expect(INSTRUMENTS["queue.depth"]).toBe("gauge");
+    expect(INSTRUMENTS["budget.saturation"]).toBe("gauge");
+    expect(INSTRUMENTS["mirror.divergence_rate"]).toBe("gauge");
+  });
+
+  it("has an instrument for every metric the app emits", () => {
+    // The map is keyed by the same union the rest of the app uses, so a new metric will
+    // not compile until somebody has decided what kind of thing it is.
+    expect(Object.keys(INSTRUMENTS).length).toBeGreaterThan(0);
+    for (const kind of Object.values(INSTRUMENTS)) {
+      expect(["counter", "histogram", "gauge"]).toContain(kind);
+    }
+  });
+});
+
+describe("attributes", () => {
+  it("keeps the labels that make a metric actionable", () => {
+    expect(attributesFrom({ shopId: "s1", queue: "execution", outcome: "verified" })).toEqual({
+      shopId: "s1",
+      queue: "execution",
+      outcome: "verified",
+    });
+  });
+
+  it("redacts a price out of a label", () => {
+    // An attribute is exported verbatim to whoever is collecting. The rule does not
+    // change because the destination is a metrics backend rather than an error tracker.
+    const attributes = attributesFrom({ shopId: "s1", price: 1999 } as never);
+
+    expect(attributes.price).not.toBe(1999);
+  });
+
+  it("drops undefined rather than exporting the string 'undefined'", () => {
+    // Which is what a naive String() would produce, and it makes a dashboard filter on
+    // an attribute that looks present and is not.
+    const attributes = attributesFrom({ shopId: "s1", runId: undefined });
+
+    expect("runId" in attributes).toBe(false);
+  });
+
+  it("stringifies anything that is not a primitive", () => {
+    const attributes = attributesFrom({ shopId: "s1", detail: { a: 1 } as never });
+
+    expect(typeof attributes.detail).toBe("string");
+  });
+});

--- a/app/lib/telemetry/metrics.ts
+++ b/app/lib/telemetry/metrics.ts
@@ -17,6 +17,7 @@
  */
 
 import { logger } from "../logging/logger";
+import { record as recordOtel } from "../observability/otel.server";
 
 /** The SLO panels. Stubbed where the feature does not exist yet, named so they can be. */
 export type Metric =
@@ -58,7 +59,11 @@ export interface MetricLabels {
  */
 export function metric(name: Metric, value: number, labels: MetricLabels = {}): void {
   try {
+    // The log line stays, and is not a placeholder for the exporter. It is the sink that
+    // keeps working when the collector is down, which is exactly when somebody is trying
+    // to work out what happened.
     logger.info("metric", { metric: name, value, ...labels });
+    recordOtel(name, value, labels);
   } catch {
     // Deliberately silent. There is nothing useful to do when the thing that reports
     // problems is the problem, and recursing into the logger to say so is worse.

--- a/app/services/admin-client.server.ts
+++ b/app/services/admin-client.server.ts
@@ -10,6 +10,7 @@
 import type { QueryCost } from "../lib/shopify/budget";
 import type { AdminClient } from "../lib/execution/sync-executor";
 import { API_VERSION_STRING } from "../lib/shopify/api-version";
+import { span } from "../lib/observability/otel.server";
 import { decryptToken, isEncrypted } from "../lib/crypto/secrets";
 import { logger } from "../lib/logging/logger";
 
@@ -23,21 +24,50 @@ export interface ShopifyAdminContext {
 export function toAdminClient(admin: ShopifyAdminContext): AdminClient {
   return {
     async request<T>(query: string, variables: Record<string, unknown>) {
-      const response = await admin.graphql(query, { variables });
-      const body = (await response.json()) as {
-        data?: T;
-        extensions?: { cost?: QueryCost };
-        errors?: unknown;
-      };
+      // One span per Admin API call, carrying the cost points and what was left in the
+      // bucket afterwards. That pair is what turns "the run was slow" into "the run was
+      // slow because this shop's budget was exhausted", which is the difference between
+      // a graph and a diagnosis.
+      //
+      // The operation name, never the query body — a mutation's variables carry prices.
+      return span("shopify.graphql", { "graphql.operation": operationName(query) }, async (active) => {
+        const response = await admin.graphql(query, { variables });
+        const body = (await response.json()) as {
+          data?: T;
+          extensions?: { cost?: QueryCost };
+          errors?: unknown;
+        };
 
-      // Top-level GraphQL errors are transport-level failures, distinct from the
-      // per-row `userErrors` the executors map back to individual variants.
-      const message = formatGraphQLErrors(body.errors);
-      if (message) throw new Error(message);
+        const cost = body.extensions?.cost;
+        if (active && cost) {
+          active.setAttribute("shopify.cost.requested", cost.requestedQueryCost ?? 0);
+          active.setAttribute("shopify.cost.actual", cost.actualQueryCost ?? 0);
+          active.setAttribute(
+            "shopify.throttle.available",
+            cost.throttleStatus?.currentlyAvailable ?? -1,
+          );
+        }
 
-      return { data: body.data, extensions: body.extensions };
+        // Top-level GraphQL errors are transport-level failures, distinct from the
+        // per-row `userErrors` the executors map back to individual variants.
+        const message = formatGraphQLErrors(body.errors);
+        if (message) throw new Error(message);
+
+        return { data: body.data, extensions: body.extensions };
+      });
     },
   };
+}
+
+/**
+ * The operation name from a GraphQL document.
+ *
+ * Never the document itself and never the variables: a price mutation's variables are
+ * exactly the thing that must not be exported, and a query body as a span attribute is
+ * both enormous and unhelpful.
+ */
+export function operationName(query: string): string {
+  return /\b(?:query|mutation)\s+(\w+)/.exec(query)?.[1] ?? "anonymous";
 }
 
 

--- a/app/services/admin-client.test.ts
+++ b/app/services/admin-client.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from "vitest";
 
 import { encryptToken } from "../lib/crypto/secrets";
-import { decryptedToken } from "./admin-client.server";
+import { decryptedToken, operationName } from "./admin-client.server";
 
 const KEY = "a-test-key-for-this-file-only";
 
@@ -48,5 +48,32 @@ describe("reading a stored token", () => {
     process.env.TOKEN_ENCRYPTION_KEY = "a-different-key-entirely";
 
     expect(decryptedToken(stored)).toBeNull();
+  });
+});
+
+
+describe("naming a GraphQL operation for a span", () => {
+  it("takes the operation name from the document", () => {
+    expect(operationName("#graphql\n  mutation AnchorPriceListUpdate($id: ID!) { … }")).toBe(
+      "AnchorPriceListUpdate",
+    );
+    expect(operationName("query AnchorPriceLists($cursor: String) { … }")).toBe(
+      "AnchorPriceLists",
+    );
+  });
+
+  it("never returns the document itself", () => {
+    // A price mutation's variables are exactly what must not be exported, and a query
+    // body as a span attribute is both enormous and unhelpful.
+    const document = "mutation AnchorX { productVariantsBulkUpdate(price: \"19.99\") { id } }";
+
+    expect(operationName(document)).toBe("AnchorX");
+    expect(operationName(document)).not.toContain("19.99");
+  });
+
+  it("names an anonymous document rather than returning undefined", () => {
+    // An attribute of "undefined" makes a dashboard filter on something that looks
+    // present and is not.
+    expect(operationName("{ shop { name } }")).toBe("anonymous");
   });
 });

--- a/app/worker/queue-runtime.server.ts
+++ b/app/worker/queue-runtime.server.ts
@@ -21,6 +21,7 @@ import { Queue, Worker, type Job } from "bullmq";
 
 import { logger } from "../lib/logging/logger";
 import { metric } from "../lib/telemetry/metrics";
+import { span } from "../lib/observability/otel.server";
 import {
   jobOptionsFor,
   QUEUE_NAMES,
@@ -47,7 +48,7 @@ export type Handler = (name: QueueName, ref: JobRef) => Promise<void>;
 export function inlineRuntime(handler: Handler): QueueRuntime {
   return {
     async enqueue(name, ref) {
-      await handler(name, ref);
+      await traced(name, ref, () => handler(name, ref));
     },
     async depths() {
       return Object.fromEntries(QUEUE_NAMES.map((name) => [name, 0])) as Record<
@@ -82,7 +83,7 @@ export function redisRuntime(handler: Handler, options: RedisRuntimeOptions): Qu
       const worker = new Worker(
         name,
         async (job: Job<JobRef>) => {
-          await handler(name, job.data);
+          await traced(name, job.data, () => handler(name, job.data));
         },
         { connection, concurrency: policy.concurrency },
       );
@@ -170,4 +171,29 @@ export async function reportDepths(runtime: QueueRuntime): Promise<void> {
   for (const [queue, depth] of Object.entries(depths)) {
     metric("queue.depth", depth, { queue });
   }
+}
+
+
+/**
+ * One span per job, whichever runtime ran it.
+ *
+ * Attributes are the queue and the ids, never the payload — a job carries ids by design
+ * and a span that re-expanded them would put back exactly what the job class avoids.
+ *
+ * Wrapped around both runtimes rather than only the Redis one, so a trace from a
+ * deployment running inline looks the same as one from a deployment with a queue. A
+ * degraded mode that is invisible in tracing is a degraded mode nobody notices.
+ */
+async function traced(name: QueueName, ref: JobRef, work: () => Promise<void>): Promise<void> {
+  await span(
+    `job ${name}`,
+    {
+      "queue.name": name,
+      "shop.id": ref.shopId,
+      ...(ref.campaignId ? { "campaign.id": ref.campaignId } : {}),
+      ...(ref.runId ? { "run.id": ref.runId } : {}),
+      ...(ref.revert === undefined ? {} : { "job.revert": ref.revert }),
+    },
+    work,
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,12 @@
     "": {
       "name": "app",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.221.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+        "@opentelemetry/resources": "^2.10.0",
+        "@opentelemetry/sdk-node": "^0.221.0",
+        "@opentelemetry/semantic-conventions": "^1.43.0",
         "@prisma/client": "^6.16.3",
         "@react-router/dev": "^7.12.0",
         "@react-router/fs-routes": "^7.12.0",
@@ -1960,6 +1966,37 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2423,6 +2460,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@mjackson/node-fetch-server": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
@@ -2604,6 +2651,34 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.221.0.tgz",
+      "integrity": "sha512-uE9y56Zdi9Gt/RdxYnVOo3YmFZkKJJMA0gqtBe8wh8gdtF5Asqe+Oh/TWiDtFb1s+31jNY4CWgnfIB1KOITfFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/core": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
@@ -2617,6 +2692,199 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-txG1G0IrYSsKKMeiWZfj/i5cQmWB+h+hf3HzPpF3RqZVwp+iQQEIsv8Vtmzy6RWVdHdJZfygmVrBI39YTBvWcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-AH6EY+47gXFaWYgG3hfeOneGiE9xIZGtDBk+9g0sM8NZWzsQhhmqPbQQXJzS7pyCh5jRRr2nYNXVrkCmoojRvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-KOgCtO15FC6C1T/xOqBcr7EyUs7B+7yomGNb5Y97d3s38rPbCCk5sewkmE2b0/itOkQ/PptX8CLlD+kn2mEtTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-metrics": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-YMF4LveY2I3yhw61rn6nmC9FE8U24IZHPeKU1Duc5+sbwjMd8FwZAwba318ImdThCg/HuVQvhm2y6bfgNPnfYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.221.0.tgz",
+      "integrity": "sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.10.0.tgz",
+      "integrity": "sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -2636,6 +2904,102 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.10.0.tgz",
+      "integrity": "sha512-GnA5B24H+1w8BO21J0q+IWNB0z1v+AGbcquTdIt/dufibhnhgxaA8YKvz0I3akRZhB1jHT+/tlzK+qlAjEDybQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+      "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/resources": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
@@ -2650,6 +3014,122 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.221.0.tgz",
+      "integrity": "sha512-UbYuvtBrQQB5Prsh9KOKy4kxzexFxfMs5MkteHeWMoswsEB7kiNhyUVkAOFW/qsEzNHtrkgyghrD2ilZJa+5YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/configuration": "0.221.0",
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-prometheus": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-zipkin": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/propagator-b3": "2.10.0",
+        "@opentelemetry/propagator-jaeger": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0",
+        "@opentelemetry/sdk-trace-node": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace": {
@@ -2685,6 +3165,23 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -3061,6 +3558,63 @@
       "dependencies": {
         "@prisma/debug": "6.19.3"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@react-router/dev": {
       "version": "7.18.2",
@@ -4056,7 +4610,6 @@
       "version": "25.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
       "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -4891,7 +5444,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4901,7 +5453,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5697,7 +6248,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5712,14 +6262,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5729,7 +6277,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5744,7 +6291,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5771,7 +6317,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5784,7 +6329,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -7711,7 +8255,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -9358,6 +9901,12 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9510,6 +10059,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -10651,6 +11206,29 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10944,7 +11522,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11804,7 +12381,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12234,7 +12810,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unixify": {
@@ -12848,7 +13423,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -12864,7 +13438,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -12880,7 +13453,6 @@
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -12899,7 +13471,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -12909,14 +13480,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12926,7 +13495,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,12 @@
     "node": ">=20.19 <22 || >=22.12"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.221.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+    "@opentelemetry/resources": "^2.10.0",
+    "@opentelemetry/sdk-node": "^0.221.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
     "@prisma/client": "^6.16.3",
     "@react-router/dev": "^7.12.0",
     "@react-router/fs-routes": "^7.12.0",

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -13,6 +13,7 @@
 import Redis from "ioredis";
 
 import { initSentry } from "../app/lib/observability/sentry.server";
+import { initOtel, shutdownOtel } from "../app/lib/observability/otel.server";
 import { tick } from "../app/services/scheduler.server";
 import { reportDepths, runtimeFor } from "../app/worker/queue-runtime.server";
 import { handleJob } from "../app/worker/handlers.server";
@@ -34,6 +35,7 @@ for (const key of ["DATABASE_URL"]) {
 }
 
 initSentry({ process: "worker" });
+void initOtel({ process: "worker" });
 
 const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
   maxRetriesPerRequest: 3,
@@ -132,7 +134,9 @@ async function shutdown(signal: string): Promise<void> {
     // The lock expires on its own; a failure here must not block exit.
   }
 
-  await Promise.allSettled([redis.quit(), prisma.$disconnect()]);
+  // Flushed before exit, so the last interval's metrics are not lost — which is the
+  // interval covering whatever made somebody restart the worker.
+  await Promise.allSettled([shutdownOtel(), queues.close(), redis.quit(), prisma.$disconnect()]);
   process.exit(0);
 }
 


### PR DESCRIPTION
Addresses #47 (the code half — the collector endpoint and dashboards need the deployment).

Metrics have emitted as structured log lines since P0.6. **That's not a placeholder being replaced** — it's the sink that keeps working when the collector is down, which is exactly when somebody is trying to work out what happened. It stays; this adds a second sink.

## Instruments are declared, not inferred

Per metric, against the same union the rest of the app uses — so a new metric won't compile until somebody decides what kind of thing it is.

The distinction fails **quietly**, which is why it's worth being explicit:

- `run.duration_ms` as a counter → total milliseconds ever spent. A number nobody wants.
- `run.rows` as a histogram → loses the total. The only thing anybody wants.

A panel built on the wrong one is worse than an empty panel, because somebody puts an alert on it.

**Gauges are observed on export, not pushed on change.** Pushing reports whichever write landed last — for queue depth that's noise, not a level.

## Spans

**Job spans cover both runtimes**, not just the Redis one, so a trace from a deployment running inline looks like one from a deployment with a queue. A degraded mode that's invisible in tracing is a degraded mode nobody notices.

Attributes are the queue and the ids, never the payload — a job carries ids by design, and a span that re-expanded them would put back exactly what the job class avoids.

**Admin API spans carry cost points and remaining throttle budget.** That pair turns *"the run was slow"* into *"the run was slow because this shop's budget was exhausted"* — the difference between a graph and a diagnosis.

The operation **name** only. A price mutation's variables are precisely what must not be exported, and a query body as a span attribute is both enormous and unhelpful.

## Same redaction rules

An attribute is exported verbatim to whoever is collecting; the rule about prices doesn't relax because the destination is a metrics backend. Undefined labels are dropped rather than stringified — an attribute reading `"undefined"` makes a dashboard filter on something that looks present and isn't.

## Degrading

Absent endpoint → absent exporter. A misconfigured collector logs and carries on: an app that stopped writing prices because a dashboard broke would have the dependency exactly backwards.

Metrics flush on shutdown — that's the interval covering whatever made somebody restart the worker.

## Tests

11. Falsified through the instrument map and attribute redaction. Also verified **`npm run dev` still starts**, which is the check CI can't do — and the one that caught the Flow manifests.

Full suite: 714 unit tests, 94 chaos scenarios, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)