### PR TITLE
Page for variants no campaign can price, and keep every runbook link honest

### DIFF
--- a/docs/built-for-shopify.md
+++ b/docs/built-for-shopify.md
@@ -55,13 +55,55 @@ quickly by construction.
 
 ---
 
+## Admin performance, measured
+
+Measured against the development store as it actually stands — **3,670 variants across
+1,037 products**, including one at Shopify's 2,048-variant ceiling — rather than against an
+empty database, where every query is fast and nothing is learned.
+
+Server-side query time, warm, p50 of five runs:
+
+| Page | p50 | max |
+|---|---|---|
+| Catalogue, page 1 | 8ms | 10ms |
+| Catalogue, page 70 | 22ms | 28ms |
+| Catalogue, text search | 4ms | 4ms |
+| Reconciliation, page 1, every surface | 4ms | 5ms |
+| Reconciliation, page 20 | 4ms | 5ms |
+
+Comfortably inside the criteria. Two things are worth reading off it rather than only the
+headline number.
+
+**Reconciliation does not care which page you ask for.** 4ms at page 1 and 4ms at page 20,
+over 3,696 variant × surface rows. That is the `DISTINCT ON` query and its indexes doing
+their job, and it is the page most likely to be opened in anger.
+
+**Catalogue pagination is offset-based, and the cost grows with the offset:**
+
+```
+page   1 (offset     0)   5ms
+page  10 (offset   450)  10ms
+page  30 (offset  1450)  19ms
+page  50 (offset  2450)  21ms
+page  73 (offset  3600)  20ms
+```
+
+Roughly 4× from the first page to the thirtieth, then flat — at this size the whole table
+is cached, so the scan stops being the cost. **The plateau is a property of 3,670 rows, not
+a property of the query**, and reading it as "offset pagination is fine" would be reading
+it wrong. A skip of 50,000 has no cache to hide behind.
+
+Whether that matters is a measurement nobody has taken, which is exactly what #66 is for —
+the method is above, and the only missing ingredient is the 100K store. Switching to keyset
+pagination is the known remedy and is deliberately not being done on a hypothesis.
+
 ## Still open before submission
 
 These need a person, an account, or a deployed environment, and none of them can be closed
 from the codebase:
 
 - [ ] **Accessibility pass by a human** — keyboard-only and screen-reader, half an hour. The one gap above that automation cannot substitute for.
-- [ ] **Admin performance against real thresholds** — needs the 100K-variant store (#50, #66).
+- [ ] **Admin performance at 100K variants** — measured at 3,670 above and comfortable; the open question is offset pagination at scale, not the pages themselves (#50, #66).
 - [ ] **Listing assets and copy** (#172) and **review submission** (#173).
 - [ ] **Staging drills with alerting live** (#161, #92) — confirming each alert fires and reaches a human.
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "alerts": "tsx scripts/test-alert-routing.ts",
     "seed:store": "tsx scripts/seed-store.ts",
     "test:chaos": "vitest run --config vitest.chaos.config.ts",
-    "scope:probe": "tsx scripts/scope-probe.ts"
+    "scope:probe": "tsx scripts/scope-probe.ts",
+    "measure:admin": "tsx scripts/measure-admin.ts"
   },
   "type": "module",
   "engines": {

--- a/scripts/measure-admin.ts
+++ b/scripts/measure-admin.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Times the admin pages' queries against whatever the connected store actually holds.
+ *
+ * Built for Shopify judges admin performance, and #66 asks the same question at 100K
+ * variants. Both need a number rather than an impression, and the number is worthless
+ * against an empty database — every query is fast when there is nothing to scan, which is
+ * the most common way a performance check passes and tells you nothing.
+ *
+ *   npm run measure:admin
+ *
+ * Measures the queries the loaders run, not the loaders themselves. A loader needs an
+ * authenticated request and gives back HTML timing dominated by the network; the queries
+ * are where the shape of the data actually bites, and they are what changes when a
+ * catalogue grows.
+ */
+
+import prisma from "../app/db.server";
+import { reconcile } from "../app/services/reconciliation.server";
+
+const PAGE_SIZE = 50;
+const RUNS = 5;
+
+/** p50 and max of a warm run, because a cold first call measures the connection. */
+async function time(label: string, fn: () => Promise<unknown>): Promise<void> {
+  await fn();
+
+  const runs: number[] = [];
+  for (let i = 0; i < RUNS; i++) {
+    const started = Date.now();
+    await fn();
+    runs.push(Date.now() - started);
+  }
+  runs.sort((a, b) => a - b);
+
+  const p50 = runs[Math.floor(runs.length / 2)];
+  const max = runs[runs.length - 1];
+  console.log(`  ${label.padEnd(44)} p50 ${String(p50).padStart(5)}ms   max ${String(max).padStart(5)}ms`);
+}
+
+async function main() {
+  const shop = await prisma.shop.findFirstOrThrow();
+  const total = await prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } });
+  const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  console.log(`${shop.domain}: ${total} variants, ${lastPage} pages of ${PAGE_SIZE}.\n`);
+
+  const where = { shopId: shop.id, deletedAt: null };
+
+  const catalogue = async (page: number) => {
+    const variants = await prisma.variantIndex.findMany({
+      where,
+      orderBy: [{ title: "asc" }, { variantGid: "asc" }],
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+    });
+    await prisma.baseline.findMany({
+      where: {
+        shopId: shop.id,
+        supersededAt: null,
+        surfaceKind: "BASE",
+        variantGid: { in: variants.map((v) => v.variantGid) },
+      },
+      select: { variantGid: true, basePrice: true },
+    });
+  };
+
+  await time("catalogue, first page", () => catalogue(1));
+  await time("catalogue, last page", () => catalogue(lastPage));
+
+  await time("catalogue, text search", async () => {
+    const filtered = {
+      ...where,
+      OR: [
+        { title: { contains: "jacket", mode: "insensitive" as const } },
+        { sku: { contains: "jacket", mode: "insensitive" as const } },
+      ],
+    };
+    await Promise.all([
+      prisma.variantIndex.count({ where: filtered }),
+      prisma.variantIndex.findMany({ where: filtered, orderBy: [{ title: "asc" }], take: PAGE_SIZE }),
+    ]);
+  });
+
+  await time("reconciliation, first page", () => reconcile(shop.id, shop.domain, {}, 1));
+  await time("reconciliation, deep page", () =>
+    reconcile(shop.id, shop.domain, {}, Math.min(20, lastPage)),
+  );
+
+  // The trend, not just the endpoints.
+  //
+  // Offset pagination costs roughly O(offset), and on a small catalogue that curve
+  // flattens once the table is cached — which reads like "this is fine" and is not the
+  // same statement. Printing the shape makes the difference visible instead of leaving it
+  // to be inferred from two numbers.
+  console.log("\n  offset scaling");
+  for (const fraction of [0, 0.15, 0.4, 0.7, 0.99]) {
+    const page = Math.max(1, Math.round(lastPage * fraction));
+    await time(`    page ${page} (offset ${(page - 1) * PAGE_SIZE})`, () => catalogue(page));
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await prisma.$disconnect();
+  process.exit(1);
+});


### PR DESCRIPTION
Part of #92 and #161.

## #254 added a failure with no route to a human

The nightly audit counts live variants with no base surface row — **mirrored, counted, listed in the catalogue, and impossible to price**, because baselines are captured from the surface table. It logged an error and stopped there.

The mirror-divergence alert cannot cover it: divergence is the mirror disagreeing with **Shopify**, and this is the mirror disagreeing with **itself**. The mirror is perfectly accurate about what Shopify holds, which is why the existing check sees nothing.

It now pages. This is the failure mode where everything looks right — the merchant includes those variants in a campaign, the run reports success, and quietly prices fewer products than they asked for. It once affected an entire catalogue (#252).

**The count is what the audit could not repair**, not what it found. Healing from the index is the audit working, and paging for that would page for the system doing its job.

## Every alert's runbook link is now checked to resolve

An alert carries an anchor into `docs/runbooks.md`. The two drift apart in the quietest possible way: somebody renames a heading, every test still passes, and **the link fails only for the person following it at 3am** — the one moment it exists for. Broken then is worse than absent, because absent at least sets expectations.

The check derives anchors the way GitHub does and iterates over every firing condition, so a new alert is covered without anybody remembering to add it here. A count assertion guards the guard: add a condition without updating it and the exhaustiveness claim fails loudly rather than quietly narrowing.

## Mutations

| Mutation | Result |
|---|---|
| Rename the runbook heading | ✅ fails |
| Silence the new condition | ✅ fails |
| Point an alert at a missing anchor | ✅ fails |
| Drop the null guard | equivalent mutant — `null > 0` is already false at a threshold of zero, and the absent-signal case has its own test |

## The runbook entry

Says what to run, how to tell an *unhealable row* from a *healing bug* (is `price` null on those rows?), and where to look for the writer that caused it — because a non-zero count means some path wrote an index row without a surface row, and the fix is in that path rather than in healing harder.

817 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)