### PR TITLE
Search the help centre, and stop table rows reading as corrupted text

### DIFF
--- a/app/lib/compliance/built-for-shopify.test.ts
+++ b/app/lib/compliance/built-for-shopify.test.ts
@@ -37,13 +37,23 @@ const components = sourceFiles("app/components", /\.tsx$/);
 /**
  * The embedded admin surface.
  *
- * `_index` is the app's public landing page — it renders outside Shopify's admin, where
- * App Bridge is not loaded and Polaris web components therefore do not exist. The design
- * criteria are about the embedded experience, so holding a plain login page to them would
- * be checking the wrong thing.
+ * Two routes are deliberately outside it, and both render where App Bridge is not loaded
+ * and Polaris web components therefore do not exist:
+ *
+ * - `_index`, the app's public landing page.
+ * - `help.$`, the help centre. A merchant reaches it from an error message, an email, or
+ *   a session that has already expired, so it must render without App Bridge — and its
+ *   search box must be a plain GET form for the same reason. Holding either page to
+ *   criteria about the embedded experience would be checking the wrong thing.
+ *
+ * The exclusion is by exact route rather than a pattern, so a new file cannot quietly opt
+ * itself out of the design criteria by living next door. The first test below makes the
+ * list earn itself.
  */
+const OUTSIDE_THE_ADMIN = ["routes/_index", "routes/help.$"];
+
 const ui = [
-  ...routes.filter((file) => !file.includes("routes/_index")),
+  ...routes.filter((file) => !OUTSIDE_THE_ADMIN.some((route) => file.includes(route))),
   ...components,
 ];
 
@@ -69,6 +79,22 @@ describe("performance — no storefront impact", () => {
 });
 
 describe("design — Polaris and App Bridge", () => {
+  it("only excuses routes that genuinely render outside the admin", () => {
+    // The exclusion list is the one way to escape every criterion below, so it has to
+    // earn itself. A route inside the embedded admin authenticates as an admin and mounts
+    // AppProvider; a route doing either of those has no business on this list.
+    for (const route of OUTSIDE_THE_ADMIN) {
+      const file = routes.find((candidate) => candidate.includes(route));
+      expect(file, `${route} is excluded but does not exist`).toBeDefined();
+
+      const source = readFileSync(file!, "utf8");
+      expect(source, `${route} is excluded but authenticates as embedded admin`).not.toMatch(
+        /authenticate\.admin/,
+      );
+      expect(source, `${route} is excluded but mounts AppProvider`).not.toMatch(/AppProvider/);
+    }
+  });
+
   it("uses no native form outside the App Bridge-safe wrapper", () => {
     // A native form does a full navigation that wipes App Bridge's host, id_token and
     // shop parameters. The server then sees no shop and the merchant gets a blank page —

--- a/app/lib/help/search.server.test.ts
+++ b/app/lib/help/search.server.test.ts
@@ -1,0 +1,162 @@
+/**
+ * A search box that returns the wrong page is worse than no search box: it answers
+ * confidently. These tests are about what a merchant would type, not about the scoring.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveHelpFile } from "./pages.server";
+import { searchHelp, toProse } from "./search.server";
+
+const HELP_ROOT = join(process.cwd(), "docs", "help");
+
+const top = (query: string) => searchHelp(query)[0]?.slug;
+
+describe("searching for the thing a page is about finds that page first", () => {
+  const expectations: Array<[string, string]> = [
+    ["drift", "concepts/drift"],
+    ["baseline", "concepts/baselines"],
+    ["revert", "concepts/revert"],
+    ["rate limits", "concepts/rate-limits"],
+    ["guardrail", "failures/guardrail-blocks"],
+    ["flow", "how-to/shopify-flow"],
+    ["first campaign", "how-to/first-campaign"],
+  ];
+
+  it.each(expectations)("%j → %s", (query, slug) => {
+    expect(top(query)).toBe(slug);
+  });
+});
+
+describe("what it refuses to do", () => {
+  it("returns nothing for an empty query rather than every page", () => {
+    // The index already lists everything; a search box that returns all of it looks like
+    // it ignored what was typed.
+    expect(searchHelp("")).toEqual([]);
+    expect(searchHelp("   ")).toEqual([]);
+    expect(searchHelp("!!")).toEqual([]);
+  });
+
+  it("narrows on a second word instead of widening", () => {
+    const broad = searchHelp("campaign");
+    const narrow = searchHelp("campaign schedule");
+
+    expect(broad.length).toBeGreaterThan(narrow.length);
+  });
+
+  it("finds nothing for a word we never wrote", () => {
+    expect(searchHelp("dropshipping")).toEqual([]);
+  });
+
+  it("never offers the index page as a result", () => {
+    // It is the page you search from; listing it is noise.
+    for (const query of ["help", "campaign", "price", "anchor"]) {
+      expect(searchHelp(query, 50).map((h) => h.slug)).not.toContain("index");
+    }
+  });
+
+  it("caps how many it returns", () => {
+    expect(searchHelp("a price campaign", 3).length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("every result is usable", () => {
+  // Every term must appear, so a long query narrows to nothing — "price" is what a
+  // merchant actually types, and it reaches most of the centre.
+  const hits = searchHelp("price", 50);
+
+  it("found something to check", () => {
+    expect(hits.length).toBeGreaterThan(5);
+  });
+
+  it("does not repeat the title as the opening of its own snippet", () => {
+    for (const hit of hits) {
+      expect(hit.snippet.startsWith(hit.title), hit.slug).toBe(false);
+    }
+  });
+
+  it("links only to pages the help centre will serve", () => {
+    for (const hit of hits) {
+      expect(resolveHelpFile(hit.slug), `${hit.slug} is not servable`).not.toBeNull();
+    }
+  });
+
+  it("shows prose, not markdown syntax", () => {
+    for (const hit of hits) {
+      // A snippet containing `](./foo.md)` or a heading's hashes reads as a bug.
+      expect(hit.snippet, hit.slug).not.toMatch(/[[\]`|]|\]\(|^#/);
+      expect(hit.snippet.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("points the highlight at the term that was actually searched", () => {
+    for (const hit of searchHelp("drift", 50)) {
+      if (!hit.match) continue;
+      expect(hit.snippet.slice(hit.match.start, hit.match.end).toLowerCase()).toBe("drift");
+    }
+  });
+
+  it("cuts snippets at word boundaries, not mid-word", () => {
+    let trimmed = 0;
+
+    for (const hit of hits) {
+      const prose = toProse(readFileSync(join(HELP_ROOT, `${hit.slug}.md`), "utf8"));
+      const body = hit.snippet.replace(/^…/, "").replace(/…$/, "");
+
+      const at = prose.indexOf(body);
+      expect(at, `${hit.slug}: snippet is not in the page`).toBeGreaterThanOrEqual(0);
+
+      // The characters just outside the cut must be spaces, or the cut sat inside a word
+      // and the merchant reads "…ign's prices are reverted".
+      if (at > 0) {
+        expect(prose[at - 1], `${hit.slug} starts mid-word`).toBe(" ");
+        trimmed += 1;
+      }
+      const after = at + body.length;
+      if (after < prose.length) {
+        expect(prose[after], `${hit.slug} ends mid-word`).toBe(" ");
+      }
+    }
+
+    expect(trimmed, "no snippet was trimmed, so this proves nothing").toBeGreaterThan(0);
+  });
+
+  it("gives a title that is the page's heading, not its slug", () => {
+    for (const hit of hits) {
+      expect(hit.title).not.toBe(hit.slug);
+    }
+  });
+});
+
+describe("markdown is reduced to the sentence a merchant read", () => {
+  it("keeps a link's text and drops its target", () => {
+    // The failure this prevents: searching "price" matching `](./prices.md)` and the
+    // snippet showing markup.
+    expect(toProse("See [how prices resolve](./concepts/resolver.md) first.")).toBe(
+      "See how prices resolve first.",
+    );
+  });
+
+  it("drops code blocks, which are syntax rather than prose", () => {
+    expect(toProse("Before\n\n```sh\nnpm run apply --force\n```\n\nAfter")).toBe("Before After");
+  });
+
+  it("drops heading marks, emphasis and table pipes", () => {
+    expect(toProse("## A heading\n\n**bold** and _thin_ and `code`")).toBe(
+      "A heading bold and thin and code",
+    );
+    // Cells get a separator rather than being run together — without one, a table row
+    // reads as corrupted text in a search result.
+    expect(toProse("| Trigger | What it means |")).toBe("Trigger · What it means");
+    expect(toProse("| A | B |\n|---|---|\n| c | d |")).toBe("A · B c · d");
+  });
+
+  it("leaves ordinary prose alone", () => {
+    expect(toProse("Drift is when a price is not what this app last wrote.")).toBe(
+      "Drift is when a price is not what this app last wrote.",
+    );
+  });
+});

--- a/app/lib/help/search.server.ts
+++ b/app/lib/help/search.server.ts
@@ -1,0 +1,214 @@
+/**
+ * Search across the help centre.
+ *
+ * Twenty-one pages is small enough that scanning all of them per query costs less than a
+ * millisecond, so there is no index to build, invalidate or get wrong. If the help centre
+ * ever grows past a few hundred pages this should be reconsidered — but building a search
+ * index for twenty-one documents would be answering a question nobody asked.
+ *
+ * The ranking is deliberately crude and explained rather than tuned: a merchant searching
+ * "drift" wants the page called drift, not the six pages that mention it in passing.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(process.cwd(), "docs", "help");
+
+/** The index page is the thing you search *from*; returning it as a result is noise. */
+const EXCLUDED = new Set(["index"]);
+
+export interface HelpHit {
+  slug: string;
+  title: string;
+  /** The text around the match, for showing why this page matched. */
+  snippet: string;
+  /** Character offsets of the match within `snippet`, so the caller can mark it. */
+  match: { start: number; end: number } | null;
+}
+
+interface Document {
+  slug: string;
+  title: string;
+  /** Markdown stripped down to prose, so a match cannot land inside syntax. */
+  text: string;
+  headings: string;
+}
+
+let cached: Document[] | null = null;
+
+/**
+ * Read once and keep. The files ship inside the container image and cannot change under a
+ * running process, so re-reading them per query would buy nothing.
+ */
+function documents(): Document[] {
+  if (cached) return cached;
+
+  const docs: Document[] = [];
+
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        walk(join(dir, entry.name), `${prefix}${entry.name}/`);
+        continue;
+      }
+      if (!entry.name.endsWith(".md")) continue;
+
+      const slug = prefix + entry.name.replace(/\.md$/, "");
+      if (EXCLUDED.has(slug)) continue;
+
+      const source = readFileSync(join(dir, entry.name), "utf8");
+      docs.push({
+        slug,
+        title: /^#\s+(.+)$/m.exec(source)?.[1]?.trim() ?? slug,
+        // The `#` heading is shown as the result's title, so leaving it in the prose makes
+        // every snippet open by repeating the line directly above it.
+        text: toProse(source.replace(/^#\s+.+$/m, "")),
+        headings: [...source.matchAll(/^#{2,}\s+(.+)$/gm)].map((m) => m[1]).join(" · "),
+      });
+    }
+  };
+
+  walk(ROOT, "");
+  cached = docs.sort((a, b) => a.slug.localeCompare(b.slug));
+  return cached;
+}
+
+/**
+ * Markdown to something a merchant would recognise as the sentence they read.
+ *
+ * Without this, a search for "price" matches the `](./prices.md)` inside a link and the
+ * snippet shows the merchant a fragment of markup, which reads as a bug.
+ *
+ * Exported for its test: whether a snippet happens to land on a link depends on the docs,
+ * and a guarantee that only holds for today's prose is not a guarantee.
+ */
+export function toProse(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .split("\n")
+    .map(tableRowToProse)
+    .join("\n")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_`>|]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * A table row as a sentence-ish fragment rather than its cells run together.
+ *
+ * Stripping the pipes alone turned "| Campaign held for drift | A campaign stopped… |"
+ * into one unpunctuated run, which in a search result reads as corrupted text. The
+ * separator row (`|---|---|`) carries no words at all and is dropped.
+ */
+function tableRowToProse(line: string): string {
+  if (!/^\s*\|/.test(line)) return line;
+  if (/^[\s|:-]+$/.test(line)) return "";
+
+  return line
+    .split("|")
+    .map((cell) => cell.trim())
+    .filter(Boolean)
+    .join(" · ");
+}
+
+/**
+ * Rank a page against a query.
+ *
+ * Title beats heading beats body, because a page *about* the thing is almost always what
+ * was wanted. Every term must appear somewhere, so a two-word query narrows rather than
+ * widens — the opposite behaviour makes a search box feel broken.
+ */
+function score(doc: Document, terms: string[]): number {
+  const title = doc.title.toLowerCase();
+  const headings = doc.headings.toLowerCase();
+  const text = doc.text.toLowerCase();
+
+  let total = 0;
+
+  for (const term of terms) {
+    const inTitle = title.includes(term);
+    const inHeadings = headings.includes(term);
+    const inText = text.includes(term);
+
+    if (!inTitle && !inHeadings && !inText) return 0;
+
+    if (inTitle) total += title === term ? 100 : 30;
+    if (inHeadings) total += 8;
+    if (inText) total += 1;
+  }
+
+  return total;
+}
+
+const SNIPPET_RADIUS = 90;
+
+/** The prose around the first term that appears, with the offsets of that term. */
+function snippetFor(doc: Document, terms: string[]): Pick<HelpHit, "snippet" | "match"> {
+  const lower = doc.text.toLowerCase();
+
+  let at = -1;
+  let term = "";
+  for (const candidate of terms) {
+    const found = lower.indexOf(candidate);
+    if (found !== -1 && (at === -1 || found < at)) {
+      at = found;
+      term = candidate;
+    }
+  }
+
+  // Matched on the title alone: the opening sentence says more than nothing.
+  if (at === -1) {
+    return { snippet: clamp(doc.text.slice(0, SNIPPET_RADIUS * 2), false, true), match: null };
+  }
+
+  const from = wordBoundaryBefore(doc.text, Math.max(0, at - SNIPPET_RADIUS));
+  const to = wordBoundaryAfter(doc.text, Math.min(doc.text.length, at + term.length + SNIPPET_RADIUS));
+  const body = clamp(doc.text.slice(from, to), from > 0, to < doc.text.length);
+  const offset = at - from + (from > 0 ? 1 : 0);
+
+  return { snippet: body, match: { start: offset, end: offset + term.length } };
+}
+
+/**
+ * Snippets are cut to a character count, which lands mid-word about as often as not.
+ * "…ign's prices are reverted" is a distraction in a list a merchant is scanning.
+ */
+function wordBoundaryBefore(text: string, at: number): number {
+  if (at === 0) return 0;
+  const space = text.indexOf(" ", at);
+  return space === -1 ? at : space + 1;
+}
+
+function wordBoundaryAfter(text: string, at: number): number {
+  if (at >= text.length) return text.length;
+  const space = text.lastIndexOf(" ", at);
+  return space <= 0 ? at : space;
+}
+
+function clamp(text: string, before: boolean, after: boolean): string {
+  return `${before ? "…" : ""}${text}${after ? "…" : ""}`;
+}
+
+/**
+ * Pages matching a query, best first. An empty or whitespace query returns nothing rather
+ * than everything, because "everything" is what the index page is already for.
+ */
+export function searchHelp(query: string, limit = 8): HelpHit[] {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.replace(/[^a-z0-9-]/g, ""))
+    .filter((t) => t.length > 1);
+
+  if (terms.length === 0) return [];
+
+  return documents()
+    .map((doc) => ({ doc, rank: score(doc, terms) }))
+    .filter(({ rank }) => rank > 0)
+    .sort((a, b) => b.rank - a.rank || a.doc.slug.localeCompare(b.doc.slug))
+    .slice(0, limit)
+    .map(({ doc }) => ({ slug: doc.slug, title: doc.title, ...snippetFor(doc, terms) }));
+}

--- a/app/routes/help.$.tsx
+++ b/app/routes/help.$.tsx
@@ -22,9 +22,17 @@ import type { LoaderFunctionArgs } from "react-router";
 import { data, isRouteErrorResponse, useLoaderData, useRouteError } from "react-router";
 
 import { INDEX_SLUG, readHelpPage } from "../lib/help/pages.server";
+import { searchHelp, type HelpHit } from "../lib/help/search.server";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ params, request }: LoaderFunctionArgs) {
   const slug = params["*"] || INDEX_SLUG;
+
+  // Search is a GET with a query string rather than a route of its own, so a merchant can
+  // bookmark or share a result list, and so the back button behaves.
+  const query = new URL(request.url).searchParams.get("q")?.trim() ?? "";
+  if (query) {
+    return { query, hits: searchHelp(query), page: null, isIndex: false };
+  }
 
   const page = await readHelpPage(slug);
 
@@ -32,12 +40,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
   // silently landing them somewhere else hides that a link in the product is wrong.
   if (!page) throw data({ slug }, { status: 404 });
 
-  return { page, isIndex: slug === INDEX_SLUG };
+  return { query, hits: null, page, isIndex: slug === INDEX_SLUG };
 }
 
 export function meta({ data: loaded }: { data?: Awaited<ReturnType<typeof loader>> }) {
   const SUFFIX = "Anchor help";
-  const title = loaded?.page.title ?? SUFFIX;
+  const title = loaded?.query ? `${loaded.query} — search` : (loaded?.page?.title ?? SUFFIX);
 
   // The index's own heading is already the suffix, and "Anchor help · Anchor help" in a
   // browser tab reads like a bug because it is one.
@@ -45,13 +53,55 @@ export function meta({ data: loaded }: { data?: Awaited<ReturnType<typeof loader
 }
 
 export default function HelpRoute() {
-  const { page, isIndex } = useLoaderData<typeof loader>();
+  const { page, isIndex, query, hits } = useLoaderData<typeof loader>();
+
+  if (hits) {
+    return (
+      <Shell showBack query={query}>
+        <h1>
+          {hits.length === 0 ? "Nothing matched" : `${hits.length} page${hits.length === 1 ? "" : "s"}`}
+          {" for "}
+          {/* Rendered as text, never as markup: this is the only thing on the page that
+              did not come from a file we wrote. */}
+          <em>{query}</em>
+        </h1>
+        {hits.length === 0 ? (
+          <p>
+            Try a single word — the pages are written in plain language, so the word you
+            would say out loud is usually the one that finds them.
+          </p>
+        ) : (
+          <ol className="hits">
+            {hits.map((hit) => (
+              <li key={hit.slug}>
+                <a href={`/help/${hit.slug}`}>{hit.title}</a>
+                <p>{highlight(hit)}</p>
+              </li>
+            ))}
+          </ol>
+        )}
+      </Shell>
+    );
+  }
 
   return (
-    <Shell showBack={!isIndex}>
+    <Shell showBack={!isIndex} query={query}>
       {/* The markdown is committed alongside this file — it is our prose, not input. */}
-      <article dangerouslySetInnerHTML={{ __html: page.html }} />
+      <article dangerouslySetInnerHTML={{ __html: page!.html }} />
     </Shell>
+  );
+}
+
+/** The matched term marked inside its snippet, split into nodes so React does the escaping. */
+function highlight(hit: HelpHit) {
+  if (!hit.match) return hit.snippet;
+
+  return (
+    <>
+      {hit.snippet.slice(0, hit.match.start)}
+      <mark>{hit.snippet.slice(hit.match.start, hit.match.end)}</mark>
+      {hit.snippet.slice(hit.match.end)}
+    </>
   );
 }
 
@@ -60,7 +110,7 @@ export function ErrorBoundary() {
   const missing = isRouteErrorResponse(error) && error.status === 404;
 
   return (
-    <Shell showBack>
+    <Shell showBack query="">
       <h1>{missing ? "No such help page" : "That page could not be loaded"}</h1>
       <p>
         {missing
@@ -71,15 +121,30 @@ export function ErrorBoundary() {
   );
 }
 
-function Shell({ children, showBack }: { children: React.ReactNode; showBack: boolean }) {
+function Shell({
+  children,
+  showBack,
+  query,
+}: {
+  children: React.ReactNode;
+  showBack: boolean;
+  query: string;
+}) {
   return (
     <main className="help">
       <style>{STYLES}</style>
-      {showBack ? (
-        <nav>
-          <a href="/help">← Help centre</a>
-        </nav>
-      ) : null}
+      <nav>
+        {showBack ? <a href="/help">← Help centre</a> : <span />}
+        {/* A plain GET form: it works before any JavaScript has loaded, which matters on
+            a page a merchant may reach while the rest of the app is misbehaving. */}
+        <form method="get" action="/help" role="search">
+          <label htmlFor="q" className="visually-hidden">
+            Search the help centre
+          </label>
+          <input id="q" type="search" name="q" defaultValue={query} placeholder="Search help" />
+          <button type="submit">Search</button>
+        </form>
+      </nav>
       {children}
     </main>
   );
@@ -98,7 +163,37 @@ const STYLES = `
   line-height: 1.65;
   color: #1a1a1a;
 }
-.help nav { margin-bottom: 2rem; font-size: 0.875rem; }
+.help nav {
+  margin-bottom: 2rem;
+  font-size: 0.875rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.help nav form { display: flex; gap: 0.5rem; }
+.help input[type="search"], .help button {
+  font: inherit;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #c9c9c9;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+}
+.help button { cursor: pointer; }
+.help mark { background: #ffe9a8; color: inherit; }
+.help ol.hits { list-style: none; padding: 0; }
+.help ol.hits li { margin: 0 0 1.5rem; }
+.help ol.hits p { margin: 0.25rem 0 0; color: #4a4a4a; }
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
 .help a { color: #005bd3; }
 .help h1 { font-size: 1.75rem; line-height: 1.3; margin: 0 0 1rem; }
 .help h2 { font-size: 1.25rem; margin: 2.5rem 0 0.75rem; }
@@ -133,5 +228,8 @@ const STYLES = `
   .help code, .help pre { background: #2a2a2a; }
   .help th, .help td { border-color: #3a3a3a; }
   .help blockquote { border-left-color: #3a3a3a; color: #b5b5b5; }
+  .help ol.hits p { color: #b5b5b5; }
+  .help mark { background: #6b5510; color: #f5f5f5; }
+  .help input[type="search"], .help button { border-color: #4a4a4a; }
 }
 `;


### PR DESCRIPTION
Completes the last unmet criterion on #162 other than screenshots.

## The approach

Twenty-one pages is small enough to scan per query in well under a millisecond, so there is no index to build, invalidate or get wrong. If the centre ever grows past a few hundred pages this should be reconsidered — but building a search index for twenty-one documents would be answering a question nobody asked.

Ranking is crude and explained rather than tuned: title beats heading beats body, because a merchant searching "drift" wants the page *called* drift, not the six that mention it in passing. Every term must appear somewhere, so a second word narrows rather than widens — the opposite behaviour is what makes a search box feel broken.

It is a plain GET form, so it works before any JavaScript has loaded and a result list can be bookmarked or shared. That matters on a page a merchant may reach while the rest of the app is misbehaving.

## Two things the first version got wrong

Both were invisible in tests and obvious the moment the page was on screen.

Stripping table pipes turned a row into one unpunctuated run — *"Campaign held for drift A campaign stopped because prices were changed outside the app Campaign id, name, how man…"* — which in a result list reads as corrupted text. Cells now join with `·`, and the `|---|---|` separator row is dropped since it carries no words.

Snippets were cut to a character count, so they routinely began or ended mid-word (*"…ign's prices are reverted"*). Both ends now snap to a word boundary.

## On the compliance failure

The Built-for-Shopify suite failed on the raw `<form>` and `<input>`, and it was right to: those are criteria about the embedded admin. The help centre is deliberately not embedded, for the same reason `_index` is not — App Bridge is absent there, so Polaris web components do not exist.

Rather than widen the rule, the exclusion list is now explicit and has to earn itself. A new test asserts every excluded route neither calls `authenticate.admin` nor mounts `AppProvider`, so a route cannot escape the design criteria just by being added to a list. Verified by adding `routes/app.settings` to the list — the test fails.

## Verification

- 911 unit tests, 104 chaos scenarios, lint and build clean
- 13 mutations checked, all caught: title no longer outranking body, OR instead of AND, empty query returning everything, index page not excluded, limit ignored, highlight offset ignoring the ellipsis prefix, both word-boundary snaps, table cells run together, separator row kept, and each markdown-stripping rule removed individually
- One mutation initially **survived** — removing the link-stripping failed nothing, because whether a snippet lands on a link depends on which docs happen to exist. `toProse` is now exported and tested directly on fixtures, and the mutation is caught
- Checked in the browser, which is where both snippet defects were found; and confirmed the query is escaped rather than rendered as markup (`?q=<img src=x onerror=...>` renders as text)

Refs #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)