### PR TITLE
Every campaign ends with a result page saying what the run actually did

### DIFF
--- a/app/components/RunResultSection.tsx
+++ b/app/components/RunResultSection.tsx
@@ -1,0 +1,109 @@
+/**
+ * The one-page result a campaign ends with.
+ *
+ * Separate from the preview's margin panel even though both describe margin, because they
+ * answer different questions: the preview says what a campaign will do, this says what it
+ * did. Showing them in the same shape would invite a merchant to read one as confirming
+ * the other, and a partial run is exactly where they disagree.
+ */
+
+import type { CampaignResult } from "../services/campaigns/result.server";
+
+export function RunResultSection({ result }: { result: CampaignResult }) {
+  const { counts, margin } = result;
+
+  return (
+    <s-section heading="What this run did">
+      {/* The headline states the outcome before any number, and leads with what went
+          wrong. A partial run that opens with its successes is the failure this whole
+          product exists to prevent. */}
+      <s-banner tone={result.clean ? "success" : counts.failed > 0 ? "critical" : "warning"}>
+        <s-paragraph>{result.summary}</s-paragraph>
+      </s-banner>
+
+      <s-stack direction="inline" gap="base">
+        <Count label="Verified" value={counts.verified} />
+        {counts.clamped > 0 ? <Count label="Clamped by a guardrail" value={counts.clamped} /> : null}
+        {counts.skipped > 0 ? <Count label="Needed no change" value={counts.skipped} /> : null}
+        {counts.reverted > 0 ? <Count label="Reverted since" value={counts.reverted} /> : null}
+        {counts.unverified > 0 ? <Count label="Not read back" value={counts.unverified} /> : null}
+        {counts.failed > 0 ? <Count label="Failed" value={counts.failed} /> : null}
+        {counts.pending > 0 ? <Count label="Still to run" value={counts.pending} /> : null}
+      </s-stack>
+
+      {margin.covered > 0 ? (
+        <>
+          <s-paragraph>
+            <s-text>
+              Average margin went from {margin.averageBefore.toFixed(1)}% to{" "}
+              {margin.averageAfter.toFixed(1)}%
+              {margin.unknown > 0
+                ? `, across the ${margin.covered} products that have a cost recorded. ${margin.unknown} do not, and are not included.`
+                : `, across all ${margin.covered} products.`}
+            </s-text>
+          </s-paragraph>
+
+          {margin.belowCost.length > 0 ? (
+            <s-banner tone="critical">
+              <s-paragraph>
+                {margin.belowCost.length} of these are now selling at or below cost:
+              </s-paragraph>
+              <s-unordered-list>
+                {margin.belowCost.map((row) => (
+                  <s-list-item key={row.variantGid}>
+                    {row.title} — {row.after.toFixed(1)}% margin
+                  </s-list-item>
+                ))}
+              </s-unordered-list>
+            </s-banner>
+          ) : null}
+
+          {margin.belowTarget.length > 0 ? (
+            <s-banner tone="warning">
+              <s-paragraph>
+                {margin.belowTarget.length} are below your target margin, worst first:
+              </s-paragraph>
+              <s-unordered-list>
+                {margin.belowTarget.map((row) => (
+                  <s-list-item key={row.variantGid}>
+                    {row.title} — {row.before.toFixed(1)}% became {row.after.toFixed(1)}%
+                  </s-list-item>
+                ))}
+              </s-unordered-list>
+            </s-banner>
+          ) : null}
+        </>
+      ) : (
+        <s-paragraph>
+          <s-text>
+            No margin figures: none of the products this run changed has a cost recorded.
+            Import your costs and this fills in for the next run.
+          </s-text>
+        </s-paragraph>
+      )}
+
+      {/* A cap that stays quiet reads as "we measured the whole campaign". */}
+      {result.marginCoveredRows !== null ? (
+        <s-paragraph>
+          <s-text tone="caution">
+            The margin figures above cover the first {result.marginCoveredRows.toLocaleString()}{" "}
+            of {counts.total.toLocaleString()} rows. The counts cover all of them.
+          </s-text>
+        </s-paragraph>
+      ) : null}
+
+      <s-paragraph>
+        <s-text tone="neutral">{result.unavailable}</s-text>
+      </s-paragraph>
+    </s-section>
+  );
+}
+
+function Count({ label, value }: { label: string; value: number }) {
+  return (
+    <s-stack gap="none">
+      <s-text type="strong">{value.toLocaleString()}</s-text>
+      <s-text tone="neutral">{label}</s-text>
+    </s-stack>
+  );
+}

--- a/app/lib/campaigns/run-result.test.ts
+++ b/app/lib/campaigns/run-result.test.ts
@@ -1,0 +1,242 @@
+/**
+ * The summary a merchant reads after a run.
+ *
+ * The failure this guards against is a partial run that reads as a success. Every
+ * assertion here is about what the sentence says and which rows the margin figure is
+ * entitled to include — not about how the counting is implemented.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { describeRun, summariseRun, tallyStatuses, type ResultRow } from "./run-result";
+
+const GBP = "GBP";
+
+let nextId = 0;
+
+function row(status: string, over: Partial<ResultRow> = {}): ResultRow {
+  return {
+    variantGid: `gid://shopify/ProductVariant/${(nextId += 1)}`,
+    title: "A product",
+    status,
+    // 10.00 → 8.00 on a cost of 5.00: 50% margin becomes 37.5%.
+    beforeMinor: 1000n,
+    afterMinor: 800n,
+    costMinor: 500n,
+    currency: GBP,
+    ...over,
+  } as ResultRow;
+}
+
+describe("which rows the margin figure may use", () => {
+  it("uses verified rows", () => {
+    const result = summariseRun([row("VERIFIED")], null);
+
+    expect(result.margin.covered).toBe(1);
+    expect(result.margin.averageBefore).toBeCloseTo(50);
+    expect(result.margin.averageAfter).toBeCloseTo(37.5);
+  });
+
+  it("uses clamped rows, because a clamped price is what a shopper pays", () => {
+    expect(summariseRun([row("CLAMPED")], null).margin.covered).toBe(1);
+  });
+
+  it("excludes a row written but not read back", () => {
+    // Invariant I5: a row we could not verify is not evidence of a price. Averaging it in
+    // would make a partial run look complete.
+    const result = summariseRun([row("APPLIED")], null);
+
+    expect(result.margin.covered).toBe(0);
+    expect(result.counts.unverified).toBe(1);
+  });
+
+  it.each(["FAILED", "SKIPPED", "PENDING", "WRITING"])("excludes a %s row", (status) => {
+    expect(summariseRun([row(status)], null).margin.covered).toBe(0);
+  });
+
+  it("counts a verified row with no cost as unknown rather than assuming one", () => {
+    // A blended margin that invented a cost for the products that have none would be a
+    // number that looks precise and is made up.
+    const result = summariseRun([row("VERIFIED", { costMinor: null })], null);
+
+    expect(result.margin.covered).toBe(0);
+    expect(result.margin.unknown).toBe(1);
+  });
+});
+
+describe("counting what happened", () => {
+  const rows = [
+    row("VERIFIED"),
+    row("VERIFIED", { title: "Another" }),
+    row("CLAMPED"),
+    row("APPLIED"),
+    row("SKIPPED"),
+    row("FAILED"),
+    row("REVERTED"),
+    row("PENDING"),
+  ];
+
+  it("puts every row in exactly one bucket", () => {
+    const { counts } = summariseRun(rows, null);
+    const bucketed =
+      counts.verified +
+      counts.unverified +
+      counts.clamped +
+      counts.skipped +
+      counts.failed +
+      counts.reverted +
+      counts.pending;
+
+    expect(bucketed).toBe(counts.total);
+    expect(counts.total).toBe(rows.length);
+  });
+
+  it("treats a reverted row as settled, not as still to run", () => {
+    // REVERTED is written by the revert path. Counting it as outstanding would report a
+    // finished campaign as still going, forever.
+    const result = summariseRun([row("VERIFIED"), row("REVERTED")], null);
+
+    expect(result.counts.reverted).toBe(1);
+    expect(result.counts.pending).toBe(0);
+    expect(result.clean).toBe(true);
+  });
+
+  it("keeps a reverted row out of the margin, because its price is gone", () => {
+    const result = summariseRun([row("REVERTED")], null);
+
+    expect(result.margin.covered).toBe(0);
+    expect(result.margin.unknown).toBe(0);
+  });
+
+  it("says how many were reverted since, rather than silently dropping them", () => {
+    expect(describeRun(summariseRun([row("VERIFIED"), row("REVERTED")], null)))
+      .toContain("1 has been reverted since");
+  });
+
+  it("treats an unrecognised status as unfinished, not as done", () => {
+    // A status added later must make a run look incomplete rather than clean, or a stuck
+    // run reports success.
+    const result = summariseRun([row("SOME_NEW_STATUS")], null);
+
+    expect(result.counts.pending).toBe(1);
+    expect(result.clean).toBe(false);
+  });
+});
+
+describe("a run is only clean when nothing is outstanding", () => {
+  it("is clean when every row verified", () => {
+    expect(summariseRun([row("VERIFIED"), row("SKIPPED")], null).clean).toBe(true);
+  });
+
+  it.each(["FAILED", "APPLIED", "PENDING"])("is not clean with a %s row", (status) => {
+    expect(summariseRun([row("VERIFIED"), row(status)], null).clean).toBe(false);
+  });
+});
+
+describe("the sentence a merchant reads", () => {
+  it("leads with the failures, not with the successes", () => {
+    // A partial run that opens by congratulating itself is the failure mode the whole
+    // product exists to avoid.
+    const text = describeRun(summariseRun([row("VERIFIED"), row("FAILED")], null));
+
+    expect(text.indexOf("failed")).toBeLessThan(text.indexOf("verified"));
+  });
+
+  it("says a row was written but not read back, rather than calling it done", () => {
+    const text = describeRun(summariseRun([row("APPLIED")], null));
+
+    expect(text).toContain("not read back");
+  });
+
+  it("mentions rows still to run", () => {
+    expect(describeRun(summariseRun([row("PENDING")], null))).toContain("still to run");
+  });
+
+  it("says plainly when a clean run needed no changes for some rows", () => {
+    const text = describeRun(summariseRun([row("VERIFIED"), row("SKIPPED")], null));
+
+    expect(text).toContain("needed no change");
+    expect(text).not.toContain("failed");
+  });
+
+  it("says a run that wrote nothing wrote nothing, in words", () => {
+    // Seen on a real abandoned run: "1020 still to run. 0 prices changed and verified."
+    // Accurate, and reads like a template that failed to fill in.
+    const text = describeRun(summariseRun([row("PENDING"), row("PENDING")], null));
+
+    expect(text).toContain("Nothing has been written");
+    expect(text).not.toContain("0 prices");
+  });
+
+  it("counts clamped rows as changed, because they were", () => {
+    expect(describeRun(summariseRun([row("CLAMPED")], null))).toContain("1 price changed");
+  });
+
+  it("uses singular and plural correctly", () => {
+    expect(describeRun(summariseRun([row("VERIFIED")], null))).toContain("1 price changed");
+    expect(describeRun(summariseRun([row("VERIFIED"), row("VERIFIED", { title: "b" })], null)))
+      .toContain("2 prices changed");
+    expect(describeRun(summariseRun([row("FAILED")], null))).toContain("1 row failed");
+    expect(describeRun(summariseRun([row("FAILED"), row("FAILED", { title: "b" })], null)))
+      .toContain("2 rows failed");
+  });
+});
+
+describe("naming the products that went wrong", () => {
+  it("names rows that end up below the target margin", () => {
+    // 10.00 → 6.00 on a 5.00 cost is a 16.7% margin.
+    const result = summariseRun([row("VERIFIED", { afterMinor: 600n })], 30);
+
+    expect(result.margin.belowTarget).toHaveLength(1);
+    expect(result.margin.belowTarget[0]!.after).toBeCloseTo(16.67, 1);
+  });
+
+  it("names rows that end up at or below cost", () => {
+    const result = summariseRun([row("VERIFIED", { afterMinor: 400n })], null);
+
+    expect(result.margin.belowCost).toHaveLength(1);
+  });
+
+  it("says nothing about a target when the store has not set one", () => {
+    expect(summariseRun([row("VERIFIED", { afterMinor: 600n })], null).margin.belowTarget)
+      .toHaveLength(0);
+  });
+});
+
+describe("tallying a database aggregate", () => {
+  // The service hands over grouped counts rather than rows, because a run can be larger
+  // than anything worth loading. Same classification, different input shape.
+  it("adds up counts rather than counting entries", () => {
+    const counts = tallyStatuses([
+      { status: "VERIFIED", count: 4_000 },
+      { status: "SKIPPED", count: 120 },
+      { status: "FAILED", count: 3 },
+    ]);
+
+    expect(counts.verified).toBe(4_000);
+    expect(counts.skipped).toBe(120);
+    expect(counts.failed).toBe(3);
+    expect(counts.total).toBe(4_123);
+  });
+
+  it("agrees with the row-walking path on the same data", () => {
+    // The whole point of sharing this function: the aggregate and the rows must never
+    // put the same status in different buckets.
+    const statuses = ["VERIFIED", "VERIFIED", "CLAMPED", "REVERTED", "FAILED", "WHAT_IS_THIS"];
+    const fromRows = summariseRun(statuses.map((status) => row(status)), null).counts;
+    const fromAggregate = tallyStatuses(statuses.map((status) => ({ status, count: 1 })));
+
+    expect(fromAggregate).toEqual(fromRows);
+  });
+
+  it("puts an unrecognised status where it cannot make a run look finished", () => {
+    const counts = tallyStatuses([{ status: "SOMETHING_NEW", count: 7 }]);
+
+    expect(counts.pending).toBe(7);
+    expect(counts.total).toBe(7);
+  });
+
+  it("counts nothing as nothing", () => {
+    expect(tallyStatuses([]).total).toBe(0);
+  });
+});

--- a/app/lib/campaigns/run-result.ts
+++ b/app/lib/campaigns/run-result.ts
@@ -1,0 +1,213 @@
+/**
+ * What a run actually did, as opposed to what it planned to do.
+ *
+ * The preview answers "what will this cost me". This answers "what did it cost me", and
+ * the two are not the same number: guardrails clamp rows, Shopify rejects rows, and a run
+ * can finish partial. A campaign that ends with a table of two hundred ledger lines and no
+ * summary has technically told the merchant everything and practically told them nothing.
+ *
+ * **Computed from verified rows only.** A row we wrote but could not read back is not
+ * evidence of a price, and averaging it in would make a partial run look complete. Those
+ * rows are counted separately and named as unverified, which is the honest reading of
+ * invariant I5.
+ *
+ * **This is arithmetic, not attribution.** It says what the margin on each product became.
+ * It says nothing about units sold or revenue earned — that needs order data, is gated on
+ * Protected Customer Data approval, and conflating the two is how a merchant makes an
+ * expensive decision on bad inference.
+ */
+
+import { marginImpact, type MarginImpact, type MarginInput } from "../pricing/margin";
+
+/** The ledger statuses that describe an outcome rather than work still in progress. */
+export interface RunCounts {
+  /** Written and read back. The only rows that prove a price. */
+  verified: number;
+  /** Written, but the read-back has not confirmed them. */
+  unverified: number;
+  /** A guardrail moved the price away from what the campaign asked for. */
+  clamped: number;
+  /** Deliberately not written — already correct, or excluded. */
+  skipped: number;
+  /** Shopify refused, or we gave up after retries. */
+  failed: number;
+  /** Written by this run, and taken back since by a revert. */
+  reverted: number;
+  /** Still queued or in flight. */
+  pending: number;
+  total: number;
+}
+
+export interface RunResult {
+  counts: RunCounts;
+  margin: MarginImpact;
+  /** True when every row reached a terminal, successful state. */
+  clean: boolean;
+}
+
+/**
+ * Ledger rows reduced to what a summary needs.
+ *
+ * `after` is the price that is actually live — for a verified row, the one the read-back
+ * confirmed. A row whose write we could not confirm is excluded by its status, which is
+ * what keeps it out of the margin average.
+ */
+export interface ResultRow {
+  variantGid: string;
+  title: string;
+  status: string;
+  /** Minor units, as stored. */
+  beforeMinor: bigint | null;
+  afterMinor: bigint | null;
+  costMinor: bigint | null;
+  currency: string;
+}
+
+/**
+ * Ledger statuses tallied into the buckets a merchant is shown.
+ *
+ * Takes counts rather than rows because the same classification has to serve two callers:
+ * this module, walking rows, and the result service, handing over a database aggregate
+ * over a run too large to load. Two implementations of "which bucket is REVERTED" is
+ * exactly the drift that makes one screen contradict another.
+ *
+ * Anything unrecognised lands in `pending`. That is the safe direction: a status added
+ * later makes a run look unfinished rather than quietly making a stuck one look clean.
+ */
+export function tallyStatuses(
+  entries: ReadonlyArray<{ status: string; count: number }>,
+): RunCounts {
+  const counts: RunCounts = {
+    verified: 0,
+    unverified: 0,
+    clamped: 0,
+    skipped: 0,
+    failed: 0,
+    reverted: 0,
+    pending: 0,
+    total: 0,
+  };
+
+  for (const { status, count } of entries) {
+    counts.total += count;
+
+    switch (status) {
+      case "VERIFIED":
+        counts.verified += count;
+        break;
+      case "APPLIED":
+        counts.unverified += count;
+        break;
+      case "CLAMPED":
+        // Clamped rows were still written, and the price a shopper sees is the clamped
+        // one — so they belong in the margin picture, not only in a warning.
+        counts.clamped += count;
+        break;
+      case "SKIPPED":
+        counts.skipped += count;
+        break;
+      case "FAILED":
+        counts.failed += count;
+        break;
+      case "REVERTED":
+        // Settled, not outstanding. This run did write the price; a later revert took it
+        // back. Counting it as pending would report a finished run as still going.
+        counts.reverted += count;
+        break;
+      default:
+        counts.pending += count;
+    }
+  }
+
+  return counts;
+}
+
+export function summariseRun(rows: readonly ResultRow[], targetPercent: number | null): RunResult {
+  const counts = tallyStatuses(rows.map((row) => ({ status: row.status, count: 1 })));
+
+  const marginRows: MarginInput[] = [];
+
+  for (const row of rows) {
+    // Only rows whose price we can actually stand behind, and which are still live. A
+    // reverted row's price is gone, so including it would describe a margin the store no
+    // longer has.
+    if (row.beforeMinor === null || row.afterMinor === null) continue;
+    if (row.status !== "VERIFIED" && row.status !== "CLAMPED") continue;
+
+    marginRows.push({
+      variantGid: row.variantGid,
+      title: row.title,
+      cost:
+        row.costMinor === null
+          ? undefined
+          : { amount: Number(row.costMinor), currency: row.currency },
+      before: { amount: Number(row.beforeMinor), currency: row.currency },
+      after: { amount: Number(row.afterMinor), currency: row.currency },
+    });
+  }
+
+  return {
+    counts,
+    // The same function the preview uses. A result that could disagree with the preview
+    // about what "margin" means would make both of them useless.
+    margin: marginImpact(marginRows, targetPercent),
+    clean: isClean(counts),
+  };
+}
+
+/**
+ * Nothing outstanding: no failures, nothing unverified, nothing still to do.
+ *
+ * Exported because the counts can also be produced by a database aggregate, and two
+ * definitions of "clean" that can disagree is precisely the bug this is here to prevent.
+ */
+export function isClean(counts: RunCounts): boolean {
+  return counts.failed === 0 && counts.pending === 0 && counts.unverified === 0;
+}
+
+/**
+ * One sentence saying what happened, in the order a merchant cares about.
+ *
+ * Bad news first and never softened: a partial run that opens by congratulating itself on
+ * the rows that worked is the failure mode this whole product exists to avoid.
+ */
+export function describeRun(result: RunResult): string {
+  const { counts } = result;
+  const parts: string[] = [];
+
+  if (counts.failed > 0) {
+    parts.push(`${counts.failed} row${counts.failed === 1 ? "" : "s"} failed`);
+  }
+  if (counts.unverified > 0) {
+    parts.push(
+      `${counts.unverified} ${counts.unverified === 1 ? "was" : "were"} written but not read back`,
+    );
+  }
+  if (counts.pending > 0) {
+    parts.push(`${counts.pending} still to run`);
+  }
+
+  const wrote = counts.verified + counts.clamped;
+  const reverted =
+    counts.reverted > 0
+      ? ` ${counts.reverted} ${counts.reverted === 1 ? "has" : "have"} been reverted since.`
+      : "";
+  // "0 prices changed and verified" is accurate and reads like a template that failed to
+  // fill in. A run that wrote nothing should say so in words.
+  const good =
+    wrote === 0
+      ? "Nothing has been written"
+      : `${wrote} price${wrote === 1 ? "" : "s"} changed and verified`;
+
+  if (parts.length === 0) {
+    return counts.skipped > 0
+      ? `${good}. ${counts.skipped} needed no change.${reverted}`
+      : `${good}.${reverted}`;
+  }
+
+  return `${capitalise(parts.join(", "))}. ${good}.${reverted}`;
+}
+
+function capitalise(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -23,6 +23,8 @@ import { downloadCsv, filenameSlug } from "../lib/reporting/csv";
 import { rollbackReportCsv } from "../lib/reporting/rollback";
 import { PreviewTable } from "../components/PreviewTable";
 import { RunHistoryTable } from "../components/RunHistoryTable";
+import { RunResultSection } from "../components/RunResultSection";
+import { campaignResult } from "../services/campaigns/result.server";
 import { ledgerCsv } from "../lib/reporting/ledger-csv";
 import { previewCsv } from "../lib/reporting/preview-csv";
 import { RouteBoundary } from "../components/RouteBoundary";
@@ -78,6 +80,11 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
   const selectedRunId = requested ?? runs[0]?.id ?? null;
   const ledger = selectedRunId ? await runLedger(shop.id, selectedRunId) : [];
 
+  // What that run actually did, as opposed to what the preview said it would. The ledger
+  // is the evidence; the preview is the intention, and a partial run is exactly where the
+  // two stop agreeing.
+  const result = selectedRunId ? await campaignResult(shop.id, selectedRunId) : null;
+
   // Only for a campaign that has actually written something and could still be
   // reverted. It costs a full plan, and on a draft it would be a report about
   // nothing -- the honest answer there is that there is nothing to roll back.
@@ -92,6 +99,7 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     preview,
     runs,
     ledger,
+    result,
     selectedRunId,
     scheduleText,
     warnings,
@@ -240,6 +248,9 @@ export default function CampaignDetail() {
     preview,
     runs,
     ledger,
+    // Renamed: `result` in this component is the fetcher's reply to the last action,
+    // and two different "results" on one page is how the wrong one gets rendered.
+    result: runResult,
     selectedRunId,
     scheduleText,
     warnings,
@@ -452,6 +463,8 @@ export default function CampaignDetail() {
           Export this preview (CSV)
         </s-button>
       </s-section>
+
+      {runResult ? <RunResultSection result={runResult} /> : null}
 
       {runs.length > 0 ? (
         <s-section heading="Run history">

--- a/app/services/campaigns/result.server.ts
+++ b/app/services/campaigns/result.server.ts
@@ -1,0 +1,170 @@
+/**
+ * The one-page answer to "what did that run actually do".
+ *
+ * Reads the ledger rather than the plan, because the plan is what we intended and the
+ * ledger is what happened. Those diverge exactly when a merchant most needs to know:
+ * guardrails clamp, Shopify rejects, a run finishes partial.
+ */
+
+import prisma from "../../db.server";
+import { readSettings } from "../settings.server";
+import {
+  describeRun,
+  isClean,
+  summariseRun,
+  tallyStatuses,
+  type ResultRow,
+  type RunResult,
+} from "../../lib/campaigns/run-result";
+
+/**
+ * How many ledger rows the margin figure will read.
+ *
+ * Counts are aggregated in the database and are exact at any size. The margin average
+ * needs each row's cost, which means reading rows — so it is bounded, and when the bound
+ * bites the page says so. A margin figure quietly computed from the first slice of a
+ * large run would be a number that looks like the whole campaign and is not.
+ */
+export const MARGIN_ROW_LIMIT = 50_000;
+
+export interface CampaignResult extends RunResult {
+  runId: string;
+  summary: string;
+  /**
+   * Set when the run had more rows than the margin calculation read. Non-null means the
+   * margin figures describe a subset, and the page must say which.
+   */
+  marginCoveredRows: number | null;
+  /**
+   * What we cannot say, and why. Units and revenue need order data, which needs Protected
+   * Customer Data approval — naming the gap beats leaving an empty panel that reads like
+   * a bug.
+   */
+  unavailable: string;
+}
+
+const UNAVAILABLE =
+  "Units sold and revenue are not shown. That needs order data, which Shopify gates " +
+  "behind Protected Customer Data approval. Margin here is arithmetic on price and " +
+  "cost — it is not a claim about what this campaign earned.";
+
+export async function campaignResult(
+  shopId: string,
+  runId: string,
+): Promise<CampaignResult | null> {
+  const run = await prisma.campaignRun.findFirst({
+    where: { id: runId, shopId },
+    select: { id: true },
+  });
+  if (!run) return null;
+
+  const [byStatus, settings] = await Promise.all([
+    prisma.variantChange.groupBy({
+      by: ["status"],
+      where: { shopId, runId },
+      _count: { _all: true },
+    }),
+    readSettings(shopId),
+  ]);
+
+  // Classified by the same function the pure summariser uses, so the aggregate path and
+  // the row path cannot disagree about which bucket a status belongs in.
+  const counts = tallyStatuses(
+    byStatus.map((group) => ({ status: group.status, count: group._count._all })),
+  );
+  if (counts.total === 0) return null;
+
+  const rows = await marginRows(shopId, runId);
+
+  // Counts come from the aggregate so they are exact even when the rows are capped;
+  // `summariseRun` would otherwise report the size of the slice it was handed.
+  // The margin comes from the rows that were read; the counts come from the aggregate,
+  // so they stay exact even when the rows are capped.
+  const result = summariseRun(rows, settings.minMarginPercent);
+  result.counts = counts;
+  result.clean = isClean(counts);
+
+  return {
+    ...result,
+    runId,
+    summary: describeRun(result),
+    marginCoveredRows: counts.total > MARGIN_ROW_LIMIT ? rows.length : null,
+    unavailable: UNAVAILABLE,
+  };
+}
+
+/**
+ * The rows the margin figure is computed from, with each variant's cost joined on.
+ *
+ * Only rows that were actually written and whose price we can stand behind: a row we
+ * could not read back is not evidence of a price, and averaging it in would make a
+ * partial run look complete.
+ *
+ * `summariseRun` applies that rule again in memory, so the status filter here is not what
+ * enforces it — dropping it changes no result at small sizes. Its job is the row budget:
+ * without it a large run spends `MARGIN_ROW_LIMIT` on skipped and failed rows and the
+ * margin quietly describes a smaller slice of the campaign than it could have.
+ *
+ * **Cost comes from the baseline, not the catalogue mirror**, matching `costsFor` in the
+ * preview — the baseline is what the margin guardrail reads at resolve time, so taking it
+ * from anywhere else would let the margin a merchant is shown disagree with the floor
+ * that clamped the price. The mirror is joined only for a readable title.
+ *
+ * A baseline whose currency differs from the row's is left out rather than divided into
+ * it. Comparing a cost in one currency against a price in another produces a margin that
+ * is arithmetically fine and completely meaningless, and "we do not know" is the honest
+ * answer.
+ *
+ * **The price falls back to `intendedPrice`.** For a VERIFIED row that is the price that
+ * is live: verification means the read-back matched what we intended, and the writer does
+ * not restate it in `verifiedPrice` — which is why `reconciliation.server.ts` reads
+ * `intendedPrice` for exactly the same purpose. The two nullable columns are preferred
+ * first anyway, so this keeps working if the writer ever starts filling them in.
+ */
+async function marginRows(shopId: string, runId: string): Promise<ResultRow[]> {
+  const rows = await prisma.$queryRaw<
+    Array<{
+      variantGid: string;
+      title: string | null;
+      status: string;
+      beforePrice: bigint | null;
+      afterPrice: bigint | null;
+      cost: bigint | null;
+      currency: string;
+    }>
+  >`
+    SELECT c."variantGid",
+           v."title",
+           c."status"::text AS "status",
+           c."beforePrice",
+           COALESCE(c."verifiedPrice", c."appliedPrice", c."intendedPrice") AS "afterPrice",
+           b."cost",
+           c."currency"
+    FROM "variant_changes" c
+    LEFT JOIN "variant_index" v
+      ON v."shopId" = c."shopId"
+     AND v."variantGid" = c."variantGid"
+    LEFT JOIN "baselines" b
+      ON b."shopId" = c."shopId"
+     AND b."variantGid" = c."variantGid"
+     AND b."surfaceKind" = 'BASE'
+     AND b."priceListGid" = ''
+     AND b."supersededAt" IS NULL
+     AND b."currency" = c."currency"
+    WHERE c."shopId" = ${shopId}
+      AND c."runId" = ${runId}
+      AND c."status" IN ('VERIFIED', 'CLAMPED')
+    ORDER BY c."createdAt" ASC
+    LIMIT ${MARGIN_ROW_LIMIT}
+  `;
+
+  return rows.map((row) => ({
+    variantGid: row.variantGid,
+    title: row.title ?? row.variantGid,
+    status: row.status,
+    beforeMinor: row.beforePrice,
+    afterMinor: row.afterPrice,
+    costMinor: row.cost,
+    currency: row.currency,
+  }));
+}

--- a/chaos/scenarios/campaign-result.chaos.ts
+++ b/chaos/scenarios/campaign-result.chaos.ts
@@ -1,0 +1,174 @@
+/**
+ * The one-page result a campaign ends with, against a real database.
+ *
+ * `run-result.ts` is tested pure, which proves the arithmetic and nothing about the query
+ * that feeds it. A wrong table name, a status cast that silently returns nothing, or a
+ * join that drops every cost all typecheck perfectly and produce a page that cheerfully
+ * reports zero — the exact failure mode this product exists to prevent, wearing a summary
+ * banner.
+ *
+ * So these assert what a merchant reads, against ledger rows a real run wrote.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos } from "../harness/scenario";
+import { isVariantWrite } from "../harness/faults";
+
+describe("chaos: what the result page says a run did", () => {
+  it("reports the prices a clean run actually changed, and calls it clean", async () => {
+    await withChaos(
+      "campaign-result-clean",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { campaignResult } = await import("../../app/services/campaigns/result.server");
+
+        const outcome = await chaos.apply();
+        const runId = await chaos.latestRunId("APPLY");
+        await chaos.expectHonest(runId);
+
+        const result = await campaignResult(chaos.fixture.shopId, runId);
+
+        expect(result).not.toBeNull();
+        expect(result!.clean).toBe(true);
+        expect(result!.counts.failed).toBe(0);
+        expect(result!.counts.pending).toBe(0);
+
+        // Two independent paths to the same fact: the runner counted rows as it wrote
+        // them, this counted them afterwards from the ledger. Disagreement means one of
+        // them is describing a run that did not happen.
+        expect(result!.counts.verified).toBe(outcome.verified);
+        expect(result!.counts.failed).toBe(outcome.failed);
+        expect(result!.counts.unverified).toBe(outcome.unverified);
+        expect(result!.clean).toBe(outcome.clean);
+        expect(result!.counts.verified).toBeGreaterThan(0);
+
+        const inLedger = await prisma.variantChange.count({
+          where: { shopId: chaos.fixture.shopId, runId },
+        });
+        expect(result!.counts.total).toBe(inLedger);
+      },
+    );
+  });
+
+  it("computes margin from the cost the catalogue actually holds", async () => {
+    await withChaos(
+      "campaign-result-margin",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        const { campaignResult } = await import("../../app/services/campaigns/result.server");
+
+        // A known cost on every baseline, so the expected margin is arithmetic rather
+        // than whatever the fixture happened to seed. The baseline, not the mirror: that
+        // is where the resolver reads cost, and the two must not disagree.
+        const baselines = await prisma.baseline.findMany({
+          where: { shopId, surfaceKind: "BASE", priceListGid: "", supersededAt: null },
+          select: { id: true, basePrice: true },
+        });
+        expect(baselines.length).toBeGreaterThan(0);
+
+        for (const baseline of baselines) {
+          // Cost at half the pre-campaign price: a 50% margin before, 37.5% after -20%.
+          await prisma.baseline.update({
+            where: { id: baseline.id },
+            data: { cost: baseline.basePrice / 2n },
+          });
+        }
+
+        await chaos.apply();
+        const runId = await chaos.latestRunId("APPLY");
+        const result = await campaignResult(shopId, runId);
+
+        // The join found the costs. A broken join reports every product as unknown,
+        // which reads as "you have no cost data" and is a lie.
+        expect(result!.margin.unknown).toBe(0);
+        expect(result!.margin.covered).toBeGreaterThan(0);
+        expect(result!.margin.averageBefore).toBeCloseTo(50, 1);
+        expect(result!.margin.averageAfter).toBeCloseTo(37.5, 1);
+      },
+    );
+  });
+
+  it("says a product has no cost rather than inventing one", async () => {
+    await withChaos(
+      "campaign-result-no-cost",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        const { campaignResult } = await import("../../app/services/campaigns/result.server");
+
+        await prisma.baseline.updateMany({
+          where: { shopId, surfaceKind: "BASE", priceListGid: "", supersededAt: null },
+          data: { cost: null },
+        });
+
+        await chaos.apply();
+        const runId = await chaos.latestRunId("APPLY");
+        const result = await campaignResult(shopId, runId);
+
+        expect(result!.margin.covered).toBe(0);
+        expect(result!.margin.unknown).toBeGreaterThan(0);
+        // Not zero-margin, not "0%" — nothing at all.
+        expect(result!.margin.averageAfter).toBe(0);
+        expect(result!.margin.belowCost).toHaveLength(0);
+      },
+    );
+  });
+
+  it("keeps a reverted run finished, rather than reporting it as still going", async () => {
+    await withChaos(
+      "campaign-result-reverted",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId } = chaos.fixture;
+        const { campaignResult } = await import("../../app/services/campaigns/result.server");
+
+        await chaos.apply();
+        const applyRunId = await chaos.latestRunId("APPLY");
+        await chaos.revert();
+
+        const result = await campaignResult(shopId, applyRunId);
+
+        // Whatever the revert did to the original rows, the apply run is over. A status
+        // this code does not recognise falls into "pending", which would report a
+        // finished campaign as still running — forever, and on every page load.
+        expect(result!.counts.pending).toBe(0);
+        expect(result!.clean).toBe(true);
+        expect(result!.summary).not.toContain("still to run");
+      },
+    );
+  });
+
+  it("refuses to call a run clean when a row never got written", async () => {
+    await withChaos(
+      "campaign-result-partial",
+      { catalog: { products: 6, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { campaignResult } = await import("../../app/services/campaigns/result.server");
+
+        // Break every write permanently: the run cannot finish, and the result page must
+        // say so rather than summarising the rows that happened to get through.
+        chaos.arm([{ fault: "server-error", match: isVariantWrite }]);
+
+        await chaos.apply();
+        const runId = await chaos.latestRunId("APPLY");
+
+        const result = await campaignResult(chaos.fixture.shopId, runId);
+
+        expect(result!.clean).toBe(false);
+        expect(result!.counts.verified + result!.counts.clamped).toBeLessThan(
+          result!.counts.total,
+        );
+        // The sentence a merchant reads must lead with the bad news.
+        expect(result!.summary).toMatch(/failed|not read back|still to run/);
+
+        // And nothing unwritten may be counted as a margin outcome.
+        expect(result!.margin.covered + result!.margin.unknown).toBe(
+          result!.counts.verified + result!.counts.clamped,
+        );
+      },
+    );
+  });
+});


### PR DESCRIPTION
Part of #175 — the half that is not blocked on Protected Customer Data approval.

The preview says what a campaign *will* do; nothing said what it *did*. A campaign ended with a run-history row and two hundred ledger lines: technically everything, practically nothing.

## What it does

Reads the ledger rather than the plan, because those diverge exactly when a merchant needs to know — guardrails clamp, Shopify rejects, a run finishes partial. The sentence leads with what went wrong; a partial run that opens by congratulating itself on the rows that worked is the failure this product exists to prevent.

Margin reuses the preview's `marginImpact`, so the two cannot disagree about what margin means. Rows written but not read back are excluded from it and counted separately — invariant I5 says an unverified row is not evidence of a price, and averaging it in makes a partial run look complete.

Counts come from a database aggregate, so they are exact at any size. Margin needs each row's cost, so it reads rows and is bounded at 50,000 — and when that bound bites, the page says which figures cover a subset rather than letting a slice look like the whole campaign.

## Two bugs the chaos scenario caught that the pure tests could not

Both typechecked perfectly and produced a page that cheerfully reported zero.

**Cost was joined from `variant_index`.** It comes from the baseline. `costsFor` in the preview explains why: the baseline is what the margin guardrail reads at resolve time, so taking it from anywhere else lets the margin a merchant is shown disagree with the floor that clamped the price.

**The price was read from `verifiedPrice`, which nothing writes.** `reconciliation.server.ts` reads `intendedPrice` for exactly the same purpose — verification means the read-back matched intent, and the writer does not restate it.

## And one caught by reading

`REVERTED` is a real terminal status written by the revert path, and an unrecognised status falls into "pending" — so a reverted row would have reported a finished campaign as still running, forever, on every page load.

Fixing it exposed the actual defect: **two status classifications**, one walking rows and one over a database aggregate. That is the drift that makes one screen contradict another. They are now a single `tallyStatuses`, and the mutation that reintroduces the bug fails a test in both paths — which it did not before the refactor.

## Also worth knowing

`verifiedPrice` and `appliedPrice` appear to be columns nothing ever writes. Not touched here — flagging it rather than fixing it in a feature PR.

## Verification

- 942 unit tests, 108 chaos scenarios (5 new, against a real Postgres), lint and build clean
- 13 mutations checked, all caught — including unverified rows entering the margin, clamped rows leaving it, successes announced before failures, `isClean` ignoring unverified rows, a missing cost silently becoming zero, counts taken from the capped row set, and `REVERTED` falling through to pending
- Run against the real dev database: it correctly refuses to call two abandoned runs clean, and reports `unknown=152` rather than inventing costs the store does not have
- One wording fix came from that run — "0 prices changed and verified" now reads "Nothing has been written"

## Not done, still blocked

Units, revenue, and the trailing-window comparison. Those need order data, gated on Protected Customer Data approval. The page names that gap rather than leaving an empty panel.

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)