### PR TITLE
Fix: a hand-set price on an adjusted market was invisible, and the campaign skipped it

### DIFF
--- a/app/services/campaigns/market-plan.server.ts
+++ b/app/services/campaigns/market-plan.server.ts
@@ -218,24 +218,45 @@ async function captureMarketBaselines(
 ): Promise<Map<string, Money>> {
   const found = new Map<string, Money>();
 
-  if (list.adjustmentBps === null) {
-    const entries = await prisma.priceSurfaceEntry.findMany({
-      where: {
-        shopId,
-        priceListGid: list.priceListGid,
-        variantGid: { in: variantGids },
-        livePrice: { not: null },
-      },
-      select: { variantGid: true, livePrice: true, currency: true },
-    });
+  // Hand-set prices first, whether or not the list also carries a rule.
+  //
+  // This used to be an either/or on `adjustmentBps`, and a list can be both: Shopify lets
+  // a fixed price shadow the parent adjustment for one variant, which is how a merchant
+  // says "10% off Japan, except this one product at ¥1,200". Asking only for derived
+  // prices on such a list gets nothing back for the overridden variants — the query is
+  // `originType: RELATIVE` and their origin is FIXED — so the campaign concluded they were
+  // not priced on that market and left them alone. The merchant's "20% off in Japan" then
+  // skipped exactly the products they had cared enough about to price by hand.
+  const entries = await prisma.priceSurfaceEntry.findMany({
+    where: {
+      shopId,
+      priceListGid: list.priceListGid,
+      variantGid: { in: variantGids },
+      livePrice: { not: null },
+    },
+    select: { variantGid: true, livePrice: true, currency: true },
+  });
 
-    for (const entry of entries) {
-      found.set(entry.variantGid, money(Number(entry.livePrice), entry.currency || list.currency));
-    }
-  } else {
-    const derived = await readDerivedPrices(client, list.priceListGid, variantGids);
-    for (const [variantGid, amount] of derived) {
-      found.set(variantGid, parseMoney(amount, list.currency));
+  for (const entry of entries) {
+    found.set(entry.variantGid, money(Number(entry.livePrice), entry.currency || list.currency));
+  }
+
+  if (list.adjustmentBps !== null) {
+    // Everything the rule still governs.
+    //
+    // Narrowing to the variants without an override saves round trips and nothing else:
+    // Shopify does not return a relative price for an overridden variant in the first
+    // place — its origin is FIXED — so asking for all of them would produce the same
+    // answers more slowly. Deliberately not relied on for correctness, because a filter
+    // that silently became the only thing preventing an override being overwritten would
+    // be a bad thing to depend on.
+    const remaining = variantGids.filter((gid) => !found.has(gid));
+
+    if (remaining.length > 0) {
+      const derived = await readDerivedPrices(client, list.priceListGid, remaining);
+      for (const [variantGid, amount] of derived) {
+        found.set(variantGid, parseMoney(amount, list.currency));
+      }
     }
   }
 

--- a/app/services/markets-sync.server.ts
+++ b/app/services/markets-sync.server.ts
@@ -201,10 +201,26 @@ export async function syncMarkets(
       // Derived. The rule is the mirror; expanding it would restate one percentage
       // once per variant per market.
       result.relative++;
-      continue;
+    } else {
+      result.fixed++;
     }
 
-    result.fixed++;
+    // Overrides are mirrored either way, and this used to `continue` past them.
+    //
+    // A list can carry a parent adjustment *and* per-variant fixed prices — Shopify lets a
+    // fixed price shadow the parent for one variant, which is how a merchant says "10% off
+    // Japan, except this one product at ¥1,200". Skipping those left the mirror asserting
+    // that every variant on the list sat at the rule, when three of them did not.
+    //
+    // It hid because the two reads that could have caught it both look past it.
+    // `readDerivedPrices` asks `originType: RELATIVE`, so an overridden variant simply
+    // does not come back — the campaign then treats it as unpriced on that market and
+    // silently leaves it alone, which is the opposite of what the merchant asked for.
+    //
+    // Not a cost concern: `mirrorFixedPrices` already stores only `FIXED` rows, so a
+    // derived list with no overrides still writes nothing. The comment at the top of this
+    // file is the justification — those are the entries carrying information the rule does
+    // not already have.
     try {
       result.entries += await mirrorFixedPrices(client, shopId, list, surfaceKind);
     } catch (error) {

--- a/chaos/scenarios/market-write.chaos.ts
+++ b/chaos/scenarios/market-write.chaos.ts
@@ -189,4 +189,84 @@ describe("chaos: writing campaign prices to markets", () => {
       },
     );
   });
+
+  it("prices a variant the merchant had hand-set on an adjusted market", async () => {
+    /**
+     * The case where a market list carries a rule *and* a hand-set price for one variant.
+     * Shopify allows it — a fixed price shadows the parent adjustment — and it is how a
+     * merchant says "10% off Japan, except this one product at ¥1,200".
+     *
+     * The campaign used to skip that variant entirely. Baselines for an adjusted list came
+     * only from `readDerivedPrices`, which asks `originType: RELATIVE`; an overridden
+     * variant has origin FIXED, so Shopify returned nothing for it and the planner
+     * concluded it was not priced on that market at all. A merchant's "20% off in Japan"
+     * therefore skipped precisely the products they had cared enough to price by hand —
+     * and the run reported them as unpriced there rather than as missed.
+     *
+     * Asserted as "was it priced, and from the right baseline", because pricing it from
+     * the *derived* number would be worse than skipping it: that is a discount off a
+     * price the merchant had explicitly overridden.
+     */
+    await withChaos(
+      "market-override-priced",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+        const overridden = variantGids[0];
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/jp",
+          name: "Japan",
+          currency: "JPY",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/jp", title: "JP", __typename: "MarketCatalog" },
+          prices: [
+            {
+              variantGid: overridden,
+              // Whole yen: JPY has no decimal places.
+              amount: "1200",
+              compareAt: null,
+              originType: "FIXED" as const,
+            },
+          ],
+        });
+
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: ["gid://shopify/PriceList/jp"] } as never },
+        });
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // The baseline is the merchant's own ¥1,200, not whatever the rule would have
+        // derived. This is the assertion that matters: a baseline taken from the rule
+        // would discount a price the merchant had deliberately overridden.
+        const baseline = await prisma.baseline.findFirstOrThrow({
+          where: {
+            shopId,
+            variantGid: overridden,
+            surfaceKind: "MARKET",
+            priceListGid: "gid://shopify/PriceList/jp",
+            supersededAt: null,
+          },
+        });
+        expect(baseline.basePrice).toBe(1_200n);
+        expect(baseline.currency).toBe("JPY");
+
+        // And it was actually repriced rather than quietly passed over — 20% off ¥1,200.
+        const jp = chaos.fake.fixedPricesOn("gid://shopify/PriceList/jp");
+        expect(jp.has(overridden), "the hand-set variant was skipped").toBe(true);
+        expect(jp.get(overridden)!.amount).toBe("960");
+
+        // The variants the rule still governs were priced too, so preferring overrides
+        // did not cost the ordinary path.
+        expect(jp.size).toBe(variantGids.length);
+      },
+    );
+  });
 });

--- a/chaos/scenarios/markets-mirror.chaos.ts
+++ b/chaos/scenarios/markets-mirror.chaos.ts
@@ -166,4 +166,70 @@ describe("chaos: mirroring market and B2B price lists", () => {
       },
     );
   });
+
+  it("mirrors a hand-set override on a list that also has a rule", async () => {
+    /**
+     * A list can be both, and this scenario is the case the file's opening argument
+     * misses. Shopify lets a fixed price shadow the parent adjustment for one variant —
+     * how a merchant says "10% off Japan, except this one product at ¥1,200" — and the
+     * sync used to skip straight past those the moment a list had an adjustment.
+     *
+     * What made it costly is that the two reads which could have caught it both look the
+     * other way. `readDerivedPrices` asks `originType: RELATIVE`, so an overridden variant
+     * does not come back at all; the campaign concluded it was not priced on that market
+     * and left it alone. A merchant's "20% off in Japan" then skipped exactly the products
+     * they had cared enough about to price by hand.
+     *
+     * The absence assertion this file was built on still holds — the rule is not expanded
+     * — so both are asserted together, because the fix is only correct if it adds the
+     * overrides *without* expanding the rule.
+     */
+    await withChaos(
+      "markets-mirror-override",
+      { catalog: { products: 4, variantsPerProduct: 2 }, percent: -10 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        const overridden = variantGids[0];
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/jp",
+          name: "Japan",
+          currency: "JPY",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/jp", title: "Japan", __typename: "MarketCatalog" },
+          prices: variantGids.map((gid) => ({
+            variantGid: gid,
+            // Whole yen, because JPY has no decimal places — a compare-at of 1800 against
+            // a price of 1200 is the per-market strike-through the product exists for.
+            amount: gid === overridden ? "1200" : "1.00",
+            compareAt: gid === overridden ? "1800" : null,
+            originType: gid === overridden ? ("FIXED" as const) : ("RELATIVE" as const),
+          })),
+        });
+
+        const result = await syncMarkets(client, shopId);
+        expect(result.errors).toEqual([]);
+
+        const mirrored = await prisma.priceSurfaceEntry.findMany({
+          where: { shopId, priceListGid: "gid://shopify/PriceList/jp" },
+        });
+
+        // Exactly the hand-set one. Not zero, which is what the bug produced, and not one
+        // per variant, which is what expanding the rule would produce.
+        expect(mirrored).toHaveLength(1);
+        expect(mirrored[0].variantGid).toBe(overridden);
+        expect(mirrored[0].livePrice).toBe(1_200n);
+        expect(mirrored[0].liveCompareAt).toBe(1_800n);
+        expect(mirrored[0].currency).toBe("JPY");
+
+        // And the rule is still stored as a rule.
+        const list = await prisma.priceListRecord.findFirstOrThrow({
+          where: { shopId, priceListGid: "gid://shopify/PriceList/jp" },
+        });
+        expect(list.adjustmentBps).toBe(-1_000);
+      },
+    );
+  });
 });


### PR DESCRIPTION
Closes #53. Found by creating real EUR and JPY markets on the dev store — the app's market path had only ever run against the fake.

## A price list can be both a rule and a set of prices

Shopify lets a fixed price **shadow** the parent adjustment for one variant. That is how a merchant says *"10% off Japan, except this one product at ¥1,200."*

`syncMarkets` skipped straight past those the moment a list had an adjustment:

```ts
if (adjustmentBps !== null) {
  result.relative++;
  continue;          // ← never mirrors the overrides
}
```

So the mirror asserted every variant on the list sat at the rule, when some of them did not.

## Why nothing caught it

Both reads that could have noticed look the other way.

`readDerivedPrices` asks `originType: RELATIVE`, and an overridden variant's origin is `FIXED` — so Shopify returns **nothing at all** for it. Verified against the real store:

```
45725716971754 base 94995 -> derived MISSING     ← hand-set to ¥1,200
45725717004522 base 88595 -> derived MISSING     ← hand-set to ¥1,300
45725717037290 base 262995 -> derived MISSING    ← hand-set to ¥1,400
45725717070058 base 88595 -> derived "797.36"
45725717102826 base 800   -> derived "7.2"
```

The planner then took "no derived price" to mean "not priced on this market" and left the variant alone — so a merchant's *"20% off in Japan"* skipped **precisely the products they had cared enough about to price by hand**, and the run reported them as unpriced there rather than as missed.

## The fix

**Mirror overrides regardless of the rule.** `mirrorFixedPrices` already stores only `FIXED` rows, so a derived list with no overrides still writes nothing — the scale argument this file was built on is untouched. These are exactly the entries the file's own opening comment calls "information the rule does not already have".

**Prefer a hand-set price over a derived one when capturing baselines.** Pricing an overridden variant from the derived number would be worse than skipping it — that is a discount off a price the merchant explicitly overrode.

## What did not need fixing

`hasFixedOverrides`, the guard that stops a market-wide parent adjustment being used when overrides exist, reads **live from Shopify** rather than from the mirror. So the dangerous path — repricing a whole market while overridden variants silently keep their old price — was never exposed by this bug. That was already the right call and it stays.

`parseMoney` also behaves correctly: it accepts `"1200.0"` as ¥1,200 and refuses genuinely fractional yen rather than rounding it away.

## Verified on the store

```
syncMarkets: {"priceLists":5,"relative":5,"fixed":0,"entries":3}
  45725716971754  live 1200 compareAt 1800 JPY
  45725717004522  live 1300 compareAt 1900 JPY
  45725717037290  live 1400 compareAt 2000 JPY
```

Whole yen, compare-at preserved — **per-market strike-through in a zero-decimal currency, against the real Admin API**. That is the product's commercial wedge, and until now it had only been proven against the fake.

## Tests

Two scenarios, three mutations that kill them:

- restoring the `continue` → the mirror scenario fails
- mirroring every row instead of only `FIXED` → all three fail (the rule gets expanded)
- restoring the planner's either/or branch → the overridden variant has no baseline and is skipped

A fourth mutation — removing the `remaining` filter — deliberately **survives**, and the comment says so: it saves round trips, it is not a correctness guard, because Shopify never returns a relative price for an overridden variant anyway.

800 unit tests, 99 chaos scenarios green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
