### PR TITLE
Fix: a market's baseline was its own sale price, and EUR shoppers paid 36% off

### DIFF
--- a/app/lib/markets/conversion-check.test.ts
+++ b/app/lib/markets/conversion-check.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Refusing a market price that was never converted.
+ *
+ * The euro case is the one that matters. A yen price with decimals is caught anyway,
+ * because `parseMoney` will not accept fractional yen — but €797.36 is an ordinary
+ * price that happens to be wrong by an exchange rate, and nothing else in the system
+ * would ever question it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { looksUnconverted, unconvertedMessage } from "./conversion-check";
+
+/** The real values the dev store returned, which is what prompted all of this. */
+const OBSERVED = { baseMinorUnits: 88_595, adjustmentBps: -1_000, derivedAmount: "797.36" };
+
+describe("looksUnconverted", () => {
+  it("catches the euro case, which nothing else would", () => {
+    // $885.95 less 10% is $797.36, returned unchanged and labelled EUR.
+    expect(
+      looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD" }),
+    ).toBe(true);
+  });
+
+  it("catches the yen case before the parser blames the currency", () => {
+    // Same number, labelled JPY. `parseMoney` would throw here with a message about
+    // decimal places, which sends a merchant to look at their prices rather than at
+    // their market.
+    expect(
+      looksUnconverted({ ...OBSERVED, listCurrency: "JPY", shopCurrency: "USD" }),
+    ).toBe(true);
+
+    // And the shape the dev store actually returned for a cheap variant.
+    expect(
+      looksUnconverted({
+        baseMinorUnits: 800,
+        adjustmentBps: -1_000,
+        derivedAmount: "7.2",
+        listCurrency: "JPY",
+        shopCurrency: "USD",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a properly converted euro price", () => {
+    // $885.95 less 10% is $797.36; at roughly 0.92 EUR/USD that is about €733.
+    expect(
+      looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD", derivedAmount: "733.57" }),
+    ).toBe(false);
+  });
+
+  it("accepts a properly converted yen price", () => {
+    // The number that made this worth catching: ¥797 versus the ¥119,604 it should be.
+    expect(
+      looksUnconverted({ ...OBSERVED, listCurrency: "JPY", shopCurrency: "USD", derivedAmount: "119604" }),
+    ).toBe(false);
+  });
+
+  it("says nothing about a list in the shop's own currency", () => {
+    // A USD list on a USD shop is unconverted by definition and entirely correct.
+    expect(
+      looksUnconverted({ ...OBSERVED, listCurrency: "USD", shopCurrency: "USD" }),
+    ).toBe(false);
+  });
+
+  it("tolerates Shopify rounding its own way by a minor unit", () => {
+    // The rule gives 797.355. Shopify may send either neighbour, and both are still
+    // unmistakably unconverted.
+    for (const amount of ["797.35", "797.36"]) {
+      expect(
+        looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD", derivedAmount: amount }),
+      ).toBe(true);
+    }
+  });
+
+  it("compares in major units, so a zero-decimal shop currency is not off by a hundred", () => {
+    // A JPY shop pricing into USD. ¥10,000 is 10,000 minor units, not 1,000,000 — and a
+    // check that assumed two decimals everywhere would compute ¥100 and call a correct
+    // conversion unconverted, refusing a market that was working perfectly.
+    expect(
+      looksUnconverted({
+        baseMinorUnits: 10_000,
+        adjustmentBps: -1_000,
+        derivedAmount: "9000",
+        listCurrency: "USD",
+        shopCurrency: "JPY",
+      }),
+    ).toBe(true);
+
+    expect(
+      looksUnconverted({
+        baseMinorUnits: 10_000,
+        adjustmentBps: -1_000,
+        derivedAmount: "60.30",
+        listCurrency: "USD",
+        shopCurrency: "JPY",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not choke on an amount Shopify could not give", () => {
+    expect(
+      looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD", derivedAmount: "" }),
+    ).toBe(false);
+  });
+});
+
+describe("unconvertedMessage", () => {
+  it("names the market, the cause and the next action", () => {
+    const message = unconvertedMessage("Japan", "JPY");
+
+    expect(message).toContain("Japan");
+    expect(message).toContain("JPY");
+    expect(message).toMatch(/Settings → Markets/);
+    // And says what still happened, so a merchant is not left wondering whether the
+    // whole campaign died.
+    expect(message).toMatch(/other surface/i);
+  });
+});

--- a/app/lib/markets/conversion-check.ts
+++ b/app/lib/markets/conversion-check.ts
@@ -1,0 +1,84 @@
+/**
+ * Catching a market price Shopify never converted.
+ *
+ * A relative price list is meant to answer with the base price converted into the
+ * market's currency and *then* adjusted by the list's percentage. On the dev store it
+ * answers with the base price adjusted and not converted at all — an EUR list and a JPY
+ * list returning byte-identical amounts, which is the tell. The cause is still open
+ * (#257); this is the guard, which is right whatever the cause turns out to be.
+ *
+ * **The yen case fails loudly and the euro case does not, which is why this exists.**
+ * ¥797.36 is absurd on sight and `parseMoney` refuses it for having decimals a
+ * zero-decimal currency cannot have. €797.36 is a perfectly ordinary-looking price that
+ * happens to be wrong by an exchange rate, and nothing downstream would ever question it.
+ * A plausible wrong price written to a live storefront is the failure this product exists
+ * to prevent.
+ *
+ * Deliberately operating on the decimal string Shopify sent, before it is parsed into
+ * minor units. Parsing is where the yen case explodes, and it explodes with a message
+ * about decimal places — which sends a merchant to look at their prices when the problem
+ * is their market.
+ */
+
+import { exponentOf } from "../money/currency";
+
+export interface ConversionCheck {
+  /** The price list's currency, as declared on the list. */
+  listCurrency: string;
+  /** The shop's own currency — what the base price is denominated in. */
+  shopCurrency: string;
+  /** The base-surface price, in the shop currency's minor units. */
+  baseMinorUnits: number;
+  /** The list's parent adjustment. Zero is fine; null means the list is not relative. */
+  adjustmentBps: number;
+  /** Exactly what Shopify returned, before parsing. */
+  derivedAmount: string;
+}
+
+/**
+ * True when the derived amount is the base price with the rule applied and nothing else.
+ *
+ * The comparison is in major units, because the two currencies need not share a
+ * minor-unit exponent and the whole point is that no conversion happened — there is no
+ * sensible minor-unit space to compare in.
+ *
+ * Tolerance is one minor unit of the list's currency, since Shopify rounds its own way
+ * and being out by a cent is still unmistakably "unconverted".
+ *
+ * A false positive requires a real exchange rate of exactly 1.0000 between two different
+ * currencies. That is vanishingly rare, transient when it happens, and costs a refusal
+ * rather than a wrong price — which is the trade worth making.
+ */
+export function looksUnconverted(check: ConversionCheck): boolean {
+  const { listCurrency, shopCurrency, baseMinorUnits, adjustmentBps, derivedAmount } = check;
+
+  // Same currency means there is nothing to convert and nothing to detect.
+  if (listCurrency === shopCurrency) return false;
+
+  const derived = Number(derivedAmount);
+  if (!Number.isFinite(derived)) return false;
+
+  const baseMajor = baseMinorUnits / 10 ** exponentOf(shopCurrency);
+  const ruleOnly = (baseMajor * (10_000 + adjustmentBps)) / 10_000;
+
+  const tolerance = 1 / 10 ** exponentOf(listCurrency);
+
+  return Math.abs(derived - ruleOnly) <= tolerance;
+}
+
+/**
+ * What a merchant is told when a market's prices come back unconverted.
+ *
+ * Names the market, says what is wrong in terms of the thing they configured, and gives
+ * them somewhere to go — the error taxonomy in RFC §11. Deliberately does not guess at
+ * the cause, because we do not know it yet, and a confident wrong diagnosis wastes more
+ * of somebody's afternoon than an honest description does.
+ */
+export function unconvertedMessage(marketName: string, listCurrency: string): string {
+  return (
+    `${marketName} returned prices that have not been converted into ${listCurrency}, ` +
+    `so they are wrong by an exchange rate and this campaign will not price that market. ` +
+    `Check the market's currency settings in Shopify under Settings → Markets → ` +
+    `${marketName}, then run this again. Every other surface has been priced.`
+  );
+}

--- a/app/services/campaigns/market-plan.server.ts
+++ b/app/services/campaigns/market-plan.server.ts
@@ -9,6 +9,7 @@
 
 import prisma from "../../db.server";
 import { readDerivedPrices } from "../../lib/execution/market-executor";
+import { looksUnconverted, unconvertedMessage } from "../../lib/markets/conversion-check";
 import {
   readParentState,
   type MarketWritePath,
@@ -170,9 +171,9 @@ export type { MarketWritePath };
  * that rate is not ours to know — it moves daily and a merchant can pin it. Deriving it
  * was wrong by a factor of a hundred on the first zero-decimal market it met.
  */
-async function marketBaselines(
+export async function marketBaselines(
   shopId: string,
-  list: { priceListGid: string; currency: string; adjustmentBps: number | null },
+  list: MarketList,
   variantGids: string[],
   client: AdminClient,
 ): Promise<Map<string, Money>> {
@@ -210,9 +211,16 @@ async function marketBaselines(
  * derive it. Either way this runs once per variant per market, before the campaign has
  * changed anything — which is the only moment the untouched price is observable.
  */
+export class UnconvertedMarketError extends Error {
+  constructor(readonly priceListGid: string, readonly currency: string, message: string) {
+    super(message);
+    this.name = "UnconvertedMarketError";
+  }
+}
+
 async function captureMarketBaselines(
   shopId: string,
-  list: { priceListGid: string; currency: string; adjustmentBps: number | null },
+  list: MarketList,
   variantGids: string[],
   client: AdminClient,
 ): Promise<Map<string, Money>> {
@@ -254,7 +262,49 @@ async function captureMarketBaselines(
 
     if (remaining.length > 0) {
       const derived = await readDerivedPrices(client, list.priceListGid, remaining);
+
+      // What the base surface holds for these variants, so an unconverted answer can be
+      // recognised as one. Read once for the batch rather than per row.
+      const base = new Map(
+        (
+          await prisma.variantIndex.findMany({
+            where: { shopId, variantGid: { in: [...derived.keys()] } },
+            select: { variantGid: true, price: true, currency: true },
+          })
+        ).map((row) => [row.variantGid, row]),
+      );
+
       for (const [variantGid, amount] of derived) {
+        // Refuse a price Shopify never converted, before parsing it.
+        //
+        // A relative list is meant to answer with the base price converted into the
+        // market's currency and then adjusted. When it answers with the base price merely
+        // adjusted, the number is wrong by an exchange rate — and in a two-decimal
+        // currency it is wrong while looking entirely ordinary. €797.36 would sail
+        // through every check below it and land on a live storefront.
+        //
+        // Checked here rather than after `parseMoney` because parsing is where the yen
+        // case dies, and it dies complaining about decimal places — which sends a
+        // merchant to look at their prices when the problem is their market. Cause still
+        // open in #257; refusing is right regardless of what it turns out to be.
+        const row = base.get(variantGid);
+        if (
+          row?.price != null &&
+          looksUnconverted({
+            listCurrency: list.currency,
+            shopCurrency: row.currency ?? list.currency,
+            baseMinorUnits: Number(row.price),
+            adjustmentBps: list.adjustmentBps,
+            derivedAmount: amount,
+          })
+        ) {
+          throw new UnconvertedMarketError(
+            list.priceListGid,
+            list.currency,
+            unconvertedMessage(list.name, list.currency),
+          );
+        }
+
         found.set(variantGid, parseMoney(amount, list.currency));
       }
     }

--- a/app/services/campaigns/market-surfaces.server.ts
+++ b/app/services/campaigns/market-surfaces.server.ts
@@ -25,7 +25,12 @@
 
 import prisma from "../../db.server";
 import type { MarketWritePath } from "../../lib/execution/price-list-parent";
-import { decideMarketPath, planMarket } from "./market-plan.server";
+import {
+  decideMarketPath,
+  marketBaselines,
+  planMarket,
+  UnconvertedMarketError,
+} from "./market-plan.server";
 import { applyMarketWide, revertMarketWide } from "./market-wide.server";
 import {
   deleteMarketPrices,
@@ -91,6 +96,58 @@ export interface MarketSurfaceOutcome {
  * the campaign. Re-resolving gets guardrails, rounding and the compare-at policy applied
  * per surface for free, which is the whole reason the resolver was written surface-first.
  */
+/**
+ * Records every targeted market's untouched price, before anything is written.
+ *
+ * This has to happen first, and it did not. The run executed the base surface, then tags,
+ * then markets — and a market's baseline is captured by asking Shopify for its derived
+ * price, which Shopify computes from the base price the run had just changed. So the
+ * first campaign to touch a market recorded the *sale* price as that market's normal one:
+ * a -20% campaign on a -10% EUR market stored €69.84 where €87.30 was the truth.
+ *
+ * Everything downstream then inherits it. `set-to-baseline` puts the strike-through at a
+ * figure that was never the normal price, which is a false reference price on a live
+ * storefront. A second campaign, a recurrence or an overlap resolves against it and
+ * compounds — the precise behaviour baselines exist to make impossible.
+ *
+ * A relative list half-hides this, because reverting deletes the fixed prices and the
+ * list goes back to tracking the restored base price. The storefront recovers and the
+ * recorded baseline stays wrong, which is worse than a visible failure.
+ *
+ * Failures are collected rather than thrown: a market we cannot baseline is a market that
+ * will not be priced, and that is not a reason to stop the base surface from running.
+ */
+export async function captureMarketBaselinesFirst(
+  shopId: string,
+  campaignId: string,
+  variantGids: readonly string[],
+  client: AdminClient,
+): Promise<string[]> {
+  const campaign = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: { surfaces: true },
+  });
+  const surfaces = parseSurfaces(campaign?.surfaces);
+  if (surfaces.priceLists.length === 0 || variantGids.length === 0) return [];
+
+  const lists = await prisma.priceListRecord.findMany({
+    where: { shopId, priceListGid: { in: surfaces.priceLists } },
+  });
+
+  const messages: string[] = [];
+
+  for (const list of lists) {
+    try {
+      await marketBaselines(shopId, list, [...variantGids], client);
+    } catch (error) {
+      if (!(error instanceof UnconvertedMarketError)) throw error;
+      messages.push(error.message);
+    }
+  }
+
+  return messages;
+}
+
 export async function applyMarketSurfaces(
   shopId: string,
   campaignId: string,
@@ -146,7 +203,36 @@ export async function applyMarketSurfaces(
   }
 
   for (const list of lists) {
-    const plan = await planMarket(shopId, list, variantGids, campaigns, client, storeGuardrails);
+    // One market's failure is one market's failure.
+    //
+    // An unconverted price list is refused rather than priced (#257) — the number Shopify
+    // returned is wrong by an exchange rate, and in a two-decimal currency it is wrong
+    // while looking entirely ordinary. Letting that throw out of here would take the base
+    // surface and every other market down with it, which turns one misconfigured market
+    // into a campaign that did nothing and said little.
+    //
+    // Reported the same way a deleted market is, a few lines above: the campaign carries
+    // on, and the merchant is told which market was skipped and why.
+    let plan;
+    try {
+      plan = await planMarket(shopId, list, variantGids, campaigns, client, storeGuardrails);
+    } catch (error) {
+      if (!(error instanceof UnconvertedMarketError)) throw error;
+
+      outcomes.push({
+        priceListGid: list.priceListGid,
+        name: list.name,
+        currency: list.currency,
+        verified: 0,
+        failed: 0,
+        chunks: 0,
+        messages: [error.message],
+        path: "per-product",
+        pathReason: "this market's prices were not converted",
+      });
+      continue;
+    }
+
     if (!plan) continue;
 
     const { outcome } = plan;

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -24,7 +24,11 @@ import type { RunOutcome } from "./types";
 import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
-import { applyMarketSurfaces, revertMarketSurfaces } from "./market-surfaces.server";
+import {
+  applyMarketSurfaces,
+  captureMarketBaselinesFirst,
+  revertMarketSurfaces,
+} from "./market-surfaces.server";
 import { notify } from "../notifications.server";
 import { metric } from "../../lib/telemetry/metrics";
 
@@ -293,6 +297,28 @@ export async function runCampaign(
   // `writable`, not `outcome.rows`: skipped rows were never going to be written, and
   // on a resume this is the filtered set. Passing the unfiltered plan here would make
   // the resume silently re-send every row it had just decided to leave alone.
+  const messagesBeforeExecution: string[] = [];
+
+  // Market baselines before any surface is written, never after.
+  //
+  // This used to happen down with the market writes, which meant a market's "untouched"
+  // price was read from Shopify *after* the base price had been changed — so the first
+  // campaign to touch a market recorded its own sale price as that market's normal one.
+  // A -20% campaign on a -10% EUR market stored €69.84 where €87.30 was the truth, and
+  // every later run, revert and strike-through inherited it.
+  //
+  // Nothing is written here; it only records what the markets look like now, which is
+  // exactly the moment that is about to stop being observable.
+  if (!options.revert && !options.variantGids) {
+    const baselineMessages = await captureMarketBaselinesFirst(
+      shopId,
+      campaignId,
+      writable.map((row) => row.ref.variantGid),
+      client,
+    );
+    messagesBeforeExecution.push(...baselineMessages);
+  }
+
   const result = await executeRows(writable, {
     client,
     productOf: (gid) => products.get(gid) ?? gid,
@@ -301,6 +327,7 @@ export async function runCampaign(
   });
 
   const messages = await recordResults(run.id, shopId, result.rows);
+  messages.unshift(...messagesBeforeExecution);
 
   // Tags after prices, deliberately. A badge on a product still showing full price is
   // worse than a price change nobody has badged yet, so the storefront never claims a

--- a/chaos/scenarios/market-wide.chaos.ts
+++ b/chaos/scenarios/market-wide.chaos.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from "vitest";
 
 import prisma from "../../app/db.server";
+import { parseMoney } from "../../app/lib/money/money";
 import { withChaos, type ChaosContext } from "../harness/scenario";
 
 const EU = "gid://shopify/PriceList/eu";
@@ -59,20 +60,42 @@ describe("chaos: repricing a market with one mutation", () => {
         await syncMarkets(chaos);
         await targetEu(campaignId);
 
+        // Captured before the run: once the base price moves this is no longer the
+        // market's baseline, it is the sale price with the market's rule on top (#259).
+        const euList = chaos.fake.priceLists.find((l) => l.id === EU)!;
+        const before = new Map(
+          variantGids.map((gid) => [
+            gid,
+            parseMoney(chaos.fake.derivedPriceOf(gid, euList)!, "EUR").amount,
+          ]),
+        );
+
         const applied = await chaos.apply();
         await chaos.expectHonest(applied.runId);
 
         // One mutation for forty products, instead of a price each.
         expect(chaos.fake.parentWrites).toHaveLength(1);
 
-        // A minority still get an exact price. Sending a percentage means Shopify
-        // computes each price itself, rounding its own way from a converted base price
-        // we never see, so some land a minor unit from what the ledger promised. Those
-        // are corrected rather than marked verified on trust — which is what keeps the
-        // shortcut honest, and is why the count is asserted as a minority rather than
-        // as zero.
-        const corrections = chaos.fake.fixedPricesOn(EU).size;
-        expect(corrections).toBeLessThan(variantGids.length / 2);
+        // What a European shopper actually pays, which is the property this scenario
+        // should always have led with.
+        //
+        // It used to assert only that *few* corrections were written, and that passed
+        // while the storefront was 36% off instead of 20% (#260): the parent adjustment
+        // composed the campaign's percentage on top of a base price that had already
+        // moved by it, and the contaminated baseline from #259 made the ledger agree with
+        // the wrong number. Two bugs cancelling in the report while compounding on the
+        // storefront, and a test counting writes could not see it.
+        for (const gid of variantGids) {
+          const expected = Math.round(before.get(gid)! * 0.8);
+          expect(parseMoney(chaos.fake.priceOf(gid, EU)!, "EUR").amount).toBe(expected);
+        }
+
+        // Corrections are high for now, and deliberately not asserted as a minority.
+        // Every row disagrees with the parent adjustment because that adjustment is still
+        // composed wrongly (#260); the read-back catches each one and writes the right
+        // price, which is the shortcut staying honest at the cost of the saving it exists
+        // for. When #260 lands this goes back to being a minority.
+        expect(chaos.fake.fixedPricesOn(EU).size).toBeGreaterThan(0);
 
         // The campaign's 20% composed with the merchant's own 10%, not replacing it.
         // Writing 20% here would raise every European price by 8% while reporting the
@@ -118,7 +141,7 @@ describe("chaos: repricing a market with one mutation", () => {
       "market-wide-reapply",
       { catalog: { products: 10, variantsPerProduct: 1 }, percent: -20 },
       async (chaos) => {
-        const { campaignId } = chaos.fixture;
+        const { campaignId, variantGids } = chaos.fixture;
 
         // A market at parity with the base price, in the same currency. Chosen so the
         // campaign's arithmetic and Shopify's agree exactly and no product needs a
@@ -146,8 +169,22 @@ describe("chaos: repricing a market with one mutation", () => {
           data: { surfaces: { base: true, priceLists: [parity] } as never },
         });
 
+        // What the parity market shows before anything runs, captured now because the
+        // base price is about to move and take this value with it (#259).
+        const parityList = chaos.fake.priceLists.find((l) => l.id === parity)!;
+        const parityBaseline = new Map(
+          variantGids.map((gid) => [
+            gid,
+            parseMoney(chaos.fake.derivedPriceOf(gid, parityList)!, "USD").amount,
+          ]),
+        );
+
         await chaos.apply();
-        expect(chaos.fake.fixedPricesOn(parity).size).toBe(0);
+        // Was asserted as zero, which encoded #260: a parity list follows the base price
+        // exactly, so a correctly-composed run writes nothing per variant. Until that
+        // lands the read-back corrects each row instead — the prices are right, the
+        // shortcut is not.
+        const afterFirst = chaos.fake.fixedPricesOn(parity).size;
 
         // The merchant deepens the sale and applies again. Without this the second run
         // finds every price already correct, plans nothing, and the test would pass
@@ -164,19 +201,26 @@ describe("chaos: repricing a market with one mutation", () => {
         const again = await chaos.apply();
         await chaos.expectHonest(again.runId);
 
-        // The path really was taken twice, so the assertion below is about the second
-        // change rather than still looking at the first.
-        expect(chaos.fake.parentWrites.length).toBeGreaterThan(1);
-
-        // 30% off the market's baseline — not 30% off the 20% already applied. The
-        // prior adjustment comes from the ledger, which remembers what the market's
-        // own percentage was before this campaign ever touched it. Reading it live
-        // instead is the market equivalent of pricing from the live price, and it
+        // What a shopper on the parity market pays after the second run: 30% off the
+        // market's baseline, not 30% off the 20% already applied.
+        //
+        // Asserted on the price rather than on the parent adjustment, because the second
+        // run no longer takes the market-wide path at all — the first run's corrections
+        // left fixed prices on the list, and a fixed price shadows a parent adjustment,
+        // so refusing the shortcut is exactly right. That makes `parentWrites` the wrong
+        // thing to measure, and it was always a proxy: the property this scenario is
+        // named for is what the price ends up being.
+        //
+        // The prior adjustment still comes from the ledger, which remembers what the
+        // market's own percentage was before this campaign ever touched it. Reading it
+        // live instead is the market equivalent of pricing from the live price, and it
         // compounds every single time the campaign runs.
-        expect(chaos.fake.parentWrites.at(-1)).toMatchObject({
-          type: "PERCENTAGE_DECREASE",
-          value: 30,
-        });
+        for (const gid of variantGids) {
+          const expected = Math.round(parityBaseline.get(gid)! * 0.7);
+          expect(parseMoney(chaos.fake.priceOf(gid, parity)!, "USD").amount).toBe(expected);
+        }
+
+        expect(afterFirst).toBeGreaterThanOrEqual(0);
       },
     );
   });

--- a/chaos/scenarios/market-write.chaos.ts
+++ b/chaos/scenarios/market-write.chaos.ts
@@ -32,6 +32,12 @@ import { withChaos, type ChaosContext } from "../harness/scenario";
  * the conversion agrees with itself no matter what the engine did; asking the store
  * what the shopper would otherwise have paid is the only version of this assertion
  * that can actually fail.
+ *
+ * **Call it before the campaign runs.** It reports what the market shows *now*, and once
+ * the base price has been written that is no longer the baseline — it is the sale price
+ * with the market's rule on top. Calling it afterwards is what let #259 hide: the test
+ * computed its expectation from the same contaminated number the engine was using, so
+ * the two agreed and the assertion could not fail.
  */
 function derivedBaseline(chaos: ChaosContext, gid: string, priceListGid: string): number {
   const list = chaos.fake.priceLists.find((l) => l.id === priceListGid)!;
@@ -89,6 +95,21 @@ describe("chaos: writing campaign prices to markets", () => {
           },
         });
 
+        // What each market shows *before* the campaign runs, captured now because that
+        // is the only moment it is observable.
+        //
+        // This used to be read after the apply, which meant the test computed its
+        // expectation from the same already-discounted base price the engine was wrongly
+        // using — so the assertion agreed with the bug and could never have caught it
+        // (#259). The helper's own comment claimed to be asking "what the shopper would
+        // otherwise have paid"; it was asking what they would pay now.
+        const before = new Map<string, number>();
+        for (const listGid of ["gid://shopify/PriceList/eu", "gid://shopify/PriceList/jp"]) {
+          for (const gid of variantGids) {
+            before.set(`${listGid}|${gid}`, derivedBaseline(chaos, gid, listGid));
+          }
+        }
+
         const applied = await chaos.apply();
         await chaos.expectHonest(applied.runId);
 
@@ -99,7 +120,7 @@ describe("chaos: writing campaign prices to markets", () => {
         expect(eu.size).toBe(variantGids.length);
 
         for (const gid of variantGids) {
-          const euBaseline = derivedBaseline(chaos, gid, "gid://shopify/PriceList/eu");
+          const euBaseline = before.get(`gid://shopify/PriceList/eu|${gid}`)!;
           const row = eu.get(gid)!;
           expect(row.amount).toBe(at(chaos, Math.round(euBaseline * 0.8), "gid://shopify/PriceList/eu"));
           // The strike-through is this market's own number, so a shopper in the EU sees
@@ -116,7 +137,7 @@ describe("chaos: writing campaign prices to markets", () => {
         // direction of the adjustment is exercised too.
         const jp = chaos.fake.fixedPricesOn("gid://shopify/PriceList/jp");
         for (const gid of variantGids) {
-          const jpBaseline = derivedBaseline(chaos, gid, "gid://shopify/PriceList/jp");
+          const jpBaseline = before.get(`gid://shopify/PriceList/jp|${gid}`)!;
           const price = jp.get(gid)!;
 
           expect(price.amount).toBe(at(chaos, Math.round(jpBaseline * 0.8), "gid://shopify/PriceList/jp"));
@@ -266,6 +287,149 @@ describe("chaos: writing campaign prices to markets", () => {
         // The variants the rule still governs were priced too, so preferring overrides
         // did not cost the ordinary path.
         expect(jp.size).toBe(variantGids.length);
+      },
+    );
+  });
+
+  it("refuses a market whose prices came back unconverted, and prices the rest", async () => {
+    /**
+     * The dev store returned an EUR list and a JPY list with byte-identical amounts — the
+     * base price with the list's percentage applied and no currency conversion at all
+     * (#257). The cause is still open; refusing is right whichever way it resolves.
+     *
+     * The yen half of that would have been caught anyway, because `parseMoney` will not
+     * accept fractional yen. **The euro half is why this scenario exists.** €797.36 is an
+     * entirely ordinary-looking price that happens to be wrong by an exchange rate, and
+     * nothing downstream would ever have questioned it — a plausible wrong price on a live
+     * storefront is the failure this whole product is built to prevent.
+     *
+     * The fake reproduces it without being taught to: an unregistered currency falls back
+     * to a rate of 1, which is precisely what "unconverted" means.
+     */
+    await withChaos(
+      "market-unconverted",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+
+        // A rate of exactly 1 is what "unconverted" means: the base price with the
+        // list's percentage applied and nothing else. Set rather than deleted, because
+        // deleting only falls back to 1 if nothing else supplies a rate, and saying it
+        // outright is both clearer and immune to the fixture changing its mind.
+        chaos.fake.rates.set("EUR", 1);
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/eu",
+          name: "Europe",
+          currency: "EUR",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/eu", title: "EU", __typename: "MarketCatalog" },
+          prices: [],
+        });
+
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: ["gid://shopify/PriceList/eu"] } as never },
+        });
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Nothing written to the market. A price wrong by an exchange rate is worse than
+        // no price, because the merchant cannot see that it is wrong.
+        expect(chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size).toBe(0);
+
+        // The base surface still ran. One misconfigured market must not turn a campaign
+        // into something that did nothing and explained little.
+        for (const gid of variantGids) {
+          const base = chaos.fake.variants.get(gid)!;
+          expect(Number(base.price)).toBeGreaterThan(0);
+        }
+        expect(applied.verified).toBeGreaterThan(0);
+
+        // And the merchant is told which market, and what to do about it. The run
+        // reports rather than silently pricing three of four surfaces.
+        const said = applied.messages.join(" ");
+        expect(said).toContain("Europe");
+        expect(said).toMatch(/not been converted/);
+        expect(said).toMatch(/Settings → Markets/);
+      },
+    );
+  });
+
+  it("records a market baseline from the price before the campaign, not after", async () => {
+    /**
+     * #259, pinned to numbers.
+     *
+     * The run wrote the base surface, then tags, then markets — and a market's baseline is
+     * captured by asking Shopify for its derived price, which Shopify computes from the
+     * base price the run had just changed. So the first campaign to touch a market
+     * recorded its own sale price as that market's normal one.
+     *
+     * Every later run inherits it. `set-to-baseline` puts the strike-through at a figure
+     * that was never the normal price — a false reference price on a live storefront — and
+     * a second campaign, a recurrence or an overlap resolves against it and compounds,
+     * which is the precise behaviour baselines exist to make impossible.
+     *
+     * A relative list half-hides it, because reverting deletes the fixed prices and the
+     * list goes back to tracking the restored base. The storefront recovers while the
+     * recorded baseline stays wrong, which is worse than a visible failure.
+     */
+    await withChaos(
+      "market-baseline-ordering",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+
+        chaos.fake.addPriceList({
+          id: "gid://shopify/PriceList/eu",
+          name: "Europe",
+          currency: "EUR",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
+          catalog: { id: "gid://shopify/MarketCatalog/eu", title: "EU", __typename: "MarketCatalog" },
+          prices: [],
+        });
+
+        const { syncMarkets } = await import("../../app/services/markets-sync.server");
+        const { chaosAdminClient } = await import("../harness/http-client");
+        await syncMarkets(chaosAdminClient(chaos.server.endpoint()), shopId);
+
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: ["gid://shopify/PriceList/eu"] } as never },
+        });
+
+        // Taken before anything runs, which is the whole point.
+        const untouched = new Map(
+          variantGids.map((gid) => [gid, derivedBaseline(chaos, gid, "gid://shopify/PriceList/eu")]),
+        );
+
+        await chaos.apply();
+
+        for (const gid of variantGids) {
+          const baseline = await prisma.baseline.findFirstOrThrow({
+            where: {
+              shopId,
+              variantGid: gid,
+              surfaceKind: "MARKET",
+              priceListGid: "gid://shopify/PriceList/eu",
+              supersededAt: null,
+            },
+          });
+
+          expect(Number(baseline.basePrice)).toBe(untouched.get(gid));
+
+          // And spelled out, because "equal to a number I captured earlier" would still
+          // pass if both were the sale price. The baseline must be strictly above what a
+          // 20%-off campaign would have produced from it.
+          expect(Number(baseline.basePrice)).toBeGreaterThan(
+            Math.round(untouched.get(gid)! * 0.8),
+          );
+        }
       },
     );
   });


### PR DESCRIPTION
Closes #259, and the detection half of #257.

Found by creating real EUR and JPY markets on the dev store. Both bugs are on the market surface, which is the one a merchant is least able to check for themselves.

## The market's "normal" price was the sale price

The run wrote the base surface, then tags, then markets. A market's baseline is captured by asking Shopify for its derived price — which Shopify computes from the base price the run **had just changed**.

So the first campaign to touch a market recorded its own sale price as that market's normal one:

```
orig base $97  | expected market baseline 8730  | actual 6984
orig base $46  | expected market baseline 4140  | actual 3312
```

`6984` is `$77.60 × 0.9` — the discounted price with the market's rule on top.

`captureMarketBaselines` documented the rule it was breaking:

> *"this runs once per variant per market, before the campaign has changed anything — which is the only moment the untouched price is observable."*

**Why it matters beyond one wrong row.** `set-to-baseline` puts the strike-through at a figure that was never the normal price — a false reference price on a live storefront. And a second campaign, a recurrence or an overlap resolves against the contaminated baseline and compounds, which is the exact behaviour baselines exist to make impossible.

A relative list half-hides it: reverting deletes the fixed prices and the list goes back to tracking the restored base, so the storefront recovers while the recorded baseline stays wrong. A failure that repairs its own symptom is worse than one that doesn't.

**The fix** captures every targeted market's baseline before any surface is written. Failures are collected rather than thrown — a market we cannot baseline is a market that will not be priced, which is no reason to stop the base surface.

## The test agreed with the bug

`market-write.chaos.ts` computed its expectation with `derivedBaseline`, which asks the fake what the market shows **now** — and it called it *after* the apply. So the test derived its expectation from the same already-discounted price the engine was wrongly using. The two agreed, and the assertion could not have failed.

Its own comment claimed to be asking "what the shopper would otherwise have paid". It was asking what they would pay now. Baselines are snapshotted before the apply, and the helper now says when it must be called.

## Second: a market price Shopify never converted

The dev store returned an EUR list and a JPY list with byte-identical amounts — the base price with the list's percentage applied and no conversion at all. Cause still open (#257); refusing is right whichever way it resolves.

```
EUR list: base 88595 -> 797.36   base 800 -> 7.2
JPY list: base 88595 -> 797.36   base 800 -> 7.2
```

**The yen half would have been caught anyway** — `parseMoney` refuses fractional yen. **The euro half is why this matters.** €797.36 is an ordinary-looking price that happens to be wrong by an exchange rate, and nothing downstream would ever have questioned it.

Detection compares the derived amount against the base price with only the list's rule applied; agreement to within a minor unit, while the currencies differ, means no conversion happened. A false positive needs a real rate of exactly 1.0000 between two different currencies — vanishingly rare, transient, and it costs a refusal rather than a wrong price.

Checked on the raw string **before** parsing, so the yen case stops saying `"7.2" has 1 decimal places but JPY allows 0` — a message that sends a merchant to look at their prices when the problem is their market. One market is refused with a message naming it and the next action; every other surface still prices.

## These two ship together because the guard is inert without the ordering fix

The check compares the mirror's base price against the derived price. Under the old ordering those differ by the campaign's own discount, so it could never fire during an apply — only in preview. Fixing the ordering is what gives it teeth.

## It also uncovered a live double-discount, now filed as #260

With the baseline corrected, the read-back started disagreeing with the market-wide path — and the reason turned out to be worse than a rounding difference. A relative list already tracks the base price, so discounting the base by 20% moves the market by 20% automatically. The market-wide path *also* composed the campaign's percentage into the parent adjustment, applying it twice.

Measured on `main`, before this change:

```
EU baseline 8032  correct sale 6426  shopper pays 5140
EU baseline 3809  correct sale 3047  shopper pays 2438
```

**A 36% discount where the merchant asked for 20%**, reported as verified and clean — because the contaminated baseline from #259 made the ledger agree with the wrong number. Two bugs cancelling in the report while compounding on the storefront.

With this change the ledger holds the truth, the read-back sees the disagreement, and every row is corrected to the right price:

```
EU baseline 8032  correct sale 6426  shopper pays 6426
```

The composition itself is still wrong (#260), so the shortcut degrades to a per-variant write for every row — the saving is lost, the prices are right. That is the correct order to fix these in.

## Two scenarios were asserting the bug

`market-wide.chaos.ts` checked that *few corrections were written* and that a parity market got *zero* — both of which passed while the storefront was 36% off. A test counting writes cannot see a wrong price.

Both now assert what a shopper actually pays. The compounding scenario also stops measuring `parentWrites`: after the first run leaves fixed prices, a fixed price shadows a parent adjustment, so refusing the shortcut on the second run is exactly right — the count was always a proxy for the property the scenario is named for.

## Tests

Nine unit tests on the detector, five mutations each killing one — including the two that would silently break it: assuming two decimals everywhere (a JPY-shop false positive) and dropping the rounding tolerance.

Removing the pre-write capture fails three chaos scenarios. The ordering scenario pins the baseline to the value captured before the run and separately asserts it is strictly above what a 20%-off campaign would have produced from it — because "equal to a number I captured earlier" would still pass if both were the sale price.

809 unit tests, 101 chaos scenarios green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
