### PR TITLE
Mirror every variant of a product, not the first hundred

### DIFF
--- a/app/services/catalog-sync.server.ts
+++ b/app/services/catalog-sync.server.ts
@@ -22,6 +22,37 @@ export interface GraphQLRunner {
   ): Promise<{ json(): Promise<unknown> }>;
 }
 
+/**
+ * The rest of one product's variants.
+ *
+ * `variants(first: 100)` on the page query is not a limit anybody chose — it is the page
+ * size — but for a product with 2,048 variants it silently dropped 1,948 of them. The app
+ * would then manage a twentieth of that product and report a clean run over the part it
+ * could see, which is the failure mode this whole product exists to prevent.
+ *
+ * 250 is the largest page Shopify allows on this connection, so a 2,048-variant product
+ * costs eight follow-up requests and only products that need them pay anything.
+ */
+const PRODUCT_VARIANTS_PAGE = `#graphql
+  query AnchorProductVariantsPage($id: ID!, $cursor: String) {
+    product(id: $id) {
+      variants(first: 250, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          title
+          sku
+          barcode
+          price
+          compareAtPrice
+          inventoryQuantity
+          inventoryItem { unitCost { amount currencyCode } }
+        }
+      }
+    }
+  }
+`;
+
 const PRODUCTS_PAGE = `#graphql
   query AnchorCatalogPage($cursor: String) {
     products(first: 50, after: $cursor) {
@@ -36,6 +67,7 @@ const PRODUCTS_PAGE = `#graphql
         updatedAt
         collections(first: 20) { nodes { id } }
         variants(first: 100) {
+          pageInfo { hasNextPage endCursor }
           nodes {
             id
             title
@@ -61,7 +93,10 @@ interface ProductNode {
   tags?: string[] | null;
   updatedAt?: string | null;
   collections?: { nodes?: Array<{ id: string }> | null } | null;
-  variants?: { nodes?: VariantNode[] | null } | null;
+  variants?: {
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null } | null;
+    nodes?: VariantNode[] | null;
+  } | null;
 }
 
 interface VariantNode {
@@ -127,7 +162,27 @@ export async function syncCatalog(
       result.products++;
       const collections = product.collections?.nodes?.map((c) => c.id) ?? [];
 
-      for (const variant of product.variants?.nodes ?? []) {
+      // Everything the page gave us, then everything it did not. A product with more
+      // variants than one page holds is rare and expensive to get wrong: those variants
+      // are not merely missing from a report, they are variants no campaign can price.
+      const variants = [...(product.variants?.nodes ?? [])];
+
+      if (product.variants?.pageInfo?.hasNextPage) {
+        try {
+          variants.push(
+            ...(await remainingVariants(client, product.id, product.variants.pageInfo.endCursor ?? null)),
+          );
+        } catch (error) {
+          // Recorded, never swallowed: a product left partly mirrored is a product whose
+          // campaigns will be partly applied, and the run has to be able to say so.
+          result.errors.push(
+            `${product.id}: could not read past the first page of variants — ` +
+              `${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+
+      for (const variant of variants) {
         try {
           await upsertVariant(shopId, product, variant, collections, shopCurrency);
           result.variants++;
@@ -148,6 +203,53 @@ export async function syncCatalog(
   }
 
   return result;
+}
+
+/**
+ * Pages through a product's variants until they are all read.
+ *
+ * Bounded at forty pages — 10,000 variants, well past Shopify's 2,048 ceiling — so a
+ * malformed cursor cannot spin a background worker forever. Hitting the bound is
+ * reported by the caller rather than passing silently, for the same reason everything
+ * else here is.
+ */
+async function remainingVariants(
+  client: GraphQLRunner,
+  productId: string,
+  after: string | null,
+): Promise<VariantNode[]> {
+  const found: VariantNode[] = [];
+  let cursor = after;
+
+  for (let page = 0; page < 40; page += 1) {
+    const response = await client.graphql(PRODUCT_VARIANTS_PAGE, {
+      variables: { id: productId, cursor },
+    });
+    const body = (await response.json()) as {
+      data?: {
+        product?: {
+          variants?: {
+            pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+            nodes?: VariantNode[];
+          } | null;
+        } | null;
+      };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (body.errors?.length) {
+      throw new Error(body.errors.map((error) => error.message).join("; "));
+    }
+
+    const connection = body.data?.product?.variants;
+    found.push(...(connection?.nodes ?? []));
+
+    if (!connection?.pageInfo?.hasNextPage) return found;
+    cursor = connection.pageInfo.endCursor ?? null;
+    if (!cursor) return found;
+  }
+
+  throw new Error("stopped after 40 pages of variants");
 }
 
 async function upsertVariant(

--- a/app/types/admin.generated.d.ts
+++ b/app/types/admin.generated.d.ts
@@ -269,6 +269,17 @@ export type AnchorCurrentBulkQueryQueryVariables = AdminTypes.Exact<{ [key: stri
 
 export type AnchorCurrentBulkQueryQuery = { currentBulkOperation?: AdminTypes.Maybe<Pick<AdminTypes.BulkOperation, 'id' | 'status' | 'url' | 'partialDataUrl' | 'objectCount' | 'errorCode'>> };
 
+export type AnchorProductVariantsPageQueryVariables = AdminTypes.Exact<{
+  id: AdminTypes.Scalars['ID']['input'];
+  cursor?: AdminTypes.InputMaybe<AdminTypes.Scalars['String']['input']>;
+}>;
+
+
+export type AnchorProductVariantsPageQuery = { product?: AdminTypes.Maybe<{ variants: { pageInfo: Pick<AdminTypes.PageInfo, 'hasNextPage' | 'endCursor'>, nodes: Array<(
+        Pick<AdminTypes.ProductVariant, 'id' | 'title' | 'sku' | 'barcode' | 'price' | 'compareAtPrice' | 'inventoryQuantity'>
+        & { inventoryItem: { unitCost?: AdminTypes.Maybe<Pick<AdminTypes.MoneyV2, 'amount' | 'currencyCode'>> } }
+      )> } }> };
+
 export type AnchorCatalogPageQueryVariables = AdminTypes.Exact<{
   cursor?: AdminTypes.InputMaybe<AdminTypes.Scalars['String']['input']>;
 }>;
@@ -276,7 +287,7 @@ export type AnchorCatalogPageQueryVariables = AdminTypes.Exact<{
 
 export type AnchorCatalogPageQuery = { products: { pageInfo: Pick<AdminTypes.PageInfo, 'hasNextPage' | 'endCursor'>, nodes: Array<(
       Pick<AdminTypes.Product, 'id' | 'title' | 'vendor' | 'productType' | 'status' | 'tags' | 'updatedAt'>
-      & { collections: { nodes: Array<Pick<AdminTypes.Collection, 'id'>> }, variants: { nodes: Array<(
+      & { collections: { nodes: Array<Pick<AdminTypes.Collection, 'id'>> }, variants: { pageInfo: Pick<AdminTypes.PageInfo, 'hasNextPage' | 'endCursor'>, nodes: Array<(
           Pick<AdminTypes.ProductVariant, 'id' | 'title' | 'sku' | 'barcode' | 'price' | 'compareAtPrice' | 'inventoryQuantity'>
           & { inventoryItem: { unitCost?: AdminTypes.Maybe<Pick<AdminTypes.MoneyV2, 'amount' | 'currencyCode'>> } }
         )> } }
@@ -396,7 +407,8 @@ interface GeneratedQueryTypes {
   "#graphql\n      query AnchorProbeCompanies {\n        companies(first: 1) { nodes { id } }\n      }\n    ": {return: AnchorProbeCompaniesQuery, variables: AnchorProbeCompaniesQueryVariables},
   "#graphql\n  query AnchorProductTags($ids: [ID!]!) {\n    nodes(ids: $ids) {\n      ... on Product { id tags }\n    }\n  }\n": {return: AnchorProductTagsQuery, variables: AnchorProductTagsQueryVariables},
   "#graphql\n  query AnchorCurrentBulkQuery {\n    currentBulkOperation(type: QUERY) {\n      id status url partialDataUrl objectCount errorCode\n    }\n  }\n": {return: AnchorCurrentBulkQueryQuery, variables: AnchorCurrentBulkQueryQueryVariables},
-  "#graphql\n  query AnchorCatalogPage($cursor: String) {\n    products(first: 50, after: $cursor) {\n      pageInfo { hasNextPage endCursor }\n      nodes {\n        id\n        title\n        vendor\n        productType\n        status\n        tags\n        updatedAt\n        collections(first: 20) { nodes { id } }\n        variants(first: 100) {\n          nodes {\n            id\n            title\n            sku\n            barcode\n            price\n            compareAtPrice\n            inventoryQuantity\n            inventoryItem { unitCost { amount currencyCode } }\n          }\n        }\n      }\n    }\n  }\n": {return: AnchorCatalogPageQuery, variables: AnchorCatalogPageQueryVariables},
+  "#graphql\n  query AnchorProductVariantsPage($id: ID!, $cursor: String) {\n    product(id: $id) {\n      variants(first: 250, after: $cursor) {\n        pageInfo { hasNextPage endCursor }\n        nodes {\n          id\n          title\n          sku\n          barcode\n          price\n          compareAtPrice\n          inventoryQuantity\n          inventoryItem { unitCost { amount currencyCode } }\n        }\n      }\n    }\n  }\n": {return: AnchorProductVariantsPageQuery, variables: AnchorProductVariantsPageQueryVariables},
+  "#graphql\n  query AnchorCatalogPage($cursor: String) {\n    products(first: 50, after: $cursor) {\n      pageInfo { hasNextPage endCursor }\n      nodes {\n        id\n        title\n        vendor\n        productType\n        status\n        tags\n        updatedAt\n        collections(first: 20) { nodes { id } }\n        variants(first: 100) {\n          pageInfo { hasNextPage endCursor }\n          nodes {\n            id\n            title\n            sku\n            barcode\n            price\n            compareAtPrice\n            inventoryQuantity\n            inventoryItem { unitCost { amount currencyCode } }\n          }\n        }\n      }\n    }\n  }\n": {return: AnchorCatalogPageQuery, variables: AnchorCatalogPageQueryVariables},
   "#graphql\n  query AnchorShopCurrency {\n    shop { currencyCode ianaTimezone }\n  }\n": {return: AnchorShopCurrencyQuery, variables: AnchorShopCurrencyQueryVariables},
   "#graphql\n  query AnchorPriceLists($cursor: String) {\n    priceLists(first: 50, after: $cursor) {\n      pageInfo { hasNextPage endCursor }\n      nodes {\n        id\n        name\n        currency\n        parent { adjustment { type value } }\n        catalog {\n          id\n          title\n          __typename\n          ... on MarketCatalog {\n            # One country this catalogue's market serves.\n            #\n            # Prices are asked for by country rather than by price list, so the market\n            # surface needs a country to ask about. Every country in a market sees the\n            # same price, so the first region answers for all of them.\n            markets(first: 1) {\n              nodes {\n                conditions {\n                  regionsCondition {\n                    regions(first: 1) {\n                      nodes { ... on MarketRegionCountry { code } }\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n": {return: AnchorPriceListsQuery, variables: AnchorPriceListsQueryVariables},
   "#graphql\n  query AnchorPriceListPrices($id: ID!, $cursor: String) {\n    priceList(id: $id) {\n      id\n      prices(first: 250, after: $cursor) {\n        pageInfo { hasNextPage endCursor }\n        nodes {\n          originType\n          variant { id }\n          price { amount currencyCode }\n          compareAtPrice { amount currencyCode }\n        }\n      }\n    }\n  }\n": {return: AnchorPriceListPricesQuery, variables: AnchorPriceListPricesQueryVariables},

--- a/chaos/scenarios/variant-pagination.chaos.ts
+++ b/chaos/scenarios/variant-pagination.chaos.ts
@@ -1,0 +1,164 @@
+/**
+ * A product with more variants than one page holds.
+ *
+ * Found on a real 100K store: `variants(first: 100)` on the catalogue page query dropped
+ * 1,948 of a 2,048-variant product's variants, silently. The store had all of them;
+ * the mirror had a twentieth. A campaign covering that product would have priced 100
+ * variants, left 1,948 at their old prices, and reported the run clean — because every
+ * row it knew about did land.
+ *
+ * That is the exact failure this product exists to prevent, and nothing caught it: the
+ * page size looks like a page size until a product is bigger than one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { withChaos } from "../harness/scenario";
+
+/** A variant node in the shape the sync reads. */
+const variant = (n: number) => ({
+  id: `gid://shopify/ProductVariant/pagination-${n}`,
+  title: `Variant ${n}`,
+  sku: `SKU-${n}`,
+  barcode: null,
+  price: "10.00",
+  compareAtPrice: null,
+  inventoryQuantity: 5,
+  inventoryItem: { unitCost: { amount: "4.00", currencyCode: "USD" } },
+});
+
+const PRODUCT_ID = "gid://shopify/Product/pagination-1";
+
+/**
+ * A store whose one product has `total` variants, served 100 on the product page and 250
+ * per follow-up — which is exactly how Shopify serves them.
+ */
+function storeWith(total: number) {
+  const all = Array.from({ length: total }, (_, i) => variant(i));
+  let followUps = 0;
+
+  return {
+    followUpCount: () => followUps,
+    async graphql(query: string, options?: { variables?: Record<string, unknown> }) {
+      if (query.includes("AnchorProductVariantsPage")) {
+        followUps += 1;
+        const after = Number((options?.variables?.cursor as string | null) ?? "100");
+        const slice = all.slice(after, after + 250);
+        const next = after + slice.length;
+
+        return {
+          json: async () => ({
+            data: {
+              product: {
+                variants: {
+                  pageInfo: { hasNextPage: next < all.length, endCursor: String(next) },
+                  nodes: slice,
+                },
+              },
+            },
+          }),
+        };
+      }
+
+      const first = all.slice(0, 100);
+      return {
+        json: async () => ({
+          data: {
+            products: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  id: PRODUCT_ID,
+                  title: "A product with too many variants",
+                  vendor: "Anchor",
+                  productType: "Test",
+                  status: "ACTIVE",
+                  tags: [],
+                  updatedAt: new Date().toISOString(),
+                  collections: { nodes: [] },
+                  variants: {
+                    pageInfo: { hasNextPage: all.length > 100, endCursor: "100" },
+                    nodes: first,
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      };
+    },
+  };
+}
+
+async function mirroredVariants(shopId: string): Promise<number> {
+  return prisma.variantIndex.count({ where: { shopId, productGid: PRODUCT_ID } });
+}
+
+describe("chaos: a product with more variants than one page", () => {
+  it("mirrors all 2,048, not the first 100", async () => {
+    await withChaos(
+      "variant-pagination-2048",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { syncCatalog } = await import("../../app/services/catalog-sync.server");
+        const store = storeWith(2_048);
+
+        const result = await syncCatalog(store, chaos.fixture.shopId, "USD");
+
+        expect(result.errors).toEqual([]);
+        expect(result.variants).toBe(2_048);
+        expect(await mirroredVariants(chaos.fixture.shopId)).toBe(2_048);
+
+        // 100 on the page, then 250 a time: eight follow-ups, not one per variant.
+        expect(store.followUpCount()).toBe(8);
+      },
+    );
+  });
+
+  it("asks for nothing extra when one page was enough", async () => {
+    await withChaos(
+      "variant-pagination-small",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { syncCatalog } = await import("../../app/services/catalog-sync.server");
+        const store = storeWith(40);
+
+        const result = await syncCatalog(store, chaos.fixture.shopId, "USD");
+
+        expect(result.variants).toBe(40);
+        expect(store.followUpCount()).toBe(0);
+      },
+    );
+  });
+
+  it("reports a product it could only read part of, rather than mirroring it quietly", async () => {
+    await withChaos(
+      "variant-pagination-failure",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        const { syncCatalog } = await import("../../app/services/catalog-sync.server");
+        const store = storeWith(2_048);
+
+        // The follow-up fails. The first hundred are still real and worth mirroring, but
+        // the product is now partly mirrored — and a partly mirrored product is one whose
+        // campaigns will be partly applied.
+        const broken = {
+          async graphql(query: string, options?: { variables?: Record<string, unknown> }) {
+            if (query.includes("AnchorProductVariantsPage")) {
+              return { json: async () => ({ errors: [{ message: "Throttled" }] }) };
+            }
+            return store.graphql(query, options);
+          },
+        };
+
+        const result = await syncCatalog(broken, chaos.fixture.shopId, "USD");
+
+        expect(result.variants).toBe(100);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain("could not read past the first page");
+        expect(result.errors[0]).toContain("Throttled");
+      },
+    );
+  });
+});

--- a/perf-baseline-100k.json
+++ b/perf-baseline-100k.json
@@ -1,0 +1,17 @@
+{
+  "label": "100k",
+  "startedAt": "2026-08-26T22:06:09.334Z",
+  "elapsedSeconds": 169,
+  "memory": {
+    "peakRssMb": 94,
+    "samples": 84
+  },
+  "variantsAfter": 100084,
+  "productsAfter": 2000,
+  "variantsAdded": 100078,
+  "maxVariantProduct": {
+    "handle": "gid://shopify/Product/9121262633114",
+    "variants": 65
+  },
+  "exitCode": 0
+}

--- a/perf-baseline-e12.json
+++ b/perf-baseline-e12.json
@@ -1,0 +1,17 @@
+{
+  "label": "e12",
+  "startedAt": "2026-08-26T22:15:05.467Z",
+  "elapsedSeconds": 42,
+  "memory": {
+    "peakRssMb": 94,
+    "samples": 20
+  },
+  "variantsAfter": 100184,
+  "productsAfter": 2001,
+  "variantsAdded": 100,
+  "maxVariantProduct": {
+    "handle": "gid://shopify/Product/9121334591642",
+    "variants": 100
+  },
+  "exitCode": 0
+}


### PR DESCRIPTION
Found by seeding a real 100K store.

## The bug

`variants(first: 100)` on the catalogue page query is a page size. It looks like one right up until a product has more variants than a page holds — at which point the rest are dropped with **no error, no warning and no count**.

The 2,048-variant product from E12 arrived in Shopify complete. The mirror recorded 100 of it.

A campaign covering that product would have priced 100 variants, left 1,948 at their old prices, and **reported the run clean** — because every row it knew about did land. That is the exact shape of failure this product exists to prevent, and it was sitting in the sync the whole time.

**Nothing caught it because nothing had a product that big.** The dev store's largest is 65 variants, so every test and every manual check went through the one branch where the bug is invisible.

## The fix

A product whose first page is full gets followed up 250 at a time — the largest page Shopify allows — so a 2,048-variant product costs eight extra requests and every other product costs none. Bounded at forty pages so a malformed cursor cannot spin a background worker forever.

**A failed follow-up is recorded, never swallowed.** The first hundred variants are real and worth mirroring, but the product is then *partly* mirrored — and a partly mirrored product is one whose campaigns will be partly applied. The sync names the product and quotes what Shopify said.

## Verification

- 1,141 unit tests, **120 chaos scenarios** (3 new), lint and build clean
- 3 mutations checked, all caught — including reintroducing the original bug, which fails two of the three new scenarios
- **Verified against the real store**: the mirror now holds 2,048 variants for that product, up from 100. A full sync of 2,001 products reads 102,132 variants across 41 pages with no errors, in 172 seconds

Refs #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)