### PR TITLE
Give a wholesale ladder a baseline, so reverting one can recompute

### DIFF
--- a/app/lib/pricing/ladder-baseline.test.ts
+++ b/app/lib/pricing/ladder-baseline.test.ts
@@ -1,0 +1,119 @@
+/**
+ * A ladder is the one part of a price the database will not check for us.
+ *
+ * It lives in a JSON column, so every guarantee the schema gives a `BigInt` price has to
+ * be re-established in code — and the failure mode is quiet: a wholesale price list where
+ * one tier is right and another is silently absent, which a buyer discovers at checkout.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { money } from "../money/money";
+import { parseLadder, serialiseLadder, type LadderRung } from "./ladder-baseline";
+
+const gbp = (minor: number) => money(minor, "GBP");
+const rung = (minimumQuantity: number, minor: number): LadderRung => ({
+  minimumQuantity,
+  price: gbp(minor),
+});
+
+describe("storing a ladder", () => {
+  it("keeps integer minor units, never a formatted price", () => {
+    // A ladder that round-trips as "36.00" and comes back a float is rule 7 broken in
+    // the least visible place there is.
+    expect(serialiseLadder([rung(12, 3600)])).toEqual([{ minimumQuantity: 12, amount: 3600 }]);
+  });
+
+  it("sorts by quantity so the stored order never depends on the caller", () => {
+    expect(serialiseLadder([rung(48, 3200), rung(1, 4000), rung(12, 3600)])).toEqual([
+      { minimumQuantity: 1, amount: 4000 },
+      { minimumQuantity: 12, amount: 3600 },
+      { minimumQuantity: 48, amount: 3200 },
+    ]);
+  });
+
+  it("stores no ladder as null rather than an empty array", () => {
+    // Two encodings of one state is how a query ends up missing rows.
+    expect(serialiseLadder([])).toBeNull();
+  });
+
+  it("refuses a fractional amount rather than rounding it", () => {
+    // `money()` refuses this first, so the case that reaches here is a Money built as an
+    // object literal — which the type allows and which is how a float actually gets in.
+    const smuggled = { minimumQuantity: 1, price: { amount: 40.5, currency: "GBP" } };
+
+    expect(() => serialiseLadder([smuggled])).toThrow(/whole number of minor units/);
+  });
+
+  it("is the second line of defence, not the first", () => {
+    expect(() => gbp(40.5)).toThrow(/integer number of minor units/);
+  });
+});
+
+describe("reading a ladder back", () => {
+  it("round-trips", () => {
+    const original = [rung(1, 4000), rung(12, 3600)];
+
+    expect(parseLadder(serialiseLadder(original), "GBP")).toEqual(original);
+  });
+
+  it("takes its currency from the baseline, not from the JSON", () => {
+    // Storing the currency twice invites the two to disagree.
+    const ladder = parseLadder([{ minimumQuantity: 1, amount: 2921 }], "JPY");
+
+    expect(ladder).toEqual([{ minimumQuantity: 1, price: money(2921, "JPY") }]);
+  });
+
+  it("sorts what it reads, whatever order the column holds", () => {
+    const ladder = parseLadder(
+      [
+        { minimumQuantity: 48, amount: 3200 },
+        { minimumQuantity: 1, amount: 4000 },
+      ],
+      "GBP",
+    );
+
+    expect(ladder!.map((r) => r.minimumQuantity)).toEqual([1, 48]);
+  });
+
+  it.each([
+    ["absent", null],
+    ["undefined", undefined],
+    ["empty", []],
+    ["not a list", { minimumQuantity: 1, amount: 4000 }],
+    ["a string", "1+ at 40.00"],
+  ])("treats %s as no ladder", (_name, raw) => {
+    expect(parseLadder(raw, "GBP")).toBeNull();
+  });
+
+  it.each([
+    ["a fractional amount", [{ minimumQuantity: 1, amount: 40.5 }]],
+    ["an amount that is a string", [{ minimumQuantity: 1, amount: "4000" }]],
+    ["a fractional quantity", [{ minimumQuantity: 1.5, amount: 4000 }]],
+    ["a zero quantity", [{ minimumQuantity: 0, amount: 4000 }]],
+    ["a missing amount", [{ minimumQuantity: 1 }]],
+    ["a null rung", [null]],
+  ])("discards the whole ladder for %s", (_name, raw) => {
+    // Half a ladder is worse than none: none is visible, half is not.
+    expect(parseLadder(raw, "GBP")).toBeNull();
+  });
+
+  it("discards a ladder where one good rung sits beside a bad one", () => {
+    const raw = [
+      { minimumQuantity: 1, amount: 4000 },
+      { minimumQuantity: 12, amount: 36.5 },
+    ];
+
+    expect(parseLadder(raw, "GBP")).toBeNull();
+  });
+
+  it("discards a ladder with two rungs at the same quantity", () => {
+    const raw = [
+      { minimumQuantity: 12, amount: 3600 },
+      { minimumQuantity: 12, amount: 3400 },
+    ];
+
+    // Shopify keeps one and there is no way to say which, so neither is the baseline.
+    expect(parseLadder(raw, "GBP")).toBeNull();
+  });
+});

--- a/app/lib/pricing/ladder-baseline.ts
+++ b/app/lib/pricing/ladder-baseline.ts
@@ -1,0 +1,97 @@
+/**
+ * A wholesale ladder as it is stored on a baseline, and read back off one.
+ *
+ * The ladder lives in a JSON column, which means it is the one part of a price that the
+ * database will not check for us. Everything here exists to make that safe:
+ *
+ * - **Integer minor units only.** A ladder that round-trips through JSON as `36.0` and
+ *   comes back as a float is rule 7 broken in the least visible possible place. Anything
+ *   that is not a whole number of minor units is refused on the way in and on the way out.
+ * - **Refused, not repaired.** A stored ladder that cannot be parsed becomes `null` — no
+ *   ladder — rather than a partial one. Half a ladder is a wholesale price list where the
+ *   12+ tier exists and the 48+ tier silently does not, and a buyer pays the difference.
+ */
+
+import { money, type Money } from "../money/money";
+
+export interface LadderRung {
+  minimumQuantity: number;
+  price: Money;
+}
+
+/** The stored shape. Amounts are integer minor units, never a formatted string. */
+interface StoredRung {
+  minimumQuantity: number;
+  amount: number;
+}
+
+/**
+ * A ladder ready to be written to the column, or null when there is nothing to store.
+ *
+ * An empty ladder stores as null rather than `[]`: "this variant has no quantity breaks"
+ * is the state, and two encodings of one state is how a query ends up missing rows.
+ */
+export function serialiseLadder(rungs: readonly LadderRung[]): StoredRung[] | null {
+  if (rungs.length === 0) return null;
+
+  return [...rungs]
+    .sort((a, b) => a.minimumQuantity - b.minimumQuantity)
+    .map((rung) => {
+      // `money()` refuses a fractional amount at construction, so this only fires for a
+      // Money built as an object literal — which the type allows, and which is exactly how
+      // a float reaches a price in practice.
+      if (!Number.isInteger(rung.price.amount)) {
+        throw new RangeError(
+          `A quantity break at ${rung.minimumQuantity}+ has a price of ${rung.price.amount}, ` +
+            `which is not a whole number of minor units.`,
+        );
+      }
+      return { minimumQuantity: rung.minimumQuantity, amount: rung.price.amount };
+    });
+}
+
+/**
+ * The ladder stored on a baseline, or null if there isn't a usable one.
+ *
+ * `currency` comes from the baseline row rather than the JSON, because a ladder is
+ * denominated in the same currency as the price it sits beside and storing it twice
+ * invites the two to disagree.
+ */
+export function parseLadder(raw: unknown, currency: string): LadderRung[] | null {
+  if (raw === null || raw === undefined) return null;
+  if (!Array.isArray(raw) || raw.length === 0) return null;
+
+  const rungs: LadderRung[] = [];
+
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) return null;
+    const rung = entry as { minimumQuantity?: unknown; amount?: unknown };
+
+    if (
+      typeof rung.minimumQuantity !== "number" ||
+      !Number.isInteger(rung.minimumQuantity) ||
+      rung.minimumQuantity < 1 ||
+      typeof rung.amount !== "number" ||
+      !Number.isInteger(rung.amount)
+    ) {
+      // One bad rung discards the ladder. See the note above: half a ladder is worse
+      // than none, because none is visible and half is not.
+      return null;
+    }
+
+    rungs.push({
+      minimumQuantity: rung.minimumQuantity,
+      price: money(rung.amount, currency),
+    });
+  }
+
+  rungs.sort((a, b) => a.minimumQuantity - b.minimumQuantity);
+
+  // Two rungs at the same quantity is a ladder nobody can act on: Shopify keeps one and
+  // there is no way to say which, so neither is the baseline.
+  const duplicated = rungs.some(
+    (rung, index) => index > 0 && rung.minimumQuantity === rungs[index - 1]!.minimumQuantity,
+  );
+
+  return duplicated ? null : rungs;
+}

--- a/prisma/migrations/20260827120000_baseline_quantity_breaks/migration.sql
+++ b/prisma/migrations/20260827120000_baseline_quantity_breaks/migration.sql
@@ -1,0 +1,4 @@
+-- Expand-only: a nullable column, so a release one version back still reads and writes
+-- these rows without noticing it. Null means "this variant had no wholesale ladder",
+-- which is the common case and a real state rather than missing data.
+ALTER TABLE "baselines" ADD COLUMN "quantityBreaks" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -233,6 +233,16 @@ model Baseline {
   /// guardrails skip or error instead.
   cost          BigInt?
 
+  /// The wholesale ladder this variant had before any campaign touched it, as
+  /// `[{ minimumQuantity, amount }]` in integer minor units of `currency`.
+  ///
+  /// Only ever set on B2B surfaces, and null there means "no ladder", which is a real
+  /// state rather than missing data -- most wholesale variants have a single price.
+  /// It lives on the baseline rather than in its own table because revert recomputes
+  /// from the baseline, so a ladder that is not part of the baseline could only be
+  /// restored, and restoring is what this product deliberately does not do.
+  quantityBreaks Json?
+
   source     BaselineSource
   capturedAt DateTime       @default(now())
   capturedBy String?


### PR DESCRIPTION
Third piece of #174, and the one that needed a decision rather than code.

## The problem

Rule 6 says **revert recomputes rather than restores**. For a base price that works because the baseline is the anchor the recomputation starts from.

A ladder had no such anchor. So reverting a tiered campaign could only have put back what was there — which is restoring, which this product deliberately does not do. Finishing the run wiring without settling this would have shipped a revert that quietly worked differently from every other revert in the app.

## The decision

A ladder is now part of the baseline: `baselines.quantityBreaks`, holding the rungs a variant had before any campaign touched it. `resolve(without C)` then yields the merchant's own ladder for the same reason it yields their own price, and reverting a tiered campaign becomes the same operation as reverting any other.

It lives on the baseline row rather than in its own table **because that is what makes the above true** — a ladder outside the baseline could only be restored.

Nullable and expand-only, so a release one version back reads and writes these rows without noticing. Null means "no ladder", which is a real state and the common one: most wholesale variants have a single price.

## A JSON column is the one part of a price the database will not check

`ladder-baseline.ts` re-establishes in code what the schema gives a `BigInt`:

- **Integer minor units only**, in and out. A ladder that round-trips as `36.0` and comes back a float is rule 7 broken in the least visible place there is.
- **A rung that cannot be read discards the whole ladder**, never a partial one. Half a ladder is a price list where the 12+ tier exists and the 48+ tier silently does not — and a buyer finds out at checkout.
- **Two rungs at one quantity discards it too.** Shopify keeps one and there is no way to say which, so neither is the baseline.
- **Empty stores as null**, not `[]`. Two encodings of one state is how a query ends up missing rows.

## Verification

- 1,069 unit tests, 112 chaos scenarios, lint and build clean
- Migration applied to the dev database; it is a single nullable column with no data movement
- 5 mutations checked, all caught — including a bad rung being skipped rather than discarding the ladder, fractional amounts accepted on read, and duplicate quantities accepted

One test taught me something: the fractional-amount guard is unreachable through `money()`, which refuses it at construction. The test now covers the case that actually reaches this code — a `Money` built as an object literal, which the type allows and which is how a float really gets in.

Refs #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)