### PR TITLE
P0.2 — Resolve D4 by probing the real store

### DIFF
--- a/app/lib/compliance/built-for-shopify.test.ts
+++ b/app/lib/compliance/built-for-shopify.test.ts
@@ -178,13 +178,19 @@ describe("integration — API, auth and webhooks", () => {
 
   it("keeps requested scopes to the ones the app demonstrably uses", () => {
     // Every extra scope is a reason a merchant declines the install, and a question at
-    // review. These three were each established empirically in P0.2.
+    // review. Both were established empirically by `npm run scope:probe` — all thirteen
+    // mutations in RFC §6 pass under `write_products` alone, and markets needs its own.
+    //
+    // `read_markets` was dropped: Shopify implies it from `write_markets` and had already
+    // collapsed the pair in its record of what the shop granted, so declaring it was a
+    // checkbox that bought nothing. See D4 in docs/decisions.md, which also records the
+    // one narrowing still open — nothing in the app writes a market.
     const toml = readFileSync(join(ROOT, "shopify.app.toml"), "utf8");
     const match = /scopes\s*=\s*"([^"]*)"/.exec(toml);
 
     expect(match).not.toBeNull();
     const scopes = (match?.[1] ?? "").split(",").map((scope) => scope.trim()).filter(Boolean);
 
-    expect(scopes.sort()).toEqual(["read_markets", "write_markets", "write_products"]);
+    expect(scopes.sort()).toEqual(["write_markets", "write_products"]);
   });
 });

--- a/app/lib/shopify/scope-probe.test.ts
+++ b/app/lib/shopify/scope-probe.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Reading a scope probe's answer.
+ *
+ * The one classification that must never be wrong is a throttle or an outage being read
+ * as a missing scope. That mistake sends somebody to widen the manifest, which forces a
+ * re-authorisation prompt on every existing install — the exact cost this task exists to
+ * avoid. So "I could not tell" has to be a verdict of its own, and it has to be the
+ * default for anything unfamiliar.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { classifyProbe, minimalScopes, PROBES, scopeGaps } from "./scope-probe";
+
+describe("classifyProbe", () => {
+  it("reads a userErrors response as granted", () => {
+    // The mutation resolved, considered our deliberate nonsense and declined it. That is
+    // the shape almost every probe produces on a healthy shop, and it is a pass.
+    const result = classifyProbe({
+      data: {
+        priceListFixedPricesAdd: {
+          userErrors: [{ field: ["priceListId"], message: "Price list does not exist" }],
+        },
+      },
+    });
+
+    expect(result.verdict).toBe("granted");
+    expect(result.detail).toBe("Price list does not exist");
+  });
+
+  it("reads a clean success as granted", () => {
+    const result = classifyProbe({ data: { stagedUploadsCreate: { userErrors: [] } } });
+
+    expect(result.verdict).toBe("granted");
+  });
+
+  it("reads an access denial as denied, and quotes the scope Shopify named", () => {
+    const result = classifyProbe({
+      errors: [
+        {
+          message:
+            "Access denied for markets field. Required access: `read_markets` access scope.",
+        },
+      ],
+      data: null,
+    });
+
+    expect(result.verdict).toBe("denied");
+    expect(result.requires).toBe("read_markets");
+  });
+
+  it("does not mistake a throttle for a missing scope", () => {
+    // Shopify sends request-level failures as a bare object, not the array the spec
+    // describes. Treating this as a denial would be an argument for adding a scope the
+    // app already has.
+    const result = classifyProbe({ errors: { query: "Throttled" } });
+
+    expect(result.verdict).toBe("inconclusive");
+    expect(result.detail).toContain("Throttled");
+  });
+
+  it("does not mistake an empty response for a granted scope", () => {
+    expect(classifyProbe({}).verdict).toBe("inconclusive");
+    expect(classifyProbe({ data: {} }).verdict).toBe("inconclusive");
+  });
+});
+
+describe("the probes themselves", () => {
+  it("never sends an input that could write something", () => {
+    // The safety property the whole approach rests on. Every probe is meant to fail
+    // validation, and it can only be trusted to fail if its ids cannot resolve and its
+    // lists are empty. A probe that grew a real id in a later edit would quietly start
+    // mutating the shop it was checking.
+    const serialised = JSON.stringify(PROBES.map((probe) => probe.variables));
+
+    const ids = serialised.match(/gid:\/\/shopify\/\w+\/(\d+)/g) ?? [];
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      expect(id).toMatch(/\/9007199254740991$/);
+    }
+
+    // Anything that would carry a payload — prices, tags, variants — is empty.
+    for (const probe of PROBES) {
+      for (const value of Object.values(probe.variables)) {
+        if (Array.isArray(value)) expect(value).toHaveLength(0);
+      }
+    }
+  });
+
+  it("covers every mutation the architecture depends on", () => {
+    const names = PROBES.map((probe) => probe.name);
+
+    // RFC §6's list. If a mutation is added to the engine and not here, the scope set
+    // stops being empirical and goes back to being a guess.
+    for (const required of [
+      "productVariantsBulkUpdate",
+      "bulkOperationRunMutation",
+      "bulkOperationRunQuery",
+      "stagedUploadsCreate",
+      "priceListCreate",
+      "priceListUpdate",
+      "priceListFixedPricesAdd",
+      "priceListFixedPricesDelete",
+      "quantityPricingByVariantUpdate",
+      "catalogCreate",
+      "catalogUpdate",
+      "tagsAdd",
+      "tagsRemove",
+    ]) {
+      expect(names).toContain(required);
+    }
+  });
+});
+
+describe("per-market compare-at, as a schema fact", () => {
+  /**
+   * The wedge, asserted against the generated schema rather than against a belief.
+   *
+   * `priceListFixedPricesByProductUpdate` is the obvious mutation for per-market pricing
+   * and its input has no compare-at field at all — which is almost certainly why the
+   * ecosystem believes Shopify cannot do per-market strike-throughs. The variant-level
+   * mutation has one. That asymmetry is the product's differentiator, and it is exactly
+   * the kind of thing that changes silently in a later API version.
+   *
+   * If Shopify adds compare-at to the product-level input, this test fails and we find
+   * out by a red build rather than by a competitor shipping it.
+   */
+  const schema = fs.readFileSync(
+    path.join(process.cwd(), "app/types/admin.types.d.ts"),
+    "utf8",
+  );
+
+  const inputFields = (name: string) => {
+    const body = new RegExp(`export type ${name} = \\{([\\s\\S]*?)\\n\\};`).exec(schema);
+    expect(body, `${name} missing from the generated schema`).not.toBeNull();
+    return body![1];
+  };
+
+  it("the product-level input still has no compare-at", () => {
+    expect(inputFields("PriceListProductPriceInput")).not.toMatch(/compareAtPrice/);
+  });
+
+  it("the variant-level input still has one", () => {
+    expect(inputFields("PriceListPriceInput")).toMatch(/compareAtPrice/);
+  });
+});
+
+describe("minimalScopes", () => {
+  it("drops a read scope its write counterpart already implies", () => {
+    // The finding that came out of the first real run: the manifest asked for
+    // `read_markets` alongside `write_markets`, and Shopify's own record of what was
+    // granted had already collapsed the pair. One fewer checkbox on the install screen,
+    // for no loss of access.
+    expect(minimalScopes(["write_products", "read_products", "write_markets"])).toEqual([
+      "write_markets",
+      "write_products",
+    ]);
+  });
+
+  it("keeps a read scope with no write counterpart", () => {
+    // `read_companies` has no write half in play — B2B catalog assignment is displayed,
+    // never edited — so this one is a genuine addition when P6.1 ships.
+    expect(minimalScopes(["write_products", "read_companies"])).toEqual([
+      "read_companies",
+      "write_products",
+    ]);
+  });
+});
+
+describe("scopeGaps", () => {
+  it("reports a write scope as over-broad when only the read was exercised", () => {
+    // The finding from the first real run. Nothing the app does *writes* a market — the
+    // market surface works by creating and updating price lists, which `write_products`
+    // covers. All we ever do to markets themselves is read which ones exist.
+    const gaps = scopeGaps(
+      ["write_markets", "write_products"],
+      ["read_markets", "write_products"],
+    );
+
+    expect(gaps.overBroad).toEqual(["write_markets"]);
+    expect(gaps.missing).toEqual([]);
+    expect(gaps.unneeded).toEqual([]);
+  });
+
+  it("counts a granted write as covering a needed read", () => {
+    // Otherwise every run would report `read_markets` missing while it plainly works,
+    // and a report that cries wolf is a report nobody reads twice.
+    expect(scopeGaps(["write_markets"], ["read_markets"]).missing).toEqual([]);
+  });
+
+  it("reports a genuinely absent scope as missing", () => {
+    expect(scopeGaps(["write_products"], ["read_companies"]).missing).toEqual([
+      "read_companies",
+    ]);
+  });
+
+  it("separates unneeded from over-broad", () => {
+    // `write_orders` has no read counterpart in the needed set either — nothing in the
+    // app touches orders at all, so it is a checkbox to delete rather than one to
+    // narrow. Different finding, different fix.
+    const gaps = scopeGaps(["write_orders", "write_products"], ["write_products"]);
+
+    expect(gaps.unneeded).toEqual(["write_orders"]);
+    expect(gaps.overBroad).toEqual([]);
+  });
+});

--- a/app/lib/shopify/scope-probe.ts
+++ b/app/lib/shopify/scope-probe.ts
@@ -1,0 +1,471 @@
+/**
+ * Empirically determines which access scopes each mutation the architecture needs
+ * actually requires — by asking Shopify rather than reading the docs.
+ *
+ * **Why this exists.** Every scope is a checkbox a merchant reads before installing, and
+ * each one costs install conversion. Widening scopes after launch forces a
+ * re-authorisation prompt for every existing install, so the set has to be right before
+ * the listing is built. The docs say `write_products` covers products, variants, price
+ * lists and catalogs. That is an unusually generous claim and it turned out to be wrong
+ * about Markets — the `markets` field answers "Access denied" under `write_products`
+ * alone, which is why `read_markets`/`write_markets` are in the manifest.
+ *
+ * **How a probe can be safe.** Shopify checks authorization when it resolves the field,
+ * *before* it validates the input. So a mutation that is going to fail its input
+ * validation still tells us whether the scope is present — and it tells us without
+ * changing anything. Every probe below therefore sends an input engineered to be
+ * rejected: an id no store can hold, or an empty list. A `userErrors` response means the
+ * mutation ran, considered our nonsense, and declined it. That is a pass.
+ *
+ * The alternative — writing a real price and putting it back — would be a live price
+ * mutation with no ledger row behind it, which is precisely the thing invariant I4
+ * exists to forbid. A probe that violates the product's central rule to prove the
+ * product works is not a probe worth having.
+ */
+
+/**
+ * An id above every id Shopify has issued, and above every one it will issue before this
+ * code is gone. Well-formed, so it passes gid parsing and reaches the resolver; absurd,
+ * so it cannot resolve to a real object on any store.
+ *
+ * The obvious choice — `.../1` — is well-formed too and *does* resolve on the oldest
+ * stores in the world. Not ours, probably. "Probably" is doing far too much work in a
+ * sentence about a mutation that could rename somebody's catalog.
+ */
+const IMPOSSIBLE = 9_007_199_254_740_991;
+
+const gid = (type: string) => `gid://shopify/${type}/${IMPOSSIBLE}`;
+
+export type ProbeVerdict = "granted" | "denied" | "inconclusive";
+
+export interface ProbeResult {
+  verdict: ProbeVerdict;
+  /** What Shopify said, trimmed to one line. Empty when it said nothing useful. */
+  detail: string;
+  /** The scope named in an access-denied message, when it named one. */
+  requires?: string;
+}
+
+export interface Probe {
+  /** The mutation or field being probed, as it appears in RFC §6. */
+  name: string;
+  /** What the architecture needs it for — so a failure reads as a consequence. */
+  purpose: string;
+  /** The scope we believe covers it, to be confirmed or contradicted. */
+  expects: string;
+  document: string;
+  variables: Record<string, unknown>;
+  /**
+   * The phase that first needs this, when it is not the one shipping now.
+   *
+   * A denial here is a scheduled cost, not a fault. Without the distinction the report
+   * says "the app cannot do what it claims" about `read_companies`, which is true of no
+   * feature that exists — B2B catalog assignment display is P6.1 — and a report that
+   * raises an alarm about something working as designed trains people to skim it.
+   */
+  neededAt?: string;
+}
+
+/**
+ * Pulls the verdict out of a GraphQL response body.
+ *
+ * The distinction that matters is *where* the failure came from. Shopify reports a
+ * missing scope as a top-level `errors` entry — the field never resolved. It reports a
+ * bad input as `userErrors` inside the payload — the field resolved, ran, and rejected
+ * us. So a mutation that fails loudly on our deliberate nonsense is exactly what a
+ * granted scope looks like.
+ *
+ * Anything else is `inconclusive` rather than a guess: a throttle, a network failure or
+ * a schema change should read as "ask again", never as "denied". Reporting a throttled
+ * probe as a missing scope would send somebody to widen the manifest, which is the one
+ * outcome this whole exercise is meant to prevent.
+ */
+export function classifyProbe(body: unknown): ProbeResult {
+  const { errors, data } = (body ?? {}) as {
+    errors?: unknown;
+    data?: Record<string, unknown> | null;
+  };
+
+  const topLevel = topLevelErrors(errors);
+
+  const denial = topLevel.find(isAccessDenial);
+  if (denial) {
+    return { verdict: "denied", detail: denial, requires: requiredScope(denial) };
+  }
+
+  if (topLevel.length > 0) {
+    return { verdict: "inconclusive", detail: topLevel.join("; ") };
+  }
+
+  // `data` present at all means the field resolved, which is the whole question. A null
+  // payload with userErrors, a payload with an empty result — both are passes.
+  if (data && Object.keys(data).length > 0) {
+    return { verdict: "granted", detail: firstUserError(data) ?? "" };
+  }
+
+  return { verdict: "inconclusive", detail: "no data and no errors" };
+}
+
+/**
+ * Shopify's error shape is not consistent — an array per the spec for field-level
+ * failures, a bare object such as `{"query": "Throttled"}` for request-level ones. Both
+ * are flattened to a list of strings here, for the same reason the admin client does it:
+ * assuming the array cost real time once already.
+ */
+function topLevelErrors(errors: unknown): string[] {
+  if (!errors) return [];
+
+  if (Array.isArray(errors)) {
+    return errors.map(
+      (entry) => (entry as { message?: string })?.message ?? JSON.stringify(entry),
+    );
+  }
+
+  if (typeof errors === "string") return [errors];
+
+  if (typeof errors === "object") {
+    return Object.entries(errors as Record<string, unknown>).map(
+      ([key, value]) =>
+        `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`,
+    );
+  }
+
+  return [String(errors)];
+}
+
+function isAccessDenial(message: string): boolean {
+  return /access denied|required access|not approved to access/i.test(message);
+}
+
+/**
+ * The scope named inside an access-denied message.
+ *
+ * Shopify is unusually helpful here — "Required access: `read_markets` access scope" —
+ * and quoting it back is better than inferring, because the message is what the merchant
+ * would be asked to grant.
+ */
+function requiredScope(message: string): string | undefined {
+  return /`([a-z_]+)`\s*access scope/i.exec(message)?.[1];
+}
+
+function firstUserError(data: Record<string, unknown>): string | null {
+  for (const payload of Object.values(data)) {
+    const errors = (payload as { userErrors?: Array<{ message?: string }> } | null)
+      ?.userErrors;
+    if (errors?.length) return errors[0]?.message ?? null;
+  }
+  return null;
+}
+
+/**
+ * Every mutation and field the architecture depends on, one probe each.
+ *
+ * The list is RFC §6's, plus the two read fields whose necessity is itself the open
+ * question: `markets` (already proven to need its own scope) and `companies` (needed
+ * only if catalog *assignment* has to be displayed, which decides whether P6.1 forces a
+ * scope change on every existing install).
+ */
+export const PROBES: Probe[] = [
+  {
+    name: "productVariantsBulkUpdate",
+    purpose: "base-price writes — the primary surface",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeVariantsBulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+        productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { productId: gid("Product"), variants: [] },
+  },
+  {
+    name: "bulkOperationRunQuery",
+    purpose: "catalog mirror sync",
+    expects: "read_products",
+    document: `#graphql
+      mutation AnchorProbeBulkQuery($query: String!) {
+        bulkOperationRunQuery(query: $query) {
+          userErrors { field message }
+        }
+      }
+    `,
+    // Deliberately not a query. A valid one would start a real bulk operation, and this
+    // shop may only run one at a time — a probe that occupies that slot is a probe that
+    // breaks the thing it is checking.
+    variables: { query: "this is not a graphql document" },
+  },
+  {
+    name: "bulkOperationRunMutation",
+    purpose: "large price writes via JSONL",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeBulkMutation($mutation: String!, $stagedUploadPath: String!) {
+        bulkOperationRunMutation(mutation: $mutation, stagedUploadPath: $stagedUploadPath) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { mutation: "not a mutation", stagedUploadPath: "nonexistent" },
+  },
+  {
+    name: "stagedUploadsCreate",
+    purpose: "uploading the JSONL a bulk mutation reads",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeStagedUploads($input: [StagedUploadInput!]!) {
+        stagedUploadsCreate(input: $input) {
+          userErrors { field message }
+        }
+      }
+    `,
+    // An empty list stages nothing. This is the one probe that may legitimately succeed
+    // rather than fail, which is fine — success is an even clearer pass.
+    variables: { input: [] },
+  },
+  {
+    name: "priceListCreate",
+    purpose: "creating a market price list",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbePriceListCreate($input: PriceListCreateInput!) {
+        priceListCreate(input: $input) {
+          userErrors { field message }
+        }
+      }
+    `,
+    // A catalog id that cannot resolve, so validation rejects it before anything is
+    // created. Without that the probe would leave a price list behind on every run.
+    variables: {
+      input: {
+        name: "anchor-scope-probe",
+        currency: "USD",
+        catalogId: gid("Catalog"),
+        parent: { adjustment: { type: "PERCENTAGE_DECREASE", value: 1 } },
+      },
+    },
+  },
+  {
+    name: "priceListUpdate",
+    purpose: "market-wide repricing in one mutation",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbePriceListUpdate($id: ID!, $input: PriceListUpdateInput!) {
+        priceListUpdate(id: $id, input: $input) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { id: gid("PriceList"), input: {} },
+  },
+  {
+    name: "priceListFixedPricesAdd",
+    purpose: "per-market prices **with compare-at** — the wedge",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeFixedPricesAdd($priceListId: ID!, $prices: [PriceListPriceInput!]!) {
+        priceListFixedPricesAdd(priceListId: $priceListId, prices: $prices) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { priceListId: gid("PriceList"), prices: [] },
+  },
+  {
+    name: "priceListFixedPricesDelete",
+    purpose: "reverting a market surface",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeFixedPricesDelete($priceListId: ID!, $variantIds: [ID!]!) {
+        priceListFixedPricesDelete(priceListId: $priceListId, variantIds: $variantIds) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { priceListId: gid("PriceList"), variantIds: [] },
+  },
+  {
+    name: "quantityPricingByVariantUpdate",
+    purpose: "B2B quantity price breaks",
+    expects: "write_products",
+    neededAt: "P6.1",
+    document: `#graphql
+      mutation AnchorProbeQuantityPricing($priceListId: ID!, $input: QuantityPricingByVariantUpdateInput!) {
+        quantityPricingByVariantUpdate(priceListId: $priceListId, input: $input) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: {
+      priceListId: gid("PriceList"),
+      input: {
+        pricesToAdd: [],
+        pricesToDeleteByVariantId: [],
+        quantityPriceBreaksToAdd: [],
+        quantityPriceBreaksToDelete: [],
+        quantityRulesToAdd: [],
+        quantityRulesToDeleteByVariantId: [],
+      },
+    },
+  },
+  {
+    name: "catalogCreate",
+    purpose: "B2B catalog surface",
+    expects: "write_products",
+    neededAt: "P6.1",
+    document: `#graphql
+      mutation AnchorProbeCatalogCreate($input: CatalogCreateInput!) {
+        catalogCreate(input: $input) {
+          userErrors { field message }
+        }
+      }
+    `,
+    // Pinned to a market that cannot exist, so nothing is created.
+    variables: {
+      input: {
+        title: "anchor-scope-probe",
+        status: "DRAFT",
+        context: { marketIds: [gid("Market")] },
+      },
+    },
+  },
+  {
+    name: "catalogUpdate",
+    purpose: "attaching a price list to a catalog",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeCatalogUpdate($id: ID!, $input: CatalogUpdateInput!) {
+        catalogUpdate(id: $id, input: $input) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { id: gid("Catalog"), input: {} },
+  },
+  {
+    name: "tagsAdd",
+    purpose: "campaign-scoped tags — the only storefront hook we allow ourselves",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeTagsAdd($id: ID!, $tags: [String!]!) {
+        tagsAdd(id: $id, tags: $tags) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { id: gid("Product"), tags: [] },
+  },
+  {
+    name: "tagsRemove",
+    purpose: "removing them when a campaign ends",
+    expects: "write_products",
+    document: `#graphql
+      mutation AnchorProbeTagsRemove($id: ID!, $tags: [String!]!) {
+        tagsRemove(id: $id, tags: $tags) {
+          userErrors { field message }
+        }
+      }
+    `,
+    variables: { id: gid("Product"), tags: [] },
+  },
+  {
+    name: "markets (query)",
+    purpose: "reading which markets exist, before pricing into any of them",
+    expects: "read_markets",
+    document: `#graphql
+      query AnchorProbeMarkets {
+        markets(first: 1) { nodes { id } }
+      }
+    `,
+    variables: {},
+  },
+  {
+    name: "companies (query)",
+    purpose: "displaying which companies a B2B catalog is assigned to",
+    expects: "read_companies",
+    neededAt: "P6.1",
+    document: `#graphql
+      query AnchorProbeCompanies {
+        companies(first: 1) { nodes { id } }
+      }
+    `,
+    variables: {},
+  },
+];
+
+/**
+ * The set of scopes to actually declare, given the set the probes proved necessary.
+ *
+ * Shopify implies `read_x` from `write_x`, and collapses the pair when it records what a
+ * shop granted — the session row for a manifest asking for
+ * `write_products,read_markets,write_markets` comes back saying `write_markets,
+ * write_products`. Declaring the implied half is therefore a checkbox on the install
+ * screen that buys nothing, and this app was declaring one.
+ *
+ * Kept as a function rather than a hand-edited string because the naive union of what
+ * each probe expects is what a person would write down, and it is wrong in exactly this
+ * way: `bulkOperationRunQuery` needs read access to products, so `read_products` looks
+ * like part of the answer right up until you notice `write_products` is already there.
+ */
+export function minimalScopes(needed: Iterable<string>): string[] {
+  const set = new Set(needed);
+  for (const scope of [...set]) {
+    if (scope.startsWith("read_") && set.has(`write_${scope.slice("read_".length)}`)) {
+      set.delete(scope);
+    }
+  }
+  return [...set].sort();
+}
+
+export interface ScopeGaps {
+  /** Needed, and not covered by anything granted. The app is broken until these land. */
+  missing: string[];
+  /** Granted as write where only read was ever exercised. A wider prompt than earned. */
+  overBroad: string[];
+  /** Granted and never exercised at all. A checkbox with nothing behind it. */
+  unneeded: string[];
+}
+
+/**
+ * Compares what a shop granted against what the probes proved necessary.
+ *
+ * The three answers are deliberately kept apart because they call for different actions.
+ * `missing` is a bug — something the app does will fail. `unneeded` is a scope to delete.
+ * `overBroad` is the subtle one: the manifest asks to *manage* markets when it only ever
+ * *reads* them, and the difference is the wording of the sentence a merchant reads on
+ * the install screen. "View your markets" and "manage your markets" are not the same ask
+ * of somebody about to hand a pricing app access to their store.
+ *
+ * None of this proves a scope is removable. This probe reports what fails under the
+ * grant in force, and a scope that is present is never exercised as absent — confirming
+ * a removal means narrowing the manifest, reinstalling, and asking again.
+ */
+export function scopeGaps(granted: Iterable<string>, needed: Iterable<string>): ScopeGaps {
+  const have = new Set(granted);
+  const want = new Set(needed);
+
+  const covers = (scope: string) =>
+    have.has(scope) ||
+    (scope.startsWith("read_") && have.has(`write_${scope.slice("read_".length)}`));
+
+  const missing = [...want].filter((scope) => !covers(scope)).sort();
+
+  const overBroad = [...have]
+    .filter(
+      (scope) =>
+        scope.startsWith("write_") &&
+        !want.has(scope) &&
+        want.has(`read_${scope.slice("write_".length)}`),
+    )
+    .sort();
+
+  const unneeded = [...have]
+    .filter((scope) => {
+      if (want.has(scope)) return false;
+      const suffix = scope.replace(/^(read|write)_/, "");
+      return !want.has(`read_${suffix}`) && !want.has(`write_${suffix}`);
+    })
+    .sort();
+
+  return { missing, overBroad, unneeded };
+}

--- a/app/types/admin.generated.d.ts
+++ b/app/types/admin.generated.d.ts
@@ -94,6 +94,116 @@ export type AnchorVariantPricesQueryVariables = AdminTypes.Exact<{
 
 export type AnchorVariantPricesQuery = { nodes: Array<AdminTypes.Maybe<Pick<AdminTypes.ProductVariant, 'id' | 'price' | 'compareAtPrice'>>> };
 
+export type AnchorProbeVariantsBulkUpdateMutationVariables = AdminTypes.Exact<{
+  productId: AdminTypes.Scalars['ID']['input'];
+  variants: Array<AdminTypes.ProductVariantsBulkInput> | AdminTypes.ProductVariantsBulkInput;
+}>;
+
+
+export type AnchorProbeVariantsBulkUpdateMutation = { productVariantsBulkUpdate?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.ProductVariantsBulkUpdateUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeBulkQueryMutationVariables = AdminTypes.Exact<{
+  query: AdminTypes.Scalars['String']['input'];
+}>;
+
+
+export type AnchorProbeBulkQueryMutation = { bulkOperationRunQuery?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.BulkOperationUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeBulkMutationMutationVariables = AdminTypes.Exact<{
+  mutation: AdminTypes.Scalars['String']['input'];
+  stagedUploadPath: AdminTypes.Scalars['String']['input'];
+}>;
+
+
+export type AnchorProbeBulkMutationMutation = { bulkOperationRunMutation?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.BulkMutationUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeStagedUploadsMutationVariables = AdminTypes.Exact<{
+  input: Array<AdminTypes.StagedUploadInput> | AdminTypes.StagedUploadInput;
+}>;
+
+
+export type AnchorProbeStagedUploadsMutation = { stagedUploadsCreate?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.UserError, 'field' | 'message'>> }> };
+
+export type AnchorProbePriceListCreateMutationVariables = AdminTypes.Exact<{
+  input: AdminTypes.PriceListCreateInput;
+}>;
+
+
+export type AnchorProbePriceListCreateMutation = { priceListCreate?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.PriceListUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbePriceListUpdateMutationVariables = AdminTypes.Exact<{
+  id: AdminTypes.Scalars['ID']['input'];
+  input: AdminTypes.PriceListUpdateInput;
+}>;
+
+
+export type AnchorProbePriceListUpdateMutation = { priceListUpdate?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.PriceListUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeFixedPricesAddMutationVariables = AdminTypes.Exact<{
+  priceListId: AdminTypes.Scalars['ID']['input'];
+  prices: Array<AdminTypes.PriceListPriceInput> | AdminTypes.PriceListPriceInput;
+}>;
+
+
+export type AnchorProbeFixedPricesAddMutation = { priceListFixedPricesAdd?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.PriceListPriceUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeFixedPricesDeleteMutationVariables = AdminTypes.Exact<{
+  priceListId: AdminTypes.Scalars['ID']['input'];
+  variantIds: Array<AdminTypes.Scalars['ID']['input']> | AdminTypes.Scalars['ID']['input'];
+}>;
+
+
+export type AnchorProbeFixedPricesDeleteMutation = { priceListFixedPricesDelete?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.PriceListPriceUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeQuantityPricingMutationVariables = AdminTypes.Exact<{
+  priceListId: AdminTypes.Scalars['ID']['input'];
+  input: AdminTypes.QuantityPricingByVariantUpdateInput;
+}>;
+
+
+export type AnchorProbeQuantityPricingMutation = { quantityPricingByVariantUpdate?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.QuantityPricingByVariantUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeCatalogCreateMutationVariables = AdminTypes.Exact<{
+  input: AdminTypes.CatalogCreateInput;
+}>;
+
+
+export type AnchorProbeCatalogCreateMutation = { catalogCreate?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.CatalogUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeCatalogUpdateMutationVariables = AdminTypes.Exact<{
+  id: AdminTypes.Scalars['ID']['input'];
+  input: AdminTypes.CatalogUpdateInput;
+}>;
+
+
+export type AnchorProbeCatalogUpdateMutation = { catalogUpdate?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.CatalogUserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeTagsAddMutationVariables = AdminTypes.Exact<{
+  id: AdminTypes.Scalars['ID']['input'];
+  tags: Array<AdminTypes.Scalars['String']['input']> | AdminTypes.Scalars['String']['input'];
+}>;
+
+
+export type AnchorProbeTagsAddMutation = { tagsAdd?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.UserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeTagsRemoveMutationVariables = AdminTypes.Exact<{
+  id: AdminTypes.Scalars['ID']['input'];
+  tags: Array<AdminTypes.Scalars['String']['input']> | AdminTypes.Scalars['String']['input'];
+}>;
+
+
+export type AnchorProbeTagsRemoveMutation = { tagsRemove?: AdminTypes.Maybe<{ userErrors: Array<Pick<AdminTypes.UserError, 'field' | 'message'>> }> };
+
+export type AnchorProbeMarketsQueryVariables = AdminTypes.Exact<{ [key: string]: never; }>;
+
+
+export type AnchorProbeMarketsQuery = { markets: { nodes: Array<Pick<AdminTypes.Market, 'id'>> } };
+
+export type AnchorProbeCompaniesQueryVariables = AdminTypes.Exact<{ [key: string]: never; }>;
+
+
+export type AnchorProbeCompaniesQuery = { companies: { nodes: Array<Pick<AdminTypes.Company, 'id'>> } };
+
 export type AnchorProductTagsQueryVariables = AdminTypes.Exact<{
   ids: Array<AdminTypes.Scalars['ID']['input']> | AdminTypes.Scalars['ID']['input'];
 }>;
@@ -200,6 +310,8 @@ interface GeneratedQueryTypes {
   "#graphql\n  query AnchorPriceListDerivedPrices($priceListId: ID!, $query: String!, $first: Int!, $after: String) {\n    priceList(id: $priceListId) {\n      currency\n      prices(originType: RELATIVE, query: $query, first: $first, after: $after) {\n        nodes {\n          variant { id }\n          price { amount currencyCode }\n        }\n        pageInfo { hasNextPage endCursor }\n      }\n    }\n  }\n": {return: AnchorPriceListDerivedPricesQuery, variables: AnchorPriceListDerivedPricesQueryVariables},
   "#graphql\n  query AnchorPriceListParent($id: ID!) {\n    priceList(id: $id) {\n      id\n      currency\n      parent {\n        adjustment { type value }\n        settings { compareAtMode }\n      }\n      fixed: prices(originType: FIXED, first: 1) {\n        nodes { variant { id } }\n      }\n    }\n  }\n": {return: AnchorPriceListParentQuery, variables: AnchorPriceListParentQueryVariables},
   "#graphql\n  query AnchorVariantPrices($ids: [ID!]!) {\n    nodes(ids: $ids) {\n      ... on ProductVariant { id price compareAtPrice }\n    }\n  }\n": {return: AnchorVariantPricesQuery, variables: AnchorVariantPricesQueryVariables},
+  "#graphql\n      query AnchorProbeMarkets {\n        markets(first: 1) { nodes { id } }\n      }\n    ": {return: AnchorProbeMarketsQuery, variables: AnchorProbeMarketsQueryVariables},
+  "#graphql\n      query AnchorProbeCompanies {\n        companies(first: 1) { nodes { id } }\n      }\n    ": {return: AnchorProbeCompaniesQuery, variables: AnchorProbeCompaniesQueryVariables},
   "#graphql\n  query AnchorProductTags($ids: [ID!]!) {\n    nodes(ids: $ids) {\n      ... on Product { id tags }\n    }\n  }\n": {return: AnchorProductTagsQuery, variables: AnchorProductTagsQueryVariables},
   "#graphql\n  query AnchorCurrentBulkQuery {\n    currentBulkOperation(type: QUERY) {\n      id status url partialDataUrl objectCount errorCode\n    }\n  }\n": {return: AnchorCurrentBulkQueryQuery, variables: AnchorCurrentBulkQueryQueryVariables},
   "#graphql\n  query AnchorCatalogPage($cursor: String) {\n    products(first: 50, after: $cursor) {\n      pageInfo { hasNextPage endCursor }\n      nodes {\n        id\n        title\n        vendor\n        productType\n        status\n        tags\n        updatedAt\n        collections(first: 20) { nodes { id } }\n        variants(first: 100) {\n          nodes {\n            id\n            title\n            sku\n            barcode\n            price\n            compareAtPrice\n            inventoryQuantity\n            inventoryItem { unitCost { amount currencyCode } }\n          }\n        }\n      }\n    }\n  }\n": {return: AnchorCatalogPageQuery, variables: AnchorCatalogPageQueryVariables},
@@ -216,6 +328,19 @@ interface GeneratedMutationTypes {
   "#graphql\n  mutation AnchorPriceListFixedPricesDelete($priceListId: ID!, $variantIds: [ID!]!) {\n    priceListFixedPricesDelete(priceListId: $priceListId, variantIds: $variantIds) {\n      deletedFixedPriceVariantIds\n      userErrors { field message code }\n    }\n  }\n": {return: AnchorPriceListFixedPricesDeleteMutation, variables: AnchorPriceListFixedPricesDeleteMutationVariables},
   "#graphql\n  mutation AnchorPriceListUpdate($id: ID!, $input: PriceListUpdateInput!) {\n    priceListUpdate(id: $id, input: $input) {\n      priceList {\n        id\n        parent { adjustment { type value } }\n      }\n      userErrors { field message code }\n    }\n  }\n": {return: AnchorPriceListUpdateMutation, variables: AnchorPriceListUpdateMutationVariables},
   "#graphql\n  mutation AnchorProductVariantsBulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {\n    productVariantsBulkUpdate(productId: $productId, variants: $variants) {\n      productVariants { id price compareAtPrice }\n      userErrors { field message code }\n    }\n  }\n": {return: AnchorProductVariantsBulkUpdateMutation, variables: AnchorProductVariantsBulkUpdateMutationVariables},
+  "#graphql\n      mutation AnchorProbeVariantsBulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {\n        productVariantsBulkUpdate(productId: $productId, variants: $variants) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeVariantsBulkUpdateMutation, variables: AnchorProbeVariantsBulkUpdateMutationVariables},
+  "#graphql\n      mutation AnchorProbeBulkQuery($query: String!) {\n        bulkOperationRunQuery(query: $query) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeBulkQueryMutation, variables: AnchorProbeBulkQueryMutationVariables},
+  "#graphql\n      mutation AnchorProbeBulkMutation($mutation: String!, $stagedUploadPath: String!) {\n        bulkOperationRunMutation(mutation: $mutation, stagedUploadPath: $stagedUploadPath) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeBulkMutationMutation, variables: AnchorProbeBulkMutationMutationVariables},
+  "#graphql\n      mutation AnchorProbeStagedUploads($input: [StagedUploadInput!]!) {\n        stagedUploadsCreate(input: $input) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeStagedUploadsMutation, variables: AnchorProbeStagedUploadsMutationVariables},
+  "#graphql\n      mutation AnchorProbePriceListCreate($input: PriceListCreateInput!) {\n        priceListCreate(input: $input) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbePriceListCreateMutation, variables: AnchorProbePriceListCreateMutationVariables},
+  "#graphql\n      mutation AnchorProbePriceListUpdate($id: ID!, $input: PriceListUpdateInput!) {\n        priceListUpdate(id: $id, input: $input) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbePriceListUpdateMutation, variables: AnchorProbePriceListUpdateMutationVariables},
+  "#graphql\n      mutation AnchorProbeFixedPricesAdd($priceListId: ID!, $prices: [PriceListPriceInput!]!) {\n        priceListFixedPricesAdd(priceListId: $priceListId, prices: $prices) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeFixedPricesAddMutation, variables: AnchorProbeFixedPricesAddMutationVariables},
+  "#graphql\n      mutation AnchorProbeFixedPricesDelete($priceListId: ID!, $variantIds: [ID!]!) {\n        priceListFixedPricesDelete(priceListId: $priceListId, variantIds: $variantIds) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeFixedPricesDeleteMutation, variables: AnchorProbeFixedPricesDeleteMutationVariables},
+  "#graphql\n      mutation AnchorProbeQuantityPricing($priceListId: ID!, $input: QuantityPricingByVariantUpdateInput!) {\n        quantityPricingByVariantUpdate(priceListId: $priceListId, input: $input) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeQuantityPricingMutation, variables: AnchorProbeQuantityPricingMutationVariables},
+  "#graphql\n      mutation AnchorProbeCatalogCreate($input: CatalogCreateInput!) {\n        catalogCreate(input: $input) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeCatalogCreateMutation, variables: AnchorProbeCatalogCreateMutationVariables},
+  "#graphql\n      mutation AnchorProbeCatalogUpdate($id: ID!, $input: CatalogUpdateInput!) {\n        catalogUpdate(id: $id, input: $input) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeCatalogUpdateMutation, variables: AnchorProbeCatalogUpdateMutationVariables},
+  "#graphql\n      mutation AnchorProbeTagsAdd($id: ID!, $tags: [String!]!) {\n        tagsAdd(id: $id, tags: $tags) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeTagsAddMutation, variables: AnchorProbeTagsAddMutationVariables},
+  "#graphql\n      mutation AnchorProbeTagsRemove($id: ID!, $tags: [String!]!) {\n        tagsRemove(id: $id, tags: $tags) {\n          userErrors { field message }\n        }\n      }\n    ": {return: AnchorProbeTagsRemoveMutation, variables: AnchorProbeTagsRemoveMutationVariables},
   "#graphql\n  mutation AnchorTagsAdd($id: ID!, $tags: [String!]!) {\n    tagsAdd(id: $id, tags: $tags) {\n      node { id }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorTagsAddMutation, variables: AnchorTagsAddMutationVariables},
   "#graphql\n  mutation AnchorTagsRemove($id: ID!, $tags: [String!]!) {\n    tagsRemove(id: $id, tags: $tags) {\n      node { id }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorTagsRemoveMutation, variables: AnchorTagsRemoveMutationVariables},
   "#graphql\n  mutation AnchorCatalogBulkQuery($query: String!) {\n    bulkOperationRunQuery(query: $query) {\n      bulkOperation { id status }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorCatalogBulkQueryMutation, variables: AnchorCatalogBulkQueryMutationVariables},

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -17,11 +17,69 @@ appending a new one, and note the reasoning.
 
 | # | Decision | Resolves at | Notes |
 |---|---|---|---|
-| D4 | Exact minimal scope set | **P0.2** | Docs indicate `write_products` covers products, variants, price lists and catalogs. Verify empirically against every mutation in RFC §6 before the listing is built. Over-asking hurts install conversion. |
+| D4 | Exact minimal scope set | **Resolved P0.2, one narrowing open** | `write_products` does cover products, variants, price lists *and* catalogs — all thirteen mutations in RFC §6 pass under it. Markets needs its own scope; `read_orders` and `read_companies` are genuinely not needed until P6.2/P6.1. Detail below. |
 | D6 | App name + App Store listing name | **Proposed, pending availability** | App name "Anchor"; listing name "Anchor: Bulk Price Editor & Market Pricing". The listing name carries the terms merchants type, because search rank in this category depends on it; the app name stays short because that is what sits in the admin sidebar daily. Cannot be *closed* until the Partner dashboard confirms availability — a taken name makes every other choice here moot. Copy drafted in `docs/app-store-listing.md`. |
 | D7 | Free-tier cap (500 vs 250 variants) | post-launch data | Start at 500 — deliberately aggressive against NA's 100 changes/month. Tighten if conversion suffers; never tighten the safety features. |
 | D8 | Pull B2B surface forward into P5 | beta signal | Swap with the calendar if the beta cohort skews B2B-heavy. |
 | D9 | Managed pricing vs the newer usage-billing App Events path | **Resolved P5.8** | Managed pricing. Variant caps are enforced in-app against the campaign's own scope, which needs no usage reporting at all — and usage billing would have meant emitting an App Event per priced variant, which is both a per-change meter by another name (contradicting D3) and a second source of truth about what we did. |
+
+### D4, in more detail
+
+Resolved by `npm run scope:probe`, which asks Shopify rather than reading the docs. The
+probe sends each mutation an input engineered to fail validation — an id no store can
+hold, or an empty list — because authorization is checked when the field resolves, *before*
+the input is validated. A `userErrors` response therefore means the mutation ran,
+considered our nonsense and declined it, which is a pass that changes nothing.
+
+Run against `boltify-apps.myshopify.com` on 26 Aug 2026, granted `write_markets,
+write_products`:
+
+| Mutation | Verdict | What Shopify said |
+|---|---|---|
+| `productVariantsBulkUpdate` | pass | Product does not exist |
+| `bulkOperationRunQuery` | pass | Invalid bulk query: syntax error |
+| `bulkOperationRunMutation` | pass | Failed to parse the mutation |
+| `stagedUploadsCreate` | pass | (accepted an empty list) |
+| `priceListCreate` | pass | Catalog does not exist. |
+| `priceListUpdate` | pass | Price list does not exist. |
+| `priceListFixedPricesAdd` | pass | Price list does not exist. |
+| `priceListFixedPricesDelete` | pass | Price list does not exist. |
+| `quantityPricingByVariantUpdate` | pass | Price list not found. |
+| `catalogCreate` | pass | Market not found. |
+| `catalogUpdate` | pass | Catalog does not exist |
+| `tagsAdd` / `tagsRemove` | pass | Product does not exist |
+| `markets` (query) | pass | — |
+| `companies` (query) | **denied** | Access denied for companies field. |
+
+**The docs' generous claim holds.** One scope covers products, variants, price lists and
+catalogs, including the B2B mutations P6.1 will need. That is the good outcome and it was
+worth proving rather than assuming, because the listing is built on it.
+
+**`read_companies` is a scheduled cost, not a gap.** Nothing that ships now touches it —
+the B2B *pricing* mutations pass under `write_products`; only displaying which companies a
+catalog is assigned to needs it. Adding a scope after launch re-prompts every existing
+install, so it is recorded here as a known price of P6.1 rather than discovered during it.
+
+**`read_orders` stays out.** It triggers Protected Customer Data review and is only needed
+for the revenue half of P6.2. Same reasoning: a known future cost, deliberately not paid
+early.
+
+**Still open: `write_markets` is over-broad.** Nothing in the app writes a market. The
+market surface works by creating and updating *price lists*, which `write_products`
+covers; the only markets access ever exercised is reading which markets exist. The install
+screen currently asks to *manage* the merchant's markets when it only needs to *view*
+them, which is not a small difference in a sentence somebody reads before handing a
+pricing app access to their store.
+
+This cannot be confirmed by probing, and the report says so. A probe reports what fails
+under the grant in force, and a scope that is present is never exercised as absent —
+confirming the narrowing means editing the manifest, reinstalling, and asking again. Filed
+rather than done, because guessing wrong here breaks the market surface, which is the
+product.
+
+The manifest's `read_markets` has been dropped in the meantime: Shopify implies it from
+`write_markets` and had already collapsed the pair in its own record of what was granted,
+so declaring it was a checkbox that bought nothing either way.
 
 ### D9, in more detail
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "feedback": "tsx scripts/feedback-review.ts",
     "alerts": "tsx scripts/test-alert-routing.ts",
     "seed:store": "tsx scripts/seed-store.ts",
-    "test:chaos": "vitest run --config vitest.chaos.config.ts"
+    "test:chaos": "vitest run --config vitest.chaos.config.ts",
+    "scope:probe": "tsx scripts/scope-probe.ts"
   },
   "type": "module",
   "engines": {

--- a/scripts/scope-probe.ts
+++ b/scripts/scope-probe.ts
@@ -1,0 +1,154 @@
+/**
+ * Runs every scope probe against the real store and prints what Shopify allowed.
+ *
+ * Resolves D4. The docs claim `write_products` covers products, variants, price lists
+ * and catalogs; the only way to know is to ask, and the answer decides how many
+ * permission checkboxes a merchant reads before installing.
+ *
+ *   npx tsx scripts/scope-probe.ts
+ *
+ * Nothing is created or changed — see the note in `app/lib/shopify/scope-probe.ts` on
+ * why a deliberately-doomed input still answers the question.
+ */
+
+import prisma from "../app/db.server";
+import { adminClientForShop } from "../app/services/admin-client.server";
+import {
+  classifyProbe,
+  minimalScopes,
+  PROBES,
+  scopeGaps,
+  type ProbeResult,
+} from "../app/lib/shopify/scope-probe";
+
+const MARK: Record<ProbeResult["verdict"], string> = {
+  granted: "PASS",
+  denied: "DENIED",
+  inconclusive: "?",
+};
+
+async function main() {
+  const shop = await prisma.shop.findFirstOrThrow();
+  const client = await adminClientForShop(shop.domain);
+  if (!client) throw new Error(`No usable session for ${shop.domain}. Reinstall the app.`);
+
+  console.log(`Probing ${shop.domain} with the scopes currently granted.\n`);
+
+  const results: Array<{ probe: (typeof PROBES)[number]; result: ProbeResult }> = [];
+
+  for (const probe of PROBES) {
+    // The admin client throws on top-level errors, which is right for the app and wrong
+    // here — a top-level error is the answer we came for. Caught and re-shaped into the
+    // body the classifier expects.
+    let body: unknown;
+    try {
+      body = await client.request(probe.document, probe.variables);
+    } catch (error) {
+      body = { errors: (error as Error).message };
+    }
+
+    const result = classifyProbe(body);
+    results.push({ probe, result });
+
+    const detail = result.requires
+      ? `needs ${result.requires}`
+      : result.detail.slice(0, 60);
+    console.log(
+      `  ${MARK[result.verdict].padEnd(7)} ${probe.name.padEnd(32)} ${detail}`,
+    );
+  }
+
+  const denied = results.filter(({ result }) => result.verdict === "denied");
+  const unknown = results.filter(({ result }) => result.verdict === "inconclusive");
+
+  console.log("");
+
+  // What Shopify recorded as actually granted, which is not the same string the manifest
+  // asks for — Shopify collapses a read scope into its write counterpart. Printing it
+  // makes the report self-describing: a PASS only means "passes under *this* grant".
+  const session = await prisma.session.findFirst({
+    where: { shop: shop.domain, isOnline: false },
+    select: { scope: true },
+  });
+  const granted = (session?.scope ?? "").split(",").filter(Boolean);
+  console.log(`Granted:   ${granted.sort().join(",") || "(unknown)"}`);
+
+  // The set the probes justify, assembled from what Shopify actually asked for rather
+  // than from what the manifest happens to say today.
+  // Scoped to what ships now. A probe marked `neededAt` belongs to a later phase, and
+  // folding it in here would mean asking merchants today for access to a feature that
+  // does not exist yet — the exact over-asking this task is meant to prevent.
+  const shippingNow = results.filter(({ probe }) => !probe.neededAt);
+  const needed = new Set(
+    shippingNow
+      .filter(({ result }) => result.verdict === "granted")
+      .map(({ probe }) => probe.expects),
+  );
+  for (const { result, probe } of shippingNow.filter((r) => r.result.verdict === "denied")) {
+    needed.add(result.requires ?? probe.expects);
+  }
+
+  const minimum = minimalScopes(needed);
+  console.log(`Justified: ${minimum.join(",")}`);
+
+  // The line that earns the task. Every scope here is a permission checkbox nothing in
+  // the probe set needed — a cost to install conversion with no capability behind it.
+  //
+  // It cannot prove the scope is removable on its own: this probe reports what fails
+  // under the *current* grant, and a scope that is present is never exercised as absent.
+  // Confirming a removal means narrowing the manifest, reinstalling, and running this
+  // again. The value is in naming the candidates, which is otherwise guesswork.
+  const gaps = scopeGaps(granted, minimum);
+  if (gaps.missing.length > 0) {
+    console.log(`\nMISSING: ${gaps.missing.join(",")} — the app cannot do what it claims.`);
+  }
+  if (gaps.overBroad.length > 0) {
+    console.log(
+      `\nOver-broad: ${gaps.overBroad.join(",")}` +
+        `\n  Only the read half was ever exercised. Narrow the manifest, reinstall, rerun.`,
+    );
+  }
+  if (gaps.unneeded.length > 0) {
+    console.log(`\nUnneeded: ${gaps.unneeded.join(",")} — no probe touched these.`);
+  }
+
+  const broken = denied.filter(({ probe }) => !probe.neededAt);
+  if (broken.length > 0) {
+    console.log(`\n${broken.length} denied and needed now:`);
+    for (const { probe, result } of broken) {
+      console.log(`  ${probe.name} — ${probe.purpose}\n    ${result.detail}`);
+    }
+  }
+
+  // Named as a future cost rather than a failure. The point of probing these early is to
+  // learn the price of the phase before committing to it: adding a scope after launch
+  // re-prompts every existing install, so "P6.1 costs one more checkbox" is a fact worth
+  // having while P6.1 is still a plan.
+  const later = denied.filter(({ probe }) => probe.neededAt);
+  if (later.length > 0) {
+    console.log("\nWill need a wider grant later:");
+    for (const { probe, result } of later) {
+      console.log(
+        `  ${probe.neededAt}: ${probe.name} needs ${result.requires ?? probe.expects} — ${probe.purpose}`,
+      );
+    }
+  }
+
+  // Never silent. An inconclusive probe is a probe that has not run, and reporting the
+  // set as settled while one of them was throttled is how a wrong scope list gets
+  // published.
+  if (unknown.length > 0) {
+    console.log(`\n${unknown.length} inconclusive — rerun before trusting the set:`);
+    for (const { probe, result } of unknown) {
+      console.log(`  ${probe.name} — ${result.detail}`);
+    }
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -34,7 +34,7 @@ api_version = "2026-07"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "write_products,read_markets,write_markets"
+scopes = "write_products,write_markets"
 optional_scopes = [ ]
 use_legacy_install_flow = false
 


### PR DESCRIPTION
Closes #21, #22, #23, #24.

The scope set is now empirical rather than doc-derived. Every scope is a checkbox a merchant reads before installing, and widening one after launch re-prompts every existing install.

## The probe never writes anything — and doesn't need to

Shopify checks authorization when it **resolves the field**, before it validates the input. So every probe sends an input engineered to fail: an id no store can hold, or an empty list. A `userErrors` response means the mutation ran, considered our nonsense, and declined it.

That's a pass that changed nothing.

The obvious alternative — write a real price and put it back — would be a live price mutation with no ledger row behind it, which is exactly what invariant **I4** forbids. A probe that breaks the product's central rule to prove the product works is not a probe worth having.

## Results — `boltify-apps`, 26 Aug

| Mutation | Verdict | What Shopify said |
|---|---|---|
| `productVariantsBulkUpdate` | pass | Product does not exist |
| `bulkOperationRunQuery` | pass | Invalid bulk query: syntax error |
| `bulkOperationRunMutation` | pass | Failed to parse the mutation |
| `stagedUploadsCreate` | pass | (accepted an empty list) |
| `priceListCreate` | pass | Catalog does not exist. |
| `priceListUpdate` | pass | Price list does not exist. |
| `priceListFixedPricesAdd` | pass | Price list does not exist. |
| `priceListFixedPricesDelete` | pass | Price list does not exist. |
| `quantityPricingByVariantUpdate` | pass | Price list not found. |
| `catalogCreate` | pass | Market not found. |
| `catalogUpdate` | pass | Catalog does not exist |
| `tagsAdd` / `tagsRemove` | pass | Product does not exist |
| `markets` (query) | pass | — |
| `companies` (query) | **denied** | Access denied for companies field. |

**The docs' generous claim holds** — one scope covers products, variants, price lists and catalogs, including the B2B mutations P6.1 needs.

## Two findings the probe wasn't looking for

**`read_markets` was redundant.** Shopify implies it from `write_markets` and had already collapsed the pair in its own record of what the shop granted — the session row read `write_markets,write_products` while the manifest asked for three. Dropped.

**`write_markets` is over-broad** — filed, not fixed. Nothing in the app writes a market: the market surface works by creating and updating *price lists* (covered by `write_products`), and the only markets access ever exercised is reading which markets exist. The install screen asks to **manage** the merchant's markets when it needs to **view** them.

Probing can't confirm that narrowing — a scope that's present is never exercised as absent — so it needs a manifest edit, a reinstall, and another run. Guessing wrong there breaks the market surface, which is the product.

## `read_companies` reads as a scheduled cost, not a fault

It's the only denial, and no feature that exists needs it. Probes carry a `neededAt`, so a later phase's requirement doesn't print as *"the app cannot do what it claims"* — a report that raises an alarm about something working as designed is a report people learn to skim.

## The wedge is now a schema tripwire

`PriceListProductPriceInput` has no compare-at field; `PriceListPriceInput` has one. That asymmetry is almost certainly why the ecosystem believes Shopify can't do per-market strike-throughs.

If a future API version closes it, a red build tells us — rather than a competitor shipping it first.

## Mutation testing

Six mutations of the classifier and two of `minimalScopes` each kill a test. The one that matters: **a throttle must never read as a missing scope**, because that sends somebody to widen the manifest — the exact cost this task exists to avoid.

765 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)