### PR TITLE
P0.7.1/2 — The seeder reported COMPLETED while creating nothing

### DIFF
--- a/app/lib/seed/catalogue.test.ts
+++ b/app/lib/seed/catalogue.test.ts
@@ -277,3 +277,45 @@ describe("distributions that make a perf number mean something", () => {
     expect(JSON.stringify(again)).toBe(JSON.stringify(products));
   });
 });
+
+describe("option values Shopify will accept", () => {
+  /**
+   * The rule: a product declares a set of options, and every variant must supply exactly
+   * one value for each of them. Break it and `productSet` rejects the whole product.
+   *
+   * This went unnoticed because the rejection is invisible. `productSet` runs inside a
+   * bulk operation, so the per-row `userErrors` land in a result file the seeder never
+   * read — Shopify reported `COMPLETED — 1 objects` and the script printed it. Every
+   * product over 48 variants failed in total silence, which at the default fifty is every
+   * product in the catalogue.
+   *
+   * `total` values chosen around the boundaries: the one-option branch, either side of
+   * colour × size running out at 48, and the ceiling.
+   */
+  for (const total of [1, 2, 6, 7, 20, 47, 48, 49, 50, 200, MAX_VARIANTS_PER_PRODUCT]) {
+    it(`gives every variant one value per option at ${total} variants`, () => {
+      const perVariant = Array.from({ length: total }, (_, index) => optionsFor(index, total));
+
+      // What the product ends up declaring: the union of every option name used, which is
+      // exactly how the uploader builds `productOptions`.
+      const declared = new Set(perVariant.flatMap((o) => o.map((v) => v.optionName)));
+
+      for (const options of perVariant) {
+        expect(options.map((o) => o.optionName).sort()).toEqual([...declared].sort());
+      }
+    });
+
+    it(`gives every variant a distinct combination at ${total} variants`, () => {
+      // Shopify's other rule, and the one that decides whether 2,048 is reachable at all:
+      // two variants cannot share an option combination. Three axes of 8 × 6 × 43 leaves
+      // just enough room.
+      const combinations = Array.from({ length: total }, (_, index) =>
+        optionsFor(index, total)
+          .map((option) => `${option.optionName}=${option.name}`)
+          .join("/"),
+      );
+
+      expect(new Set(combinations).size).toBe(total);
+    });
+  }
+});

--- a/app/lib/seed/catalogue.ts
+++ b/app/lib/seed/catalogue.ts
@@ -249,13 +249,28 @@ export function optionsFor(index: number, total: number): Array<{ optionName: st
 
   const colour = COLOURS[index % COLOURS.length];
   const size = SIZES[Math.floor(index / COLOURS.length) % SIZES.length];
-  // A third axis once colour × size runs out, which is what it takes to reach 2,048.
+
+  // The axis count comes from `total`, not from `index`. It used to come from the index —
+  // an "Edition" value appeared only once colour × size ran out at variant 48 — which
+  // meant the product declared three options while its first 48 variants supplied two
+  // values. Shopify requires exactly one value per option and rejected every row.
+  //
+  // Because `productSet` runs inside a bulk operation, all Shopify reported was
+  // `COMPLETED — 1 objects`. Every product over 48 variants failed in total silence, which
+  // is every product in a catalogue seeded at the default fifty.
+  if (total <= COLOURS.length * SIZES.length) {
+    return [
+      { optionName: "Colour", name: colour },
+      { optionName: "Size", name: size },
+    ];
+  }
+
   const edition = Math.floor(index / (COLOURS.length * SIZES.length));
 
   return [
     { optionName: "Colour", name: colour },
     { optionName: "Size", name: size },
-    ...(edition > 0 ? [{ optionName: "Edition", name: `E${edition}` }] : []),
+    { optionName: "Edition", name: `E${edition}` },
   ];
 }
 

--- a/app/types/admin.generated.d.ts
+++ b/app/types/admin.generated.d.ts
@@ -352,7 +352,7 @@ export type SeedBulkRunMutation = { bulkOperationRunMutation?: AdminTypes.Maybe<
 export type SeedBulkStatusQueryVariables = AdminTypes.Exact<{ [key: string]: never; }>;
 
 
-export type SeedBulkStatusQuery = { currentBulkOperation?: AdminTypes.Maybe<Pick<AdminTypes.BulkOperation, 'id' | 'status' | 'objectCount' | 'errorCode'>> };
+export type SeedBulkStatusQuery = { currentBulkOperation?: AdminTypes.Maybe<Pick<AdminTypes.BulkOperation, 'id' | 'status' | 'objectCount' | 'errorCode' | 'url' | 'partialDataUrl'>> };
 
 interface GeneratedQueryTypes {
   "#graphql\n  query AnchorCurrentBulkOperation {\n    currentBulkOperation(type: MUTATION) {\n      id status url partialDataUrl objectCount errorCode\n    }\n  }\n": {return: AnchorCurrentBulkOperationQuery, variables: AnchorCurrentBulkOperationQueryVariables},
@@ -370,7 +370,7 @@ interface GeneratedQueryTypes {
   "#graphql\n  query AnchorAuditVariants($ids: [ID!]!) {\n    nodes(ids: $ids) {\n      ... on ProductVariant { id price compareAtPrice }\n    }\n  }\n": {return: AnchorAuditVariantsQuery, variables: AnchorAuditVariantsQueryVariables},
   "#graphql\n          query SeedExisting($cursor: String) {\n            products(first: 250, after: $cursor, query: \"handle:anchor-perf-*\") {\n              nodes { handle }\n              pageInfo { hasNextPage endCursor }\n            }\n          }\n        ": {return: SeedExistingQuery, variables: SeedExistingQueryVariables},
   "#graphql\n        query SeedCollectionByHandle($handle: String!) {\n          collectionByHandle(handle: $handle) { id }\n        }\n      ": {return: SeedCollectionByHandleQuery, variables: SeedCollectionByHandleQueryVariables},
-  "#graphql\n        query SeedBulkStatus {\n          currentBulkOperation(type: MUTATION) { id status objectCount errorCode }\n        }\n      ": {return: SeedBulkStatusQuery, variables: SeedBulkStatusQueryVariables},
+  "#graphql\n        query SeedBulkStatus {\n          currentBulkOperation(type: MUTATION) {\n            id status objectCount errorCode url partialDataUrl\n          }\n        }\n      ": {return: SeedBulkStatusQuery, variables: SeedBulkStatusQueryVariables},
 }
 
 interface GeneratedMutationTypes {

--- a/scripts/seed-store.ts
+++ b/scripts/seed-store.ts
@@ -312,11 +312,19 @@ async function poll(client: AdminClient): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 5_000));
 
     const status = await client.request<{
-      currentBulkOperation?: { status: string; objectCount?: string; errorCode?: string | null };
+      currentBulkOperation?: {
+        status: string;
+        objectCount?: string;
+        errorCode?: string | null;
+        url?: string | null;
+        partialDataUrl?: string | null;
+      };
     }>(
       `#graphql
         query SeedBulkStatus {
-          currentBulkOperation(type: MUTATION) { id status objectCount errorCode }
+          currentBulkOperation(type: MUTATION) {
+            id status objectCount errorCode url partialDataUrl
+          }
         }
       `,
       {},
@@ -331,11 +339,68 @@ async function poll(client: AdminClient): Promise<void> {
       console.log(
         `\n  finished: ${operation.status}${operation.errorCode ? ` (${operation.errorCode})` : ""}`,
       );
+      await reportRowErrors(operation.url ?? operation.partialDataUrl ?? null);
       return;
     }
   }
 
   console.log("\n  still running — check the Dev Dashboard");
+}
+
+/**
+ * Reads what the bulk mutation actually did, rather than trusting that it finished.
+ *
+ * `COMPLETED` means Shopify ran every line, not that any of them worked. Each line's
+ * `userErrors` are in the result file and nowhere else — so a seed where every single
+ * product was rejected printed `COMPLETED — 1 objects` and exited zero. It did exactly
+ * that for the 2,048-variant product, and the failure was only visible by fetching this
+ * file by hand afterwards.
+ *
+ * That is the same mistake the app itself is built not to make: a run is clean only when
+ * its rows have been read back. A seeding script gets no exemption — it is the thing
+ * every perf number is measured against.
+ */
+async function reportRowErrors(url: string | null): Promise<void> {
+  if (!url) {
+    console.log("  no result file — cannot confirm any row succeeded");
+    return;
+  }
+
+  const body = await (await fetch(url)).text();
+  const lines = body.split("\n").filter(Boolean);
+
+  let created = 0;
+  const messages = new Map<string, number>();
+
+  for (const line of lines) {
+    const parsed = JSON.parse(line) as {
+      data?: { productSet?: { product?: { id?: string } | null; userErrors?: Array<{ message?: string }> } };
+    };
+    const payload = parsed.data?.productSet;
+
+    if (payload?.product?.id) created++;
+
+    // Counted by message rather than listed. One malformed input produces one error per
+    // variant, so a single bad product yields two thousand identical lines — printing
+    // them all buries the one line that says what to fix.
+    for (const error of payload?.userErrors ?? []) {
+      const message = error.message ?? "unknown";
+      messages.set(message, (messages.get(message) ?? 0) + 1);
+    }
+  }
+
+  console.log(`  created ${created}/${lines.length}`);
+
+  if (messages.size === 0) return;
+
+  console.log("  errors:");
+  for (const [message, count] of [...messages.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${count}× ${message}`);
+  }
+
+  // Non-zero exit, because a seed that created nothing must not look like a success to
+  // whatever ran it.
+  if (created === 0) process.exitCode = 1;
 }
 
 async function seedMarkets(): Promise<void> {


### PR DESCRIPTION
Closes #51, #52.

Two bugs, and the second is why the first survived.

## 1. `optionsFor` chose its axes from the variant index, not the product's total

An `Edition` value appeared only once colour × size ran out at variant 48 — so a product with more than 48 variants **declared three options while its first 48 supplied two values**. Shopify requires exactly one value per option and rejected every row.

At the default `--variants 50`, that is every product in the catalogue. The 100K perf store this script exists to build has never once been creatable.

## 2. The seeder never read the bulk operation's result file

`COMPLETED` means Shopify ran every line — not that any line worked. Each line's `userErrors` live in the result file and nowhere else.

The 2,048-variant product printed this and exited zero:

```
  COMPLETED — 1 objects
  finished: COMPLETED
```

It created nothing. Every one of the 2,048 rows had failed. I only found it by fetching the result file by hand after noticing the mirror's largest product had five variants.

**This is precisely the failure the app is built not to have** — a run is clean only when its rows are read back. The seeding script had quietly exempted itself, and it is the thing every perf number is measured against.

It now downloads the result, counts created against attempted, groups errors by message (one malformed product yields two thousand identical lines — printing them all buries the one that says what to fix), and exits non-zero when nothing was created.

## Verified on the store, end to end

```
  created 1/1
  shopify: 2048 variants, Colour(8) x Size(6) x Edition(43)
  bulk query in 9s: products=1037 variants=3669 malformed=0 orphans=0
  mirrored for that product: 2048 / 2048
```

That round-trip is **#52's entire acceptance criterion**, and it was previously unverifiable — because the product could not be created.

## Tests

The two rules Shopify actually enforces, asserted across the boundaries either side of 48: one value per declared option, and no two variants sharing a combination.

- Reinstating the original index-based choice → **4 tests fail**
- Collapsing the Edition axis → **5 tests fail**

792 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)