### PR TITLE
Verify the market price too, and make the fake as strict as the schema

### DIFF
--- a/app/lib/execution/market-executor.test.ts
+++ b/app/lib/execution/market-executor.test.ts
@@ -39,8 +39,13 @@ function acceptingClient(seen: Array<Record<string, unknown>> = []): AdminClient
   return {
     async request<T>(_query: string, variables: Record<string, unknown>) {
       seen.push(variables);
-      const prices = ((variables.prices ?? []) as Array<{ variantId: string }>).map((p) => ({
+      // `PriceListPrice.price` is non-null in the schema: Shopify always echoes back
+      // what it stored. A stub that omitted it was easier to satisfy than the real API.
+      const prices = (
+        (variables.prices ?? []) as Array<{ variantId: string; price: { amount: string } }>
+      ).map((p) => ({
         variant: { id: p.variantId },
+        price: { amount: p.price.amount, currencyCode: "EUR" },
       }));
       return { data: { priceListFixedPricesAdd: { prices, userErrors: [] } } as T };
     },
@@ -114,7 +119,12 @@ describe("writeMarketPrices", () => {
         return {
           data: {
             priceListFixedPricesAdd: {
-              prices: [{ variant: { id: "gid://shopify/ProductVariant/1" } }],
+              prices: [
+                {
+                  variant: { id: "gid://shopify/ProductVariant/1" },
+                  price: { amount: "10.01", currencyCode: "EUR" },
+                },
+              ],
               userErrors: [],
             },
           } as T,
@@ -129,13 +139,47 @@ describe("writeMarketPrices", () => {
     expect(result.rows.find((r) => r.variantGid.endsWith("/2"))?.failureReason).toMatch(/did not confirm/i);
   });
 
+  it("refuses a row Shopify confirmed at a different price", async () => {
+    // The failure this exists to catch: a price list with a rounding rule accepts the
+    // write, stores something else, and returns no error at all. "It confirmed the
+    // variant" is a weaker claim than "it stored what we asked for", and a shopper pays
+    // the difference.
+    const rounding: AdminClient = {
+      async request<T>(_q: string, variables: Record<string, unknown>) {
+        const prices = (
+          (variables.prices ?? []) as Array<{ variantId: string; price: { amount: string } }>
+        ).map((p) => ({
+          variant: { id: p.variantId },
+          // Rounded down to a whole unit, exactly as a price list rule might.
+          price: { amount: `${Math.floor(Number(p.price.amount))}.00`, currencyCode: "EUR" },
+        }));
+        return { data: { priceListFixedPricesAdd: { prices, userErrors: [] } } as T };
+      },
+    };
+
+    const result = await writeMarketPrices(rounding, "gid://PriceList/1", "EUR", [row(1), row(2)]);
+
+    expect(result.clean).toBe(false);
+    expect(result.verified).toBe(0);
+    expect(result.failed).toBe(2);
+    expect(result.rows[0]?.failureReason).toMatch(/Read-back mismatch/);
+    // Both numbers, so support can act without opening the Shopify admin.
+    expect(result.rows[0]?.failureReason).toContain("10.01");
+    expect(result.rows[0]?.guidance).toMatch(/rounding or adjustment/i);
+  });
+
   it("maps a positional userError back to its own row", async () => {
     const rejecting: AdminClient = {
       async request<T>() {
         return {
           data: {
             priceListFixedPricesAdd: {
-              prices: [{ variant: { id: "gid://shopify/ProductVariant/1" } }],
+              prices: [
+                {
+                  variant: { id: "gid://shopify/ProductVariant/1" },
+                  price: { amount: "10.01", currencyCode: "EUR" },
+                },
+              ],
               userErrors: [{ field: ["prices", "1", "price"], message: "Price is invalid" }],
             },
           } as T,
@@ -154,8 +198,11 @@ describe("writeMarketPrices", () => {
     const flaky: AdminClient = {
       async request<T>(_q: string, variables: Record<string, unknown>) {
         if (++call === 2) throw new Error("fetch failed");
-        const prices = ((variables.prices ?? []) as Array<{ variantId: string }>).map((p) => ({
+        const prices = (
+          (variables.prices ?? []) as Array<{ variantId: string; price: { amount: string } }>
+        ).map((p) => ({
           variant: { id: p.variantId },
+          price: { amount: p.price.amount, currencyCode: "EUR" },
         }));
         return { data: { priceListFixedPricesAdd: { prices, userErrors: [] } } as T };
       },

--- a/app/lib/execution/market-executor.ts
+++ b/app/lib/execution/market-executor.ts
@@ -31,6 +31,7 @@
 import { formatMoney, type Money } from "../money/money";
 import { isThrottledError, withRetry } from "../shopify/budget";
 import { classifyFailure } from "./classify";
+import { readBackVerdict } from "./read-back";
 import type { AdminClient } from "./sync-executor";
 
 /** Shopify's cap. Not a tuning knob — the request is rejected above it. */
@@ -165,9 +166,14 @@ export async function writeMarketPrices(
         else errorsByIndex.set(at, text);
       }
 
-      const confirmed = new Set(
-        (payload?.prices ?? []).map((entry) => entry.variant?.id).filter(Boolean) as string[],
-      );
+      // Keep the amount, not just the id. Shopify echoes back what it stored, and
+      // "it mentioned this variant" is a weaker claim than "it stored the price we
+      // asked for" — a price list can reshape a number without raising a userError.
+      const confirmed = new Map<string, string | undefined>();
+      for (const entry of payload?.prices ?? []) {
+        const id = entry.variant?.id;
+        if (id) confirmed.set(id, entry.price?.amount);
+      }
 
       chunk.forEach((row, at) => {
         const reason = errorsByIndex.get(at) ?? chunkWide;
@@ -191,6 +197,22 @@ export async function writeMarketPrices(
               "Shopify accepted the request but did not confirm this variant's market price.",
             guidance:
               "The market price for this variant may not have been set. Resume the campaign to try it again.",
+          });
+          return;
+        }
+
+        // The same comparison the base surface makes, for the same reason: a market
+        // price that Shopify stored differently is a price a shopper pays and nobody
+        // approved. Markets are where that has actually bitten.
+        const verdict = readBackVerdict(row.price, confirmed.get(row.variantGid));
+        if (!verdict.ok) {
+          results.set(row.variantGid, {
+            variantGid: row.variantGid,
+            status: "failed",
+            failureReason: verdict.reason,
+            guidance:
+              "Shopify stored a different price for this market than the campaign asked " +
+              "for. Check the price list for rounding or adjustment rules, then resume.",
           });
           return;
         }

--- a/chaos/harness/fake-shopify.ts
+++ b/chaos/harness/fake-shopify.ts
@@ -113,8 +113,14 @@ export class FakeShopify {
    *
    * Takes and returns the decimal string Shopify deals in, so a scenario can model
    * rounding to whole units without this file knowing about currency precision.
+   *
+   * `priceListGid` is null for the base surface, so a scenario can distort one surface
+   * and leave the other alone — a base write that fails aborts the run before it ever
+   * reaches the markets, which would make a market assertion vacuous.
    */
-  distortStoredPrice: ((requested: string, variantGid: string) => string) | null = null;
+  distortStoredPrice:
+    | ((requested: string, variantGid: string, priceListGid: string | null) => string)
+    | null = null;
 
   /**
    * Exchange rates from the shop currency, per market currency.
@@ -344,7 +350,7 @@ export class FakeShopify {
       if (typeof input.price === "string") {
         // What the shop ends up holding, which is not always what was asked for.
         const stored = this.distortStoredPrice
-          ? this.distortStoredPrice(input.price, id)
+          ? this.distortStoredPrice(input.price, id, null)
           : input.price;
         variant.price = stored;
         this.writeLog.push({ variantGid: id, price: stored, priceListGid: null });
@@ -715,13 +721,25 @@ export class FakeShopify {
       };
     }
 
-    const confirmed: Array<{ variant: { id: string } }> = [];
+    // Shopify echoes back what it stored, and `PriceListPrice.price` is non-null in the
+    // schema — so a fake that returned only the variant id was easier to satisfy than the
+    // real API, which is the wrong direction for a fake to be wrong in.
+    const confirmed: Array<{
+      variant: { id: string };
+      price: { amount: string; currencyCode: string };
+      compareAtPrice: { amount: string; currencyCode: string } | null;
+    }> = [];
 
     for (const price of prices) {
       const existing = list.prices.findIndex((entry) => entry.variantGid === price.variantId);
+      // What the list ends up holding, which a distorting shop may change.
+      const stored = this.distortStoredPrice
+        ? this.distortStoredPrice(price.price.amount, price.variantId, list.id)
+        : price.price.amount;
+
       const row = {
         variantGid: price.variantId,
-        amount: price.price.amount,
+        amount: stored,
         compareAt: price.compareAtPrice?.amount ?? null,
         originType: "FIXED" as const,
       };
@@ -731,10 +749,16 @@ export class FakeShopify {
 
       this.writeLog.push({
         variantGid: price.variantId,
-        price: price.price.amount,
+        price: stored,
         priceListGid: list.id,
       });
-      confirmed.push({ variant: { id: price.variantId } });
+      confirmed.push({
+        variant: { id: price.variantId },
+        price: { amount: stored, currencyCode: list.currency },
+        compareAtPrice: row.compareAt
+          ? { amount: row.compareAt, currencyCode: list.currency }
+          : null,
+      });
     }
 
     return {

--- a/chaos/scenarios/silent-divergence.chaos.ts
+++ b/chaos/scenarios/silent-divergence.chaos.ts
@@ -10,9 +10,10 @@
  * to look. Invariant I5 exists for exactly this, and it only holds if verification
  * compares prices rather than checking for errors.
  *
- * Both write paths are covered. The bulk path is the one that used to check only for
- * `userError`s, which meant the largest campaigns — the ones nobody can eyeball — had the
- * weakest guarantee.
+ * Both base-surface write paths are covered here. The market path makes the same
+ * comparison and is covered by `market-executor.test.ts` instead — getting a market
+ * surface planned inside a chaos fixture needs setup this scenario does not otherwise
+ * need, and the unit test exercises the same refusal directly.
  */
 
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
Follow-up to #274. The third write path had the same gap.

## The gap

`writeMarketPrices` asked whether Shopify had *confirmed the variant*, not whether it had *stored the price*:

```ts
if (!confirmed.has(row.variantGid)) { ...failed... }
results.set(row.variantGid, { variantGid: row.variantGid, status: "verified" });
```

"It mentioned this variant" is a weaker claim than "it stored what we asked for" — and a price list is precisely where a number gets reshaped, because rounding rules live there. The mutation already requested `price { amount }` and `AddResponse` already modelled it. The value was parsed and dropped.

**Markets are where this has actually bitten.** Earlier this month EUR shoppers paid 36% off a 20% sale while the run reported verified clean.

## Why nothing caught it

`PriceListPrice.price` is `NON_NULL` in the pinned 2025-10 schema — real Shopify *always* returns it. But `FakeShopify` and two unit stubs returned only `variant { id }`.

A fake that is easier to satisfy than the API it stands in for cannot catch a bug in the code that talks to that API. That is #274's lesson from the other direction: there, the fake could not express "stored something else"; here, it omitted a field the API guarantees. Both now echo the stored price back.

`distortStoredPrice` also gained the price list id, so a scenario can distort one surface and leave the other honest — a failing base write aborts the run before it reaches the markets.

## Coverage, stated plainly

The market refusal is proved by a **unit test**, not a chaos scenario. Getting a market surface planned inside a chaos fixture needs setup the divergence scenario does not otherwise need, and after three attempts the market writes still were not firing, so I stopped rather than keep going. `market-write.chaos.ts` and `market-wide.chaos.ts` do exercise the market write path and pass, so a regression that broke it wholesale would still be caught; what the unit test adds is the divergence case specifically.

## Verification

- 956 unit tests, 112 chaos scenarios, lint and build clean
- The new market test fails against the old code (verified by reverting the comparison): `× refuses a row Shopify confirmed at a different price`
- Two existing stubs had to be corrected to echo the intended amount, because they asserted confirmation behaviour and would otherwise have become mismatch tests by accident

🤖 Generated with [Claude Code](https://claude.com/claude-code)