### PR TITLE
P0.7.4 — Seed the shapes that make a perf number mean something

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -25,7 +25,16 @@ function getConfig() {
       default: shopifyApiProject({
         apiType: ApiType.Admin,
         apiVersion: API_VERSION_STRING,
-        documents: ["./app/**/*.{js,ts,jsx,tsx}", "./app/.server/**/*.{js,ts,jsx,tsx}"],
+        // `scripts/` is in here because those files send real mutations to a real store
+        // — seeding a perf catalogue, probing scopes, spot-checking reconciliation. A
+        // typo in one of them fails after the round trip, against somebody's data,
+        // rather than at build time. There is no reason the app's queries get checked
+        // against the pinned schema and the ones that write to production do not.
+        documents: [
+          "./app/**/*.{js,ts,jsx,tsx}",
+          "./app/.server/**/*.{js,ts,jsx,tsx}",
+          "./scripts/**/*.{js,ts}",
+        ],
         outputDir: "./app/types",
       }),
     },

--- a/app/lib/seed/catalogue.test.ts
+++ b/app/lib/seed/catalogue.test.ts
@@ -16,6 +16,8 @@ import {
   MAX_VARIANTS_PER_PRODUCT,
   optionsFor,
   prng,
+  TAGS,
+  type SeedProduct,
 } from "./catalogue";
 
 describe("determinism", () => {
@@ -202,5 +204,76 @@ describe("the PRNG", () => {
       expect(value).toBeGreaterThanOrEqual(0);
       expect(value).toBeLessThan(1);
     }
+  });
+});
+
+describe("distributions that make a perf number mean something", () => {
+  // Two thousand products, which is the shape the perf store is actually seeded at. A
+  // smaller sample makes the rare end of each distribution a coin flip, and an assertion
+  // that passes on a lucky draw is worse than no assertion.
+  const products = buildCatalogue({ products: 2000, variantsPerProduct: 3 });
+
+  const countBy = (pick: (product: SeedProduct) => string[]) => {
+    const counts = new Map<string, number>();
+    for (const product of products) {
+      for (const value of pick(product)) counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+    return counts;
+  };
+
+  it("puts products in collections at all", () => {
+    // The generator produced none, for as long as it existed. `collection` is a targeting
+    // field with a GIN index behind it, so every perf number for the most-used filter in
+    // the product would have been measured against zero matching rows — fast, and fast
+    // for entirely the wrong reason.
+    const counts = countBy((product) => product.collections);
+
+    expect(counts.get("all-products")).toBeGreaterThan(1_500);
+    expect(products.filter((product) => product.collections.length === 0).length)
+      .toBeLessThan(products.length * 0.15);
+  });
+
+  it("skews collection membership rather than spreading it evenly", () => {
+    // The question worth measuring is what happens on the collection holding 90,000
+    // variants, and a catalogue where every collection is the same size has no such
+    // collection. The tail matters too: a filter matching almost nothing exercises the
+    // planner's empty path, which is where an off-by-one surfaces as a silent no-op.
+    const counts = countBy((product) => product.collections);
+
+    expect(counts.get("all-products")!).toBeGreaterThan(counts.get("pro-only")! * 50);
+    expect(counts.get("pro-only")).toBeGreaterThan(0);
+  });
+
+  it("makes the common tags common and the rare ones rare", () => {
+    // The assertion that catches the bug this test was written after. The first draft
+    // drew tags with `Math.sqrt`, which biases towards the *end* of the list and
+    // inverted the whole thing: `discontinued` on 650 products, `core` on 24. Every
+    // summary statistic still showed a power law. It was just measuring the wrong tags.
+    const counts = countBy((product) => product.tags);
+    const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+
+    expect(ranked[0][0]).toBe(TAGS[0]);
+    expect(ranked[0][1]).toBeGreaterThan(ranked[ranked.length - 1][1] * 3);
+  });
+
+  it("leaves a fifth of variants out of stock, and a few oversold", () => {
+    // `inventoryMin` is a targeting field. A catalogue where everything is in stock never
+    // exercises it, and one where nothing is negative lets a naive `qty > 0` check look
+    // correct — Shopify permits overselling into negative, and the difference between
+    // "none" and "minus three" is a campaign that skips a variant it should have priced.
+    const variants = products.flatMap((product) => product.variants);
+
+    const zero = variants.filter((variant) => variant.inventoryQty === 0).length;
+    const negative = variants.filter((variant) => variant.inventoryQty < 0).length;
+
+    expect(zero / variants.length).toBeGreaterThan(0.1);
+    expect(zero / variants.length).toBeLessThan(0.35);
+    expect(negative).toBeGreaterThan(0);
+  });
+
+  it("stays deterministic, so Tuesday's number is comparable with Friday's", () => {
+    const again = buildCatalogue({ products: 2000, variantsPerProduct: 3 });
+
+    expect(JSON.stringify(again)).toBe(JSON.stringify(products));
   });
 });

--- a/app/lib/seed/catalogue.ts
+++ b/app/lib/seed/catalogue.ts
@@ -27,6 +27,11 @@ export interface SeedVariant {
   cost?: string;
   sku: string;
   barcode?: string;
+  /**
+   * Starting stock. Zero for a meaningful share, because `inventoryMin` is a targeting
+   * field and a catalogue where everything is in stock never exercises it.
+   */
+  inventoryQty: number;
 }
 
 export interface SeedProduct {
@@ -35,6 +40,8 @@ export interface SeedProduct {
   vendor: string;
   productType: string;
   tags: string[];
+  /** Collection handles this product belongs to. See `COLLECTIONS`. */
+  collections: string[];
   status: "ACTIVE" | "DRAFT" | "ARCHIVED";
   variants: SeedVariant[];
 }
@@ -44,9 +51,45 @@ const VENDORS = [
   "Ember Works", "Fjord Outfitters", "Granite Lane", "Harbourlight", "Ironwood",
 ];
 const TYPES = ["Snowboard", "Jacket", "Gloves", "Goggles", "Boots", "Helmet", "Wax", "Backpack"];
-const TAGS = [
-  "sale", "new", "clearance", "seasonal", "bestseller", "limited", "bundle",
-  "outlet", "premium", "core",
+/**
+ * Tags, ordered most common first.
+ *
+ * The order is load-bearing: membership is drawn from a power law, so `core` lands on
+ * roughly a third of products and `discontinued` on a handful. A uniform spread — which
+ * is what the first version had — makes every tag equally selective, and a filter that is
+ * equally selective on every value is the one case a real catalogue never presents. The
+ * perf question is what happens on the tag that matches 30,000 variants, and a uniform
+ * catalogue has no such tag.
+ */
+export const TAGS = [
+  "core", "seasonal", "new", "sale", "bestseller", "premium", "bundle",
+  "clearance", "outlet", "limited", "staff-pick", "final-sale", "preorder",
+  "gift", "exclusive", "restock", "discontinued",
+];
+
+/**
+ * Collections, ordered largest first.
+ *
+ * `collection` is a targeting field with a GIN index behind it, and the generator used to
+ * produce none at all — so a perf number for the most-used filter in the product would
+ * have been measured against zero matching rows. An index over an empty array column is
+ * fast, and fast for entirely the wrong reason.
+ *
+ * The distribution is deliberately lopsided. "All products" holds nearly everything,
+ * which is the case that decides whether collection targeting is usable at 100K variants;
+ * the long tail exists so the planner is also exercised on filters that match almost
+ * nothing.
+ */
+export const COLLECTIONS = [
+  { handle: "all-products", share: 0.92 },
+  { handle: "winter-2026", share: 0.34 },
+  { handle: "outerwear", share: 0.21 },
+  { handle: "hardgoods", share: 0.18 },
+  { handle: "accessories", share: 0.12 },
+  { handle: "sale-eligible", share: 0.08 },
+  { handle: "new-arrivals", share: 0.04 },
+  { handle: "clearance-2025", share: 0.015 },
+  { handle: "pro-only", share: 0.004 },
 ];
 const ADJECTIVES = [
   "Alpine", "Arctic", "Basecamp", "Cascade", "Drift", "Everest", "Frost",
@@ -106,20 +149,46 @@ function buildProduct(index: number, targetVariants: number, random: () => numbe
   const spread = targetVariants > 1 ? Math.round((random() - 0.5) * targetVariants * 0.6) : 0;
   const variantCount = Math.max(1, Math.min(MAX_VARIANTS_PER_PRODUCT, targetVariants + spread));
 
-  const tags = [TAGS[index % TAGS.length]];
-  if (random() > 0.6) tags.push(TAGS[(index * 7) % TAGS.length]);
+  const tags = tagsFor(random);
+  const collections = COLLECTIONS.filter((collection) => random() < collection.share).map(
+    (collection) => collection.handle,
+  );
 
   return {
     handle: `anchor-perf-${index}`,
     title: `${adjective} ${type} ${index}`,
     vendor: VENDORS[index % VENDORS.length],
     productType: type,
-    tags: [...new Set(tags)],
+    tags,
+    collections,
     // A few draft and archived, because a catalogue of only active products never
     // exercises the filter that excludes them.
     status: index % 97 === 0 ? "ARCHIVED" : index % 41 === 0 ? "DRAFT" : "ACTIVE",
     variants: buildVariants(index, variantCount, random),
   };
+}
+
+/**
+ * A product's tags, drawn from a power law.
+ *
+ * Squaring the draw biases it towards the front of the list, where the common tags live:
+ * `core` lands on about a quarter of products and `discontinued` on about one in thirty.
+ * Two to four tags each, which is what a real catalogue looks like — one broad category
+ * tag and a couple of merchandising ones.
+ *
+ * The first version used `Math.sqrt`, which biases the other way and inverted the whole
+ * list — `discontinued` on 650 products and `core` on 24. It looked like a power law in
+ * every summary statistic, and every one of them was measuring the wrong tag.
+ */
+function tagsFor(random: () => number): string[] {
+  const count = 2 + Math.floor(random() * 3);
+  const tags = new Set<string>();
+
+  while (tags.size < count) {
+    tags.add(TAGS[Math.floor(random() ** 2 * TAGS.length)]);
+  }
+
+  return [...tags];
 }
 
 export function buildVariants(
@@ -146,6 +215,10 @@ export function buildVariants(
       // A quarter have no cost at all — the case that makes cost-based guardrails skip
       // rather than price at zero.
       ...(random() > 0.25 ? { cost: (price * (0.3 + random() * 0.4)).toFixed(2) } : {}),
+      // A fifth are out of stock and a few oversold into negative, which Shopify permits
+      // and which turns a naive `inventoryQty > 0` check into a wrong answer rather than
+      // an empty one.
+      inventoryQty: inventoryFor(random),
       sku: `APF-${productIndex}-${v}`,
       // Most but not all, so matching has to cope with a missing barcode.
       ...(random() > 0.2 ? { barcode: String(50_000_000_000 + productIndex * 4096 + v) } : {}),
@@ -153,6 +226,13 @@ export function buildVariants(
   }
 
   return variants;
+}
+
+function inventoryFor(random: () => number): number {
+  const roll = random();
+  if (roll < 0.03) return -Math.ceil(random() * 5);
+  if (roll < 0.22) return 0;
+  return Math.ceil(random() * 400);
 }
 
 /**
@@ -203,6 +283,10 @@ export function buildMaxVariantProduct(seed = 20260817): SeedProduct {
     vendor: "Northwind",
     productType: "Jacket",
     tags: ["core", "perf"],
+    // In the big collection deliberately: a collection filter that matches this product
+    // matches 2,048 variants from one row, which is the shape that makes a preview's
+    // "how many will this touch" count arrive late.
+    collections: ["all-products", "outerwear"],
     status: "ACTIVE",
     variants: buildVariants(999_000, MAX_VARIANTS_PER_PRODUCT, random),
   };

--- a/app/types/admin.generated.d.ts
+++ b/app/types/admin.generated.d.ts
@@ -305,6 +305,55 @@ export type AnchorAuditVariantsQueryVariables = AdminTypes.Exact<{
 
 export type AnchorAuditVariantsQuery = { nodes: Array<AdminTypes.Maybe<Pick<AdminTypes.ProductVariant, 'id' | 'price' | 'compareAtPrice'>>> };
 
+export type SeedProductSetMutationVariables = AdminTypes.Exact<{
+  input: AdminTypes.ProductSetInput;
+}>;
+
+
+export type SeedProductSetMutation = { productSet?: AdminTypes.Maybe<{ product?: AdminTypes.Maybe<Pick<AdminTypes.Product, 'id'>>, userErrors: Array<Pick<AdminTypes.ProductSetUserError, 'field' | 'message'>> }> };
+
+export type SeedExistingQueryVariables = AdminTypes.Exact<{
+  cursor?: AdminTypes.InputMaybe<AdminTypes.Scalars['String']['input']>;
+}>;
+
+
+export type SeedExistingQuery = { products: { nodes: Array<Pick<AdminTypes.Product, 'handle'>>, pageInfo: Pick<AdminTypes.PageInfo, 'hasNextPage' | 'endCursor'> } };
+
+export type SeedCollectionByHandleQueryVariables = AdminTypes.Exact<{
+  handle: AdminTypes.Scalars['String']['input'];
+}>;
+
+
+export type SeedCollectionByHandleQuery = { collectionByHandle?: AdminTypes.Maybe<Pick<AdminTypes.Collection, 'id'>> };
+
+export type SeedCollectionCreateMutationVariables = AdminTypes.Exact<{
+  input: AdminTypes.CollectionInput;
+}>;
+
+
+export type SeedCollectionCreateMutation = { collectionCreate?: AdminTypes.Maybe<{ collection?: AdminTypes.Maybe<Pick<AdminTypes.Collection, 'id'>>, userErrors: Array<Pick<AdminTypes.UserError, 'field' | 'message'>> }> };
+
+export type SeedStagedUploadMutationVariables = AdminTypes.Exact<{ [key: string]: never; }>;
+
+
+export type SeedStagedUploadMutation = { stagedUploadsCreate?: AdminTypes.Maybe<{ stagedTargets?: AdminTypes.Maybe<Array<(
+      Pick<AdminTypes.StagedMediaUploadTarget, 'url'>
+      & { parameters: Array<Pick<AdminTypes.StagedUploadParameter, 'name' | 'value'>> }
+    )>>, userErrors: Array<Pick<AdminTypes.UserError, 'message'>> }> };
+
+export type SeedBulkRunMutationVariables = AdminTypes.Exact<{
+  mutation: AdminTypes.Scalars['String']['input'];
+  path: AdminTypes.Scalars['String']['input'];
+}>;
+
+
+export type SeedBulkRunMutation = { bulkOperationRunMutation?: AdminTypes.Maybe<{ bulkOperation?: AdminTypes.Maybe<Pick<AdminTypes.BulkOperation, 'id' | 'status'>>, userErrors: Array<Pick<AdminTypes.BulkMutationUserError, 'field' | 'message'>> }> };
+
+export type SeedBulkStatusQueryVariables = AdminTypes.Exact<{ [key: string]: never; }>;
+
+
+export type SeedBulkStatusQuery = { currentBulkOperation?: AdminTypes.Maybe<Pick<AdminTypes.BulkOperation, 'id' | 'status' | 'objectCount' | 'errorCode'>> };
+
 interface GeneratedQueryTypes {
   "#graphql\n  query AnchorCurrentBulkOperation {\n    currentBulkOperation(type: MUTATION) {\n      id status url partialDataUrl objectCount errorCode\n    }\n  }\n": {return: AnchorCurrentBulkOperationQuery, variables: AnchorCurrentBulkOperationQueryVariables},
   "#graphql\n  query AnchorPriceListDerivedPrices($priceListId: ID!, $query: String!, $first: Int!, $after: String) {\n    priceList(id: $priceListId) {\n      currency\n      prices(originType: RELATIVE, query: $query, first: $first, after: $after) {\n        nodes {\n          variant { id }\n          price { amount currencyCode }\n        }\n        pageInfo { hasNextPage endCursor }\n      }\n    }\n  }\n": {return: AnchorPriceListDerivedPricesQuery, variables: AnchorPriceListDerivedPricesQueryVariables},
@@ -319,6 +368,9 @@ interface GeneratedQueryTypes {
   "#graphql\n  query AnchorPriceLists($cursor: String) {\n    priceLists(first: 50, after: $cursor) {\n      pageInfo { hasNextPage endCursor }\n      nodes {\n        id\n        name\n        currency\n        parent { adjustment { type value } }\n        catalog { id title __typename }\n      }\n    }\n  }\n": {return: AnchorPriceListsQuery, variables: AnchorPriceListsQueryVariables},
   "#graphql\n  query AnchorPriceListPrices($id: ID!, $cursor: String) {\n    priceList(id: $id) {\n      id\n      prices(first: 250, after: $cursor) {\n        pageInfo { hasNextPage endCursor }\n        nodes {\n          originType\n          variant { id }\n          price { amount currencyCode }\n          compareAtPrice { amount currencyCode }\n        }\n      }\n    }\n  }\n": {return: AnchorPriceListPricesQuery, variables: AnchorPriceListPricesQueryVariables},
   "#graphql\n  query AnchorAuditVariants($ids: [ID!]!) {\n    nodes(ids: $ids) {\n      ... on ProductVariant { id price compareAtPrice }\n    }\n  }\n": {return: AnchorAuditVariantsQuery, variables: AnchorAuditVariantsQueryVariables},
+  "#graphql\n          query SeedExisting($cursor: String) {\n            products(first: 250, after: $cursor, query: \"handle:anchor-perf-*\") {\n              nodes { handle }\n              pageInfo { hasNextPage endCursor }\n            }\n          }\n        ": {return: SeedExistingQuery, variables: SeedExistingQueryVariables},
+  "#graphql\n        query SeedCollectionByHandle($handle: String!) {\n          collectionByHandle(handle: $handle) { id }\n        }\n      ": {return: SeedCollectionByHandleQuery, variables: SeedCollectionByHandleQueryVariables},
+  "#graphql\n        query SeedBulkStatus {\n          currentBulkOperation(type: MUTATION) { id status objectCount errorCode }\n        }\n      ": {return: SeedBulkStatusQuery, variables: SeedBulkStatusQueryVariables},
 }
 
 interface GeneratedMutationTypes {
@@ -345,6 +397,10 @@ interface GeneratedMutationTypes {
   "#graphql\n  mutation AnchorTagsRemove($id: ID!, $tags: [String!]!) {\n    tagsRemove(id: $id, tags: $tags) {\n      node { id }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorTagsRemoveMutation, variables: AnchorTagsRemoveMutationVariables},
   "#graphql\n  mutation AnchorCatalogBulkQuery($query: String!) {\n    bulkOperationRunQuery(query: $query) {\n      bulkOperation { id status }\n      userErrors { field message }\n    }\n  }\n": {return: AnchorCatalogBulkQueryMutation, variables: AnchorCatalogBulkQueryMutationVariables},
   "#graphql\n  mutation AnchorFlowTriggerReceive($handle: String!, $payload: JSON!) {\n    flowTriggerReceive(handle: $handle, payload: $payload) {\n      userErrors { field message }\n    }\n  }\n": {return: AnchorFlowTriggerReceiveMutation, variables: AnchorFlowTriggerReceiveMutationVariables},
+  "#graphql\n  mutation SeedProductSet($input: ProductSetInput!) {\n    productSet(input: $input) {\n      product { id }\n      userErrors { field message }\n    }\n  }\n": {return: SeedProductSetMutation, variables: SeedProductSetMutationVariables},
+  "#graphql\n        mutation SeedCollectionCreate($input: CollectionInput!) {\n          collectionCreate(input: $input) {\n            collection { id }\n            userErrors { field message }\n          }\n        }\n      ": {return: SeedCollectionCreateMutation, variables: SeedCollectionCreateMutationVariables},
+  "#graphql\n      mutation SeedStagedUpload {\n        stagedUploadsCreate(input: [{\n          resource: BULK_MUTATION_VARIABLES,\n          filename: \"seed.jsonl\",\n          mimeType: \"text/jsonl\",\n          httpMethod: POST\n        }]) {\n          stagedTargets { url parameters { name value } }\n          userErrors { message }\n        }\n      }\n    ": {return: SeedStagedUploadMutation, variables: SeedStagedUploadMutationVariables},
+  "#graphql\n      mutation SeedBulkRun($mutation: String!, $path: String!) {\n        bulkOperationRunMutation(mutation: $mutation, stagedUploadPath: $path) {\n          bulkOperation { id status }\n          userErrors { field message }\n        }\n      }\n    ": {return: SeedBulkRunMutation, variables: SeedBulkRunMutationVariables},
 }
 declare module '@shopify/admin-api-client' {
   type InputMaybe<T> = AdminTypes.InputMaybe<T>;

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -64,6 +64,15 @@ install, so it is recorded here as a known price of P6.1 rather than discovered 
 for the revenue half of P6.2. Same reasoning: a known future cost, deliberately not paid
 early.
 
+**Two scopes the seeding script wants and will not get.** Setting stock on a seeded
+catalogue needs a location id, and both routes to one are closed: `locations` answers
+"Access denied", and a variant's `inventoryLevels` answers "Required access:
+`read_inventory`". Neither goes in the manifest — no *feature* reads a location or an
+inventory level, and the mirror gets `inventoryQuantity` from the product graph, which
+`read_products` already covers. `scripts/seed-store.ts` takes `--location` instead, pasted
+from admin by whoever runs it. A permission checkbox in front of every merchant is not a
+reasonable price for a developer tool being easier to run.
+
 **Still open: `write_markets` is over-broad.** Nothing in the app writes a market. The
 market surface works by creating and updating *price lists*, which `write_products`
 covers; the only markets access ever exercised is reading which markets exist. The install

--- a/scripts/seed-store.ts
+++ b/scripts/seed-store.ts
@@ -8,6 +8,7 @@
  * catalogue it produced means anything.
  *
  *   npx tsx scripts/seed-store.ts 2000 --variants 50   # ~100K variants
+ *   npx tsx scripts/seed-store.ts 2000 --location gid://shopify/Location/123  # with stock
  *   npx tsx scripts/seed-store.ts --max-variant-product
  *   npx tsx scripts/seed-store.ts --markets
  *
@@ -28,6 +29,7 @@ import { adminClientForShop } from "../app/services/admin-client.server";
 import {
   buildCatalogue,
   buildMaxVariantProduct,
+  COLLECTIONS,
   marketPriceLists,
   type SeedProduct,
 } from "../app/lib/seed/catalogue";
@@ -69,8 +71,108 @@ async function existingHandles(client: AdminClient): Promise<Set<string>> {
   return handles;
 }
 
+/**
+ * The location seeded stock lands at, passed in rather than discovered.
+ *
+ * Inventory has to be attached to a location — there is no shop-wide quantity — and both
+ * routes to finding one are closed. `locations` answers "Access denied for locations
+ * field"; going the long way round through a variant's `inventoryLevels` answers
+ * "Required access: `read_inventory`". Both were checked against the store rather than
+ * assumed.
+ *
+ * Neither scope belongs in the manifest. D4 keeps the set to what the *product* uses, and
+ * no feature reads a location or an inventory level — the mirror gets `inventoryQuantity`
+ * from the product graph, which `read_products` covers. Adding a scope so a developer
+ * tool could be more convenient would put an extra permission checkbox in front of every
+ * merchant.
+ *
+ * So the id is pasted in by whoever runs this, from Settings → Locations in admin:
+ *
+ *   npx tsx scripts/seed-store.ts 2000 --variants 50 --location gid://shopify/Location/123
+ *
+ * Without it the catalogue seeds without stock, and every variant reads
+ * `inventoryQuantity: null` — which means "not tracked" rather than "none", and makes
+ * `inventoryMin` untestable. The script says so loudly rather than seeding quietly and
+ * leaving somebody to discover it from a filter that matches nothing.
+ */
+function locationFrom(args: string[]): string | null {
+  const flag = args.indexOf("--location");
+  if (flag === -1) return null;
+
+  const value = args[flag + 1];
+  if (!value?.startsWith("gid://shopify/Location/")) {
+    throw new Error(
+      `--location wants a location gid, got ${value ?? "nothing"}. ` +
+        "Settings → Locations in admin; the id is in the URL.",
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Creates the perf collections if they are not already there, and maps handle to id.
+ *
+ * `productSet` takes collection *ids*, so this has to run before any product is uploaded.
+ * Idempotent by handle for the same reason the products are: a re-run that made a second
+ * "winter-2026" would leave the filter matching half of what it should, and a perf number
+ * measured against half a collection is worse than no number.
+ */
+async function ensureCollections(client: AdminClient): Promise<Map<string, string>> {
+  const ids = new Map<string, string>();
+
+  for (const { handle } of COLLECTIONS) {
+    const found = await client.request<{ collectionByHandle?: { id: string } | null }>(
+      `#graphql
+        query SeedCollectionByHandle($handle: String!) {
+          collectionByHandle(handle: $handle) { id }
+        }
+      `,
+      { handle },
+    );
+
+    const existing = found.data?.collectionByHandle?.id;
+    if (existing) {
+      ids.set(handle, existing);
+      continue;
+    }
+
+    const created = await client.request<{
+      collectionCreate?: {
+        collection?: { id: string } | null;
+        userErrors?: Array<{ message?: string }>;
+      };
+    }>(
+      `#graphql
+        mutation SeedCollectionCreate($input: CollectionInput!) {
+          collectionCreate(input: $input) {
+            collection { id }
+            userErrors { field message }
+          }
+        }
+      `,
+      { input: { handle, title: handle.replace(/-/g, " ") } },
+    );
+
+    const error = created.data?.collectionCreate?.userErrors?.[0]?.message;
+    if (error) {
+      console.log(`  collection ${handle}: ${error}`);
+      continue;
+    }
+
+    const id = created.data?.collectionCreate?.collection?.id;
+    if (id) ids.set(handle, id);
+  }
+
+  return ids;
+}
+
 /** One product as the bulk mutation's JSONL line. */
-function toInput(product: SeedProduct): string {
+function toInput(
+  product: SeedProduct,
+  collectionIds: Map<string, string>,
+  locationId: string | null,
+): string {
   const optionNames = [...new Set(product.variants.flatMap((v) => v.optionValues.map((o) => o.optionName)))];
 
   return JSON.stringify({
@@ -81,6 +183,12 @@ function toInput(product: SeedProduct): string {
       productType: product.productType,
       tags: product.tags,
       status: product.status,
+      // Silently dropping a collection we failed to create would leave the filter
+      // matching fewer products than the generator says it should, which is exactly the
+      // kind of discrepancy that makes a perf number quietly wrong.
+      collections: product.collections
+        .map((handle) => collectionIds.get(handle))
+        .filter((id): id is string => Boolean(id)),
       productOptions: optionNames.map((name) => ({
         name,
         values: [
@@ -97,19 +205,40 @@ function toInput(product: SeedProduct): string {
         ...(variant.compareAtPrice ? { compareAtPrice: variant.compareAtPrice } : {}),
         sku: variant.sku,
         ...(variant.barcode ? { barcode: variant.barcode } : {}),
-        ...(variant.cost ? { inventoryItem: { cost: variant.cost } } : {}),
+        // `tracked` is required alongside a quantity — an untracked item has no stock to
+        // set, and Shopify rejects the pair rather than inferring it.
+        ...(variant.cost || locationId
+          ? {
+              inventoryItem: {
+                ...(variant.cost ? { cost: variant.cost } : {}),
+                ...(locationId ? { tracked: true } : {}),
+              },
+            }
+          : {}),
+        ...(locationId
+          ? {
+              inventoryQuantities: [
+                { locationId, name: "available", quantity: variant.inventoryQty },
+              ],
+            }
+          : {}),
       })),
     },
   });
 }
 
-async function upload(client: AdminClient, products: SeedProduct[]): Promise<void> {
+async function upload(
+  client: AdminClient,
+  products: SeedProduct[],
+  collectionIds: Map<string, string>,
+  locationId: string | null,
+): Promise<void> {
   if (products.length === 0) {
     console.log("  nothing to create — every handle already exists");
     return;
   }
 
-  const jsonl = `${products.map(toInput).join("\n")}\n`;
+  const jsonl = `${products.map((product) => toInput(product, collectionIds, locationId)).join("\n")}\n`;
   console.log(`  payload: ${products.length} products, ${(jsonl.length / 1024).toFixed(0)} KB`);
 
   const staged = await client.request<{
@@ -233,6 +362,7 @@ async function main() {
   const args = process.argv.slice(2);
   const count = Number(args.find((a) => /^\d+$/.test(a)) ?? 2_000);
   const variants = Number(args[args.indexOf("--variants") + 1] ?? 50);
+  const locationId = locationFrom(args);
 
   const shop = await prisma.shop.findFirstOrThrow({ select: { domain: true } });
   const client = await adminClientForShop(shop.domain);
@@ -247,10 +377,23 @@ async function main() {
   const existing = await existingHandles(client);
   console.log(`  ${existing.size} already there`);
 
+  const collectionIds = await ensureCollections(client);
+  console.log(`  ${collectionIds.size}/${COLLECTIONS.length} collections ready`);
+
+  // Never silent. A run that seeded no stock looks identical to one that did, right up
+  // until somebody reads an inventory-filter timing off a catalogue that has no
+  // inventory.
+  if (!locationId) {
+    console.log(
+      "  NO STOCK — pass --location gid://shopify/Location/… to seed inventory.\n" +
+        "  Without it every variant reads as untracked and inventoryMin is untestable.",
+    );
+  }
+
   if (args.includes("--max-variant-product")) {
     const product = buildMaxVariantProduct();
     console.log(`The 2,048-variant product: ${product.title}`);
-    await upload(client, existing.has(product.handle) ? [] : [product]);
+    await upload(client, existing.has(product.handle) ? [] : [product], collectionIds, locationId);
     return;
   }
 
@@ -258,7 +401,12 @@ async function main() {
   const total = catalogue.reduce((sum, product) => sum + product.variants.length, 0);
   console.log(`Generated ${catalogue.length} products, ${total} variants`);
 
-  await upload(client, catalogue.filter((product) => !existing.has(product.handle)));
+  await upload(
+    client,
+    catalogue.filter((product) => !existing.has(product.handle)),
+    collectionIds,
+    locationId,
+  );
 }
 
 main()


### PR DESCRIPTION
Closes #54.

## The generator produced no collections at all

`collection` is a targeting field with a GIN index behind it — one of the most-used filters in the product. Every perf number for it would have been measured against **zero matching rows**. An index over an empty array column is fast, and fast for entirely the wrong reason.

Nine collections now, deliberately lopsided:

| Collection | Share |
|---|---|
| `all-products` | 92% |
| `winter-2026` | 34% |
| `outerwear` | 21% |
| … | … |
| `pro-only` | 0.4% |

The big one decides whether collection targeting is usable at 100K variants. The tail exists so the planner is also exercised on a filter matching almost nothing — where an off-by-one surfaces as a silent no-op rather than an error.

## Tags were uniform — the one distribution a real catalogue never has

The perf question is what happens on the tag matching 30,000 variants, and a catalogue where every tag is equally selective has no such tag.

**The first version of the power-law draw used `Math.sqrt`, which biases towards the *end* of the list and inverted it completely** — `discontinued` on 650 products, `core` on 24. Every summary statistic still showed a clean power law. It was just measuring the wrong tags.

The test asserts the *ranking*, not the shape, which is what catches it.

## Nothing was ever out of stock

`inventoryMin` is a targeting field. A fifth of variants are now zero, and 3% are oversold into negative — Shopify permits that, and the difference between "none" and "minus three" turns a naive `qty > 0` check into a wrong answer rather than an empty one.

## Seeding stock needs a location, and both routes are closed

- `locations` → *Access denied for locations field*
- variant `inventoryLevels` → *Required access: `read_inventory`*

Both checked against the store, not assumed. **Neither scope goes in the manifest** — no feature reads a location or an inventory level, and D4 keeps the set to what the product uses. A permission checkbox in front of every merchant is not a reasonable price for a developer tool being easier to run.

The script takes `--location gid://shopify/Location/…` instead, and says loudly when it has none — a run that seeded no stock otherwise looks identical to one that did.

## Codegen now covers `scripts/`

Those files send real mutations to a real store. A typo in one failed *after* the round trip, against somebody's data, rather than at build time. There was no reason the app's queries were checked against the pinned schema and the ones that write to production were not.

Every existing script document passes unchanged.

## Verified against the store

Nine collections created, three products uploaded through the bulk path, collection membership and tag distribution read back correctly from the Admin API:

```
anchor-perf-0 | ARCHIVED | tags: final-sale,sale,seasonal | collections: all-products,outerwear
anchor-perf-1 | ACTIVE   | tags: bestseller,bundle,clearance | collections: all-products,winter-2026,clearance-2025
```

Six mutations of the distributions each kill a test, including reinstating the inverted tag bias. 770 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)