### PR TITLE
The nightly audit now checks the mirror against itself, not just against Shopify

### DIFF
--- a/app/lib/observability/otel.server.ts
+++ b/app/lib/observability/otel.server.ts
@@ -37,6 +37,10 @@ export const INSTRUMENTS: Record<Metric, "counter" | "histogram" | "gauge"> = {
   "run.rows": "counter",
   "webhook.lag_ms": "histogram",
   "mirror.divergence_rate": "gauge",
+  // A gauge, not a counter: the question is "how many are broken right now", and the
+  // healthy answer is zero. A counter would accumulate across nights and never come back
+  // down after a fix.
+  "mirror.unpriceable": "gauge",
   "scheduler.tick": "counter",
   "budget.saturation": "gauge",
   "queue.depth": "gauge",

--- a/app/lib/telemetry/metrics.ts
+++ b/app/lib/telemetry/metrics.ts
@@ -31,6 +31,14 @@ export type Metric =
   | "webhook.lag_ms"
   /** Fraction of a sampled mirror that disagreed with Shopify. */
   | "mirror.divergence_rate"
+  /**
+   * Live variants with no base surface row — mirrored, but impossible to price.
+   *
+   * A count rather than a rate, because the healthy value is zero and any other value
+   * means an import path has stopped writing surface rows. A rate would make one broken
+   * path on a large catalogue look like a rounding error.
+   */
+  | "mirror.unpriceable"
   /** That the scheduler is alive and doing work. */
   | "scheduler.tick"
   /** How much of a shop's rate-limit budget a run consumed. */

--- a/app/services/catalog-bulk-sync.server.ts
+++ b/app/services/catalog-bulk-sync.server.ts
@@ -253,7 +253,7 @@ async function ingest(
  */
 async function writeBatch(shopId: string, currency: string, rows: CatalogRow[]): Promise<void> {
   await prisma.$transaction(
-    rows.map((row) =>
+    rows.flatMap((row) => [
       prisma.variantIndex.upsert({
         where: { shopId_variantGid: { shopId, variantGid: row.variantGid } },
         create: {
@@ -296,7 +296,52 @@ async function writeBatch(shopId: string, currency: string, rows: CatalogRow[]):
           syncedAt: new Date(),
         },
       }),
-    ),
+      // The base-surface row, in the same transaction as the index row.
+      //
+      // This was missing, and the consequence was that the bulk path could not produce a
+      // priceable variant. Baselines are captured from `price_surface_entries`, not from
+      // `variant_index` — so a variant imported here got mirrored, counted, and shown in
+      // the catalogue, and then had no baseline, and a variant with no baseline cannot be
+      // included in a campaign.
+      //
+      // The dashboard's remedy made it worse rather than better: "N variants have no
+      // baseline yet — re-sync to capture them" ran the bulk path again, which again wrote
+      // no surface row. The warning could not be cleared by the only action offered for
+      // clearing it.
+      //
+      // Small stores hid it. The paginated path writes both tables and runs whenever the
+      // bulk path errors or returns nothing, so the failure was invisible until a
+      // catalogue was big enough for the bulk path to succeed — which is to say, the app
+      // was broken specifically on the stores it exists for.
+      //
+      // Same transaction rather than a second pass, because the two tables disagreeing is
+      // the bug itself, and a second pass can fail on its own.
+      prisma.priceSurfaceEntry.upsert({
+        where: {
+          shopId_variantGid_surfaceKind_priceListGid: {
+            shopId,
+            variantGid: row.variantGid,
+            surfaceKind: "BASE",
+            priceListGid: "",
+          },
+        },
+        create: {
+          shopId,
+          variantGid: row.variantGid,
+          surfaceKind: "BASE",
+          priceListGid: "",
+          currency: row.price?.currency ?? currency,
+          livePrice: row.price ? BigInt(row.price.amount) : null,
+          liveCompareAt: row.compareAt ? BigInt(row.compareAt.amount) : null,
+        },
+        update: {
+          currency: row.price?.currency ?? currency,
+          livePrice: row.price ? BigInt(row.price.amount) : null,
+          liveCompareAt: row.compareAt ? BigInt(row.compareAt.amount) : null,
+          syncedAt: new Date(),
+        },
+      }),
+    ]),
   );
 }
 

--- a/app/services/mirror-audit.server.ts
+++ b/app/services/mirror-audit.server.ts
@@ -44,6 +44,10 @@ export interface AuditResult extends AuditVerdict {
   healed: number;
   /** Variants Shopify no longer knows about, tombstoned rather than deleted. */
   tombstoned: number;
+  /** Variants with no base surface row — mirrored, but impossible to price. */
+  unpriceable: number;
+  /** How many of those this run rebuilt from the index. */
+  unpriceableHealed: number;
 }
 
 /** Read in batches Shopify will accept, and small enough not to dominate the budget. */
@@ -64,7 +68,10 @@ export async function auditMirror(
   const size = Math.min(total, options.size ?? sampleSize(total));
 
   if (size === 0) {
-    return { shopId, checked: 0, diverged: 0, rate: 0, divergences: [], alert: false, healed: 0, tombstoned: 0 };
+    return {
+      shopId, checked: 0, diverged: 0, rate: 0, divergences: [], alert: false,
+      healed: 0, tombstoned: 0, unpriceable: 0, unpriceableHealed: 0,
+    };
   }
 
   // Random rows rather than the first N. Ordering by id would check the same variants
@@ -113,7 +120,9 @@ export async function auditMirror(
   }
 
   const verdict = auditSample(sample, live, threshold);
-  const result: AuditResult = { shopId, ...verdict, healed: 0, tombstoned: 0 };
+  const result: AuditResult = {
+    shopId, ...verdict, healed: 0, tombstoned: 0, unpriceable: 0, unpriceableHealed: 0,
+  };
 
   // Healed as they are found. The point of the audit is a mirror that is right
   // afterwards, not a report saying it was wrong.
@@ -142,6 +151,19 @@ export async function auditMirror(
     result.healed++;
   }
 
+  // The other way the mirror can be wrong, and the one the sample above cannot see.
+  //
+  // Everything so far compares us against Shopify. This compares us against ourselves:
+  // `variant_index` and `price_surface_entries` are written together by six code paths,
+  // and nothing checked that they agreed. When the bulk import stopped writing the second
+  // one, a whole catalogue was mirrored, counted and displayed — and could not be priced,
+  // because baselines are captured from the surface table. The nightly audit found
+  // nothing, correctly: the mirror was right about what Shopify held. The disagreement
+  // was between our own two tables.
+  const unpriceable = await healUnpriceable(shopId);
+  result.unpriceable = unpriceable.found;
+  result.unpriceableHealed = unpriceable.healed;
+
   // Recorded whether or not it alerted. A rate that is fine tonight and fine tomorrow
   // and creeping the week after is the signal worth having, and it only exists if the
   // quiet nights are written down too.
@@ -158,6 +180,7 @@ export async function auditMirror(
         ratePercent: Number((verdict.rate * 100).toFixed(2)),
         healed: result.healed,
         tombstoned: result.tombstoned,
+        unpriceable: result.unpriceable,
         alert: verdict.alert,
       },
     },
@@ -170,9 +193,24 @@ export async function auditMirror(
     ratePercent: Number((verdict.rate * 100).toFixed(2)),
     healed: result.healed,
     tombstoned: result.tombstoned,
+    unpriceable: result.unpriceable,
   };
 
   metric("mirror.divergence_rate", verdict.rate, { shopId, checked: verdict.checked });
+  metric("mirror.unpriceable", result.unpriceable, { shopId });
+
+  // Separate from the divergence alert because it is a different fault with a different
+  // remedy. Divergence above threshold means re-sync; this means an import path has
+  // stopped writing surface rows, and re-syncing through that same path is exactly what
+  // will not fix it.
+  if (unpriceable.found > unpriceable.healed) {
+    logger.error("variants cannot be priced: no base surface row", {
+      shopId,
+      unpriceable: unpriceable.found,
+      healed: unpriceable.healed,
+      remaining: unpriceable.found - unpriceable.healed,
+    });
+  }
 
   if (verdict.alert) {
     // Systematic. One missed webhook is a row; half a percent of a sample is a
@@ -202,4 +240,55 @@ export async function auditMirror(
   });
 
   return result;
+}
+
+/**
+ * Rebuilds base surface rows for live variants that have none.
+ *
+ * Heals from `variant_index` rather than from Shopify: the index row already holds the
+ * price this row should carry, and a variant that is merely missing its surface row is
+ * not evidence that our price is stale. Re-reading Shopify for it would spend budget to
+ * learn something we already know.
+ *
+ * A variant whose index row has no price cannot be healed — there is nothing to write —
+ * so it stays in the count and the caller alerts on the difference. Writing a surface row
+ * with a null price would clear the symptom and leave the variant exactly as unpriceable,
+ * one table further along.
+ */
+async function healUnpriceable(shopId: string): Promise<{ found: number; healed: number }> {
+  const orphans = await prisma.$queryRaw<Array<{ variantGid: string; price: bigint | null; compareAt: bigint | null; currency: string | null }>>`
+    SELECT vi."variantGid", vi."price", vi."compareAt", vi."currency"
+    FROM variant_index vi
+    WHERE vi."shopId" = ${shopId}
+      AND vi."deletedAt" IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM price_surface_entries pse
+        WHERE pse."shopId" = vi."shopId"
+          AND pse."variantGid" = vi."variantGid"
+          AND pse."surfaceKind" = 'BASE'
+          AND pse."priceListGid" = ''
+      )
+    LIMIT 5000
+  `;
+
+  let healed = 0;
+
+  for (const orphan of orphans) {
+    if (orphan.price === null || !orphan.currency) continue;
+
+    await prisma.priceSurfaceEntry.create({
+      data: {
+        shopId,
+        variantGid: orphan.variantGid,
+        surfaceKind: "BASE",
+        priceListGid: "",
+        currency: orphan.currency,
+        livePrice: orphan.price,
+        liveCompareAt: orphan.compareAt,
+      },
+    });
+    healed++;
+  }
+
+  return { found: orphans.length, healed };
 }

--- a/chaos/scenarios/bulk-import.chaos.ts
+++ b/chaos/scenarios/bulk-import.chaos.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "vitest";
 
 import prisma from "../../app/db.server";
 import type { AdminClient } from "../../app/lib/execution/sync-executor";
+import { captureBaselines } from "../../app/services/baselines.server";
 import { syncCatalogViaBulk } from "../../app/services/catalog-bulk-sync.server";
 import { withChaos } from "../harness/scenario";
 
@@ -162,6 +163,74 @@ describe("chaos: the catalogue bulk import", () => {
 
         expect(result.errors[0]).toMatch(/already running/i);
         expect(result.written).toBe(0);
+      },
+    );
+  });
+
+  it("leaves every imported variant priceable, not merely mirrored", async () => {
+    /**
+     * The property that matters, and the one the count assertions above all missed.
+     *
+     * A variant is not usable because it is in `variant_index`. It is usable when it has
+     * a baseline, and baselines are captured from `price_surface_entries` — a second
+     * table the bulk path did not write. So an imported variant was mirrored, counted,
+     * listed in the catalogue, and could not be put in a campaign.
+     *
+     * The dashboard's remedy pointed the wrong way: "N variants have no baseline yet —
+     * re-sync to capture them" ran the bulk path again and wrote no surface row again.
+     * The warning could not be cleared by the only action offered for clearing it.
+     *
+     * It stayed hidden because the paginated path writes both tables and takes over
+     * whenever the bulk path errors or returns nothing. Only a catalogue big enough for
+     * the bulk path to succeed was affected — which is to say, the app was broken
+     * specifically on the stores it exists for.
+     *
+     * Asserted as "can this variant be priced" rather than "does this row exist",
+     * because the row is an implementation detail and the campaign is the point.
+     */
+    await withChaos(
+      "bulk-import-priceable",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+
+        await syncCatalogViaBulk(
+          bulkClient("https://example.invalid/file.jsonl"),
+          shopId,
+          "USD",
+          {
+            fetchResult: chunked([product("A"), variant("a1", "A", "10.00")]) as never,
+            sleep: async () => {},
+          },
+        );
+
+        const imported = "gid://shopify/ProductVariant/a1";
+
+        const surface = await prisma.priceSurfaceEntry.findUnique({
+          where: {
+            shopId_variantGid_surfaceKind_priceListGid: {
+              shopId,
+              variantGid: imported,
+              surfaceKind: "BASE",
+              priceListGid: "",
+            },
+          },
+        });
+
+        expect(surface, "imported variant has no base surface row").not.toBeNull();
+        // The price came through the surface row too, not just the index row — a surface
+        // entry with a null price captures a null baseline, which is the same dead end
+        // one table further along.
+        expect(surface?.livePrice).toBe(1_000n);
+
+        await captureBaselines(shopId);
+
+        const baseline = await prisma.baseline.findFirst({
+          where: { shopId, variantGid: imported, supersededAt: null },
+        });
+
+        expect(baseline, "imported variant cannot be priced by a campaign").not.toBeNull();
+        expect(baseline?.basePrice).toBe(1_000n);
       },
     );
   });

--- a/chaos/scenarios/mirror-audit.chaos.ts
+++ b/chaos/scenarios/mirror-audit.chaos.ts
@@ -115,4 +115,108 @@ describe("chaos: the nightly mirror audit", () => {
       },
     );
   });
+
+  it("finds variants that are mirrored but impossible to price, and rebuilds them", async () => {
+    /**
+     * The other way the mirror can be wrong, and the one every other check here misses.
+     *
+     * Everything above compares us against Shopify. This compares us against ourselves.
+     * `variant_index` and `price_surface_entries` are written together by six code paths,
+     * and nothing checked that they agreed — so when the bulk import stopped writing the
+     * second one, a whole catalogue was mirrored, counted and displayed, and could not be
+     * priced, because baselines are captured from the surface table.
+     *
+     * The nightly audit reported all clear, and it was right to: the mirror agreed with
+     * Shopify perfectly. The disagreement was between our own two tables, and nobody was
+     * looking there.
+     */
+    await withChaos(
+      "mirror-audit-unpriceable",
+      { catalog: { products: 4, variantsPerProduct: 2 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        const healthy = await auditMirror(client, shopId);
+        expect(healthy.unpriceable).toBe(0);
+
+        // What a broken import path leaves behind: the index row is there, the surface
+        // row is not. Nothing about the store has changed, so no amount of comparing
+        // against Shopify would ever notice.
+        const orphaned = variantGids[0];
+        await prisma.priceSurfaceEntry.deleteMany({
+          where: { shopId, variantGid: orphaned, surfaceKind: "BASE", priceListGid: "" },
+        });
+
+        const found = await auditMirror(client, shopId);
+
+        expect(found.unpriceable).toBe(1);
+        expect(found.unpriceableHealed).toBe(1);
+
+        // Rebuilt from the index row, which already held the price — re-reading Shopify
+        // for something we know would spend budget to learn nothing.
+        const index = await prisma.variantIndex.findUniqueOrThrow({
+          where: { shopId_variantGid: { shopId, variantGid: orphaned } },
+        });
+        const rebuilt = await prisma.priceSurfaceEntry.findUniqueOrThrow({
+          where: {
+            shopId_variantGid_surfaceKind_priceListGid: {
+              shopId, variantGid: orphaned, surfaceKind: "BASE", priceListGid: "",
+            },
+          },
+        });
+        expect(rebuilt.livePrice).toBe(index.price);
+
+        // And it stays fixed rather than being rebuilt every night.
+        const after = await auditMirror(client, shopId);
+        expect(after.unpriceable).toBe(0);
+      },
+    );
+  });
+
+  it("does not claim to have healed a variant it cannot heal", async () => {
+    /**
+     * A surface row with a null price clears the symptom and leaves the variant exactly
+     * as unpriceable, one table further along — `captureBaselines` would capture nothing
+     * from it. So a variant whose index row has no price is counted and not healed, and
+     * the caller alerts on the difference.
+     *
+     * Shopify has no price for it either, which is what makes this the unhealable case
+     * rather than a repairable one. With a price in Shopify the audit would simply fix
+     * the index row and the rebuild would then succeed — that is the ordinary path, and
+     * it is why this test sets both sides to nothing. There is no price to be had.
+     */
+    await withChaos(
+      "mirror-audit-unhealable",
+      { catalog: { products: 4, variantsPerProduct: 2 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        const orphaned = variantGids[variantGids.length - 1];
+        await prisma.priceSurfaceEntry.deleteMany({
+          where: { shopId, variantGid: orphaned, surfaceKind: "BASE", priceListGid: "" },
+        });
+        await prisma.variantIndex.updateMany({
+          where: { shopId, variantGid: orphaned },
+          data: { price: null },
+        });
+        // Priceless on both sides, so the sample agrees with the mirror and the repair
+        // path has nothing to repair. Without this the outcome would depend on whether
+        // the random sample happened to draw this row.
+        chaos.fake.variants.get(orphaned)!.price = "";
+
+        const result = await auditMirror(client, shopId);
+
+        expect(result.unpriceable).toBe(1);
+        // Not healed, and not pretended to be. The alert is on the difference.
+        expect(result.unpriceableHealed).toBe(0);
+
+        const still = await prisma.priceSurfaceEntry.findFirst({
+          where: { shopId, variantGid: orphaned, surfaceKind: "BASE", priceListGid: "" },
+        });
+        expect(still, "wrote a surface row with no price to clear the symptom").toBeNull();
+      },
+    );
+  });
 });


### PR DESCRIPTION
Closes #253. Follow-up to #252, which fixed **one instance** of a class of fault the app had no way to see.

## The gap

`variant_index` and `price_surface_entries` are written together by six code paths, and nothing checked that they agreed.

When the bulk import stopped writing the second one, a whole catalogue was mirrored, counted and displayed — and could not be priced, because baselines are captured from the surface table.

**The nightly audit reported all clear, and it was right to.** It compares us against Shopify, and the mirror agreed with Shopify perfectly. The disagreement was between our own two tables, and nobody was looking there.

## The check

A live `variant_index` row with no `BASE` surface row cannot be priced. The healthy count is zero.

**Healed from the index, not from Shopify.** The index row already holds the price the surface row should carry, and a missing surface row is not evidence that our price is stale — re-reading Shopify would spend a merchant's rate-limit budget to learn something we already know.

**A variant whose index row has no price is counted and not healed.** Writing a surface row with a null price would clear the symptom and leave the variant exactly as unpriceable, one table further along, where the next person would have to find it again.

## Alerted separately from divergence

The remedies are opposite:

| Fault | Remedy |
|---|---|
| Divergence above threshold | Re-sync |
| Unpriceable variants | An import path stopped writing surface rows — **re-syncing through that same path is what will not fix it** |

`mirror.unpriceable` is a **gauge**, not a counter: the question is how many are broken *now*, and a counter would never come back down after a fix.

## Tests

Four mutations each kill a test — check disabled, heals with a null price anyway, rebuilt row carries no price, healed never counted.

The unhealable scenario sets the price to nothing on **both** sides deliberately. With a price in Shopify the audit repairs the index row first and the rebuild then succeeds — that's the ordinary path — so without it the outcome would depend on whether the random sample happened to draw that row. Ran three times to confirm.

792 unit tests, 97 chaos scenarios green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)