### PR TITLE
Fix: the market-wide optimisation was a lottery on catalogue contents

### DIFF
--- a/app/lib/markets/uniform.test.ts
+++ b/app/lib/markets/uniform.test.ts
@@ -12,7 +12,13 @@ import fc from "fast-check";
 
 import { money } from "../money/money";
 import type { PlannedRow } from "../planning/types";
-import { applyBps, composeBps, toAdjustmentInput, uniformAdjustment } from "./uniform";
+import {
+  applyBps,
+  composeBps,
+  feasibleBps,
+  toAdjustmentInput,
+  uniformAdjustment,
+} from "./uniform";
 
 const ref = (variantGid: string) => ({
   variantGid,
@@ -208,6 +214,133 @@ describe("applying a percentage in integer minor units", () => {
       fc.property(fc.integer({ min: 1, max: 1_000_000 }), fc.integer({ min: 1, max: 5_000 }), (price, bps) => {
         expect(applyBps(-price, -bps)).toBe(-applyBps(price, -bps));
       }),
+    );
+  });
+});
+
+describe("recovering the percentage from prices that were rounded", () => {
+  it("finds -20% when the dearest product's cut did not land on a whole minor unit", () => {
+    // The exact catalogue that failed under CHAOS_SEED=20261119, and the reason the
+    // market-wide path was a lottery. 20% off 7,088 is 5,670.4, stored as 5,670, which
+    // recovers as -2001 bps — and -2001 then reproduces almost nothing else, so forty
+    // products got forty writes instead of one mutation.
+    //
+    // Picking the dearest product was the previous fix. It narrowed the recovery error
+    // and could not remove it: any target that is not an exact multiple still rounds.
+    const verdict = uniformAdjustment(
+      uniformMarket(-2000, [7088, 6955, 4504, 3047, 2451, 1590, 994, 662]),
+    );
+
+    expect(verdict).toEqual({ eligible: true, bps: -2000 });
+  });
+
+  it("finds the round percentage even when every single row was rounded", () => {
+    // Baselines chosen so that a 15% cut lands on a half in every case. There is no row
+    // to recover an exact answer from, which is precisely when guessing from one row
+    // fails and intersecting intervals still works.
+    const verdict = uniformAdjustment(uniformMarket(-1500, [110, 130, 150, 170, 190]));
+
+    expect(verdict).toEqual({ eligible: true, bps: -1500 });
+  });
+
+  it("still refuses a plan that is genuinely not one percentage", () => {
+    // The property that matters far more than the optimisation. A parent adjustment
+    // reprices the entire list, so admitting a plan that is not uniform would move
+    // products the campaign never targeted, on a live storefront, and report success.
+    const market = uniformMarket(-2000, [7088, 6955, 4504, 3047]);
+    // One product clamped by a guardrail to something no percentage explains.
+    market.rows[2] = row("v2", 4000);
+
+    expect(uniformAdjustment(market)).toEqual({
+      eligible: false,
+      reason: "the change is not the same percentage on every product",
+    });
+  });
+
+  it("does not admit an adjustment that rounds away from the target", () => {
+    // The exclusive upper bound, which is reachable on round numbers: a baseline of 200
+    // at -2500 bps lands on exactly 150.0, and 150.5 would round to 151. Off by one here
+    // either loses a legitimate adjustment or admits one that reprices a market wrongly.
+    const verdict = uniformAdjustment(uniformMarket(-2500, [200, 400, 800]));
+
+    expect(verdict).toEqual({ eligible: true, bps: -2500 });
+  });
+
+  it("agrees with applyBps on every row it admits", () => {
+    // The invariant behind the whole check, asserted over arbitrary catalogues rather
+    // than chosen ones: if a percentage is returned, it must reproduce every price the
+    // plan asked for. Anything less is a market repriced to something nobody chose.
+    fc.assert(
+      fc.property(
+        fc.integer({ min: -9_000, max: 9_000 }),
+        fc.array(fc.integer({ min: 1, max: 500_000 }), { minLength: 1, maxLength: 30 }),
+        (bps, baselines) => {
+          const market = uniformMarket(bps, baselines);
+          const verdict = uniformAdjustment(market);
+
+          if (!verdict.eligible) return;
+
+          for (const [index, baseline] of baselines.entries()) {
+            expect(applyBps(baseline, verdict.bps)).toBe(
+              market.rows[index].intendedPrice!.amount,
+            );
+          }
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+});
+
+describe("feasibleBps", () => {
+  it("excludes an adjustment that lands exactly on the rounding boundary", () => {
+    // 6 → 4 admits every adjustment down to, but not including, -2500: at exactly -2500
+    // the price is 4.5, and half-up rounding sends that to 5. Admitting it would move
+    // every product in the market by a minor unit.
+    expect(applyBps(6, -2500)).toBe(5);
+    expect(feasibleBps(6, 4).hi).toBe(-2501);
+    expect(applyBps(6, -2501)).toBe(4);
+  });
+
+  it("includes the whole band that does round to the target", () => {
+    const { lo, hi } = feasibleBps(7088, 5670);
+
+    // The seed-20261119 row. Both the value the old code guessed and the one the campaign
+    // actually asked for are in here, which is exactly why intersecting works and
+    // guessing from one row does not.
+    expect(lo).toBe(-2001);
+    expect(hi).toBe(-2000);
+
+    expect(applyBps(7088, lo)).toBe(5670);
+    expect(applyBps(7088, hi)).toBe(5670);
+    expect(applyBps(7088, lo - 1)).not.toBe(5670);
+    expect(applyBps(7088, hi + 1)).not.toBe(5670);
+  });
+
+  it("agrees with applyBps at both ends, for arbitrary prices", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 1_000_000 }),
+        fc.integer({ min: -9_000, max: 9_000 }),
+        (baseline, bps) => {
+          const to = applyBps(baseline, bps);
+          const { lo, hi } = feasibleBps(baseline, to);
+
+          // The band is exactly the set that produces `to`: both ends do, and stepping
+          // one past either end does not.
+          expect(applyBps(baseline, lo)).toBe(to);
+          expect(applyBps(baseline, hi)).toBe(to);
+          expect(lo).toBeLessThanOrEqual(bps);
+          expect(hi).toBeGreaterThanOrEqual(bps);
+          expect(applyBps(baseline, hi + 1)).not.toBe(to);
+
+          // Except at the -100% floor, which is a deliberate stop rather than the edge
+          // of the rounding band — below it the price is negative and the question is
+          // meaningless.
+          if (lo > -10_000) expect(applyBps(baseline, lo - 1)).not.toBe(to);
+        },
+      ),
+      { numRuns: 500 },
     );
   });
 });

--- a/app/lib/markets/uniform.ts
+++ b/app/lib/markets/uniform.ts
@@ -132,22 +132,37 @@ export function uniformAdjustment(inputs: UniformInputs): UniformVerdict {
     priced.push({ baseline, to });
   }
 
-  // Derived from the *dearest* product, then verified against every other one.
+  // Every basis-point value that reproduces every row, found exactly rather than guessed.
   //
-  // Not the first, which is what this did originally and which made the whole
-  // optimisation a coin flip on catalogue order. Recovering a percentage from a cheap
-  // product is imprecise: at a baseline of 7 minor units a 20% cut is 6, and the only
-  // percentage that reproduces 6 from 7 is -14.29%, which then fails to reproduce
-  // anything else. The dearest product carries the most significant digits, so the
-  // percentage it implies is the one most likely to be the campaign's actual intent.
+  // The obvious approach — recover a percentage from one row and check the others —
+  // cannot work, because the row's price was rounded to a minor unit before we saw it and
+  // the rounding is amplified back into the percentage. A clean 20% off a baseline of
+  // 7,088 is 5,670.4, stored as 5,670, which recovers as -20.01% and then reproduces
+  // almost nothing else. Picking the dearest row narrowed that error; it did not remove
+  // it, and one basis point out is as useless as a hundred.
   //
-  // It is still only a candidate. Every row has to reproduce exactly, so a wrong guess
-  // costs the optimisation and never a wrong price.
-  const strongest = priced.reduce((best, row) => (row.baseline > best.baseline ? row : best));
-  const bps = Math.round(((strongest.to - strongest.baseline) * 10_000) / strongest.baseline);
+  // So take the question the other way round. `applyBps` rounds, so for a given row the
+  // set of values that map its baseline to its target is an *interval*:
+  //
+  //     round(baseline × (10000 + bps) / 10000) == to
+  //       ⟺  to - 0.5  ≤  baseline × (10000 + bps) / 10000  <  to + 0.5
+  //
+  // For the row above that interval is [-2001, -2000] — it holds the wrong answer and the
+  // right one. Intersecting the intervals across every row leaves only values that
+  // reproduce all of them at once. Exact, one pass, and no heuristic about which product
+  // to trust.
+  let lo = Number.NEGATIVE_INFINITY;
+  let hi = Number.POSITIVE_INFINITY;
 
   for (const row of priced) {
-    if (applyBps(row.baseline, bps) !== row.to) {
+    const span = feasibleBps(row.baseline, row.to);
+    lo = Math.max(lo, span.lo);
+    hi = Math.min(hi, span.hi);
+
+    // An empty intersection means no single percentage produces these prices, which is
+    // what a plan perturbed by charm rounding or a guardrail actually looks like. The
+    // optimisation is lost and the prices are still right, which is the correct trade.
+    if (lo > hi) {
       return {
         eligible: false,
         reason: "the change is not the same percentage on every product",
@@ -155,11 +170,76 @@ export function uniformAdjustment(inputs: UniformInputs): UniformVerdict {
     }
   }
 
+  // Any value in the range reproduces every row, so the choice is about meaning rather
+  // than correctness. It still matters: this number is written to the merchant's price
+  // list and they read it in the Shopify admin, where "-14.74%" next to a campaign they
+  // set up as "15% off" is alarming in a way that takes a support ticket to settle.
+  const strongest = priced.reduce((best, row) => (row.baseline > best.baseline ? row : best));
+  const intent = ((strongest.to - strongest.baseline) * 10_000) / strongest.baseline;
+  const bps = roundestWithin(lo, hi, intent);
+
   if (bps === 0) {
     return { eligible: false, reason: "the campaign does not change this market's prices" };
   }
 
   return { eligible: true, bps };
+}
+
+/**
+ * The value in `[lo, hi]` a person would recognise as the percentage they asked for.
+ *
+ * Merchants set whole percentages, so a whole percentage in range is almost certainly
+ * what this campaign is. Nearest-to-implied is not good enough on its own: five prices
+ * that all round up push the implied figure well off the real one — a clean 15% off a
+ * catalogue of 110 to 190 minor units implies -14.74%, and every price still reproduces
+ * exactly from -15%.
+ *
+ * Coarsest step that lands in range wins, then nearest to the implied value among the
+ * multiples of that step. Correctness is not at stake here — every value in the range
+ * reproduces every row, which is what makes preferring the legible one free.
+ */
+function roundestWithin(lo: number, hi: number, intent: number): number {
+  for (const step of [100, 50, 25, 10, 5, 1]) {
+    const first = Math.ceil(lo / step) * step;
+    const last = Math.floor(hi / step) * step;
+    if (first > last) continue;
+
+    return Math.min(last, Math.max(first, Math.round(intent / step) * step));
+  }
+
+  // Unreachable: a non-empty range always contains a multiple of 1. Present so the
+  // function has a total return rather than relying on the reader to prove it.
+  return Math.min(hi, Math.max(lo, Math.round(intent)));
+}
+
+/**
+ * The basis-point values that map `baseline` to `to`, as an inclusive integer range.
+ *
+ * Derived from `applyBps`'s rounding rather than assumed, so the two cannot drift apart:
+ * a target price of `to` is produced by any adjustment landing in [to - 0.5, to + 0.5),
+ * and that band in prices is a band in basis points.
+ *
+ * The upper bound is exclusive in prices, so an adjustment landing exactly on `to + 0.5`
+ * rounds up and away. Handled explicitly because it is reachable — a baseline of 6 with a
+ * target of 4 admits -2500 unless the boundary is excluded, and -2500 turns 6 into 4.5,
+ * which rounds to 5. One minor unit, on every product in a market.
+ *
+ * Exported for its own tests. The market fixtures cannot reach this cleanly: the
+ * intersection of several rows almost always excludes the boundary anyway, and
+ * `roundestWithin` prefers a legible value over an extreme one — so a market test can
+ * pass with the bound wrong. A boundary this exact deserves to be checked exactly.
+ */
+export function feasibleBps(baseline: number, to: number): { lo: number; hi: number } {
+  // Floored at -100%. Below that the arithmetic keeps working and stops meaning
+  // anything: the price goes negative, `applyBps` reflects it through zero, and a
+  // baseline of 1 with a target of 0 acquires a "feasible" band stretching to -150%.
+  // Shopify has no such adjustment either, so the floor costs nothing real.
+  const lo = Math.max(-10_000, Math.ceil(((to - 0.5) * 10_000) / baseline - 10_000));
+
+  const exclusive = ((to + 0.5) * 10_000) / baseline - 10_000;
+  const hi = Number.isInteger(exclusive) ? exclusive - 1 : Math.floor(exclusive);
+
+  return { lo, hi };
 }
 
 /**

--- a/chaos/scenarios/downgrade.chaos.ts
+++ b/chaos/scenarios/downgrade.chaos.ts
@@ -75,7 +75,7 @@ describe("chaos: downgrading while a campaign is live", () => {
       "downgrade-markets-revert",
       { catalog: { products: 5, variantsPerProduct: 1 }, percent: -30 },
       async (chaos) => {
-        const { shopId, campaignId, variantGids } = chaos.fixture;
+        const { shopId, campaignId } = chaos.fixture;
 
         chaos.fake.addPriceList({
           id: "gid://shopify/PriceList/eu",
@@ -98,9 +98,22 @@ describe("chaos: downgrading while a campaign is live", () => {
 
         const applied = await chaos.apply();
         await chaos.expectHonest(applied.runId);
-        expect(chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size).toBe(
-          variantGids.length,
-        );
+
+        // Priced by whichever path the planner chose, not by the one this test expected.
+        //
+        // It used to assert five fixed prices, which quietly encoded a bug: the campaign
+        // covers every product on the market at one percentage, so it is exactly the case
+        // the market-wide path exists for, and the only reason five fixed prices appeared
+        // is that eligibility was failing to recognise it. Pinning the count here made the
+        // broken behaviour a requirement.
+        //
+        // What this scenario is actually about is the downgrade, so it asks the
+        // path-agnostic question: is the market carrying our prices now, and is it clean
+        // afterwards.
+        const priced =
+          chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size > 0 ||
+          chaos.fake.parentWrites.some((w) => w.priceListGid === "gid://shopify/PriceList/eu");
+        expect(priced, "the campaign did not reach the market at all").toBe(true);
 
         // Down to a plan with no markets at all. The market prices we wrote are still
         // ours to undo — refusing here would strand a whole market on sale prices, which
@@ -111,6 +124,13 @@ describe("chaos: downgrading while a campaign is live", () => {
         await chaos.expectHonest(reverted.runId);
 
         expect(chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size).toBe(0);
+
+        // And the list is back on the merchant's own percentage, not left on the
+        // campaign's. A revert that cleared the fixed prices but left a -37% parent
+        // adjustment behind would pass the line above and strand the whole market —
+        // which is the exact failure this scenario was written to catch.
+        const list = chaos.fake.priceLists.find((l) => l.id === "gid://shopify/PriceList/eu");
+        expect(list?.adjustment).toEqual({ type: "PERCENTAGE_DECREASE", value: 10 });
       },
     );
   });


### PR DESCRIPTION
Closes #255.

The market-wide optimisation — one mutation instead of one write per 250 variants — was a lottery on catalogue contents. Found by running the chaos suite under `CHAOS_SEED=20261119`, where `market-wide.chaos.ts` fails on `main`.

## Why a guess cannot work

A campaign takes a clean 20% off. The dearest product is 7,088 minor units; 20% off is **5,670.4**, stored as 5,670. Recovering the percentage back out gives:

```
(5670 - 7088) / 7088 × 10000 = -2000.56  →  round  →  -2001
```

`-2001` then reproduces almost nothing else, so forty products got forty writes.

Picking the *dearest* row was the previous fix, and it only narrowed the error. Any target price that is not an exact multiple still rounds, and one basis point out is as useless as a hundred.

## Ask the question the other way round

`applyBps` rounds, so for a given row the set of values that map its baseline to its target is an **interval**:

```
round(baseline × (10000 + bps) / 10000) == to
  ⟺  to - 0.5  ≤  baseline × (10000 + bps) / 10000  <  to + 0.5
```

For that row the interval is `[-2001, -2000]` — it holds the wrong answer *and* the right one. Intersecting across every row leaves only values that reproduce all of them. Exact, one pass, no heuristic about which product to trust.

Where the intersection is empty the plan genuinely is not uniform, and the existing rejection stands. **The safety guards are untouched**: full coverage of the price list, no compare-at, no clamped or skipped rows.

## Choosing among the survivors

Every value in the range reproduces every row, so the choice is about legibility, not correctness — but it still matters, because this number is written to the merchant's price list and they read it in the Shopify admin. Five prices that all round up push the implied figure to **-14.74%** for a campaign set up as "15% off".

`roundestWithin` takes the coarsest step (100, 50, 25, 10, 5, 1) that lands in range, then the nearest multiple to the implied value. `-15%` survives.

## Two edges the property test found

**The upper bound is exclusive.** A baseline of 6 with a target of 4 admits `-2500` unless the boundary is excluded — and `-2500` turns 6 into 4.5, which rounds to 5. One minor unit, on every product in a market. This is unreachable through a market fixture (the intersection usually excludes it, and `roundestWithin` prefers legible values over extremes), so `feasibleBps` is exported and tested directly.

**The band is floored at -100%.** Below that the arithmetic keeps working and stops meaning anything: `applyBps` reflects negative prices through zero, so `baseline=1, to=0` acquired a "feasible" band stretching to -150%. Found by fast-check, not by me.

## The downgrade scenario had encoded the bug

`downgrade.chaos.ts` asserted **five fixed prices** on a five-product market priced at one percentage — which is precisely the case the market-wide path exists for. The only reason five fixed prices appeared is that eligibility was failing to recognise it. The assertion made the broken behaviour a requirement.

Now it asks the path-agnostic question its title implies — is the market carrying our prices, and is it clean afterwards — plus a check the old version was missing: the price list is back on the merchant's **own** -10%, not left on the campaign's. A revert that cleared fixed prices but stranded a parent adjustment would have passed before.

## Tests

Five mutations each kill a test: widened upper bound, exclusive bound treated as inclusive, legibility preference removed, empty intersection not rejected, floor removed.

`market-wide.chaos.ts` passes under all seven seeds that have ever been used here, including all four that failed historically.

800 unit tests, 97 chaos scenarios green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
