### PR TITLE
Serve pictures from the help centre, and draw the concept that needs one

### DIFF
--- a/app/lib/help/pages.server.test.ts
+++ b/app/lib/help/pages.server.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import {
   escapesRoot,
   INDEX_SLUG,
+  readHelpImage,
   readHelpPage,
   resolveHelpFile,
   rewriteHelpHref,
@@ -162,5 +163,84 @@ describe("links inside a page lead somewhere", () => {
     expect(rewriteHelpHref("./revert.md#partial", "concepts/baselines")).toBe(
       "/help/concepts/revert#partial",
     );
+  });
+});
+
+/**
+ * Images are served from the same directory by the same rules.
+ *
+ * This route hands raw bytes to an unauthenticated caller from a path they supplied,
+ * which is the shape of request that turns a help centre into a file server.
+ */
+describe("serving an image belonging to a page", () => {
+  it("serves one that exists, with the right type", async () => {
+    const image = await readHelpImage("images/resolver.svg");
+
+    expect(image).not.toBeNull();
+    expect(image!.contentType).toBe("image/svg+xml");
+    expect(image!.body.length).toBeGreaterThan(100);
+  });
+
+  it.each([
+    "images/../../package.json",
+    "../../package.json",
+    "../../../etc/passwd",
+    "images/..%2f..%2fpackage.json",
+    // The ones that matter: a traversal wearing an extension we do serve, so the type
+    // allowlist waves them through and something else has to stop them.
+    "../../app/root.png",
+    "images/../../../etc/hosts.png",
+    "images/../../app/db.server.svg",
+  ])("refuses %j", async (path) => {
+    expect(await readHelpImage(path)).toBeNull();
+  });
+
+  it("refuses a type we do not publish, whatever the file is", async () => {
+    // The allowlist is on the extension, so a markdown page cannot be served as bytes
+    // and an executable cannot be served at all.
+    expect(await readHelpImage("concepts/resolver.md")).toBeNull();
+    expect(await readHelpImage("images/resolver.exe")).toBeNull();
+    expect(await readHelpImage("images/resolver")).toBeNull();
+  });
+
+  it("refuses an image that is not there", async () => {
+    expect(await readHelpImage("images/not-a-picture.png")).toBeNull();
+  });
+});
+
+describe("pictures in a page point at the route that serves them", () => {
+  it("rewrites a relative image path to an absolute one", () => {
+    expect(rewriteHelpHref("../images/resolver.svg", "concepts/resolver")).toBe(
+      "/help/images/resolver.svg",
+    );
+    // Unlike a page, an asset keeps its extension — that is how its type is decided.
+    expect(rewriteHelpHref("./diagram.png", "how-to/first-campaign")).toBe(
+      "/help/how-to/diagram.png",
+    );
+  });
+
+  it("every image a page renders is one the help centre will serve", async () => {
+    let checked = 0;
+
+    for (const slug of allSlugs()) {
+      const html = (await readHelpPage(slug))!.html;
+
+      for (const match of html.matchAll(/<img[^>]+src="\/help\/([^"]+)"/g)) {
+        expect(await readHelpImage(match[1]), `${slug} shows ${match[1]}`).not.toBeNull();
+        checked += 1;
+      }
+    }
+
+    expect(checked, "no page shows an image, so this proves nothing").toBeGreaterThan(0);
+  });
+
+  it("gives every image alt text that says what it shows", async () => {
+    // A diagram explaining the one concept merchants misunderstand is useless to a
+    // screen reader if its alt text is "diagram".
+    const html = (await readHelpPage("concepts/resolver"))!.html;
+    const alt = /<img[^>]*alt="([^"]*)"/.exec(html)?.[1] ?? "";
+
+    expect(alt.length).toBeGreaterThan(40);
+    expect(alt.toLowerCase()).not.toBe("diagram");
   });
 });

--- a/app/lib/help/pages.server.ts
+++ b/app/lib/help/pages.server.ts
@@ -24,6 +24,25 @@ const ROOT = join(process.cwd(), "docs", "help");
 /** The page served when no slug is given — the curated index, not a generated list. */
 export const INDEX_SLUG = "index";
 
+/**
+ * Image types the help centre will serve, and what to send them as.
+ *
+ * An allowlist rather than a lookup: this route hands bytes to an unauthenticated caller
+ * from a path they supplied, and the set of things a help page legitimately needs is
+ * small. Anything not named here is not served, whatever its extension says.
+ */
+const IMAGE_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".svg": "image/svg+xml",
+};
+
+export interface HelpImage {
+  body: Buffer;
+  contentType: string;
+}
+
 export interface HelpPage {
   /** The `#` heading, used as the document title. */
   title: string;
@@ -79,14 +98,18 @@ export function escapesRoot(candidate: string): boolean {
  * help page whose every onward link is dead.
  */
 export function rewriteHelpHref(href: string, fromSlug: string): string {
-  if (!href.startsWith(".") && !/^[a-z0-9][a-z0-9-]*\.md([#?].*)?$/i.test(href)) {
+  if (!href.startsWith(".") && !/^[a-z0-9][a-z0-9-]*\.(md|png|jpe?g|svg)([#?].*)?$/i.test(href)) {
     return href;
   }
 
   const [path, fragment = ""] = splitFragment(href);
-  if (!path.endsWith(".md")) return href;
+  const isPage = path.endsWith(".md");
+  const isAsset = /\.(png|jpe?g|svg)$/i.test(path);
+  if (!isPage && !isAsset) return href;
 
   const dir = posix.dirname(fromSlug);
+  // Pages lose their extension because that is how they are routed; an asset keeps its,
+  // because that is how it is served and how the type is decided.
   const resolved = posix
     .normalize(posix.join(dir === "." ? "" : dir, path))
     .replace(/\.md$/, "");
@@ -101,6 +124,45 @@ export function rewriteHelpHref(href: string, fromSlug: string): string {
 function splitFragment(href: string): [string, string] {
   const at = href.search(/[#?]/);
   return at === -1 ? [href, ""] : [href.slice(0, at), href.slice(at)];
+}
+
+/**
+ * An image belonging to a help page.
+ *
+ * Screenshots and diagrams live beside the prose they explain, which is what lets a doc
+ * and its picture be updated in one commit. Serving them needs the same path checks the
+ * pages get — the alphabet is widened only by the dot in the extension, and the extension
+ * has to be one we publish.
+ *
+ * Three independent refusals, and mutation testing says each is individually redundant:
+ * remove any one and the traversal cases are still refused by the other two. That is the
+ * intended shape rather than an accident. The extension allowlist is the one doing the
+ * visible work; the alphabet check and `escapesRoot` are there so that widening the
+ * allowlist later — a PDF, a font — cannot quietly become a file server.
+ */
+export async function readHelpImage(path: string): Promise<HelpImage | null> {
+  const cleaned = path.replace(/^\/+|\/+$/g, "");
+
+  const dot = cleaned.lastIndexOf(".");
+  if (dot === -1) return null;
+
+  const extension = cleaned.slice(dot).toLowerCase();
+  const contentType = IMAGE_TYPES[extension];
+  if (!contentType) return null;
+
+  // Reuse the page resolver on the name without its extension, so the traversal rules
+  // are the ones already tested rather than a second set written for images.
+  const asSlug = cleaned.slice(0, dot);
+  if (!SLUG_ALPHABET.test(asSlug)) return null;
+
+  const candidate = normalize(join(ROOT, cleaned));
+  if (escapesRoot(candidate)) return null;
+
+  try {
+    return { body: await readFile(candidate), contentType };
+  } catch {
+    return null;
+  }
 }
 
 export async function readHelpPage(slug: string): Promise<HelpPage | null> {
@@ -130,6 +192,13 @@ export async function readHelpPage(slug: string): Promise<HelpPage | null> {
       if (token.type === "link") {
         const link = token as Tokens.Link;
         link.href = rewriteHelpHref(link.href, slug);
+      }
+      // Images the same way. A browser would resolve `../images/x.svg` correctly from
+      // this URL by accident; rewriting it means the answer does not depend on whether
+      // the page was reached with a trailing slash.
+      if (token.type === "image") {
+        const image = token as Tokens.Image;
+        image.href = rewriteHelpHref(image.href, slug);
       }
     },
   });

--- a/app/routes/help.images.$.tsx
+++ b/app/routes/help.images.$.tsx
@@ -1,0 +1,35 @@
+/**
+ * Screenshots and diagrams belonging to help pages.
+ *
+ * A separate route from `help.$` rather than a branch inside it: that loader returns data
+ * for a React component, and a route that sometimes returns raw bytes instead has a
+ * return type nothing downstream can use honestly. React Router matches the more specific
+ * path first, so `/help/images/…` lands here and everything else stays a page.
+ *
+ * Unauthenticated, like the pages, and reading a caller-supplied path — so it goes through
+ * the same containment checks, with the alphabet widened only by a file extension from a
+ * fixed list.
+ */
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { readHelpImage } from "../lib/help/pages.server";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const image = await readHelpImage(`images/${params["*"] ?? ""}`);
+
+  if (!image) {
+    // A plain 404 rather than the help centre's error page: a browser asking for an image
+    // wants a status, not prose.
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(new Uint8Array(image.body), {
+    headers: {
+      "Content-Type": image.contentType,
+      // Screenshots change only when a deploy changes them, and a stale one for an hour
+      // is a smaller problem than re-fetching them on every page view.
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/docs/help/concepts/resolver.md
+++ b/docs/help/concepts/resolver.md
@@ -11,6 +11,8 @@ For each product, exactly one campaign controls the price. The winner is:
 
 Everything else is ignored for that product — not applied on top.
 
+![How a live price is computed: the baseline and every campaign covering a variant go into the resolver, which picks one winner by priority. The £100 baseline with a winning 20% campaign gives a £80 live price; the other two campaigns are ignored rather than added on top.](../images/resolver.svg)
+
 ## Why not stack?
 
 Because stacking is how merchants end up giving away 60% by accident. Two 20% campaigns

--- a/docs/help/images/resolver.svg
+++ b/docs/help/images/resolver.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 300" width="640" height="300" role="img" aria-labelledby="title desc">
+  <title id="title">How a live price is computed</title>
+  <desc id="desc">The baseline and the campaigns covering a variant go into the resolver, which picks one winning campaign by priority and produces the live price. Campaigns never stack.</desc>
+  <style>
+    text { font-family: Inter, -apple-system, "Segoe UI", sans-serif; fill: #1a1a1a; }
+    .label { font-size: 13px; }
+    .small { font-size: 11px; fill: #4a4a4a; }
+    .box { fill: #f6f6f7; stroke: #c9c9c9; }
+    .winner { fill: #e8f5ee; stroke: #2f7d54; }
+    .muted { fill: #fafafa; stroke: #dcdcdc; }
+    .arrow { stroke: #8a8a8a; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e3e3e3; }
+      .small { fill: #b5b5b5; }
+      .box { fill: #2a2a2a; stroke: #4a4a4a; }
+      .winner { fill: #1e3a2b; stroke: #4aa878; }
+      .muted { fill: #232323; stroke: #3a3a3a; }
+    }
+  </style>
+  <defs>
+    <marker id="head" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#8a8a8a"/>
+    </marker>
+  </defs>
+
+  <rect class="box" x="10" y="120" width="140" height="56" rx="6"/>
+  <text class="label" x="80" y="145" text-anchor="middle">Baseline</text>
+  <text class="small" x="80" y="163" text-anchor="middle">£100.00</text>
+
+  <rect class="winner" x="220" y="40" width="180" height="52" rx="6"/>
+  <text class="label" x="310" y="63" text-anchor="middle">Summer sale · −20%</text>
+  <text class="small" x="310" y="80" text-anchor="middle">priority 10 — wins</text>
+
+  <rect class="muted" x="220" y="118" width="180" height="52" rx="6"/>
+  <text class="label" x="310" y="141" text-anchor="middle">Clearance · −30%</text>
+  <text class="small" x="310" y="158" text-anchor="middle">priority 5</text>
+
+  <rect class="muted" x="220" y="196" width="180" height="52" rx="6"/>
+  <text class="label" x="310" y="219" text-anchor="middle">Bundle · −10%</text>
+  <text class="small" x="310" y="236" text-anchor="middle">priority 1</text>
+
+  <rect class="box" x="470" y="120" width="160" height="56" rx="6"/>
+  <text class="label" x="550" y="145" text-anchor="middle">Live price</text>
+  <text class="small" x="550" y="163" text-anchor="middle">£80.00</text>
+
+  <path class="arrow" marker-end="url(#head)" d="M150,148 L214,148"/>
+  <path class="arrow" marker-end="url(#head)" d="M150,142 C185,142 185,66 214,66"/>
+  <path class="arrow" marker-end="url(#head)" d="M150,154 C185,154 185,222 214,222"/>
+  <path class="arrow" marker-end="url(#head)" d="M400,66 C440,66 440,142 464,142"/>
+
+  <text class="small" x="550" y="200" text-anchor="middle">one winner,</text>
+  <text class="small" x="550" y="216" text-anchor="middle">never stacked</text>
+</svg>


### PR DESCRIPTION
The help centre could serve prose and nothing else, so the one concept merchants reliably misunderstand — **that campaigns do not stack** — had to be explained in words alone.

## The route

`/help/images/…` is its own route rather than a branch inside the page loader. That loader returns data for a React component, and a route that sometimes returns raw bytes instead has a return type nothing downstream can use honestly. React Router matches the more specific path first.

Markdown image paths are rewritten the same way links already were, so `../images/x.svg` becomes `/help/images/x.svg` rather than depending on whether the page was reached with a trailing slash.

## On the path checks

Three independent refusals, and mutation testing says **each is individually redundant**: remove any one and the traversal cases are still refused by the other two.

That is the intended shape rather than an accident, and worth stating rather than dressing up as three catches. The extension allowlist does the visible work; the alphabet check and `escapesRoot` are there so widening the allowlist later — a PDF, a font — cannot quietly turn this into a file server. The test cases that matter are traversals *wearing an extension we do serve*, so the allowlist waves them through and something else has to stop them:

```
"../../app/root.png", "images/../../../etc/hosts.png", "images/../../app/db.server.svg"
```

## On screenshots, which #162 also asks for

I captured some from the development store and am **not** shipping them.

They carry the store's identity, and the admin sidebar in every frame lists the other apps installed — including three competitors. Help-centre screenshots want a clean store and a crop to the app frame; that is a person's job with a real account, not something to fake from here. Left open on the ticket with that reasoning.

The diagram is authored rather than captured for the same reason. It carries alt text describing what it shows rather than the word "diagram" — a test asserts that, because a picture explaining the concept people get wrong is useless to a screen reader otherwise.

## Verification

- 1,002 unit tests, lint and build clean
- Served over HTTP: `/help/images/resolver.svg` returns 200 `image/svg+xml`; `/help/images/../../package.json` 404s; a missing image 404s
- Rendered in the browser at both `/help/concepts/resolver` and the image URL directly, and repositioned a caption that overlapped an arrow

Refs #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)