### PR TITLE
Stop the help centre promising a Flow integration that is not switched on

### DIFF
--- a/app/lib/help/promises.test.ts
+++ b/app/lib/help/promises.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The help centre does not promise things the app cannot do.
+ *
+ * A dead link was the last version of this problem and it got fixed. This is the worse
+ * version: a page that loads perfectly and describes a feature that is not there. The
+ * Flow page told merchants "Anchor adds three triggers and three actions to Flow" while
+ * `extensions/` held no manifests, so Flow showed nothing. A merchant following it would
+ * search, find nothing, and conclude the app is broken — which is a support ticket and a
+ * one-star review, not a missing feature.
+ *
+ * Tying the notice to the manifests means the doc cannot drift in either direction: ship
+ * the extension without updating the page and this fails; remove the extension without
+ * restoring the notice and it fails too.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const NOTICE = "Not available yet";
+
+/** Extension manifests, which is what actually puts triggers and actions in Flow. */
+function manifests(): string[] {
+  const dir = join(ROOT, "extensions");
+  if (!existsSync(dir)) return [];
+
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(dir, entry.name, "shopify.extension.toml"))
+    .filter((file) => existsSync(file));
+}
+
+describe("Shopify Flow", () => {
+  const doc = readFileSync(join(ROOT, "docs/help/how-to/shopify-flow.md"), "utf8");
+  const index = readFileSync(join(ROOT, "docs/help/index.md"), "utf8");
+  const shipped = manifests().length > 0;
+
+  it("says whether it is available, matching whether it actually is", () => {
+    if (shipped) {
+      expect(
+        doc,
+        "Flow extensions exist now, so the help page should stop saying it is unavailable.",
+      ).not.toContain(NOTICE);
+    } else {
+      expect(
+        doc,
+        "There are no Flow extension manifests, so the help page must not describe Flow " +
+          "as something a merchant can set up today.",
+      ).toContain(NOTICE);
+    }
+  });
+
+  it("does not describe it in the present tense while it is unavailable", () => {
+    if (shipped) return;
+
+    // "Anchor adds three triggers" reads as a statement of fact about today.
+    expect(doc).not.toMatch(/^Anchor adds /m);
+  });
+
+  it("warns on the index too, where merchants choose what to read", () => {
+    if (shipped) return;
+
+    const line = index.split("\n").find((row) => row.includes("shopify-flow.md")) ?? "";
+
+    expect(line, "the index links to Flow with no hint that it is unavailable").toMatch(
+      /not available yet/i,
+    );
+  });
+});

--- a/docs/help/how-to/shopify-flow.md
+++ b/docs/help/how-to/shopify-flow.md
@@ -1,6 +1,11 @@
 # Wiring pricing into Shopify Flow
 
-Anchor adds three triggers and three actions to Flow, so pricing can be part of the
+> **Not available yet.** This page describes an integration that is built but not yet
+> switched on. If you open Flow today you will not find these triggers and actions. It is
+> here so you can see what is coming and tell us whether it is the right shape — not so you
+> can set it up.
+
+Anchor will add three triggers and three actions to Flow, so pricing can be part of the
 automations you already have rather than something you remember to do separately.
 
 ## Triggers

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -18,7 +18,7 @@ first campaign.
 - [Scheduling a sale](./how-to/schedule-a-sale.md)
 - [Running a sale across several markets](./how-to/multi-market-sale.md)
 - [Importing your own prices](./how-to/import-baselines.md)
-- [Wiring pricing into Shopify Flow](./how-to/shopify-flow.md)
+- [Wiring pricing into Shopify Flow](./how-to/shopify-flow.md) — not available yet; what it will do
 
 ## When something goes wrong
 


### PR DESCRIPTION
The Flow help page opened with:

> Anchor adds three triggers and three actions to Flow…

`extensions/` holds no manifests, so **Flow shows nothing**. A merchant following that page would search, find nothing, and conclude the app is broken — a support ticket and a one-star review, not a missing feature.

This is the worse version of the dead-link problem fixed in #271. That page failed to load, which at least looks like a fault. This one loads perfectly and describes something that is not there.

## What changed

The page stays — the design is worth showing and worth getting feedback on — but it now leads with a plain notice and switches to the future tense. The index says so too, where merchants choose what to read.

## The test

A test ties the notice to the manifests, so the doc cannot drift in either direction:

- ship the extension without updating the page → fails
- remove the extension without restoring the notice → fails

Verified both ways, including by dropping a real manifest into `extensions/` and watching the notice become the failure.

## Worth noting

`extensions/README.md` already explained this honestly and in detail — the CLI rejects the manifests here with `is invalid` and no field named, so they were pulled rather than block `npm run dev` for the whole repo. But that explanation only reaches whoever reads the repo, which is not the audience that needed telling.

Authoring the manifests still needs a Partner app with Flow enabled.

## Verification

- 1,005 unit tests, lint and build clean
- 4 mutations checked, all caught
- Rendered in the browser to confirm the notice reads as a notice rather than disappearing into the prose

Refs #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)