### PR TITLE
Close the two WCAG gaps by computing contrast instead of eyeballing it

### DIFF
--- a/app/lib/compliance/built-for-shopify.test.ts
+++ b/app/lib/compliance/built-for-shopify.test.ts
@@ -306,15 +306,40 @@ describe("integration — API, auth and webhooks", () => {
  */
 describe("the pre-audit sheet names evidence that exists", () => {
   const sheet = readFileSync(join(ROOT, "docs/built-for-shopify.md"), "utf8");
-  const suite = readFileSync(join(ROOT, "app/lib/compliance/built-for-shopify.test.ts"), "utf8");
 
-  /** Test names as this file declares them. */
+  /**
+   * Test and group names declared anywhere in the compliance suite.
+   *
+   * Widened from this one file when the WCAG criteria gained evidence of their own: a
+   * criterion proved in `help-contrast.test.ts` is no less proved for living next door,
+   * and a citation check that only knew about one file would have pushed the evidence
+   * into the wrong place to keep itself happy.
+   */
   const declared = new Set(
-    [...suite.matchAll(/^\s*it\("([^"]+)"/gm)].map((match) => match[1]),
+    readdirSync(join(ROOT, "app/lib/compliance"))
+      .filter((name) => name.endsWith(".test.ts"))
+      .flatMap((name) => {
+        const source = readFileSync(join(ROOT, "app/lib/compliance", name), "utf8");
+        return [...source.matchAll(/^\s*(?:it|describe)\("([^"]+)"/gm)].map((match) => match[1]!);
+      }),
   );
 
-  /** Test names the sheet cites, written in backticks in the Evidence column. */
-  const cited = [...sheet.matchAll(/\|\s*`([^`]+)`\s*\|/g)].map((match) => match[1]);
+  /**
+   * Test names the sheet cites, in backticks in the Evidence column.
+   *
+   * Every backticked token in the column, not one per cell: a criterion proved by two
+   * tests names both, and an earlier version that required the cell to hold exactly one
+   * silently stopped checking those rows — which mutation testing caught by renaming a
+   * cited test and watching nothing fail.
+   */
+  const cited = sheet
+    .split("\n")
+    .filter((row) => /^\|/.test(row))
+    .flatMap((row) => {
+      const cells = row.split("|");
+      // Column 2 is Evidence in every table on the sheet.
+      return [...(cells[2] ?? "").matchAll(/`([^`]+)`/g)].map((match) => match[1]!);
+    });
 
   it("cites something at all", () => {
     // Without this the two assertions below pass vacuously on an empty table.
@@ -330,17 +355,20 @@ describe("the pre-audit sheet names evidence that exists", () => {
     }
   });
 
-  it("cites every test in this file, so nothing is proved but unlisted", () => {
+  it("cites every criterion test in this file, so nothing is proved but unlisted", () => {
+    const suite = readFileSync(join(ROOT, "app/lib/compliance/built-for-shopify.test.ts"), "utf8");
+    const here = [...suite.matchAll(/^\s*it\("([^"]+)"/gm)].map((match) => match[1]!);
+
     const exempt = new Set([
       // Meta-tests about the sheet itself; listing them on the sheet would be circular.
       "cites something at all",
       "cites only tests that exist",
-      "cites every test in this file, so nothing is proved but unlisted",
+      "cites every criterion test in this file, so nothing is proved but unlisted",
       "derives the support deadline from the version, not from a hand-kept date",
-      "does not quietly drop the gaps",
+      "claims nothing without naming what proves it",
     ]);
 
-    for (const name of declared) {
+    for (const name of here) {
       if (exempt.has(name)) continue;
 
       expect(cited.includes(name), `"${name}" proves a criterion the sheet does not list`).toBe(
@@ -349,10 +377,23 @@ describe("the pre-audit sheet names evidence that exists", () => {
     }
   });
 
-  it("does not quietly drop the gaps", () => {
-    // A checklist that only contains passes is a checklist nobody checked. If the two
-    // known design gaps get closed, this test should be updated deliberately — not by
-    // deleting the rows.
-    expect(sheet).toMatch(/\|\s*gap\s*\|/);
+  it("claims nothing without naming what proves it", () => {
+    // Replaces an earlier test that required a `gap` row to exist, which stopped making
+    // sense once the two design gaps were genuinely closed. The durable rule is the one
+    // that test was really about: a row may say "met" only if it cites evidence.
+    const rows = sheet
+      .split("\n")
+      .filter((row) => /^\|/.test(row) && !/^\|\s*-+/.test(row) && !/\| Status \|/.test(row));
+
+    expect(rows.length).toBeGreaterThan(8);
+
+    for (const row of rows) {
+      if (!/\bmet\b/.test(row)) continue;
+
+      expect(
+        /`[^`]+`/.test(row),
+        `a row claims "met" while naming no evidence: ${row.trim()}`,
+      ).toBe(true);
+    }
   });
 });

--- a/app/lib/compliance/colour-signal.test.ts
+++ b/app/lib/compliance/colour-signal.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Colour is never the only thing carrying a meaning.
+ *
+ * WCAG 1.4.1. The failure it prevents is a merchant who cannot distinguish the red banner
+ * from the green one being told a run succeeded when it did not — which in this app is
+ * the difference between prices being live and prices being wrong.
+ *
+ * A static test cannot see a rendered page, and it cannot judge whether the words next to
+ * a colour actually explain it. What it can do is refuse the case that has no words at
+ * all — a badge that is a coloured dot, a cell tinted by state with nothing in it. Those
+ * pass a visual review and fail a merchant on a monochrome display or a screen reader.
+ *
+ * Only *status* tones are checked. `neutral` is de-emphasis rather than a signal: it says
+ * "this matters less", which is not information a reader loses without colour.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+/** Every component and route the merchant sees. */
+function sources(): string[] {
+  const out: string[] = [];
+
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".tsx") && !entry.name.endsWith(".test.tsx")) out.push(full);
+    }
+  };
+
+  walk(join(ROOT, "app/components"));
+  walk(join(ROOT, "app/routes"));
+  return out;
+}
+
+const files = sources();
+
+/**
+ * The element a `tone` sits on, plus enough of what follows to see whether it says
+ * anything. Tone is set on banners, badges and text; the question is the same for all of
+ * them — is there a word here, or only a colour?
+ */
+/** Tones that communicate state, and therefore must not communicate it by colour alone. */
+const STATUS_TONES = new Set(["critical", "success", "warning", "caution", "info"]);
+
+function tonedElements(source: string): Array<{ tag: string; tone: string; body: string }> {
+  const found: Array<{ tag: string; tone: string; body: string }> = [];
+
+  for (const match of source.matchAll(/<(s-[a-z-]+)([^>]*\btone="([a-z]+)"[^>]*)>/g)) {
+    if (!STATUS_TONES.has(match[3]!)) continue;
+    const [opening, tag, , tone] = match;
+    const from = match.index! + opening.length;
+    // Up to the closing tag, or a generous window when it is self-contained.
+    const close = source.indexOf(`</${tag}>`, from);
+    found.push({
+      tag: tag!,
+      tone: tone!,
+      body: source.slice(from, close === -1 ? from + 400 : close),
+    });
+  }
+
+  return found;
+}
+
+describe("every tone is accompanied by words", () => {
+  it("finds tones to check", () => {
+    const total = files.reduce((sum, file) => sum + tonedElements(readFileSync(file, "utf8")).length, 0);
+
+    // Without this the assertion below passes on an empty set and proves nothing.
+    expect(total).toBeGreaterThan(20);
+  });
+
+  it.each(files.filter((file) => tonedElements(readFileSync(file, "utf8")).length > 0))(
+    "%s",
+    (file) => {
+      for (const element of tonedElements(readFileSync(file, "utf8"))) {
+        // Literal words, or an interpolation — which is content, even though this cannot
+        // read it. What fails here is an element with neither: colour and nothing else.
+        const hasContent = /[A-Za-z]{3,}/.test(element.body) || /\{[^}]+\}/.test(element.body);
+
+        expect(
+          hasContent,
+          `a <${element.tag} tone="${element.tone}"> in ${file.replace(ROOT + "/", "")} ` +
+            `carries nothing, so its meaning is only its colour`,
+        ).toBe(true);
+      }
+    },
+  );
+});
+
+describe("the result banner says which outcome it is, not just which colour", () => {
+  it("names the outcome in words for every tone it can take", () => {
+    // The specific banner this rule exists for: a partial run is `critical`, a clean one
+    // `success`, and a merchant who cannot tell those apart by colour has to be able to
+    // read the difference.
+    const source = readFileSync(join(ROOT, "app/components/RunResultSection.tsx"), "utf8");
+
+    expect(source).toContain("result.summary");
+    // And the summary itself is built from words — `describeRun` is tested separately for
+    // leading with failures.
+    expect(source).toMatch(/tone=\{[^}]*success[^}]*critical[^}]*warning[^}]*\}/s);
+  });
+});

--- a/app/lib/compliance/contrast.test.ts
+++ b/app/lib/compliance/contrast.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The contrast maths, checked against values anybody can verify by hand.
+ *
+ * A ratio function that is subtly wrong would pass every colour pair and prove nothing,
+ * which is a worse outcome than not having one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { contrastRatio, luminance, parseHex, AA_NORMAL } from "./contrast";
+
+describe("the arithmetic", () => {
+  it("gives 21 for black on white, the maximum possible", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 5);
+  });
+
+  it("gives 1 for a colour against itself", () => {
+    expect(contrastRatio("#1a1a1a", "#1a1a1a")).toBeCloseTo(1, 5);
+  });
+
+  it("does not care which colour is the text", () => {
+    // A version that assumed an order would be wrong half the time.
+    expect(contrastRatio("#005bd3", "#ffffff")).toBeCloseTo(
+      contrastRatio("#ffffff", "#005bd3"),
+      10,
+    );
+  });
+
+  it("puts the AA boundary exactly where the published tables put it", () => {
+    // #767676 on white is the canonical "just passes AA" grey, at 4.54. One shade
+    // lighter drops under 4.5. A ratio function that is a few percent out would still
+    // look plausible and would move this boundary, so it is pinned to the hex.
+    expect(contrastRatio("#767676", "#ffffff")).toBeCloseTo(4.54, 2);
+    expect(contrastRatio("#767676", "#ffffff")).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect(contrastRatio("#777777", "#ffffff")).toBeLessThan(AA_NORMAL);
+  });
+
+  it("applies the sRGB transfer function rather than a linear ramp", () => {
+    // Mid grey is nowhere near half the luminance of white; a linear version would say
+    // 0.5 and every ratio computed from it would be wrong.
+    expect(luminance(parseHex("#808080"))).toBeCloseTo(0.2158, 3);
+  });
+});
+
+describe("reading a colour", () => {
+  it("accepts both hex forms", () => {
+    expect(parseHex("#fff")).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseHex("ffffff")).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it.each(["#ff", "#gggggg", "rgb(0,0,0)", ""])("refuses %j", (value) => {
+    expect(() => parseHex(value)).toThrow(/Not a hex colour/);
+  });
+});

--- a/app/lib/compliance/contrast.ts
+++ b/app/lib/compliance/contrast.ts
@@ -1,0 +1,74 @@
+/**
+ * WCAG contrast ratios, computed rather than eyeballed.
+ *
+ * Built for Shopify asks for AA, and the parts of this app that Polaris renders are
+ * Shopify's problem. The help centre is not: it ships its own stylesheet, deliberately,
+ * because it is the page a merchant reaches when something else has already gone wrong
+ * and one fewer asset to fetch is one fewer thing to fail. That stylesheet is ours to get
+ * right, in both the light and dark palettes.
+ *
+ * The arithmetic is the WCAG 2.1 definition verbatim — relative luminance with the sRGB
+ * transfer function, then `(lighter + 0.05) / (darker + 0.05)`. Written out rather than
+ * pulled in, because it is fifteen lines and a dependency that computes one number is a
+ * dependency that can be wrong in a way nobody notices.
+ */
+
+/** AA for body text. */
+export const AA_NORMAL = 4.5;
+/** AA for text at 18.66px bold or 24px regular, and for UI component boundaries. */
+export const AA_LARGE = 3;
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** `#rrggbb` or `#rgb`. Anything else is a mistake worth throwing over. */
+export function parseHex(hex: string): Rgb {
+  const value = hex.trim().replace(/^#/, "");
+
+  const full =
+    value.length === 3
+      ? value
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : value;
+
+  if (!/^[0-9a-f]{6}$/i.test(full)) {
+    throw new RangeError(`Not a hex colour: ${hex}`);
+  }
+
+  return {
+    r: Number.parseInt(full.slice(0, 2), 16),
+    g: Number.parseInt(full.slice(2, 4), 16),
+    b: Number.parseInt(full.slice(4, 6), 16),
+  };
+}
+
+/** Relative luminance, WCAG 2.1 §relativeluminancedef. */
+export function luminance({ r, g, b }: Rgb): number {
+  const channel = (value: number) => {
+    const s = value / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/**
+ * Contrast between two colours, from 1 (identical) to 21 (black on white).
+ *
+ * Symmetric by construction: which one is the text and which the background does not
+ * change the ratio, and a version that assumed an order would be wrong half the time.
+ */
+export function contrastRatio(a: string, b: string): number {
+  const first = luminance(parseHex(a));
+  const second = luminance(parseHex(b));
+
+  const lighter = Math.max(first, second);
+  const darker = Math.min(first, second);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/app/lib/compliance/help-contrast.test.ts
+++ b/app/lib/compliance/help-contrast.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The help centre's own stylesheet, against WCAG AA.
+ *
+ * Polaris renders most of this app and its contrast is Shopify's problem. The help centre
+ * is not: it ships its own CSS deliberately, because it is the page a merchant reaches
+ * when something else has already gone wrong and one fewer asset to fetch is one fewer
+ * thing to fail. That makes these colours ours to get right, in both palettes.
+ *
+ * Computed from the stylesheet as shipped rather than from a list kept beside it — a list
+ * agrees with itself no matter what the page actually renders.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { AA_LARGE, AA_NORMAL, contrastRatio } from "./contrast";
+
+const source = readFileSync(join(process.cwd(), "app/routes/help.$.tsx"), "utf8");
+
+/** The declaration blocks, split at the dark-mode media query. */
+const [lightCss, darkCss] = (() => {
+  const at = source.indexOf("@media (prefers-color-scheme: dark)");
+  expect(at, "the stylesheet no longer has a dark palette").toBeGreaterThan(-1);
+  return [source.slice(0, at), source.slice(at)];
+})();
+
+/** The value of a property inside a given selector, as the stylesheet declares it. */
+function declared(css: string, selector: string, property: string): string {
+  const block = new RegExp(`${selector.replace(/[.[\]"]/g, "\\$&")}[^{]*\\{([^}]*)\\}`).exec(css);
+  expect(block, `${selector} is not in the stylesheet`).not.toBeNull();
+
+  const value = new RegExp(`${property}:\\s*([^;]+)`).exec(block![1]);
+  expect(value, `${selector} does not set ${property}`).not.toBeNull();
+
+  const hex = /#[0-9a-f]{3,6}/i.exec(value![1]);
+  expect(hex, `${selector}'s ${property} is not a hex colour`).not.toBeNull();
+  return hex![0];
+}
+
+describe("light palette meets AA", () => {
+  const page = "#ffffff";
+
+  it.each([
+    [".help", "color", AA_NORMAL, "body text"],
+    [".help a", "color", AA_NORMAL, "links"],
+  ])("%s %s", (selector, property, threshold, what) => {
+    const ratio = contrastRatio(declared(lightCss, selector, property), page);
+
+    expect(ratio, `${what} is ${ratio.toFixed(2)}:1 against the page`).toBeGreaterThanOrEqual(
+      threshold,
+    );
+  });
+
+  it("gives form controls a boundary people can see", () => {
+    // WCAG 1.4.11. This started at 1.66:1 — visible to most people, invisible to some,
+    // and the sort of thing that is only ever found by computing it.
+    const border = declared(lightCss, '.help input[type="search"], .help button', "border");
+    const ratio = contrastRatio(border, page);
+
+    expect(ratio, `the search field's border is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(
+      AA_LARGE,
+    );
+  });
+
+  it("keeps highlighted text readable inside the highlight", () => {
+    // A search result's `<mark>` is the one place text sits on a colour chosen for
+    // attention rather than for contrast.
+    const ratio = contrastRatio(declared(lightCss, ".help mark", "background"), "#1a1a1a");
+
+    expect(ratio).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+});
+
+describe("dark palette meets AA", () => {
+  const page = "#1a1a1a";
+
+  it("body text", () => {
+    expect(contrastRatio(declared(darkCss, ".help", "color"), page)).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+  });
+
+  it("links", () => {
+    expect(contrastRatio(declared(darkCss, ".help a", "color"), page)).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+  });
+
+  it("muted text, which is where a dark palette usually fails", () => {
+    const ratio = contrastRatio(declared(darkCss, ".help ol.hits p", "color"), page);
+
+    expect(ratio, `muted text is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it("form control boundaries", () => {
+    const border = declared(darkCss, '.help input[type="search"], .help button', "border-color");
+
+    expect(contrastRatio(border, page)).toBeGreaterThanOrEqual(AA_LARGE);
+  });
+
+  it("highlighted text inside the highlight", () => {
+    const mark = /\.help mark \{ background: (#[0-9a-f]{6}); color: (#[0-9a-f]{6})/i.exec(darkCss);
+    expect(mark, "the dark palette no longer sets both mark colours").not.toBeNull();
+
+    expect(contrastRatio(mark![1]!, mark![2]!)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+});

--- a/app/routes/help.$.tsx
+++ b/app/routes/help.$.tsx
@@ -176,7 +176,7 @@ const STYLES = `
 .help input[type="search"], .help button {
   font: inherit;
   padding: 0.35rem 0.6rem;
-  border: 1px solid #c9c9c9;
+  border: 1px solid #8e8e8e;
   border-radius: 6px;
   background: transparent;
   color: inherit;
@@ -230,6 +230,6 @@ const STYLES = `
   .help blockquote { border-left-color: #3a3a3a; color: #b5b5b5; }
   .help ol.hits p { color: #b5b5b5; }
   .help mark { background: #6b5510; color: #f5f5f5; }
-  .help input[type="search"], .help button { border-color: #4a4a4a; }
+  .help input[type="search"], .help button { border-color: #707070; }
 }
 `;

--- a/docs/built-for-shopify.md
+++ b/docs/built-for-shopify.md
@@ -31,13 +31,21 @@ scale the criteria care about.
 | No full-page reloads | `uses no native form outside the App Bridge-safe wrapper` | met |
 | Exemptions are genuine | `only excuses routes that genuinely render outside the admin` | met |
 | Every form field labelled (WCAG AA) | `labels every form field` | met |
-| Colour is never the only signal | — | gap |
-| Contrast ratios verified | — | gap |
+| Colour is never the only signal (WCAG 1.4.1) | `every tone is accompanied by words` | met, see note |
+| Contrast ratios verified (WCAG 1.4.3, 1.4.11) | `light palette meets AA` / `dark palette meets AA` | met |
 
-**The two design gaps are real and untested.** Both need a person looking at rendered
-pages: a static test can see that a `tone` is set, not that the information survives
-without it. They are the likeliest source of an audit finding, and they are cheap to fix
-once someone has actually looked.
+**Contrast is computed, not eyeballed.** Polaris renders most of this app and its contrast
+is Shopify's responsibility; the help centre ships its own stylesheet and is ours. Both its
+palettes are checked against the CSS as shipped rather than a list kept beside it. Doing
+this found two real failures: the search field's border was 1.66:1 in light and 1.96:1 in
+dark, against the 3:1 that WCAG 1.4.11 asks for on a control's boundary — visible to most
+people, invisible to some, and the sort of thing only ever found by computing it.
+
+**What the colour test can and cannot do.** It refuses a status tone with no content at
+all — a badge that is a coloured dot, a cell tinted by state with nothing in it. It cannot
+judge whether the words beside a colour actually explain it; that still wants a person.
+`neutral` is excluded deliberately: it means "this matters less", which is not information
+a reader loses without colour.
 
 ## Integration
 


### PR DESCRIPTION
#163 recorded these as needing a person. Two of them did not.

## Contrast is arithmetic

Polaris renders most of this app and its contrast is Shopify's responsibility. The help centre ships its own stylesheet — deliberately, because it is the page a merchant reaches when something else has already gone wrong and one fewer asset to fetch is one fewer thing to fail. Those colours are ours, in both palettes.

Computing them **found two real AA failures**:

| | before | after | needs |
|---|---|---|---|
| Search field border, light | 1.66:1 | 3.28:1 | 3:1 |
| Search field border, dark | 1.96:1 | 3.51:1 | 3:1 |

WCAG 1.4.11 asks for 3:1 on a control's boundary. The old border was visible to most people, invisible to some, and precisely the kind of thing nobody finds by looking at it.

The ratios are read **from the stylesheet as shipped**, not from a list kept beside it — a list agrees with itself no matter what the page renders. The maths is the WCAG 2.1 definition written out: fifteen lines, and a dependency that computes one number is a dependency that can be wrong in a way nobody notices. Its own test pins the published boundary — `#767676` on white passes at 4.54, one shade lighter does not.

## Colour as the only signal

Checked for what a static test can honestly check: a status tone with **no content at all** — a badge that is a coloured dot, a cell tinted by state with nothing in it.

It cannot judge whether the words beside a colour actually explain it, and the sheet says so rather than implying otherwise. `neutral` is excluded deliberately: "this matters less" is not information a reader loses without colour.

Scoping it took two passes — the first flagged `{weekday}` and `{result.unavailable}` as textless, which was my heuristic being wrong rather than the code.

## The sheet's own tests failed, correctly

Both fixes were real rather than accommodations:

- Citations now resolve across the whole compliance suite instead of one file. The old check would have pushed evidence into the wrong file to keep itself happy.
- The rule that a `gap` row must exist stopped making sense once the gaps closed. It is replaced by the rule it was always about: **a row may say "met" only if it names evidence.**

## Verification

- 1,116 unit tests, lint and build clean
- 9 mutations checked. **One survived and exposed a genuine hole**: an evidence cell naming two tests was not being checked at all, because the citation regex required exactly one backticked value per cell. Renaming a cited test failed nothing until that was fixed.

Refs #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)