### PR TITLE
Retire the unconverted-price heuristic, now that the fact replaced it

### DIFF
--- a/app/lib/markets/conversion-check.test.ts
+++ b/app/lib/markets/conversion-check.test.ts
@@ -1,119 +1,40 @@
 /**
- * Refusing a market price that was never converted.
+ * The sentence a merchant reads when a market answers in the wrong currency.
  *
- * The euro case is the one that matters. A yen price with decimals is caught anyway,
- * because `parseMoney` will not accept fractional yen — but €797.36 is an ordinary
- * price that happens to be wrong by an exchange rate, and nothing else in the system
- * would ever question it.
+ * The detector that used to live beside this is gone (#257). It inferred the problem from
+ * arithmetic on a theory that turned out to be wrong, and market prices now come from
+ * `contextualPricing`, where the currency is stated rather than deduced.
+ *
+ * What survives is the wording, because that half was always the useful one: a price in
+ * the wrong currency is the only kind of wrong price that looks entirely ordinary — €797.36
+ * where ¥797.36 would be absurd on sight — so the message has to say which currency turned
+ * up, not merely that something was off.
  */
 
 import { describe, expect, it } from "vitest";
 
-import { looksUnconverted, unconvertedMessage } from "./conversion-check";
-
-/** The real values the dev store returned, which is what prompted all of this. */
-const OBSERVED = { baseMinorUnits: 88_595, adjustmentBps: -1_000, derivedAmount: "797.36" };
-
-describe("looksUnconverted", () => {
-  it("catches the euro case, which nothing else would", () => {
-    // $885.95 less 10% is $797.36, returned unchanged and labelled EUR.
-    expect(
-      looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD" }),
-    ).toBe(true);
-  });
-
-  it("catches the yen case before the parser blames the currency", () => {
-    // Same number, labelled JPY. `parseMoney` would throw here with a message about
-    // decimal places, which sends a merchant to look at their prices rather than at
-    // their market.
-    expect(
-      looksUnconverted({ ...OBSERVED, listCurrency: "JPY", shopCurrency: "USD" }),
-    ).toBe(true);
-
-    // And the shape the dev store actually returned for a cheap variant.
-    expect(
-      looksUnconverted({
-        baseMinorUnits: 800,
-        adjustmentBps: -1_000,
-        derivedAmount: "7.2",
-        listCurrency: "JPY",
-        shopCurrency: "USD",
-      }),
-    ).toBe(true);
-  });
-
-  it("accepts a properly converted euro price", () => {
-    // $885.95 less 10% is $797.36; at roughly 0.92 EUR/USD that is about €733.
-    expect(
-      looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD", derivedAmount: "733.57" }),
-    ).toBe(false);
-  });
-
-  it("accepts a properly converted yen price", () => {
-    // The number that made this worth catching: ¥797 versus the ¥119,604 it should be.
-    expect(
-      looksUnconverted({ ...OBSERVED, listCurrency: "JPY", shopCurrency: "USD", derivedAmount: "119604" }),
-    ).toBe(false);
-  });
-
-  it("says nothing about a list in the shop's own currency", () => {
-    // A USD list on a USD shop is unconverted by definition and entirely correct.
-    expect(
-      looksUnconverted({ ...OBSERVED, listCurrency: "USD", shopCurrency: "USD" }),
-    ).toBe(false);
-  });
-
-  it("tolerates Shopify rounding its own way by a minor unit", () => {
-    // The rule gives 797.355. Shopify may send either neighbour, and both are still
-    // unmistakably unconverted.
-    for (const amount of ["797.35", "797.36"]) {
-      expect(
-        looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD", derivedAmount: amount }),
-      ).toBe(true);
-    }
-  });
-
-  it("compares in major units, so a zero-decimal shop currency is not off by a hundred", () => {
-    // A JPY shop pricing into USD. ¥10,000 is 10,000 minor units, not 1,000,000 — and a
-    // check that assumed two decimals everywhere would compute ¥100 and call a correct
-    // conversion unconverted, refusing a market that was working perfectly.
-    expect(
-      looksUnconverted({
-        baseMinorUnits: 10_000,
-        adjustmentBps: -1_000,
-        derivedAmount: "9000",
-        listCurrency: "USD",
-        shopCurrency: "JPY",
-      }),
-    ).toBe(true);
-
-    expect(
-      looksUnconverted({
-        baseMinorUnits: 10_000,
-        adjustmentBps: -1_000,
-        derivedAmount: "60.30",
-        listCurrency: "USD",
-        shopCurrency: "JPY",
-      }),
-    ).toBe(false);
-  });
-
-  it("does not choke on an amount Shopify could not give", () => {
-    expect(
-      looksUnconverted({ ...OBSERVED, listCurrency: "EUR", shopCurrency: "USD", derivedAmount: "" }),
-    ).toBe(false);
-  });
-});
+import { unconvertedMessage } from "./conversion-check";
 
 describe("unconvertedMessage", () => {
-  it("names the market, the cause and the next action", () => {
-    const message = unconvertedMessage("Japan", "JPY");
+  it("names the market, the currency that arrived, and the next action", () => {
+    const message = unconvertedMessage("Japan", "JPY", "USD");
 
     expect(message).toContain("Japan");
     expect(message).toContain("JPY");
+    // Without this, "wrong currency" and "wrong by an exchange rate" are the same
+    // unhelpful sentence to somebody trying to work out what happened.
+    expect(message).toContain("USD");
     expect(message).toMatch(/Settings → Markets/);
-    // And says what still happened, so a merchant is not left wondering whether the
-    // whole campaign died.
+    // And says what still happened, so a merchant is not left wondering whether the whole
+    // campaign died.
     expect(message).toMatch(/other surface/i);
+  });
+
+  it("still reads sensibly when the currency is unknown", () => {
+    const message = unconvertedMessage("Europe", "EUR");
+
+    expect(message).toContain("Europe");
+    expect(message).toContain("EUR");
+    expect(message).not.toContain("undefined");
   });
 });

--- a/app/lib/markets/conversion-check.ts
+++ b/app/lib/markets/conversion-check.ts
@@ -1,78 +1,21 @@
 /**
- * Catching a market price Shopify never converted.
+ * What a merchant is told when a market answers in the wrong currency.
  *
- * A relative price list is meant to answer with the base price converted into the
- * market's currency and *then* adjusted by the list's percentage. On the dev store it
- * answers with the base price adjusted and not converted at all — an EUR list and a JPY
- * list returning byte-identical amounts, which is the tell. The cause is still open
- * (#257); this is the guard, which is right whatever the cause turns out to be.
+ * There used to be a detector here too, inferring the problem from arithmetic: if the
+ * amount equalled the base price with only the list's rule applied, no conversion had
+ * happened. It was built on a wrong theory — that the market was misconfigured — and it
+ * happened to catch the real case anyway.
  *
- * **The yen case fails loudly and the euro case does not, which is why this exists.**
- * ¥797.36 is absurd on sight and `parseMoney` refuses it for having decimals a
- * zero-decimal currency cannot have. €797.36 is a perfectly ordinary-looking price that
- * happens to be wrong by an exchange rate, and nothing downstream would ever question it.
- * A plausible wrong price written to a live storefront is the failure this product exists
- * to prevent.
- *
- * Deliberately operating on the decimal string Shopify sent, before it is parsed into
- * minor units. Parsing is where the yen case explodes, and it explodes with a message
- * about decimal places — which sends a merchant to look at their prices when the problem
- * is their market.
+ * The real case turned out to be that `priceList.prices(originType: RELATIVE)` answers in
+ * the *shop's* currency by design, and market prices now come from `contextualPricing`
+ * instead (#264). So the check is a fact rather than an inference: refuse when the stated
+ * currency is not the list's. The inference is gone; only the sentence a merchant reads
+ * remains, because that part was always the useful half.
  */
 
-import { exponentOf } from "../money/currency";
-
-export interface ConversionCheck {
-  /** The price list's currency, as declared on the list. */
-  listCurrency: string;
-  /** The shop's own currency — what the base price is denominated in. */
-  shopCurrency: string;
-  /** The base-surface price, in the shop currency's minor units. */
-  baseMinorUnits: number;
-  /** The list's parent adjustment. Zero is fine; null means the list is not relative. */
-  adjustmentBps: number;
-  /** Exactly what Shopify returned, before parsing. */
-  derivedAmount: string;
-}
-
 /**
- * True when the derived amount is the base price with the rule applied and nothing else.
- *
- * The comparison is in major units, because the two currencies need not share a
- * minor-unit exponent and the whole point is that no conversion happened — there is no
- * sensible minor-unit space to compare in.
- *
- * Tolerance is one minor unit of the list's currency, since Shopify rounds its own way
- * and being out by a cent is still unmistakably "unconverted".
- *
- * A false positive requires a real exchange rate of exactly 1.0000 between two different
- * currencies. That is vanishingly rare, transient when it happens, and costs a refusal
- * rather than a wrong price — which is the trade worth making.
- */
-export function looksUnconverted(check: ConversionCheck): boolean {
-  const { listCurrency, shopCurrency, baseMinorUnits, adjustmentBps, derivedAmount } = check;
-
-  // Same currency means there is nothing to convert and nothing to detect.
-  if (listCurrency === shopCurrency) return false;
-
-  const derived = Number(derivedAmount);
-  if (!Number.isFinite(derived)) return false;
-
-  const baseMajor = baseMinorUnits / 10 ** exponentOf(shopCurrency);
-  const ruleOnly = (baseMajor * (10_000 + adjustmentBps)) / 10_000;
-
-  const tolerance = 1 / 10 ** exponentOf(listCurrency);
-
-  return Math.abs(derived - ruleOnly) <= tolerance;
-}
-
-/**
- * What a merchant is told when a market's prices come back unconverted.
- *
  * Names the market, says what is wrong in terms of the thing they configured, and gives
- * them somewhere to go — the error taxonomy in RFC §11. Deliberately does not guess at
- * the cause, because we do not know it yet, and a confident wrong diagnosis wastes more
- * of somebody's afternoon than an honest description does.
+ * them somewhere to go — the error taxonomy in RFC §11.
  */
 export function unconvertedMessage(
   marketName: string,


### PR DESCRIPTION
Closes #257.

The detector inferred the problem from arithmetic — *if the amount equals the base price with only the list's rule applied, no conversion happened* — on a theory that turned out to be wrong. It was never a misconfigured market: `priceList.prices(originType: RELATIVE)` answers in the shop's currency **by design**.

It caught the real case anyway. That is a poor reason to keep something guarding a live storefront.

Market prices come from `contextualPricing` now (#264), where the currency is *stated* rather than deduced, and the refusal compares it directly. Nothing called `looksUnconverted` any more, so it and its tests are gone.

## What survives, and why

The sentence a merchant reads — now naming the currency that actually turned up:

> Japan returned prices that are not in JPY — **it answered in USD**, so they are wrong by an exchange rate and this campaign will not price that market.

Without that detail, *"wrong currency"* and *"wrong by an exchange rate"* are the same unhelpful sentence. And this matters more than it looks: a price in the wrong currency is the only kind of wrong price that looks entirely ordinary. **€797.36 where ¥797.36 would be absurd on sight.**

817 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)