### PR TITLE
Group every count a merchant reads, not just the ones on the plan page

### DIFF
--- a/app/components/CountsRow.tsx
+++ b/app/components/CountsRow.tsx
@@ -1,3 +1,5 @@
+import { formatCount } from "../lib/format/display";
+
 /** A row of labelled figures, used for preview and catalogue summaries. */
 export function CountsRow({ items }: { items: Array<{ label: string; value: number }> }) {
   return (
@@ -5,7 +7,7 @@ export function CountsRow({ items }: { items: Array<{ label: string; value: numb
       {items.map((item) => (
         <s-box key={item.label}>
           <s-text>{item.label}</s-text>
-          <s-heading>{item.value}</s-heading>
+          <s-heading>{formatCount(item.value)}</s-heading>
         </s-box>
       ))}
     </s-stack>

--- a/app/lib/format/display.test.ts
+++ b/app/lib/format/display.test.ts
@@ -112,3 +112,26 @@ describe("nothing formats against the ambient environment", () => {
     }
   });
 });
+
+describe("counts a merchant reads are grouped, wherever they appear", () => {
+  /**
+   * The inconsistency this pins: the plan page rendered "3,670" while the dashboard and
+   * reconciliation rendered "3670" for the same catalogue. Below a thousand nobody
+   * notices; on a 120,000-variant store the two pages disagree about the same number and
+   * one of them looks broken.
+   */
+  const merchantFacing = [
+    "app/components/CountsRow.tsx",
+    "app/routes/app._index.tsx",
+    "app/routes/app.reconciliation.tsx",
+    "app/routes/app.activity.tsx",
+    "app/routes/app.plan.tsx",
+    "app/components/RunResultSection.tsx",
+  ];
+
+  it.each(merchantFacing)("%s formats its counts", (file) => {
+    const source = readFileSync(join(process.cwd(), file), "utf8");
+
+    expect(source, `${file} shows counts without grouping them`).toContain("formatCount");
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -1,4 +1,4 @@
-import { formatDay, formatWhen } from "../lib/format/display";
+import { formatCount, formatDay, formatWhen } from "../lib/format/display";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -243,19 +243,19 @@ export default function Dashboard() {
           <s-stack direction="inline" gap="large">
             <s-box>
               <s-text>Variants</s-text>
-              <s-heading>{health.variants}</s-heading>
+              <s-heading>{formatCount(health.variants)}</s-heading>
             </s-box>
             <s-box>
               <s-text>With baseline</s-text>
-              <s-heading>{health.withBaseline}</s-heading>
+              <s-heading>{formatCount(health.withBaseline)}</s-heading>
             </s-box>
             <s-box>
               <s-text>Not at baseline</s-text>
-              <s-heading>{health.drifted}</s-heading>
+              <s-heading>{formatCount(health.drifted)}</s-heading>
             </s-box>
             <s-box>
               <s-text>Campaigns</s-text>
-              <s-heading>{campaigns}</s-heading>
+              <s-heading>{formatCount(campaigns)}</s-heading>
             </s-box>
           </s-stack>
 
@@ -337,19 +337,19 @@ export default function Dashboard() {
           <s-stack direction="inline" gap="large">
             <s-box>
               <s-text>Campaigns running</s-text>
-              <s-heading>{live}</s-heading>
+              <s-heading>{formatCount(live)}</s-heading>
             </s-box>
             <s-box>
               <s-text>Scheduled</s-text>
-              <s-heading>{upcoming}</s-heading>
+              <s-heading>{formatCount(upcoming)}</s-heading>
             </s-box>
             <s-box>
               <s-text>Need attention</s-text>
-              <s-heading>{needsAttention}</s-heading>
+              <s-heading>{formatCount(needsAttention)}</s-heading>
             </s-box>
             <s-box>
               <s-text>Prices changed outside the app</s-text>
-              <s-heading>{driftOpen}</s-heading>
+              <s-heading>{formatCount(driftOpen)}</s-heading>
             </s-box>
           </s-stack>
 

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -6,6 +6,7 @@
  * sale?" or "who turned the cost floor off?" without opening a database client.
  */
 
+import { formatCount } from "../lib/format/display";
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -109,7 +110,7 @@ export default function Activity() {
             <s-stack direction="inline" gap="base">
               <s-paragraph>
                 <s-text>
-                  {total} entr{total === 1 ? "y" : "ies"} · times shown in {timeZone}
+                  {formatCount(total)} entr{total === 1 ? "y" : "ies"} · times shown in {timeZone}
                 </s-text>
               </s-paragraph>
               <s-button

--- a/app/routes/app.reconciliation.tsx
+++ b/app/routes/app.reconciliation.tsx
@@ -1,3 +1,4 @@
+import { formatCount } from "../lib/format/display";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -82,7 +83,7 @@ export default function Reconciliation() {
         <s-paragraph>
           <s-text>
             Every price on every surface, next to the baseline it was computed from and
-            the campaign that put it there. {total} rows.
+            the campaign that put it there. {formatCount(total)} rows.
           </s-text>
         </s-paragraph>
 


### PR DESCRIPTION
Spotted in the browser immediately after #278: the plan page rendered **3,670** while the dashboard and reconciliation rendered **3670** for the same catalogue.

Below a thousand nobody notices. On a 120,000-variant store the two pages disagree about the same number, and one of them looks broken.

## What changed

`CountsRow` is the shared component, so the dashboard, preview and catalogue summaries move together. The dashboard's own headline figures, reconciliation's row count and the activity log's entry count were direct interpolations and are now formatted too.

A test lists the merchant-facing files and asserts each formats its counts. That is coarse on purpose — the precise version would be a renderer nobody can bypass, which is a bigger change than this inconsistency warrants.

## Verification

- 983 unit tests, lint and build clean
- **Checked in the live app**: the dashboard now reads 3,670 and 3,693, matching the plan page

🤖 Generated with [Claude Code](https://claude.com/claude-code)