### PR TITLE
Verify the price on the bulk path, which reported clean while prices were wrong

### DIFF
--- a/app/lib/execution/read-back.test.ts
+++ b/app/lib/execution/read-back.test.ts
@@ -1,0 +1,88 @@
+/**
+ * What "verified" is allowed to mean.
+ *
+ * The bug this exists to prevent: Shopify accepts a mutation, stores something else, and
+ * the run reports clean while the storefront is wrong. Every case here is a way that can
+ * happen without a single error being returned.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { money } from "../money/money";
+import { parseObserved, readBackVerdict } from "./read-back";
+
+const usd = (minor: number) => money(minor, "USD");
+const jpy = (minor: number) => money(minor, "JPY");
+const kwd = (minor: number) => money(minor, "KWD");
+
+describe("a row is verified only when the prices match", () => {
+  it("passes when Shopify stored what we asked for", () => {
+    const verdict = readBackVerdict(usd(1999), "19.99");
+
+    expect(verdict.ok).toBe(true);
+    expect(verdict.ok && verdict.observed).toEqual(usd(1999));
+  });
+
+  it("fails when Shopify stored something else", () => {
+    const verdict = readBackVerdict(usd(1999), "24.99");
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok === false && verdict.observed).toEqual(usd(2499));
+  });
+
+  it("fails on a difference of a single minor unit", () => {
+    // A cent is not a rounding detail: it is the difference between the price a merchant
+    // approved and a price they did not.
+    expect(readBackVerdict(usd(1999), "20.00").ok).toBe(false);
+  });
+
+  it("names both numbers, because support reads this", () => {
+    const verdict = readBackVerdict(usd(1999), "24.99");
+
+    expect(verdict.ok === false && verdict.reason).toContain("19.99");
+    expect(verdict.ok === false && verdict.reason).toContain("24.99");
+  });
+});
+
+describe("no answer is never a pass", () => {
+  it.each([undefined, null, ""])("refuses %j", (observed) => {
+    // Treating "we did not hear back" as "correct" is how a partial run reports clean.
+    expect(readBackVerdict(usd(1999), observed).ok).toBe(false);
+  });
+
+  it("refuses a value that is not a number", () => {
+    expect(readBackVerdict(usd(1999), "not-a-price").ok).toBe(false);
+  });
+
+  it("refuses when there was no intended price to compare against", () => {
+    expect(readBackVerdict(undefined, "19.99").ok).toBe(false);
+  });
+});
+
+describe("currency precision", () => {
+  it("handles a zero-decimal currency", () => {
+    // ¥2,921 is 2921 minor units, not 292100. Getting the scale wrong here fails every
+    // row in Japan, or passes every one of them regardless of what was stored.
+    expect(readBackVerdict(jpy(2921), "2921").ok).toBe(true);
+    expect(readBackVerdict(jpy(2921), "2920").ok).toBe(false);
+  });
+
+  it("handles a three-decimal currency", () => {
+    expect(readBackVerdict(kwd(19_500), "19.500").ok).toBe(true);
+    expect(readBackVerdict(kwd(19_500), "19.501").ok).toBe(false);
+  });
+
+  it("parses to the intended currency's scale", () => {
+    expect(parseObserved("19.99", usd(0))).toEqual(usd(1999));
+    expect(parseObserved("2921", jpy(0))).toEqual(jpy(2921));
+    expect(parseObserved("19.500", kwd(0))).toEqual(kwd(19_500));
+  });
+
+  it("does not lose a minor unit to floating point", () => {
+    // 0.1 + 0.2 arithmetic on prices is the failure mode rule 7 exists to prevent.
+    for (const cents of [1, 7, 29, 35_17, 99_99, 1_234_56]) {
+      const text = (cents / 100).toFixed(2);
+      expect(parseObserved(text, usd(0)), text).toEqual(usd(cents));
+    }
+  });
+});

--- a/app/lib/execution/read-back.ts
+++ b/app/lib/execution/read-back.ts
@@ -1,0 +1,78 @@
+/**
+ * Comparing what we asked Shopify to store against what it says it stored.
+ *
+ * This is what invariant I5 actually means. "Shopify accepted the mutation" is not the
+ * same claim as "the price on the storefront is the price we intended", and the gap
+ * between them is where a silently wrong price lives: a rounding rule, a currency with
+ * different precision, a price list that adjusts what it was handed.
+ *
+ * Extracted because both write paths need it and they were not agreeing. The sync path
+ * read prices back and compared them; the bulk path — the one every large campaign takes —
+ * checked only that no `userError` came back, and threw away the price Shopify returned
+ * in the very same response. A verification that the biggest runs skip is not a
+ * verification.
+ */
+
+import { formatMoney, money, type Money } from "../money/money";
+
+export type ReadBackVerdict =
+  | { ok: true; observed: Money }
+  | { ok: false; reason: string; observed?: Money };
+
+/**
+ * Shopify reports money as a decimal string; the ledger holds integer minor units.
+ *
+ * The scale comes from formatting the intended amount rather than from a currency table,
+ * so zero-decimal currencies (JPY) and three-decimal ones (KWD) both round-trip. Getting
+ * this wrong by a factor of a hundred is exactly the class of bug that makes a comparison
+ * fail on every row, or pass on none.
+ */
+export function parseObserved(text: string, intended: Money): Money | null {
+  const value = Number(text);
+  if (!Number.isFinite(value)) return null;
+
+  return money(Math.round(value * 10 ** decimalsOf(intended)), intended.currency);
+}
+
+/**
+ * Whether a row may be called verified.
+ *
+ * An absent price is a refusal, not a pass. A read that came back without the field tells
+ * us nothing, and treating "no answer" as "correct" is how a partial run reports clean.
+ */
+export function readBackVerdict(
+  intended: Money | undefined,
+  observedText: string | null | undefined,
+): ReadBackVerdict {
+  if (!intended) {
+    return { ok: false, reason: "No intended price to verify against." };
+  }
+  if (observedText === null || observedText === undefined || observedText === "") {
+    return { ok: false, reason: "Verification read returned no price for this variant." };
+  }
+
+  const observed = parseObserved(observedText, intended);
+  if (!observed) {
+    return { ok: false, reason: `Verification read returned "${observedText}", which is not a price.` };
+  }
+
+  if (observed.amount !== intended.amount) {
+    return {
+      ok: false,
+      // Names the object, the cause and both numbers: support reads these, and "mismatch"
+      // on its own sends them back to the Shopify admin to find out what happened.
+      reason: `Read-back mismatch: expected ${formatMoney(intended)}, found ${observedText}.`,
+      observed,
+    };
+  }
+
+  return { ok: true, observed };
+}
+
+function decimalsOf(amount: Money): number {
+  // Derived from the formatted representation so zero-decimal currencies (JPY) and
+  // three-decimal ones (KWD) both round-trip correctly.
+  const formatted = formatMoney(amount);
+  const dot = formatted.indexOf(".");
+  return dot === -1 ? 0 : formatted.length - dot - 1;
+}

--- a/app/lib/execution/sync-executor.ts
+++ b/app/lib/execution/sync-executor.ts
@@ -18,7 +18,8 @@
  *   ledger exists to prevent.
  */
 
-import { formatMoney, money, type Money } from "../money/money";
+import { formatMoney, type Money } from "../money/money";
+import { readBackVerdict } from "./read-back";
 import type { PlannedRow } from "../planning/types";
 import { isThrottledError, RateLimitBudget, withRetry } from "../shopify/budget";
 import {
@@ -359,25 +360,16 @@ async function verifyRows(
 
   for (const entry of sample) {
     const node = byId.get(entry.row.ref.variantGid);
-    const intended = entry.row.intendedPrice;
-    if (!node?.price || !intended) {
-      entry.status = "failed";
-      entry.failureReason = "Verification read returned no price for this variant.";
-      continue;
-    }
+    // Shared with the bulk path, so the two cannot disagree about what "verified" means.
+    const verdict = readBackVerdict(entry.row.intendedPrice, node?.price);
 
-    const actual = money(
-      Math.round(Number(node.price) * 10 ** decimalsOf(intended)),
-      intended.currency,
-    );
-
-    if (actual.amount !== intended.amount) {
-      entry.status = "failed";
-      entry.failureReason =
-        `Read-back mismatch: expected ${formatMoney(intended)}, found ${node.price}.`;
-      entry.observedPrice = actual;
-    } else {
+    if (verdict.ok) {
       entry.status = "verified";
+      entry.observedPrice = verdict.observed;
+    } else {
+      entry.status = "failed";
+      entry.failureReason = verdict.reason;
+      entry.observedPrice = verdict.observed;
     }
   }
 }
@@ -391,13 +383,6 @@ export function indexFromField(field?: string[] | null): number | undefined {
   return undefined;
 }
 
-function decimalsOf(m: Money): number {
-  // Derived from the formatted representation so zero-decimal currencies (JPY) and
-  // three-decimal ones (KWD) both round-trip correctly.
-  const formatted = formatMoney(m);
-  const dot = formatted.indexOf(".");
-  return dot === -1 ? 0 : formatted.length - dot - 1;
-}
 
 /** Deterministic-with-injected-random sample, without mutating the input. */
 function pickSample<T>(items: T[], size: number, random: () => number): T[] {

--- a/app/services/campaigns/execute.server.ts
+++ b/app/services/campaigns/execute.server.ts
@@ -5,6 +5,10 @@
  * normalises both into the same per-row result shape, so the caller records
  * outcomes identically either way.
  *
+ * Both paths now verify the same way — by comparing the price Shopify reports against the
+ * price the campaign intended. They did not always: the bulk path checked only for
+ * `userError`s, which meant the largest campaigns got the weakest guarantee.
+ *
  * Without this, a 1,615-row campaign would preview as "bulk" and then execute
  * synchronously -- roughly one variant every two seconds against a standard shop's
  * rate limit, which is not merely slow but infeasible.
@@ -17,6 +21,7 @@ import {
   type StagedTarget,
 } from "../../lib/execution/bulk-executor";
 import { executeSync, type AdminClient, type ExecutedRow } from "../../lib/execution/sync-executor";
+import { readBackVerdict } from "../../lib/execution/read-back";
 import type { PlannedRow } from "../../lib/planning/types";
 import { selectWritePath } from "../../lib/planning/write-path";
 import { RateLimitBudget } from "../../lib/shopify/budget";
@@ -144,7 +149,22 @@ async function executeBulk(
     if (!outcome || !outcome.ok) {
       return { row, status: "failed", failureReason: outcome?.failureReason ?? "Unknown failure" };
     }
-    return { row, status: "verified" };
+
+    // The result file carries the price Shopify stored, and this used to throw it away —
+    // marking a row verified because no `userError` came back. That is a claim about the
+    // mutation, not about the storefront, and invariant I5 asks for the second one. The
+    // comparison is free: no extra request, the number is already in hand.
+    const verdict = readBackVerdict(row.intendedPrice, outcome.price);
+    if (!verdict.ok) {
+      return {
+        row,
+        status: "failed",
+        failureReason: verdict.reason,
+        observedPrice: verdict.observed,
+      };
+    }
+
+    return { row, status: "verified", observedPrice: verdict.observed };
   });
 
   const rows = [...executed, ...skipped];

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -36,10 +36,18 @@ export interface RunOptions {
   revert?: boolean;
   /**
    * Fraction of applied rows to read back. Defaults to full verification, which
-   * suits the catalogue sizes the sync path handles; the bulk path gets per-row
-   * confirmation from its result file instead.
+   * suits the catalogue sizes the sync path handles; the bulk path compares every row
+   * against the price its result file reports, so it does not sample.
    */
   verifySampleRate?: number;
+  /**
+   * Forces the write path instead of choosing it by row count.
+   *
+   * For tests and diagnostics only. Both paths must behave identically on the things
+   * that matter, and the cheapest way to keep that true is to be able to run the same
+   * scenario down each of them without seeding a thousand variants.
+   */
+  forcePath?: "sync" | "bulk";
   /**
    * Continue an interrupted run instead of starting fresh.
    *
@@ -326,6 +334,7 @@ export async function runCampaign(
     client,
     productOf: (gid) => products.get(gid) ?? gid,
     verifySampleRate: options.verifySampleRate ?? 1,
+    forcePath: options.forcePath,
     onProgress: heartbeat(run.id),
   });
 
@@ -811,6 +820,17 @@ async function recordResults(
         failureReason: executed.guidance
           ? `${executed.guidance} (Shopify said: ${executed.failureReason})`
           : executed.failureReason,
+        // The number the store actually holds, when the read-back found a different
+        // one. The failure reason says it in prose; this says it in a column, so
+        // reconciliation and support can act on it without parsing English.
+        //
+        // Only set on divergence: for a verified row the observed price equals the
+        // intended one by definition, and writing it back per row would cost a query
+        // each to record something already in `intendedPrice`.
+        appliedPrice:
+          executed.observedPrice !== undefined
+            ? BigInt(executed.observedPrice.amount)
+            : undefined,
         // Counts toward quarantine: a row that has burned its attempts is left alone
         // by the next resume rather than retried forever.
         attempt: { increment: 1 },

--- a/chaos/harness/fake-shopify.ts
+++ b/chaos/harness/fake-shopify.ts
@@ -104,6 +104,19 @@ export class FakeShopify {
   shopCurrency = "USD";
 
   /**
+   * Stores a different price than the one requested, and reports the stored one.
+   *
+   * Models a shop that quietly adjusts what it is given — a rounding rule, a currency
+   * setting, a price list that reshapes the number. Shopify returns no error for this:
+   * the mutation succeeds and the storefront simply shows something else. Verification
+   * that only checks for `userError`s cannot see it, which is the point.
+   *
+   * Takes and returns the decimal string Shopify deals in, so a scenario can model
+   * rounding to whole units without this file knowing about currency precision.
+   */
+  distortStoredPrice: ((requested: string, variantGid: string) => string) | null = null;
+
+  /**
    * Exchange rates from the shop currency, per market currency.
    *
    * Present so the fake can derive a relative list's prices the way Shopify does:
@@ -329,8 +342,12 @@ export class FakeShopify {
       }
 
       if (typeof input.price === "string") {
-        variant.price = input.price;
-        this.writeLog.push({ variantGid: id, price: input.price, priceListGid: null });
+        // What the shop ends up holding, which is not always what was asked for.
+        const stored = this.distortStoredPrice
+          ? this.distortStoredPrice(input.price, id)
+          : input.price;
+        variant.price = stored;
+        this.writeLog.push({ variantGid: id, price: stored, priceListGid: null });
       }
       if ("compareAtPrice" in input) {
         variant.compareAtPrice = input.compareAtPrice === null ? null : String(input.compareAtPrice);

--- a/chaos/scenarios/silent-divergence.chaos.ts
+++ b/chaos/scenarios/silent-divergence.chaos.ts
@@ -1,0 +1,79 @@
+/**
+ * Shopify accepts the write, stores something else, and says nothing.
+ *
+ * No error, no throttle, no failure — the mutation succeeds and the storefront simply
+ * shows a different price. A rounding rule, a currency setting, a price list that
+ * reshapes the number: the merchant approved one price and shoppers pay another.
+ *
+ * A run that reports "verified clean" here is the single worst outcome this product can
+ * produce, because the merchant has been told the opposite of the truth and has no reason
+ * to look. Invariant I5 exists for exactly this, and it only holds if verification
+ * compares prices rather than checking for errors.
+ *
+ * Both write paths are covered. The bulk path is the one that used to check only for
+ * `userError`s, which meant the largest campaigns — the ones nobody can eyeball — had the
+ * weakest guarantee.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos } from "../harness/scenario";
+
+/** A shop that rounds every stored price down to a whole unit. */
+const roundsToWholeUnits = (requested: string) => `${Math.floor(Number(requested))}.00`;
+
+describe("chaos: Shopify stores a price we did not ask for", () => {
+  for (const path of ["sync", "bulk"] as const) {
+    it(`refuses to call the run clean on the ${path} path`, async () => {
+      await withChaos(
+        `silent-divergence-${path}`,
+        { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+        async (chaos) => {
+          chaos.fake.distortStoredPrice = roundsToWholeUnits;
+
+          const outcome = await chaos.apply({ forcePath: path });
+
+          // The whole point: no row may be called verified when the store holds a
+          // different number, however quietly it got there.
+          expect(outcome.clean, "reported clean while the storefront disagreed").toBe(false);
+          expect(outcome.verified).toBe(0);
+          expect(outcome.failed).toBeGreaterThan(0);
+
+          const runId = await chaos.latestRunId("APPLY");
+
+          // The reason has to name both numbers, and the ledger has to carry the one the
+          // store actually holds — in a column, not only in prose.
+          const ledgered = await prisma.variantChange.findMany({
+            where: { runId, shopId: chaos.fixture.shopId, status: "FAILED" },
+            select: { failureReason: true, intendedPrice: true, appliedPrice: true },
+          });
+
+          expect(ledgered.length).toBeGreaterThan(0);
+          for (const change of ledgered) {
+            expect(change.failureReason, "the reason must say what happened")
+              .toMatch(/Read-back mismatch/);
+            expect(change.appliedPrice, "the observed price was not recorded").not.toBeNull();
+            expect(change.appliedPrice).not.toBe(change.intendedPrice);
+          }
+        },
+      );
+    });
+  }
+
+  it("still verifies normally when the shop stores what it was asked for", async () => {
+    // The control. Without it, a verification that failed everything would pass the
+    // tests above and prove nothing.
+    await withChaos(
+      "silent-divergence-control",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const outcome = await chaos.apply();
+
+        expect(outcome.clean).toBe(true);
+        expect(outcome.verified).toBeGreaterThan(0);
+        expect(outcome.failed).toBe(0);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Rule 5 says a run is clean only when every row is **read-back verified**. The sync path did that. The bulk path did not.

## What was wrong

`executeBulk` checked the result file for `userErrors` and, finding none, marked the row verified:

```ts
const outcome = outcomes.get(gid);
if (!outcome || !outcome.ok) return { row, status: "failed", ... };
return { row, status: "verified" };   // outcome.price never read
```

So "verified" meant *the mutation was accepted* — a claim about the request, not about the storefront. If a shop stores something other than what it was asked for (a rounding rule, a currency setting, a price list that reshapes the number), Shopify returns **no error at all**: the run reports clean and the wrong price is live.

This was on the path every large campaign takes. Sync handles up to 1,000 rows; bulk handles everything above it. **The biggest runs — the ones nobody can eyeball — had the weakest guarantee.**

`RunOptions.verifySampleRate` even documented the opposite: *"the bulk path gets per-row confirmation from its result file instead."* That comment is now true.

## The fix

It costs nothing. `VariantOutcome.price` was already parsed out of the result file and thrown away. It is now compared — no extra request, no extra latency.

The comparison moved to `read-back.ts` and **both paths use it**, because two definitions of "verified" that can disagree is how this happened in the first place. Currency scale is derived from the intended amount rather than a lookup table, so JPY (no decimals) and KWD (three) both round-trip — getting that wrong fails every row in a market, or passes every one regardless of what was stored.

A mismatch now also records the observed price in `variant_changes`, so the ledger carries the divergence as a number rather than only inside an English failure reason. Only on divergence: for a verified row the observed price equals the intended one by definition, so writing it per row would cost a query each to record something already in `intendedPrice`.

## The test that matters

`silent-divergence.chaos.ts` models a shop that quietly rounds every stored price to a whole unit, and runs it down **both** paths.

Against the previous code it fails exactly as it should:

```
× refuses to call the run clean on the bulk path
  → reported clean while the storefront disagreed: expected true to be false
```

A control case asserts a well-behaved shop still verifies cleanly, so the scenario cannot pass by simply failing everything.

`FakeShopify.distortStoredPrice` is the new hook — the fake previously always echoed back exactly what it was given, so it could not express "accepted, but stored something else", which is why 942 tests passed over this bug.

## Verification

- 955 unit tests, 112 chaos scenarios, lint and build clean
- 9 mutations checked, all caught: a missing price counting as a pass, the currency scale ignored, differences tolerated, the observed price not reaching the ledger, and the original bulk behaviour restored
- Note that **every existing test passed both before and after the behavioural fix** — nothing exercised bulk verification against a divergent price. That gap is the finding as much as the bug is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)