### PR TITLE
Refuse a market price by the currency Shopify stated, not by guessing at it

### DIFF
--- a/app/lib/execution/market-executor.test.ts
+++ b/app/lib/execution/market-executor.test.ts
@@ -299,7 +299,10 @@ describe("reading what a market currently derives", () => {
     ]);
 
     expect(prices.size).toBe(2);
-    expect(prices.get("gid://shopify/ProductVariant/2")).toBe("2960");
+    expect(prices.get("gid://shopify/ProductVariant/2")).toEqual({
+      amount: "2960",
+      currency: "JPY",
+    });
   });
 
   it("batches large scopes into several queries", async () => {
@@ -327,5 +330,70 @@ describe("reading what a market currently derives", () => {
     // has nothing to compute against on this market, and the honest response is to
     // leave the variant unpriced there.
     expect(prices.has("gid://shopify/ProductVariant/2")).toBe(false);
+  });
+
+  it("keeps the currency Shopify stated, which is not always the list's", async () => {
+    /**
+     * The distinction that cost the most to find. `priceList.prices(originType: RELATIVE)`
+     * answers in the **shop's** currency with the list's adjustment applied, while a
+     * `FIXED` price on the same list answers in the list's own currency.
+     *
+     * On the store: a JPY list at -10% returned `{"amount":"18.0","currencyCode":"USD"}`
+     * for a $20 variant, whose real market price is ¥2,921. Reading the amount and
+     * assuming the list's currency recorded a baseline of ¥18 — wrong by the exchange
+     * rate, on the surface a merchant is least able to check.
+     *
+     * So the currency travels with the amount, and the caller compares it rather than
+     * assuming. Dropping it here is what let the mistake happen once already.
+     */
+    const { client } = reader([
+      {
+        priceList: {
+          currency: "JPY",
+          prices: {
+            nodes: [
+              {
+                variant: { id: "gid://shopify/ProductVariant/1" },
+                price: { amount: "18.0", currencyCode: "USD" },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    ]);
+
+    const prices = await readDerivedPrices(client, "gid://shopify/PriceList/jp", [
+      "gid://shopify/ProductVariant/1",
+    ]);
+
+    expect(prices.get("gid://shopify/ProductVariant/1")).toEqual({
+      amount: "18.0",
+      currency: "USD",
+    });
+  });
+
+  it("drops a price with no stated currency rather than guessing one", async () => {
+    // Guessing is the whole bug. A row left out goes down the ordinary write path, which
+    // is the safe direction; a row guessed at goes to a storefront.
+    const { client } = reader([
+      {
+        priceList: {
+          currency: "JPY",
+          prices: {
+            nodes: [
+              { variant: { id: "gid://shopify/ProductVariant/1" }, price: { amount: "18.0" } },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    ]);
+
+    const prices = await readDerivedPrices(client, "gid://shopify/PriceList/jp", [
+      "gid://shopify/ProductVariant/1",
+    ]);
+
+    expect(prices.size).toBe(0);
   });
 });

--- a/app/lib/execution/market-executor.ts
+++ b/app/lib/execution/market-executor.ts
@@ -321,7 +321,10 @@ interface DerivedPricesResponse {
   priceList?: {
     currency?: string;
     prices?: {
-      nodes?: Array<{ variant?: { id?: string }; price?: { amount?: string } }>;
+      nodes?: Array<{
+        variant?: { id?: string };
+        price?: { amount?: string; currencyCode?: string };
+      }>;
       pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
     };
   } | null;
@@ -336,12 +339,31 @@ interface DerivedPricesResponse {
  */
 export const MAX_VARIANTS_PER_PRICE_QUERY = 50;
 
+/** A price exactly as Shopify stated it, including the currency it is denominated in. */
+export interface DerivedPrice {
+  amount: string;
+  /**
+   * The currency Shopify put on the number — **not** the price list's currency.
+   *
+   * These differ, and the difference is the whole reason this field is carried. A
+   * `RELATIVE` price comes back in the *shop's* currency with the list's adjustment
+   * applied; a `FIXED` price on the same list comes back in the list's own currency. A
+   * JPY list at -10% answers `{"amount":"18.0","currencyCode":"USD"}` for a $20 variant,
+   * while its hand-set override answers `{"amount":"1200.0","currencyCode":"JPY"}`.
+   *
+   * Reading the amount and assuming the list's currency turned $18.00 into ¥18, against a
+   * real market price of ¥2,921 — wrong by the exchange rate, on the surface a merchant
+   * is least able to check.
+   */
+  currency: string;
+}
+
 export async function readDerivedPrices(
   client: AdminClient,
   priceListGid: string,
   variantGids: readonly string[],
-): Promise<Map<string, string>> {
-  const out = new Map<string, string>();
+): Promise<Map<string, DerivedPrice>> {
+  const out = new Map<string, DerivedPrice>();
 
   for (let i = 0; i < variantGids.length; i += MAX_VARIANTS_PER_PRICE_QUERY) {
     const batch = variantGids.slice(i, i + MAX_VARIANTS_PER_PRICE_QUERY);
@@ -361,7 +383,11 @@ export async function readDerivedPrices(
       for (const node of prices?.nodes ?? []) {
         const gid = node.variant?.id;
         const amount = node.price?.amount;
-        if (gid && amount) out.set(gid, amount);
+        const currency = node.price?.currencyCode;
+        // A price with no stated currency is a price we cannot place. Dropping it sends
+        // the row down the ordinary path rather than guessing which currency it is in,
+        // and guessing is the entire bug this field exists to prevent.
+        if (gid && amount && currency) out.set(gid, { amount, currency });
       }
 
       after = prices?.pageInfo?.hasNextPage ? (prices.pageInfo.endCursor ?? null) : null;

--- a/app/lib/markets/conversion-check.ts
+++ b/app/lib/markets/conversion-check.ts
@@ -74,10 +74,15 @@ export function looksUnconverted(check: ConversionCheck): boolean {
  * the cause, because we do not know it yet, and a confident wrong diagnosis wastes more
  * of somebody's afternoon than an honest description does.
  */
-export function unconvertedMessage(marketName: string, listCurrency: string): string {
+export function unconvertedMessage(
+  marketName: string,
+  listCurrency: string,
+  statedCurrency?: string,
+): string {
+  const inWhat = statedCurrency ? ` — it answered in ${statedCurrency}` : "";
   return (
-    `${marketName} returned prices that have not been converted into ${listCurrency}, ` +
-    `so they are wrong by an exchange rate and this campaign will not price that market. ` +
+    `${marketName} returned prices that are not in ${listCurrency}${inWhat}, so they are ` +
+    `wrong by an exchange rate and this campaign will not price that market. ` +
     `Check the market's currency settings in Shopify under Settings → Markets → ` +
     `${marketName}, then run this again. Every other surface has been priced.`
   );

--- a/app/services/campaigns/market-plan.server.ts
+++ b/app/services/campaigns/market-plan.server.ts
@@ -9,7 +9,7 @@
 
 import prisma from "../../db.server";
 import { readDerivedPrices } from "../../lib/execution/market-executor";
-import { looksUnconverted, unconvertedMessage } from "../../lib/markets/conversion-check";
+import { unconvertedMessage } from "../../lib/markets/conversion-check";
 import {
   readParentState,
   type MarketWritePath,
@@ -263,49 +263,31 @@ async function captureMarketBaselines(
     if (remaining.length > 0) {
       const derived = await readDerivedPrices(client, list.priceListGid, remaining);
 
-      // What the base surface holds for these variants, so an unconverted answer can be
-      // recognised as one. Read once for the batch rather than per row.
-      const base = new Map(
-        (
-          await prisma.variantIndex.findMany({
-            where: { shopId, variantGid: { in: [...derived.keys()] } },
-            select: { variantGid: true, price: true, currency: true },
-          })
-        ).map((row) => [row.variantGid, row]),
-      );
-
-      for (const [variantGid, amount] of derived) {
-        // Refuse a price Shopify never converted, before parsing it.
+      for (const [variantGid, derivedPrice] of derived) {
+        // Refuse a price Shopify did not state in this market's currency.
         //
-        // A relative list is meant to answer with the base price converted into the
-        // market's currency and then adjusted. When it answers with the base price merely
-        // adjusted, the number is wrong by an exchange rate — and in a two-decimal
-        // currency it is wrong while looking entirely ordinary. €797.36 would sail
-        // through every check below it and land on a live storefront.
+        // `priceList.prices(originType: RELATIVE)` answers in the *shop's* currency with
+        // the list's adjustment applied — a JPY list at -10% returns
+        // `{"amount":"18.0","currencyCode":"USD"}` for a $20 variant, while a hand-set
+        // override on the same list returns `{"amount":"1200.0","currencyCode":"JPY"}`.
+        // Reading the amount and assuming the list's currency made that ¥18, against a
+        // real market price of ¥2,921. Wrong by the exchange rate, on the surface a
+        // merchant is least able to check, and the same failure P1.2 hit — because the
+        // fix then read the right field and ignored the currency beside it.
         //
-        // Checked here rather than after `parseMoney` because parsing is where the yen
-        // case dies, and it dies complaining about decimal places — which sends a
-        // merchant to look at their prices when the problem is their market. Cause still
-        // open in #257; refusing is right regardless of what it turns out to be.
-        const row = base.get(variantGid);
-        if (
-          row?.price != null &&
-          looksUnconverted({
-            listCurrency: list.currency,
-            shopCurrency: row.currency ?? list.currency,
-            baseMinorUnits: Number(row.price),
-            adjustmentBps: list.adjustmentBps,
-            derivedAmount: amount,
-          })
-        ) {
+        // Checked as a fact rather than inferred from the arithmetic. The heuristic this
+        // replaces compared the amount against the base price times the rule and happened
+        // to catch the same case; it was right by accident, and an accident is a poor
+        // thing to leave guarding a live storefront.
+        if (derivedPrice.currency !== list.currency) {
           throw new UnconvertedMarketError(
             list.priceListGid,
             list.currency,
-            unconvertedMessage(list.name, list.currency),
+            unconvertedMessage(list.name, list.currency, derivedPrice.currency),
           );
         }
 
-        found.set(variantGid, parseMoney(amount, list.currency));
+        found.set(variantGid, parseMoney(derivedPrice.amount, list.currency));
       }
     }
   }

--- a/app/services/campaigns/market-surfaces.server.ts
+++ b/app/services/campaigns/market-surfaces.server.ts
@@ -566,11 +566,17 @@ async function alreadyCorrect(
     const live = derived.get(row.variantGid);
     if (live === undefined) continue;
 
+    // Only a price Shopify stated in this market's own currency can be compared with what
+    // the plan intends. A `RELATIVE` price comes back in the *shop's* currency (#257), and
+    // comparing 18.00 USD against ¥2,629 would settle nothing — or, with the currency
+    // assumed rather than read, would settle it wrongly.
+    if (live.currency !== list.currency) continue;
+
     // A price we cannot parse is a price we have not verified. Skipping it here sends the
     // row down the ordinary write path, which is the safe direction.
     let amount: number;
     try {
-      amount = parseMoney(live, list.currency).amount;
+      amount = parseMoney(live.amount, live.currency).amount;
     } catch {
       continue;
     }

--- a/app/services/campaigns/market-wide.server.ts
+++ b/app/services/campaigns/market-wide.server.ts
@@ -131,8 +131,16 @@ export async function applyMarketWide(
     const intended = row.intendedPrice;
     if (!intended) continue;
 
+    // Verified only against a price Shopify stated in this market's currency. A
+    // `RELATIVE` price arrives in the *shop's* currency (#257), and a read-back that
+    // compared it as though it were the market's would mark a row verified against a
+    // number denominated in something else entirely.
     const live = derived.get(row.ref.variantGid);
-    if (live !== undefined && parseMoney(live, list.currency).amount === intended.amount) {
+    if (
+      live !== undefined &&
+      live.currency === list.currency &&
+      parseMoney(live.amount, live.currency).amount === intended.amount
+    ) {
       verified.push(row.ref.variantGid);
     } else {
       drifted.push({ variantGid: row.ref.variantGid, price: intended, compareAt: null });

--- a/chaos/harness/fake-shopify.ts
+++ b/chaos/harness/fake-shopify.ts
@@ -42,6 +42,24 @@ export interface FakePriceList {
   /** Percentage adjustment, or null when the list stores fixed per-variant prices. */
   adjustment: { type: string; value: number } | null;
   catalog: { id: string; title: string; __typename: string } | null;
+  /**
+   * The currency this list reports its `RELATIVE` prices in.
+   *
+   * **The real API always answers in the shop's currency here**, whatever the list's own
+   * currency is — a JPY list at -10% returns `{"amount":"18.0","currencyCode":"USD"}` for
+   * a $20 variant, while a `FIXED` price on the same list returns
+   * `{"amount":"1200.0","currencyCode":"JPY"}`. Conversion happens later, at presentment.
+   *
+   * This fake still defaults to the list's own currency, which is wrong, and that is
+   * exactly why the mistake it models went unnoticed: the production code matched the
+   * fake and neither matched Shopify. Flipping the default is the remaining half of #257
+   * — it turns thirteen market scenarios red, because the app cannot currently price a
+   * relative list at all, and repairing them needs the baseline to come from
+   * `presentmentPrices` rather than from here.
+   *
+   * Until then a scenario can opt into the truth by setting this.
+   */
+  relativeCurrency?: string;
   /** Per-variant entries, as Shopify reports them -- fixed and derived alike. */
   prices: Array<{
     variantGid: string;
@@ -508,7 +526,10 @@ export class FakeShopify {
 
         const amount = this.derivedPriceOf(gid, list);
         if (amount) {
-          nodes.push({ variant: { id: gid }, price: { amount, currencyCode: list.currency } });
+          nodes.push({
+            variant: { id: gid },
+            price: { amount, currencyCode: list.relativeCurrency ?? list.currency },
+          });
         }
       }
     }

--- a/chaos/scenarios/market-write.chaos.ts
+++ b/chaos/scenarios/market-write.chaos.ts
@@ -328,10 +328,6 @@ describe("chaos: writing campaign prices to markets", () => {
       async (chaos) => {
         const { shopId, campaignId, variantGids } = chaos.fixture;
 
-        // A rate of exactly 1 is what "unconverted" means: the base price with the
-        // list's percentage applied and nothing else. Set rather than deleted, because
-        // deleting only falls back to 1 if nothing else supplies a rate, and saying it
-        // outright is both clearer and immune to the fixture changing its mind.
         chaos.fake.rates.set("EUR", 1);
 
         chaos.fake.addPriceList({
@@ -340,6 +336,12 @@ describe("chaos: writing campaign prices to markets", () => {
           currency: "EUR",
           adjustment: { type: "PERCENTAGE_DECREASE", value: 10 },
           catalog: { id: "gid://shopify/MarketCatalog/eu", title: "EU", __typename: "MarketCatalog" },
+          // What the real API does: a relative price comes back in the *shop's* currency,
+          // whatever the list's own currency is (#257). Opted into here because the fake
+          // still defaults to the list's currency everywhere else — the mistake this
+          // scenario guards against is precisely that the fake and the code agreed with
+          // each other and neither agreed with Shopify.
+          relativeCurrency: "USD",
           prices: [],
         });
 
@@ -380,7 +382,11 @@ describe("chaos: writing campaign prices to markets", () => {
         // reports rather than silently pricing three of four surfaces.
         const said = applied.messages.join(" ");
         expect(said).toContain("Europe");
-        expect(said).toMatch(/not been converted/);
+        expect(said).toMatch(/not in EUR/);
+        // Names the currency Shopify actually answered in, because "wrong currency" and
+        // "wrong by an exchange rate" are the same sentence to a merchant only once you
+        // say which currency arrived.
+        expect(said).toMatch(/answered in USD/);
         expect(said).toMatch(/Settings → Markets/);
       },
     );


### PR DESCRIPTION
Part of #257; the rest is **#264**.

## The finding

`priceList.prices(originType: RELATIVE)` answers in the **shop's** currency. `FIXED` answers in the **list's**. Same field, same list, two currencies — proven on the store:

```jsonc
// JPY list at -10%, $20.00 variant
{"originType":"RELATIVE","price":{"amount":"18.0","currencyCode":"USD"}}
{"originType":"FIXED",   "price":{"amount":"1200.0","currencyCode":"JPY"}}
```

`readDerivedPrices` returned bare amount strings and the caller did `parseMoney(amount, list.currency)` — so **$18.00 became ¥18**.

That variant's real market price, from `presentmentPrices`:

```
¥2921 / €17.49 / $20.00
```

Wrong by the exchange rate, on the surface a merchant is least able to check. It is the same failure P1.2 hit, because the fix then read the right *field* and ignored the currency sitting beside it.

## The change

The currency travels with the amount, and every caller compares it:

- **baseline capture** refuses a mismatch outright
- **market-wide read-back** will not mark a row verified against a number denominated in something else
- **already-correct** will not settle a row it cannot compare

## This replaces a heuristic that was right by accident

The unconverted guard from #261 inferred the problem from arithmetic — *derived equals base × rule* — on a theory about unconfigured exchange rates that turned out to be wrong. It caught this shape anyway.

It is now a fact rather than an inference. The message also names the currency that arrived, because *"wrong currency"* and *"wrong by an exchange rate"* only become the same sentence to a merchant once you say which one turned up:

> Europe returned prices that are not in EUR — **it answered in USD**, so they are wrong by an exchange rate and this campaign will not price that market.

## Why the fake is still wrong, deliberately

`fake-shopify.ts` answers relative prices in the list's currency. **The production code matched the fake and neither matched Shopify** — that is precisely how this survived.

Flipping the default turns **13 scenarios red** across the whole market surface, because the app cannot price a relative list at all until baselines come from `presentmentPrices`. That is measured and filed as #264 rather than half-done here, and the `relativeCurrency` field lets a scenario opt into the truth meanwhile — the refusal test does, so the exact check is exercised against the real shape.

## Tests

Two new unit tests on `readDerivedPrices`: it keeps the currency Shopify stated even when that is not the list's, and it drops a price with no stated currency rather than guessing one — guessing being the entire bug.

812 unit tests, 104 chaos scenarios green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)