### PR TITLE
Fix: ask the market what it already shows before writing to it

### DIFF
--- a/app/services/campaigns/market-surfaces.server.ts
+++ b/app/services/campaigns/market-surfaces.server.ts
@@ -32,6 +32,8 @@ import {
   UnconvertedMarketError,
 } from "./market-plan.server";
 import { applyMarketWide, revertMarketWide } from "./market-wide.server";
+import { readDerivedPrices } from "../../lib/execution/market-executor";
+import { parseMoney } from "../../lib/money/money";
 import {
   deleteMarketPrices,
   writeMarketPrices,
@@ -122,13 +124,15 @@ export async function captureMarketBaselinesFirst(
   campaignId: string,
   variantGids: readonly string[],
   client: AdminClient,
-): Promise<string[]> {
+): Promise<{ messages: string[]; refused: string[] }> {
   const campaign = await prisma.campaign.findUnique({
     where: { id: campaignId },
     select: { surfaces: true },
   });
   const surfaces = parseSurfaces(campaign?.surfaces);
-  if (surfaces.priceLists.length === 0 || variantGids.length === 0) return [];
+  if (surfaces.priceLists.length === 0 || variantGids.length === 0) {
+    return { messages: [], refused: [] };
+  }
 
   const lists = await prisma.priceListRecord.findMany({
     where: { shopId, priceListGid: { in: surfaces.priceLists } },
@@ -136,16 +140,29 @@ export async function captureMarketBaselinesFirst(
 
   const messages: string[] = [];
 
+  // Markets that cannot be baselined, so they must not be priced later either.
+  //
+  // Refusing here and forgetting was the hole: the run reported "not converted", then the
+  // market loop planned the same list again a few steps later. By then the base price had
+  // moved, so the mirror was stale, the unconverted check no longer matched, and the
+  // market was priced from a baseline derived after the campaign — the very contamination
+  // #259 was about, reintroduced for exactly the market we had just declared unsafe.
+  //
+  // It hid because the shortcut writes a parent adjustment rather than fixed prices, and
+  // the scenario counted fixed prices. Zero of them looked like "refused".
+  const refused: string[] = [];
+
   for (const list of lists) {
     try {
       await marketBaselines(shopId, list, [...variantGids], client);
     } catch (error) {
       if (!(error instanceof UnconvertedMarketError)) throw error;
       messages.push(error.message);
+      refused.push(list.priceListGid);
     }
   }
 
-  return messages;
+  return { messages, refused };
 }
 
 export async function applyMarketSurfaces(
@@ -156,6 +173,7 @@ export async function applyMarketSurfaces(
   variantGids: readonly string[],
   client: AdminClient,
   storeGuardrails?: Guardrails,
+  refusedPriceListGids: readonly string[] = [],
 ): Promise<MarketSurfaceOutcome[]> {
   const campaign = await prisma.campaign.findUnique({
     where: { id: campaignId },
@@ -202,7 +220,28 @@ export async function applyMarketSurfaces(
     });
   }
 
+  const refused = new Set(refusedPriceListGids);
+
   for (const list of lists) {
+    // A market already refused before the base surface moved. Pricing it now would use a
+    // baseline derived from the post-campaign base price, which is the contamination
+    // #259 fixed — so it is skipped rather than re-attempted, and the reason was already
+    // reported by the pre-write capture that refused it.
+    if (refused.has(list.priceListGid)) {
+      outcomes.push({
+        priceListGid: list.priceListGid,
+        name: list.name,
+        currency: list.currency,
+        verified: 0,
+        failed: 0,
+        chunks: 0,
+        messages: [],
+        path: "per-product",
+        pathReason: "this market's prices were not converted",
+      });
+      continue;
+    }
+
     // One market's failure is one market's failure.
     //
     // An unconverted price list is refused rather than priced (#257) — the number Shopify
@@ -266,11 +305,98 @@ export async function applyMarketSurfaces(
 
     if (rows.length === 0) continue;
 
+    // What this market already shows, before deciding to write anything.
+    //
+    // A relative price list tracks the base price, and the base surface was written
+    // several steps ago — so Shopify has already moved every variant on this list by the
+    // campaign's own percentage. For an ordinary percentage campaign that lands exactly
+    // on the intended market price, and the correct number of mutations is none.
+    //
+    // Writing anyway is what made #260: the market-wide path composed the campaign's
+    // percentage into the parent adjustment on top of a base price that had already moved
+    // by it, so a European shopper paid 36% off a 20% sale. Asking the store first
+    // removes the whole class — there is no percentage to compose if there is nothing
+    // left to change.
+    //
+    // Read back and compared, never inferred from the rule. That is the standard rule 5
+    // sets for a write, applied to a non-write: "we did nothing" must not become a way to
+    // report success without having checked.
+    const settled = await alreadyCorrect(client, list, rows);
+
+    if (settled.size > 0) {
+      // Ledgered even though nothing is written, because the campaign *is* the reason
+      // these prices changed — it moved the base price they follow. Without a row the
+      // reconciliation view cannot say which campaign put Germany on sale, and overlap
+      // resolution cannot see that this campaign touched the surface at all.
+      //
+      // Revert needs nothing extra: reverting the base restores the market, which is the
+      // same reason no write was needed here.
+      const already = rows.filter((row) => settled.has(row.variantGid));
+      await ledgerChunk(runId, shopId, list, already, 0);
+      await prisma.variantChange.updateMany({
+        where: {
+          runId,
+          priceListGid: list.priceListGid,
+          variantGid: { in: already.map((row) => row.variantGid) },
+        },
+        data: { status: "VERIFIED", appliedAt: new Date(), verifiedAt: new Date() },
+      });
+    }
+
+    const remaining = rows.filter((row) => !settled.has(row.variantGid));
+
+    if (remaining.length === 0) {
+      outcomes.push({
+        priceListGid: list.priceListGid,
+        name: list.name,
+        currency: list.currency,
+        verified: settled.size,
+        failed: 0,
+        chunks: 0,
+        messages: [
+          `${list.name}: already at the campaign's prices, because this market follows ` +
+            `the base price. ${settled.size} verified, nothing written.`,
+        ],
+        path: "market-wide",
+        pathReason: "this market follows the base price and was already correct",
+      });
+      continue;
+    }
+
     // The same decision the review step showed the merchant, taken by the same
     // function, so the run cannot quietly do something else.
     const decision = await decideMarketPath(plan, client);
 
-    if (decision.path === "market-wide") {
+    // A parent adjustment cannot express these prices once the base surface has moved.
+    //
+    // The shortcut works by setting one percentage and letting Shopify derive every
+    // price. But Shopify derives from the *current* base price, which this campaign has
+    // already changed by its own percentage — so the only parent adjustment that
+    // reproduces the intended prices is the list's existing one, unchanged. Writing
+    // anything else applies the campaign twice, which is what put a European shopper on a
+    // 36% discount off a 20% sale (#260).
+    //
+    // And leaving it unchanged is what `alreadyCorrect` above has just tested against.
+    // Whatever it did not settle differs by rounding — our intended price comes from a
+    // baseline that was rounded once already, Shopify's comes from rounding the whole
+    // conversion at the end — and a percentage cannot close a one-minor-unit gap. Those
+    // rows need explicit prices, and a parent write before them is a wrong price briefly
+    // live for no benefit.
+    //
+    // The shortcut keeps its whole value for a markets-only campaign, which is the case
+    // it was designed for and the case where the base price has not moved underneath it.
+    const baseAlreadyMoved = surfaces.base;
+
+    if (decision.path === "market-wide" && baseAlreadyMoved) {
+      logger.info("market-wide skipped: base surface moved this list already", {
+        runId,
+        priceListGid: list.priceListGid,
+        settled: settled.size,
+        remaining: remaining.length,
+      });
+    }
+
+    if (decision.path === "market-wide" && !baseAlreadyMoved) {
       // Write-ahead for every row first, exactly as the chunked path does. The
       // shortcut is in the number of requests, not in the ledger.
       await ledgerChunk(runId, shopId, list, rows, 0);
@@ -299,16 +425,31 @@ export async function applyMarketSurfaces(
       continue;
     }
 
+    // `remaining`, not `rows`: anything `alreadyCorrect` settled is already at the right
+    // price and already ledgered as verified. Writing it again would spend a request to
+    // set a value to itself, and would re-ledger a row that is done.
     const result = await writeMarketPrices(
       client,
       list.priceListGid,
       list.currency,
-      rows,
+      remaining,
       (chunk, index) => ledgerChunk(runId, shopId, list, chunk, index),
     );
 
     await recordResults(runId, shopId, list.priceListGid, result);
-    outcomes.push({ ...summarise(list, result), path: "per-product", pathReason: decision.reason });
+
+    const summary = summarise(list, result);
+    outcomes.push({
+      ...summary,
+      // Rows settled without a write count as verified — they were read back from Shopify
+      // and matched, which is the same evidence a written row needs.
+      verified: summary.verified + settled.size,
+      path: "per-product",
+      pathReason:
+        decision.path === "market-wide"
+          ? "this market already follows the base price, so a percentage would apply the campaign twice"
+          : decision.reason,
+    });
   }
 
   return outcomes;
@@ -392,6 +533,54 @@ function wideOutcomes(messages: string[]): MarketSurfaceOutcome[] {
 }
 
 /** Write-ahead, per chunk. A chunk is the smallest thing that can independently fail. */
+/**
+ * The rows this market already shows at the campaign's intended price.
+ *
+ * Only for a list with a parent adjustment: a fixed list stores its own numbers and does
+ * not move when the base price does, so there is nothing to have happened already.
+ *
+ * Only for rows wanting no strike-through, and that exclusion is the important one. A
+ * relative list has no per-variant compare-at — the parent adjustment either scales the
+ * compare-at or nullifies it, and neither is "set it to what the price used to be". A row
+ * needing a strike-through cannot be satisfied by doing nothing however right its price
+ * looks, and treating it as settled would report a sale that shows no sale.
+ */
+async function alreadyCorrect(
+  client: AdminClient,
+  list: { priceListGid: string; currency: string; adjustmentBps: number | null },
+  rows: readonly MarketPriceRow[],
+): Promise<Set<string>> {
+  const settled = new Set<string>();
+  if (list.adjustmentBps === null) return settled;
+
+  const candidates = rows.filter((row) => !row.compareAt);
+  if (candidates.length === 0) return settled;
+
+  const derived = await readDerivedPrices(
+    client,
+    list.priceListGid,
+    candidates.map((row) => row.variantGid),
+  );
+
+  for (const row of candidates) {
+    const live = derived.get(row.variantGid);
+    if (live === undefined) continue;
+
+    // A price we cannot parse is a price we have not verified. Skipping it here sends the
+    // row down the ordinary write path, which is the safe direction.
+    let amount: number;
+    try {
+      amount = parseMoney(live, list.currency).amount;
+    } catch {
+      continue;
+    }
+
+    if (amount === row.price.amount) settled.add(row.variantGid);
+  }
+
+  return settled;
+}
+
 async function ledgerChunk(
   runId: string,
   shopId: string,

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -298,6 +298,7 @@ export async function runCampaign(
   // on a resume this is the filtered set. Passing the unfiltered plan here would make
   // the resume silently re-send every row it had just decided to leave alone.
   const messagesBeforeExecution: string[] = [];
+  const refusedMarkets: string[] = [];
 
   // Market baselines before any surface is written, never after.
   //
@@ -310,13 +311,15 @@ export async function runCampaign(
   // Nothing is written here; it only records what the markets look like now, which is
   // exactly the moment that is about to stop being observable.
   if (!options.revert && !options.variantGids) {
-    const baselineMessages = await captureMarketBaselinesFirst(
+    const baselines = await captureMarketBaselinesFirst(
       shopId,
       campaignId,
       writable.map((row) => row.ref.variantGid),
       client,
     );
-    messagesBeforeExecution.push(...baselineMessages);
+    messagesBeforeExecution.push(...baselines.messages);
+    // Carried to the market step so a market refused here is not quietly priced there.
+    refusedMarkets.push(...baselines.refused);
   }
 
   const result = await executeRows(writable, {
@@ -355,6 +358,7 @@ export async function runCampaign(
             writable.map((row) => row.ref.variantGid),
             client,
             storeGuardrails,
+            refusedMarkets,
           );
 
     for (const market of markets) {

--- a/chaos/scenarios/downgrade.chaos.ts
+++ b/chaos/scenarios/downgrade.chaos.ts
@@ -110,10 +110,28 @@ describe("chaos: downgrading while a campaign is live", () => {
         // What this scenario is actually about is the downgrade, so it asks the
         // path-agnostic question: is the market carrying our prices now, and is it clean
         // afterwards.
-        const priced =
-          chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size > 0 ||
-          chaos.fake.parentWrites.some((w) => w.priceListGid === "gid://shopify/PriceList/eu");
-        expect(priced, "the campaign did not reach the market at all").toBe(true);
+        //
+        // Asked of the ledger rather than of the write log, because "reached the market"
+        // and "wrote to the market" stopped being the same thing. A market that already
+        // follows the base price is at the campaign's prices with no mutation at all
+        // (#260), and counting writes reported that correct outcome as a failure — on one
+        // chaos seed and not another, because whether the arithmetic lands exactly depends
+        // on the prices the fixture happened to generate.
+        //
+        // The ledger is the record of what the campaign did, which is the question.
+        const ledgered = await prisma.variantChange.findMany({
+          where: {
+            shopId,
+            priceListGid: "gid://shopify/PriceList/eu",
+            surfaceKind: "MARKET",
+            status: "VERIFIED",
+          },
+          select: { variantGid: true },
+        });
+        expect(
+          ledgered.length,
+          "the campaign did not reach the market at all",
+        ).toBeGreaterThan(0);
 
         // Down to a plan with no markets at all. The market prices we wrote are still
         // ours to undo — refusing here would strand a whole market on sale prices, which

--- a/chaos/scenarios/market-wide.chaos.ts
+++ b/chaos/scenarios/market-wide.chaos.ts
@@ -35,10 +35,19 @@ function addEuMarket(chaos: ChaosContext) {
   });
 }
 
-async function targetEu(campaignId: string) {
+/**
+ * Points the campaign at the EU market.
+ *
+ * `base` matters more than it looks. The shortcut sets one percentage and lets Shopify
+ * derive every price from the *current* base price — so if the campaign also moves the
+ * base price, the only adjustment that reproduces the intended prices is the list's
+ * existing one, unchanged, and the shortcut has nothing to do (#260). It is for a
+ * markets-only campaign: a promotion running in Europe and nowhere else.
+ */
+async function targetEu(campaignId: string, base = true) {
   await prisma.campaign.update({
     where: { id: campaignId },
-    data: { surfaces: { base: true, priceLists: [EU] } as never },
+    data: { surfaces: { base, priceLists: [EU] } as never },
   });
 }
 
@@ -58,7 +67,11 @@ describe("chaos: repricing a market with one mutation", () => {
 
         addEuMarket(chaos);
         await syncMarkets(chaos);
-        await targetEu(campaignId);
+        // Markets only. With the base surface in the campaign the market follows it
+        // automatically and a parent adjustment would apply the discount twice (#260),
+        // so the shortcut is deliberately not taken — which is a different scenario from
+        // this one.
+        await targetEu(campaignId, false);
 
         // Captured before the run: once the base price moves this is no longer the
         // market's baseline, it is the sale price with the market's rule on top (#259).
@@ -90,11 +103,21 @@ describe("chaos: repricing a market with one mutation", () => {
           expect(parseMoney(chaos.fake.priceOf(gid, EU)!, "EUR").amount).toBe(expected);
         }
 
-        // Corrections are high for now, and deliberately not asserted as a minority.
-        // Every row disagrees with the parent adjustment because that adjustment is still
-        // composed wrongly (#260); the read-back catches each one and writes the right
-        // price, which is the shortcut staying honest at the cost of the saving it exists
-        // for. When #260 lands this goes back to being a minority.
+        // Rows are corrected rather than marked verified on trust, and for a market in
+        // another currency that is most of them.
+        //
+        // I predicted a minority here and was wrong. The two sides round at different
+        // points: our intended price is the *recorded baseline* — itself already rounded
+        // into euros — times the campaign's percentage, while Shopify applies one composed
+        // percentage to the unrounded base price. `round(round(x × 0.9) × 0.8)` and
+        // `round(x × 0.72)` agree only by luck, so nearly every row lands a minor unit
+        // apart and gets an exact price written after the shortcut.
+        //
+        // That makes the shortcut roughly break-even for a cross-currency market — one
+        // parent write plus a correction per row — and genuinely cheap only where no
+        // conversion is involved. Noted on #260 rather than papered over; what is asserted
+        // here is that every row is corrected to the *right* number, which is the property
+        // that matters and the one the count was only ever a proxy for.
         expect(chaos.fake.fixedPricesOn(EU).size).toBeGreaterThan(0);
 
         // The campaign's 20% composed with the merchant's own 10%, not replacing it.
@@ -257,11 +280,33 @@ describe("chaos: repricing a market with one mutation", () => {
           },
         });
 
+        const euList = chaos.fake.priceLists.find((l) => l.id === EU)!;
+        const before = new Map(
+          variantGids.map((gid) => [
+            gid,
+            parseMoney(chaos.fake.derivedPriceOf(gid, euList)!, "EUR").amount,
+          ]),
+        );
+
         const applied = await chaos.apply();
         await chaos.expectHonest(applied.runId);
 
         expect(chaos.fake.parentWrites).toHaveLength(0);
-        expect(chaos.fake.fixedPricesOn(EU).size).toBe(3);
+
+        // The three in scope end up at the campaign's price and the other three do not
+        // move, which is the property this scenario is named for.
+        //
+        // Asserted on prices rather than on how many were written: this campaign moves the
+        // base price too, so a market row already showing the right price is left alone
+        // rather than written again (#260). Counting writes would make "we did not need
+        // to" look like a failure.
+        for (const gid of inScope) {
+          const expected = Math.round(before.get(gid)! * 0.8);
+          expect(parseMoney(chaos.fake.priceOf(gid, EU)!, "EUR").amount).toBe(expected);
+        }
+        for (const gid of variantGids.filter((g) => !inScope.includes(g))) {
+          expect(parseMoney(chaos.fake.priceOf(gid, EU)!, "EUR").amount).toBe(before.get(gid));
+        }
       },
     );
   });
@@ -351,6 +396,209 @@ describe("chaos: repricing a market with one mutation", () => {
         expect(chaos.fake.parentWrites).toHaveLength(0);
         const prices = chaos.fake.fixedPricesOn(EU);
         expect([...prices.values()].every((price) => price.compareAt !== null)).toBe(true);
+      },
+    );
+  });
+
+  it("writes nothing to a market that already follows the base price", async () => {
+    /**
+     * The best outcome the market path has: no mutations at all.
+     *
+     * A price list in the shop's own currency with no adjustment — a wholesale or parity
+     * list — tracks the base price exactly. When the campaign moves the base price, that
+     * market is *already* at the campaign's price before the market step begins, and
+     * there is no arithmetic left to disagree about: no conversion, so no second rounding.
+     *
+     * Asking the store first is what makes this visible. Before #260 the run wrote a
+     * parent adjustment composing the campaign's percentage on top of a base price that
+     * had already moved by it, which is how a European shopper ended up on a 36% discount
+     * off a 20% sale.
+     *
+     * The rows are still ledgered and still verified — read back from Shopify and
+     * compared, exactly as a written row is. "We did nothing" must not become a way to
+     * report success without having checked.
+     */
+    await withChaos(
+      "market-follows-base",
+      { catalog: { products: 6, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, campaignId, variantGids } = chaos.fixture;
+        const parity = "gid://shopify/PriceList/parity";
+
+        chaos.fake.addPriceList({
+          id: parity,
+          name: "Wholesale",
+          currency: "USD",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 0 },
+          catalog: {
+            id: "gid://shopify/MarketCatalog/parity",
+            title: "Wholesale",
+            __typename: "MarketCatalog",
+          },
+          prices: [],
+        });
+
+        await syncMarkets(chaos);
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { surfaces: { base: true, priceLists: [parity] } as never },
+        });
+
+        const parityList = chaos.fake.priceLists.find((l) => l.id === parity)!;
+        const before = new Map(
+          variantGids.map((gid) => [
+            gid,
+            parseMoney(chaos.fake.derivedPriceOf(gid, parityList)!, "USD").amount,
+          ]),
+        );
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Not one request against this market, by either route.
+        expect(chaos.fake.fixedPricesOn(parity).size, "wrote prices that were already right").toBe(0);
+        expect(
+          chaos.fake.parentWrites.filter((w) => w.priceListGid === parity),
+          "wrote a parent adjustment on top of a base price that had already moved",
+        ).toHaveLength(0);
+
+        // And the market is nonetheless at the campaign's price, because it followed the
+        // base surface there.
+        for (const gid of variantGids) {
+          const expected = Math.round(before.get(gid)! * 0.8);
+          expect(parseMoney(chaos.fake.priceOf(gid, parity)!, "USD").amount).toBe(expected);
+        }
+
+        // Ledgered and verified, so reconciliation can still say which campaign put this
+        // market on sale and an overlapping campaign can see the surface was touched.
+        const ledgered = await prisma.variantChange.findMany({
+          where: { shopId, priceListGid: parity, surfaceKind: "MARKET" },
+          select: { variantGid: true, status: true, intendedPrice: true },
+        });
+        expect(ledgered).toHaveLength(variantGids.length);
+        for (const row of ledgered) {
+          expect(row.status).toBe("VERIFIED");
+          expect(Number(row.intendedPrice)).toBe(Math.round(before.get(row.variantGid)! * 0.8));
+        }
+      },
+    );
+  });
+
+  it("still writes a row that needs a strike-through, even at the right price", async () => {
+    /**
+     * The exclusion that makes "already correct" safe.
+     *
+     * A relative list has no per-variant compare-at: the parent adjustment either scales
+     * the compare-at or nullifies it, and neither is "set it to what the price used to
+     * be". So a row whose *price* already matches can still need writing, because the
+     * strike-through is the part that has not happened.
+     *
+     * Treating it as settled would report a sale that shows no sale — the price quietly
+     * right and the customer given no reason to believe it moved, which for a sale is the
+     * entire point.
+     */
+    await withChaos(
+      "market-follows-base-compare-at",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { campaignId, variantGids } = chaos.fixture;
+        const parity = "gid://shopify/PriceList/parity";
+
+        chaos.fake.addPriceList({
+          id: parity,
+          name: "Wholesale",
+          currency: "USD",
+          adjustment: { type: "PERCENTAGE_DECREASE", value: 0 },
+          catalog: {
+            id: "gid://shopify/MarketCatalog/parity",
+            title: "Wholesale",
+            __typename: "MarketCatalog",
+          },
+          prices: [],
+        });
+
+        await syncMarkets(chaos);
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: {
+            surfaces: { base: true, priceLists: [parity] } as never,
+            compareAtPolicy: { kind: "set-to-baseline" } as never,
+          },
+        });
+
+        const parityList = chaos.fake.priceLists.find((l) => l.id === parity)!;
+        const before = new Map(
+          variantGids.map((gid) => [
+            gid,
+            parseMoney(chaos.fake.derivedPriceOf(gid, parityList)!, "USD").amount,
+          ]),
+        );
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        // Every row written, despite the price already being right.
+        const written = chaos.fake.fixedPricesOn(parity);
+        expect(written.size).toBe(variantGids.length);
+
+        for (const gid of variantGids) {
+          const row = written.get(gid)!;
+          expect(parseMoney(row.amount, "USD").amount).toBe(Math.round(before.get(gid)! * 0.8));
+          // The strike-through, which is the reason the write was needed at all.
+          expect(row.compareAt, "the sale price landed with no strike-through").not.toBeNull();
+          expect(parseMoney(row.compareAt!, "USD").amount).toBe(before.get(gid));
+        }
+      },
+    );
+  });
+
+  it("does not set a percentage on a market the base surface has already moved", async () => {
+    /**
+     * #260 in one assertion.
+     *
+     * The shortcut derives every price from a single parent percentage — but Shopify
+     * derives it from the *current* base price, which this campaign has already changed.
+     * Composing the campaign's percentage on top applies it twice: a European shopper on
+     * a 36% discount off a 20% sale, with the run reporting verified and clean.
+     *
+     * Cross-currency, so nothing settles as already-correct — the baseline is rounded into
+     * euros before the campaign's percentage is applied, and Shopify rounds the whole
+     * conversion at the end, so the two land a minor unit apart. Every row therefore needs
+     * an exact price, and a parent write before them would be a wrong price briefly live
+     * for no benefit whatever.
+     */
+    await withChaos(
+      "market-wide-base-moved",
+      { catalog: { products: 6, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { campaignId, variantGids } = chaos.fixture;
+
+        addEuMarket(chaos);
+        await syncMarkets(chaos);
+        await targetEu(campaignId, true);
+
+        const euList = chaos.fake.priceLists.find((l) => l.id === EU)!;
+        const before = new Map(
+          variantGids.map((gid) => [
+            gid,
+            parseMoney(chaos.fake.derivedPriceOf(gid, euList)!, "EUR").amount,
+          ]),
+        );
+
+        const applied = await chaos.apply();
+        await chaos.expectHonest(applied.runId);
+
+        expect(
+          chaos.fake.parentWrites.filter((w) => w.priceListGid === EU),
+          "composed the campaign's percentage onto a base price that had already moved",
+        ).toHaveLength(0);
+
+        // 20% off the market's own baseline — not 36% off it.
+        for (const gid of variantGids) {
+          expect(parseMoney(chaos.fake.priceOf(gid, EU)!, "EUR").amount).toBe(
+            Math.round(before.get(gid)! * 0.8),
+          );
+        }
       },
     );
   });

--- a/chaos/scenarios/market-write.chaos.ts
+++ b/chaos/scenarios/market-write.chaos.ts
@@ -197,7 +197,18 @@ describe("chaos: writing campaign prices to markets", () => {
 
         await prisma.campaign.update({
           where: { id: campaignId },
-          data: { surfaces: { base: true, priceLists: ["gid://shopify/PriceList/big"] } as never },
+          data: {
+            surfaces: { base: true, priceLists: ["gid://shopify/PriceList/big"] } as never,
+            // A strike-through, so every one of the 300 rows genuinely needs writing.
+            //
+            // Without it most rows need no write at all: a relative list already follows
+            // the base price this campaign just moved, so they are correct before we
+            // start (#260) and only the ones rounding pushes off by a minor unit are
+            // written — 62 of 300, which never reaches the 250 boundary this scenario
+            // exists to test. A compare-at cannot be expressed by a parent adjustment, so
+            // asking for one puts every row back on the per-variant path.
+            compareAtPolicy: { kind: "set-to-baseline" } as never,
+          },
         });
 
         const applied = await chaos.apply();
@@ -284,9 +295,14 @@ describe("chaos: writing campaign prices to markets", () => {
         expect(jp.has(overridden), "the hand-set variant was skipped").toBe(true);
         expect(jp.get(overridden)!.amount).toBe("960");
 
-        // The variants the rule still governs were priced too, so preferring overrides
-        // did not cost the ordinary path.
-        expect(jp.size).toBe(variantGids.length);
+        // The variants the rule still governs end up right too, so preferring overrides
+        // did not cost the ordinary path. Asserted on the prices rather than on how many
+        // were written, because a variant already showing the correct price is now left
+        // alone rather than written to (#260) — and "we did not need to write it" is a
+        // better outcome than "we wrote it again", not a worse one.
+        for (const gid of variantGids) {
+          expect(chaos.fake.priceOf(gid, "gid://shopify/PriceList/jp")).toBeDefined();
+        }
       },
     );
   });
@@ -339,9 +355,18 @@ describe("chaos: writing campaign prices to markets", () => {
         const applied = await chaos.apply();
         await chaos.expectHonest(applied.runId);
 
-        // Nothing written to the market. A price wrong by an exchange rate is worse than
-        // no price, because the merchant cannot see that it is wrong.
+        // Nothing written to the market, by either route. A price wrong by an exchange
+        // rate is worse than no price, because the merchant cannot see it is wrong.
+        //
+        // Both are asserted because counting only fixed prices is how this passed while
+        // the market was in fact being priced: the market-wide shortcut sets a parent
+        // adjustment and writes no per-variant prices at all, so zero fixed prices looked
+        // like "refused" when it meant "repriced wholesale".
         expect(chaos.fake.fixedPricesOn("gid://shopify/PriceList/eu").size).toBe(0);
+        expect(
+          chaos.fake.parentWrites.filter((w) => w.priceListGid === "gid://shopify/PriceList/eu"),
+          "the market was repriced by a parent adjustment despite being refused",
+        ).toHaveLength(0);
 
         // The base surface still ran. One misconfigured market must not turn a campaign
         // into something that did nothing and explained little.


### PR DESCRIPTION
Closes #260, and fixes a hole left in #261.

## Ask the market what it already shows, before writing anything

A relative price list tracks the base price, and the base surface is written several steps earlier — so by the time markets are planned, Shopify has already moved every variant on the list by the campaign's own percentage.

The shortcut wrote a parent adjustment anyway, composing the campaign's percentage on top of a base price that had already moved by it. That is how a European shopper ended up on a **36% discount off a 20% sale**, reported verified and clean.

Now each market's current prices are read first, and rows already at the intended price need no mutation at all.

**Where no conversion is involved** — a wholesale or parity list in the shop's own currency — that is every row:

```
fixed prices written: 0 of 6
parent writes:        0
shopper pays:         7760, 3680, 5040   (correct)
```

**Read back and compared, never inferred from the rule.** That is the standard rule 5 sets for a write, applied to a non-write: "we did nothing" must not become a way to report success without having checked.

The rows are still ledgered and marked verified, because the campaign *is* why those prices changed — it moved the base price they follow. Without a row, reconciliation cannot say which campaign put a market on sale and overlap resolution cannot see the surface was touched. Revert needs nothing extra: reverting the base restores the market, which is the same reason no write was needed.

## The shortcut is skipped when the base surface moved

Once the base has moved, the only parent adjustment that reproduces the intended prices is the list's existing one, unchanged — which is exactly what the check above has just tested against. Anything left over differs by rounding, and a percentage cannot close a one-minor-unit gap.

So a parent write there is a wrong price briefly live for no benefit. The shortcut keeps its full value for a markets-only campaign, which is the case it was designed for.

## A refused market was still being priced

#261 detects a market whose prices come back unconverted and refuses it before any write. It then forgot: the market loop planned the same list again a few steps later, by which time the base price had moved, the mirror was stale, the check no longer matched, and the market was priced from a baseline captured *after* the campaign — the contamination #259 was about, reintroduced for the one market we had just declared unsafe.

It hid because the shortcut writes a parent adjustment rather than fixed prices, and the scenario counted fixed prices. **Zero of them looked like "refused" when it meant "repriced wholesale."** The scenario now asserts both routes are untouched.

Refusals are carried from the pre-write capture into the market step, so a market refused there is skipped rather than re-attempted.

## A prediction I got wrong

In #261 I wrote that corrections on the cross-currency shortcut would "go back to being a minority" once this landed. They do not, and the comment now says so.

Our intended price is the recorded baseline — already rounded into euros — times the campaign's percentage. Shopify applies one composed percentage to the unrounded base. `round(round(x × 0.9) × 0.8)` and `round(x × 0.72)` agree only by luck, so nearly every row lands a minor unit apart.

That makes the shortcut roughly break-even for a market in another currency, and genuinely cheap only where no conversion is involved. Recorded rather than papered over.

## Tests

Five mutations, each killing a test: never skipping a correct row; settling a row that needs a strike-through; taking the shortcut when the base moved; not marking settled rows verified; settling without comparing the price.

The strike-through exclusion has its own scenario, because a row whose price is already right can still need writing — a relative list has no per-variant compare-at, and treating it as settled would report a sale that shows no sale.

`market-write.chaos.ts`'s chunking scenario now asks for a strike-through, so all 300 rows genuinely need writing and the 250 boundary is still exercised — otherwise only 62 were written and the test had quietly stopped testing chunking.

## And one more test that measured the wrong thing

`downgrade.chaos.ts` asked "did the campaign reach the market?" by checking whether anything had been written. That passed on one chaos seed and failed on another, because whether the arithmetic lands exactly depends on the prices the fixture happened to generate — a market needing no writes was reported as a market the campaign never reached.

It now asks the ledger, which is the record of what the campaign did. **"Reached the market" and "wrote to the market" have stopped being the same thing**, and that is the point of this change.

809 unit tests, 104 chaos scenarios green on three seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
