### PR TITLE
P0.2 — Ask to view the merchant's markets, not to manage them

### DIFF
--- a/app/lib/compliance/built-for-shopify.test.ts
+++ b/app/lib/compliance/built-for-shopify.test.ts
@@ -181,16 +181,66 @@ describe("integration — API, auth and webhooks", () => {
     // review. Both were established empirically by `npm run scope:probe` — all thirteen
     // mutations in RFC §6 pass under `write_products` alone, and markets needs its own.
     //
-    // `read_markets` was dropped: Shopify implies it from `write_markets` and had already
-    // collapsed the pair in its record of what the shop granted, so declaring it was a
-    // checkbox that bought nothing. See D4 in docs/decisions.md, which also records the
-    // one narrowing still open — nothing in the app writes a market.
+    // `read_markets` rather than `write_markets`: nothing in the app writes a market, and
+    // the test below keeps that true. The install screen asks to *view* the merchant's
+    // markets instead of to *manage* them, which is not a small difference in a sentence
+    // somebody reads before handing a pricing app access to their store.
     const toml = readFileSync(join(ROOT, "shopify.app.toml"), "utf8");
     const match = /scopes\s*=\s*"([^"]*)"/.exec(toml);
 
     expect(match).not.toBeNull();
     const scopes = (match?.[1] ?? "").split(",").map((scope) => scope.trim()).filter(Boolean);
 
-    expect(scopes.sort()).toEqual(["write_markets", "write_products"]);
+    expect(scopes.sort()).toEqual(["read_markets", "write_products"]);
+  });
+
+  it("sends no mutation that would need write access to markets", () => {
+    /**
+     * The evidence behind asking for `read_markets` rather than `write_markets`.
+     *
+     * The market surface works entirely through *price lists* — created, adjusted and
+     * populated under `write_products` — plus a read of which markets exist. No market
+     * itself is ever created, renamed, deleted or reconfigured by this app.
+     *
+     * That cannot be proven by probing, because a scope that is present is never
+     * exercised as absent: with `write_markets` granted, every probe passes whether or not
+     * it needs the scope. And narrowing the manifest does not narrow an existing install —
+     * the granted set still read `write_markets` after the change, because a smaller ask
+     * needs no new consent. So the argument has to be static, and static arguments rot.
+     *
+     * This is the argument, enforced. Adding a market mutation is a legitimate thing to
+     * want; doing it without widening the manifest would be a run that fails on every
+     * merchant store, and doing it *with* one is a re-authorisation prompt for every
+     * existing install. Either way it should be a decision, not a surprise.
+     */
+    const roots = ["app/lib", "app/services", "app/routes", "scripts"];
+    const offenders: string[] = [];
+
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(join(ROOT, dir), { withFileTypes: true })) {
+        const path = `${dir}/${entry.name}`;
+        if (entry.isDirectory()) {
+          walk(path);
+          continue;
+        }
+        if (!/\.(ts|tsx)$/.test(entry.name)) continue;
+
+        const source = readFileSync(join(ROOT, path), "utf8");
+        // A mutation field on the root Mutation type whose name begins with `market`.
+        // Deliberately not matching `marketing…` or a `markets` query.
+        for (const [match] of source.matchAll(
+          /\bmarket(?:Create|Update|Delete|CurrencySettingsUpdate|RegionsDelete|RegionCreate|LocalConditionsUpdate|WebPresence\w*)\s*\(/g,
+        )) {
+          offenders.push(`${path}: ${match.trim()}`);
+        }
+      }
+    };
+
+    for (const root of roots) walk(root);
+
+    expect(
+      offenders,
+      "a market mutation needs write_markets, which the manifest no longer asks for",
+    ).toEqual([]);
   });
 });

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -73,7 +73,29 @@ inventory level, and the mirror gets `inventoryQuantity` from the product graph,
 from admin by whoever runs it. A permission checkbox in front of every merchant is not a
 reasonable price for a developer tool being easier to run.
 
-**Still open: `write_markets` is over-broad.** Nothing in the app writes a market. The
+**Resolved: `write_markets` narrowed to `read_markets`.** Nothing in the app writes a
+market. Every mutation it sends is a price list, catalog, product, tag, staged upload or
+bulk operation — all covered by `write_products` — and the only markets access ever
+exercised is reading which markets exist.
+
+That could not be settled by probing, and the attempt showed why twice over. A scope that
+is present is never exercised as absent, so with `write_markets` granted every probe
+passes whether or not it needs the scope. And **narrowing the manifest does not narrow an
+existing install**: after the change the CLI reported `Access scopes auto-granted:
+read_markets, write_products`, while the stored grant still read `write_markets,
+write_products`. A smaller ask needs no new consent, so the old grant simply persists.
+Only a reinstall would settle it, and uninstalling a store to prove a scope is not a
+reasonable trade.
+
+So the argument is static, and enforced rather than asserted: a test in
+`app/lib/compliance/built-for-shopify.test.ts` fails if any market mutation is ever added.
+Adding one is a legitimate thing to want — doing it without widening the manifest is a run
+that fails on every merchant store, and doing it with one is a re-authorisation prompt for
+every existing install. Either way it should be a decision rather than a surprise.
+
+The install screen now asks to *view* the merchant's markets rather than to *manage* them.
+
+**Previously open, for the record: `write_markets` was over-broad.** Nothing in the app writes a market. The
 market surface works by creating and updating *price lists*, which `write_products`
 covers; the only markets access ever exercised is reading which markets exist. The install
 screen currently asks to *manage* the merchant's markets when it only needs to *view*

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -34,7 +34,7 @@ api_version = "2026-07"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "write_products,write_markets"
+scopes = "write_products,read_markets"
 optional_scopes = [ ]
 use_legacy_install_flow = false
 


### PR DESCRIPTION
Closes #249.

Nothing in the app writes a market. Every mutation it sends is a price list, catalog, product, tag, staged upload or bulk operation — all covered by `write_products` — and the only markets access ever exercised is reading which markets exist.

So the install screen now asks to **view** the merchant's markets rather than to **manage** them. That is not a small difference in a sentence somebody reads before handing a pricing app access to their store.

## Probing could not settle this, and the attempt showed why twice over

**A scope that is present is never exercised as absent.** With `write_markets` granted, every probe passes whether or not it needs the scope.

**And narrowing the manifest does not narrow an existing install.** After the change the CLI reported:

```
Access scopes auto-granted: read_markets, write_products
```

while the stored grant still read:

```
write_markets,write_products
```

A smaller ask needs no new consent, so the old grant simply persists. Only a reinstall would settle it — and uninstalling somebody's store to prove a scope is not a reasonable trade.

## So the argument is static, and enforced rather than asserted

Static arguments rot. A test now fails if any market mutation appears anywhere in `app/` or `scripts/`:

```
a market mutation needs write_markets, which the manifest no longer asks for
```

Adding one is a legitimate thing to want. Doing it *without* widening the manifest is a run that fails on every merchant store; doing it *with* one is a re-authorisation prompt for every existing install. Either way it should be a decision rather than a surprise.

The scope list itself stays pinned by the existing test, so the manifest and the assertion cannot drift apart.

## Verified under the narrowed manifest

Against the real store, after the CLI re-granted:

```
syncMarkets: {"priceLists":5,"relative":5,"fixed":0,"entries":3}
JPY derived reads: [["…135594","18.0"],["…168362","36.0"]]
```

Markets mirrored, five price lists read, the three JPY fixed-price entries intact, derived prices still readable.

**One honest limit:** the store used for this still has `write_markets` in its grant, for the reason above. What is verified is that the app works with the narrower *manifest*; what is argued statically — and now enforced — is that it needs nothing more.

810 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)