### PR TITLE
Revert a wholesale ladder by recomputing it, including to nothing

### DIFF
--- a/app/lib/execution/quantity-executor.test.ts
+++ b/app/lib/execution/quantity-executor.test.ts
@@ -243,6 +243,71 @@ describe("accepted is not the same as stored", () => {
   });
 });
 
+describe("clearing a ladder", () => {
+  /** A price list that acknowledges the delete and then keeps the ladder anyway. */
+  function ignoresDeletes() {
+    return {
+      async request<T>(query: string) {
+        if (query.includes("quantityPricingByVariantUpdate")) {
+          return {
+            data: {
+              quantityPricingByVariantUpdate: { productVariants: [], userErrors: [] },
+            } as T,
+          };
+        }
+        return {
+          data: {
+            priceList: {
+              prices: {
+                nodes: [
+                  {
+                    variant: { id: row(1).variantGid },
+                    quantityPriceBreaks: {
+                      nodes: [{ minimumQuantity: 12, price: { amount: "36.00" } }],
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          } as T,
+        };
+      },
+    };
+  }
+
+  const clearing: QuantityRow = { variantGid: row(1).variantGid, breaks: [] };
+
+  it("succeeds by the ladder being gone", async () => {
+    const result = await writeQuantityBreaks(honestClient(), "gid://PriceList/1", [clearing]);
+
+    expect(result.clean).toBe(true);
+    expect(result.verified).toBe(1);
+  });
+
+  it("is not called done just because the mutation returned no errors", async () => {
+    // A clearing row adds nothing, so the mutation names no variant for it. Confirmation
+    // cannot speak to it either way — only the read-back can, and it has to.
+    const result = await writeQuantityBreaks(ignoresDeletes(), "gid://PriceList/1", [clearing]);
+
+    expect(result.clean).toBe(false);
+    expect(result.rows[0]!.failureReason).toMatch(/asked for no quantity breaks.*still holds 1/);
+    expect(result.rows[0]!.guidance).toMatch(/still live/);
+  });
+
+  it("asks Shopify to delete the variant's breaks", async () => {
+    const client = honestClient();
+    await writeQuantityBreaks(client, "gid://PriceList/1", [clearing]);
+
+    const input = client.sent[0]!.input as {
+      quantityPriceBreaksToDeleteByVariantId: string[];
+      quantityPriceBreaksToAdd: unknown[];
+    };
+    expect(input.quantityPriceBreaksToDeleteByVariantId).toEqual([clearing.variantGid]);
+    expect(input.quantityPriceBreaksToAdd).toEqual([]);
+  });
+});
+
 describe("reading the ladders a catalogue already holds", () => {
   /**
    * The same read serves two purposes: checking what a run just wrote, and capturing what

--- a/app/lib/execution/quantity-executor.ts
+++ b/app/lib/execution/quantity-executor.ts
@@ -56,7 +56,13 @@ export const PRICE_LIST_QUANTITY_BREAKS = `#graphql
 
 export interface QuantityRow {
   variantGid: string;
-  /** Ascending by quantity, already guardrail-checked by `resolveBreaks`. */
+  /**
+   * Ascending by quantity, already guardrail-checked by `resolveBreaks`.
+   *
+   * Empty means "this variant should have no ladder" — which is what recomputing without
+   * a campaign yields for a variant that never had one. It is a real instruction rather
+   * than a no-op, because the campaign's ladder is there and has to be taken away.
+   */
   breaks: Array<{ minimumQuantity: number; price: Money }>;
 }
 
@@ -162,6 +168,13 @@ export async function writeQuantityBreaks(
       );
 
       for (const row of chunk) {
+        // A row that clears a ladder adds nothing, so the mutation has no variant to name
+        // for it. Confirmation cannot speak to it either way; the read-back can, and does.
+        if (row.breaks.length === 0) {
+          results.set(row.variantGid, { variantGid: row.variantGid, status: "verified" });
+          continue;
+        }
+
         if (!confirmed.has(row.variantGid)) {
           results.set(row.variantGid, {
             variantGid: row.variantGid,
@@ -262,6 +275,21 @@ async function verifyLadders(
     if (!current || current.status !== "verified") continue;
 
     const actual = seen.get(row.variantGid);
+
+    // Clearing a ladder succeeds by the ladder being gone. `readLadders` omits a variant
+    // with no rungs, so absence is exactly the outcome asked for.
+    if (row.breaks.length === 0) {
+      if (actual && actual.length > 0) {
+        results.set(row.variantGid, {
+          variantGid: row.variantGid,
+          status: "failed",
+          failureReason: `Read-back mismatch: asked for no quantity breaks, the price list still holds ${actual.length}.`,
+          guidance: "The old ladder is still live for this product. Resume the revert to clear it.",
+        });
+      }
+      continue;
+    }
+
     if (!actual) {
       results.set(row.variantGid, {
         variantGid: row.variantGid,

--- a/app/services/campaigns/b2b-surfaces.server.ts
+++ b/app/services/campaigns/b2b-surfaces.server.ts
@@ -17,7 +17,7 @@ import { Prisma } from "@prisma/client";
 import prisma from "../../db.server";
 import { writeQuantityBreaks, type QuantityRow } from "../../lib/execution/quantity-executor";
 import type { AdminClient } from "../../lib/execution/sync-executor";
-import { serialiseLadder } from "../../lib/pricing/ladder-baseline";
+import { parseLadder, serialiseLadder } from "../../lib/pricing/ladder-baseline";
 import type { WholesaleGuardrail } from "../../lib/pricing/quantity-breaks";
 import type { QuantityTier } from "../../lib/pricing/quantity-breaks";
 import { logger } from "../../lib/logging/logger";
@@ -101,7 +101,7 @@ export async function applyQuantityBreaks(
 }
 
 /**
- * One ledger row per variant, carrying the whole ladder.
+ * One ledger row per variant, carrying the whole ladder — or the absence of one.
  *
  * `intendedPrice` holds the first rung as well, so every existing query that reads a
  * price off the ledger — reconciliation, the rollback report, the result page — keeps
@@ -122,7 +122,10 @@ async function ledgerLadderChunk(
       surfaceKind: "B2B" as const,
       priceListGid: list.priceListGid,
       currency: list.currency,
-      intendedPrice: BigInt(row.breaks[0]!.price.amount),
+      // A row that clears a ladder has no rungs and therefore no intended price. Null
+      // rather than a stand-in: this row is not setting the variant's single price, and
+      // recording one would tell reconciliation that it is.
+      intendedPrice: row.breaks.length > 0 ? BigInt(row.breaks[0]!.price.amount) : null,
       intendedCompareAtSet: false,
       // Cast at the boundary. Prisma's JSON input type is structurally strict; the shape
       // is validated by `serialiseLadder`, which is the check that matters.
@@ -176,4 +179,103 @@ async function recordLadderResults(
       },
     });
   }
+}
+
+/**
+ * Takes a campaign's ladders back off a catalogue.
+ *
+ * Rule 6: revert recomputes rather than restores. For a ladder that means writing the one
+ * the baseline holds — the merchant's own, captured before any campaign touched it — and
+ * for a variant whose baseline holds none, it means clearing the ladder entirely. Both
+ * are the same operation: write what `resolve(without C)` says, which here is simply the
+ * baseline, because no other campaign writes ladders yet.
+ *
+ * Clearing is a real instruction, not a no-op. The campaign's ladder is live on the
+ * catalogue and a buyer is being quoted from it, so "there is nothing to write" would
+ * leave the sale price in place forever.
+ */
+export async function revertQuantityBreaks(
+  shopId: string,
+  runId: string,
+  list: { priceListGid: string; name: string; currency: string },
+  variantGids: readonly string[],
+  client: AdminClient,
+): Promise<B2BSurfaceOutcome | null> {
+  if (variantGids.length === 0) return null;
+
+  // Only variants this campaign actually gave a ladder to. Clearing one it never touched
+  // would take away a ladder somebody else set.
+  const written = await prisma.variantChange.findMany({
+    where: {
+      shopId,
+      priceListGid: list.priceListGid,
+      surfaceKind: "B2B",
+      variantGid: { in: [...variantGids] },
+      status: { in: ["VERIFIED", "CLAMPED"] },
+      // Rows that *gave* a ladder. A clearing row from an earlier revert carries none,
+      // and re-clearing would be a harmless no-op — this narrows the write rather than
+      // guarding correctness, which is why removing it fails no test.
+      quantityBreaks: { not: Prisma.DbNull },
+    },
+    select: { variantGid: true },
+    distinct: ["variantGid"],
+  });
+
+  const ours = [...new Set(written.map((row) => row.variantGid))];
+  if (ours.length === 0) return null;
+
+  const baselines = await prisma.baseline.findMany({
+    where: {
+      shopId,
+      priceListGid: list.priceListGid,
+      variantGid: { in: ours },
+      supersededAt: null,
+    },
+    select: { variantGid: true, currency: true, quantityBreaks: true },
+  });
+
+  const byVariant = new Map(baselines.map((row) => [row.variantGid, row]));
+
+  const rows: QuantityRow[] = ours.map((variantGid) => {
+    const baseline = byVariant.get(variantGid);
+    const ladder = baseline
+      ? parseLadder(baseline.quantityBreaks, baseline.currency || list.currency)
+      : null;
+
+    // No baseline ladder means the merchant had none, so the correct end state is none.
+    return { variantGid, breaks: ladder ?? [] };
+  });
+
+  const result = await writeQuantityBreaks(client, list.priceListGid, rows, async (chunk, index) => {
+    await ledgerLadderChunk(runId, shopId, list, chunk, index);
+  });
+
+  await recordLadderResults(runId, shopId, list.priceListGid, result.rows);
+
+  const cleared = rows.filter((row) => row.breaks.length === 0).length;
+  const messages: string[] = [];
+
+  if (result.failed > 0) {
+    messages.push(
+      `${list.name}: ${result.failed} product${result.failed === 1 ? "" : "s"} still have this campaign's quantity breaks. Each batch is all-or-nothing, so nothing in a failed batch changed.`,
+    );
+  }
+  if (cleared > 0 && result.clean) {
+    messages.push(
+      `${list.name}: ${cleared} product${cleared === 1 ? "" : "s"} had no quantity breaks before this campaign, so they have none now.`,
+    );
+  }
+
+  metric("run.rows", result.verified, { runId, surface: "b2b", outcome: "reverted" });
+
+  return {
+    priceListGid: list.priceListGid,
+    name: list.name,
+    verified: result.verified,
+    failed: result.failed,
+    refused: 0,
+    chunks: result.chunks,
+    messages,
+    clean: result.clean,
+  };
 }

--- a/chaos/scenarios/b2b-quantity.chaos.ts
+++ b/chaos/scenarios/b2b-quantity.chaos.ts
@@ -172,4 +172,151 @@ describe("chaos: wholesale quantity breaks", () => {
       },
     );
   });
+
+  it("puts back the ladder the catalogue had, and clears one it never had", async () => {
+    await withChaos(
+      "b2b-quantity-revert",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const { applyQuantityBreaks, revertQuantityBreaks } = await import(
+          "../../app/services/campaigns/b2b-surfaces.server"
+        );
+
+        chaos.fake.addPriceList({
+          id: LIST.priceListGid,
+          name: LIST.name,
+          currency: LIST.currency,
+          adjustment: null,
+          catalog: {
+            id: "gid://shopify/CompanyLocationCatalog/1",
+            title: "Wholesale",
+            __typename: "CompanyLocationCatalog",
+          },
+          prices: [],
+        });
+
+        // One variant already has the merchant's own ladder; the other has none. Revert
+        // has to reach both end states, and they are different end states.
+        const [withLadder, withoutLadder] = variantGids;
+        chaos.fake.ladders.set(`${LIST.priceListGid}|${withLadder}`, [
+          { minimumQuantity: 1, amount: "50.00" },
+          { minimumQuantity: 24, amount: "45.00" },
+        ]);
+
+        await chaos.apply();
+        const runId = await chaos.latestRunId("APPLY");
+        const client = chaosAdminClient(chaos.server.endpoint());
+
+        // Capture baselines the way a real run does, so the ladder above becomes the
+        // baseline rather than something this test asserts into place.
+        await prisma.baseline.createMany({
+          data: [
+            {
+              shopId,
+              variantGid: withLadder!,
+              surfaceKind: "MARKET" as const,
+              priceListGid: LIST.priceListGid,
+              currency: LIST.currency,
+              basePrice: 5000n,
+              quantityBreaks: [
+                { minimumQuantity: 1, amount: 5000 },
+                { minimumQuantity: 24, amount: 4500 },
+              ],
+              source: "AUTO_ENROLL" as const,
+            },
+            {
+              shopId,
+              variantGid: withoutLadder!,
+              surfaceKind: "MARKET" as const,
+              priceListGid: LIST.priceListGid,
+              currency: LIST.currency,
+              basePrice: 4000n,
+              source: "AUTO_ENROLL" as const,
+            },
+          ],
+          skipDuplicates: true,
+        });
+
+        const applied = await applyQuantityBreaks(
+          shopId,
+          runId,
+          LIST,
+          catalogue(variantGids),
+          TIERS,
+          { minMarginPercent: 20, missingCost: "refuse" },
+          client,
+        );
+        expect(applied!.clean).toBe(true);
+
+        await chaos.revert();
+        const revertRunId = await chaos.latestRunId("REVERT");
+
+        const outcome = await revertQuantityBreaks(shopId, revertRunId, LIST, variantGids, client);
+
+        expect(outcome!.clean).toBe(true);
+        expect(outcome!.messages.join(" ")).toMatch(/had no quantity breaks before/);
+
+        // Recomputed, not restored — but for this variant the two agree, which is the
+        // point: the baseline is the anchor and the anchor is the merchant's own ladder.
+        expect(chaos.fake.ladders.get(`${LIST.priceListGid}|${withLadder}`)).toEqual([
+          { minimumQuantity: 1, amount: "50.00" },
+          { minimumQuantity: 24, amount: "45.00" },
+        ]);
+
+        // And the one that never had a ladder ends with none, rather than keeping the
+        // campaign's — which would leave a buyer quoted a sale price forever.
+        expect(chaos.fake.ladders.get(`${LIST.priceListGid}|${withoutLadder}`) ?? []).toEqual([]);
+      },
+    );
+  });
+
+  it("leaves alone a ladder this campaign never wrote", async () => {
+    // A wholesale catalogue may carry ladders somebody set by hand. Reverting a campaign
+    // takes away the campaign's, and taking away a ladder the merchant set themselves
+    // would be this app deleting a price it never owned.
+    await withChaos(
+      "b2b-quantity-not-ours",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const { shopId, variantGids } = chaos.fixture;
+        const { revertQuantityBreaks } = await import(
+          "../../app/services/campaigns/b2b-surfaces.server"
+        );
+
+        chaos.fake.addPriceList({
+          id: LIST.priceListGid,
+          name: LIST.name,
+          currency: LIST.currency,
+          adjustment: null,
+          catalog: {
+            id: "gid://shopify/CompanyLocationCatalog/1",
+            title: "Wholesale",
+            __typename: "CompanyLocationCatalog",
+          },
+          prices: [],
+        });
+
+        const handSet = [{ minimumQuantity: 6, amount: "38.00" }];
+        chaos.fake.ladders.set(`${LIST.priceListGid}|${variantGids[0]}`, handSet);
+
+        await chaos.apply();
+        await chaos.revert();
+        const revertRunId = await chaos.latestRunId("REVERT");
+
+        // No ledger row says this campaign gave that variant a ladder, so there is
+        // nothing of ours to take back.
+        const outcome = await revertQuantityBreaks(
+          shopId,
+          revertRunId,
+          LIST,
+          variantGids,
+          chaosAdminClient(chaos.server.endpoint()),
+        );
+
+        expect(outcome).toBeNull();
+        expect(chaos.fake.ladders.get(`${LIST.priceListGid}|${variantGids[0]}`)).toEqual(handSet);
+      },
+    );
+  });
 });


### PR DESCRIPTION
Last piece of #174.

## Rule 6 in its least convenient form

Reverting a tiered campaign writes **the ladder the baseline holds** — the merchant's own, captured before any campaign touched it. For a variant whose baseline holds none, it writes **no ladder**. Both are the same operation: write what `resolve(without C)` says.

Clearing is a real instruction rather than a no-op. The campaign's ladder is live on the catalogue and a buyer is being quoted from it, so treating "no rungs" as "nothing to do" would leave the sale price up forever.

## Which surfaced a genuine bug

A clearing row adds nothing, so the mutation names no variant for it — and the confirmation check duly marked every clear as *"Shopify did not confirm this variant"*.

Confirmation cannot speak to a deletion either way. The read-back can, and now does: a clear succeeds by the ladder being gone, and fails if the price list still holds one.

## Only what this campaign owns

A wholesale catalogue may carry ladders somebody set by hand. Taking one of those away would be this app deleting a price it never owned, so revert only reaches variants a ledger row says this campaign gave a ladder to.

## On the mutations

Two survived the first pass, and **both were gaps in the tests rather than the code**:

- a clear that Shopify acknowledges and then ignores
- a revert reaching a ladder the campaign never wrote

Both now have cases. A third survives **by design** and says so in a comment: a clearing row carries no ladder, so re-clearing it would be a harmless no-op — that filter narrows the write rather than guarding correctness.

## Verification

- 1,076 unit tests, **117 chaos scenarios**, lint and build clean
- The revert scenario runs both end states in one campaign: a variant that had a ladder gets exactly its own back, and one that never had a ladder ends with none

## Where #174 stands

Every acceptance criterion is met except the demand gate itself (≥3 paying stores with B2B catalogs), which was a prioritisation call rather than a technical one.

Refs #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)