### PR TITLE
Fix: the bulk catalogue import produced variants that could never be priced

### DIFF
--- a/app/services/catalog-bulk-sync.server.ts
+++ b/app/services/catalog-bulk-sync.server.ts
@@ -253,7 +253,7 @@ async function ingest(
  */
 async function writeBatch(shopId: string, currency: string, rows: CatalogRow[]): Promise<void> {
   await prisma.$transaction(
-    rows.map((row) =>
+    rows.flatMap((row) => [
       prisma.variantIndex.upsert({
         where: { shopId_variantGid: { shopId, variantGid: row.variantGid } },
         create: {
@@ -296,7 +296,52 @@ async function writeBatch(shopId: string, currency: string, rows: CatalogRow[]):
           syncedAt: new Date(),
         },
       }),
-    ),
+      // The base-surface row, in the same transaction as the index row.
+      //
+      // This was missing, and the consequence was that the bulk path could not produce a
+      // priceable variant. Baselines are captured from `price_surface_entries`, not from
+      // `variant_index` — so a variant imported here got mirrored, counted, and shown in
+      // the catalogue, and then had no baseline, and a variant with no baseline cannot be
+      // included in a campaign.
+      //
+      // The dashboard's remedy made it worse rather than better: "N variants have no
+      // baseline yet — re-sync to capture them" ran the bulk path again, which again wrote
+      // no surface row. The warning could not be cleared by the only action offered for
+      // clearing it.
+      //
+      // Small stores hid it. The paginated path writes both tables and runs whenever the
+      // bulk path errors or returns nothing, so the failure was invisible until a
+      // catalogue was big enough for the bulk path to succeed — which is to say, the app
+      // was broken specifically on the stores it exists for.
+      //
+      // Same transaction rather than a second pass, because the two tables disagreeing is
+      // the bug itself, and a second pass can fail on its own.
+      prisma.priceSurfaceEntry.upsert({
+        where: {
+          shopId_variantGid_surfaceKind_priceListGid: {
+            shopId,
+            variantGid: row.variantGid,
+            surfaceKind: "BASE",
+            priceListGid: "",
+          },
+        },
+        create: {
+          shopId,
+          variantGid: row.variantGid,
+          surfaceKind: "BASE",
+          priceListGid: "",
+          currency: row.price?.currency ?? currency,
+          livePrice: row.price ? BigInt(row.price.amount) : null,
+          liveCompareAt: row.compareAt ? BigInt(row.compareAt.amount) : null,
+        },
+        update: {
+          currency: row.price?.currency ?? currency,
+          livePrice: row.price ? BigInt(row.price.amount) : null,
+          liveCompareAt: row.compareAt ? BigInt(row.compareAt.amount) : null,
+          syncedAt: new Date(),
+        },
+      }),
+    ]),
   );
 }
 

--- a/chaos/scenarios/bulk-import.chaos.ts
+++ b/chaos/scenarios/bulk-import.chaos.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 
 import prisma from "../../app/db.server";
 import type { AdminClient } from "../../app/lib/execution/sync-executor";
+import { captureBaselines } from "../../app/services/baselines.server";
 import { syncCatalogViaBulk } from "../../app/services/catalog-bulk-sync.server";
 import { withChaos } from "../harness/scenario";
 
@@ -162,6 +163,74 @@ describe("chaos: the catalogue bulk import", () => {
 
         expect(result.errors[0]).toMatch(/already running/i);
         expect(result.written).toBe(0);
+      },
+    );
+  });
+
+  it("leaves every imported variant priceable, not merely mirrored", async () => {
+    /**
+     * The property that matters, and the one the count assertions above all missed.
+     *
+     * A variant is not usable because it is in `variant_index`. It is usable when it has
+     * a baseline, and baselines are captured from `price_surface_entries` — a second
+     * table the bulk path did not write. So an imported variant was mirrored, counted,
+     * listed in the catalogue, and could not be put in a campaign.
+     *
+     * The dashboard's remedy pointed the wrong way: "N variants have no baseline yet —
+     * re-sync to capture them" ran the bulk path again and wrote no surface row again.
+     * The warning could not be cleared by the only action offered for clearing it.
+     *
+     * It stayed hidden because the paginated path writes both tables and takes over
+     * whenever the bulk path errors or returns nothing. Only a catalogue big enough for
+     * the bulk path to succeed was affected — which is to say, the app was broken
+     * specifically on the stores it exists for.
+     *
+     * Asserted as "can this variant be priced" rather than "does this row exist",
+     * because the row is an implementation detail and the campaign is the point.
+     */
+    await withChaos(
+      "bulk-import-priceable",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+
+        await syncCatalogViaBulk(
+          bulkClient("https://example.invalid/file.jsonl"),
+          shopId,
+          "USD",
+          {
+            fetchResult: chunked([product("A"), variant("a1", "A", "10.00")]) as never,
+            sleep: async () => {},
+          },
+        );
+
+        const imported = "gid://shopify/ProductVariant/a1";
+
+        const surface = await prisma.priceSurfaceEntry.findUnique({
+          where: {
+            shopId_variantGid_surfaceKind_priceListGid: {
+              shopId,
+              variantGid: imported,
+              surfaceKind: "BASE",
+              priceListGid: "",
+            },
+          },
+        });
+
+        expect(surface, "imported variant has no base surface row").not.toBeNull();
+        // The price came through the surface row too, not just the index row — a surface
+        // entry with a null price captures a null baseline, which is the same dead end
+        // one table further along.
+        expect(surface?.livePrice).toBe(1_000n);
+
+        await captureBaselines(shopId);
+
+        const baseline = await prisma.baseline.findFirst({
+          where: { shopId, variantGid: imported, supersededAt: null },
+        });
+
+        expect(baseline, "imported variant cannot be priced by a campaign").not.toBeNull();
+        expect(baseline?.basePrice).toBe(1_000n);
       },
     );
   });


### PR DESCRIPTION
Baselines are captured from `price_surface_entries`. **The bulk import wrote only `variant_index`.**

So a variant imported through the bulk path was mirrored, counted, listed in the catalogue — and had no baseline. A variant with no baseline cannot be included in a campaign.

## The dashboard's remedy pointed the wrong way

> ⚠️ 2033 variants have no baseline yet and cannot be included in a campaign. **Re-sync to capture them.**

Re-syncing ran the bulk path again, which wrote no surface row again. **The warning could not be cleared by the only action offered for clearing it.**

## It hid behind the fallback

The paginated path writes *both* tables, and it takes over whenever the bulk path errors or returns nothing. Only a catalogue big enough for the bulk path to succeed was affected.

The app was broken specifically on the stores it exists for. A 100K-variant store would have imported cleanly and been able to price none of it.

## The fix

The surface row now goes in the **same `$transaction`** as the index row — the two tables disagreeing *is* the bug, and a second pass can fail on its own.

## Why 94 chaos scenarios and 792 unit tests missed it

Every existing assertion counted `variant_index` rows. The mirror was measured, and the mirror was correct.

The new scenario asserts an imported variant can be **priced** — surface row → `captureBaselines` → a baseline with the right value — rather than that a row exists. The row is an implementation detail; the campaign is the point.

- Removing the fix → fails on the surface row
- Writing the surface row with a null price → fails on the baseline (the same dead end, one table further along)

## Verified on the store

Re-syncing 3,670 variants:

```
after sync — variant_index: 3670  base surface entries: 1639 -> 3693
captureBaselines: {"captured":2054,"alreadyCurrent":1639,"superseded":0}
```

2,054 captured — the 2,033 the dashboard had been stuck reporting, plus the rest.

792 unit tests, 95 chaos scenarios green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)