### PR TITLE
Release Flow, and point the app at Railway instead of a dead tunnel

### DIFF
--- a/app/lib/help/promises.test.ts
+++ b/app/lib/help/promises.test.ts
@@ -8,15 +8,13 @@
  * search, find nothing, and conclude the app is broken — which is a support ticket and a
  * one-star review, not a missing feature.
  *
- * The notice used to be tied to the extension manifests existing. That was a proxy for
- * "a merchant can use this", and once the manifests were written it became visibly too
- * loose: an extension in the repo is not an extension in a merchant's Flow. The real gate
- * is a release, which a test cannot see.
+ * Flow is released as of app version `bulk-price-editor-8`, so the page describes
+ * something a merchant can actually set up and the "not available yet" notice is gone.
  *
- * So the rule is weaker and honest: while the page says it is unavailable, it must also
- * say what is missing, and it must not describe the integration in the present tense.
- * Removing the notice is a deliberate act somebody performs when Flow actually works,
- * and the manifests' existence no longer forces it.
+ * What remains worth asserting is the pair that made the notice necessary in the first
+ * place: the page describes triggers and actions, and the extensions that declare them to
+ * Shopify exist. Delete the extensions and the page becomes a promise again — which is
+ * the state this test was written to catch.
  */
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
@@ -41,31 +39,20 @@ function manifests(): string[] {
 describe("Shopify Flow", () => {
   const doc = readFileSync(join(ROOT, "docs/help/how-to/shopify-flow.md"), "utf8");
   const index = readFileSync(join(ROOT, "docs/help/index.md"), "utf8");
-  it("says plainly that it is not available", () => {
-    // Until somebody removes this deliberately, the page must not read as instructions.
-    expect(doc).toContain(NOTICE);
+  it("has an extension for everything the page describes", () => {
+    // Six: three triggers and three actions. Fewer means the page promises something
+    // Shopify was never told about, which is how it read before the release.
+    expect(manifests().length, "the Flow extension manifests are gone").toBe(6);
   });
 
-  it("names what is actually missing, not just that something is", () => {
-    // "Not available yet" with no reason invites a merchant to go looking for a setting.
-    expect(doc).toMatch(/has not been released|not been released/);
+  it("no longer warns that it is unavailable, because it is not", () => {
+    expect(doc).not.toContain(NOTICE);
   });
 
-  it("has the extensions that a release would publish", () => {
-    // The half that *is* done. If these disappear, the page is describing nothing at all.
-    expect(manifests().length, "the Flow extension manifests are gone").toBeGreaterThan(0);
-  });
-
-  it("does not describe it in the present tense while it is unavailable", () => {
-    // "Anchor adds three triggers" reads as a statement of fact about today.
-    expect(doc).not.toMatch(/^Anchor adds /m);
-  });
-
-  it("warns on the index too, where merchants choose what to read", () => {
+  it("does not warn on the index either", () => {
     const line = index.split("\n").find((row) => row.includes("shopify-flow.md")) ?? "";
 
-    expect(line, "the index links to Flow with no hint that it is unavailable").toMatch(
-      /not available yet/i,
-    );
+    expect(line).not.toMatch(/not available/i);
   });
+
 });

--- a/docs/help/how-to/shopify-flow.md
+++ b/docs/help/how-to/shopify-flow.md
@@ -1,11 +1,6 @@
 # Wiring pricing into Shopify Flow
 
-> **Not available yet.** The integration is built — triggers, actions and the extensions
-> that declare them to Shopify — but it has not been released. If you open Flow today you
-> will not find these. This page is here so you can see what is coming and tell us whether
-> it is the right shape, not so you can set it up.
-
-Anchor will add three triggers and three actions to Flow, so pricing can be part of the
+Anchor adds three triggers and three actions to Flow, so pricing can be part of the
 automations you already have rather than something you remember to do separately.
 
 ## Triggers

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -18,7 +18,7 @@ first campaign.
 - [Scheduling a sale](./how-to/schedule-a-sale.md)
 - [Running a sale across several markets](./how-to/multi-market-sale.md)
 - [Importing your own prices](./how-to/import-baselines.md)
-- [Wiring pricing into Shopify Flow](./how-to/shopify-flow.md) — not available yet; what it will do
+- [Wiring pricing into Shopify Flow](./how-to/shopify-flow.md)
 
 ## When something goes wrong
 

--- a/extensions/anchor-capture-baselines/shopify.extension.toml
+++ b/extensions/anchor-capture-baselines/shopify.extension.toml
@@ -11,7 +11,7 @@ handle = "capture-baselines"
 type = "flow_action"
 uid = "8326affd-60e9-c20b-a403-6e1c1cf64ca1b5ad9926"
 description = "Records today's prices as the new normal for a segment. Refused while a campaign is running."
-runtime_url = "https://increasingly-functioning-funk-firm.trycloudflare.com/flow/actions/capture-baselines"
+runtime_url = "https://bulk-price-editor-production-eb91.up.railway.app/flow/actions/capture-baselines"
 
 [settings]
 

--- a/extensions/anchor-end-campaign/shopify.extension.toml
+++ b/extensions/anchor-end-campaign/shopify.extension.toml
@@ -11,7 +11,7 @@ handle = "end-campaign"
 type = "flow_action"
 uid = "2f1ca836-d0ff-d660-ed32-554a5196ff87fdd8fe9a"
 description = "Reverts a campaign's prices. Recomputes each price without it rather than restoring old values."
-runtime_url = "https://increasingly-functioning-funk-firm.trycloudflare.com/flow/actions/end-campaign"
+runtime_url = "https://bulk-price-editor-production-eb91.up.railway.app/flow/actions/end-campaign"
 
 [settings]
 

--- a/extensions/anchor-start-campaign/shopify.extension.toml
+++ b/extensions/anchor-start-campaign/shopify.extension.toml
@@ -11,7 +11,7 @@ handle = "start-campaign"
 type = "flow_action"
 uid = "fd8b7033-d33a-12f2-0b57-dca2a841f8b50d99715b"
 description = "Applies a campaign exactly as the Apply button does, including your guardrails and your plan's limits."
-runtime_url = "https://increasingly-functioning-funk-firm.trycloudflare.com/flow/actions/start-campaign"
+runtime_url = "https://bulk-price-editor-production-eb91.up.railway.app/flow/actions/start-campaign"
 
 [settings]
 

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,8 +1,18 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
+# `application_url` and `redirect_urls` below are the deployed app on Railway.
+#
+# `automatically_update_urls_on_dev` is true, so `shopify app dev` rewrites them to its
+# tunnel for the duration of a dev session and leaves the tunnel here afterwards. That is
+# the dev loop working as intended, but it means this file drifts: check these two values
+# point at Railway before running `shopify app deploy`, or the deploy will publish a dead
+# tunnel as the app's real URL.
+#
+# The proper fix is a second app record for production, so dev and deploy stop sharing one
+# set of URLs. Until somebody makes that call, this comment is the guardrail.
 client_id = "5401aeddaf37aac5c9e1650bf6abb462"
 name = "bulk-price-editor"
-application_url = "https://olympic-hit-forum-thomas.trycloudflare.com"
+application_url = "https://bulk-price-editor-production-eb91.up.railway.app"
 embedded = true
 
 [build]
@@ -39,4 +49,4 @@ optional_scopes = [ ]
 use_legacy_install_flow = false
 
 [auth]
-redirect_urls = [ "https://olympic-hit-forum-thomas.trycloudflare.com/auth/callback", "https://olympic-hit-forum-thomas.trycloudflare.com/auth/shopify/callback", "https://olympic-hit-forum-thomas.trycloudflare.com/api/auth/callback" ]
+redirect_urls = [ "https://bulk-price-editor-production-eb91.up.railway.app/auth/callback", "https://bulk-price-editor-production-eb91.up.railway.app/auth/shopify/callback", "https://bulk-price-editor-production-eb91.up.railway.app/api/auth/callback" ]


### PR DESCRIPTION
`shopify app deploy` publishes extensions **and** `application_url`. That is why the deploy had been held: the config still held a `trycloudflare.com` tunnel from the last `shopify app dev`, and releasing it would have pointed the live app at nothing.

## Railway was already current

`/healthz` green, and `/help/images/drift-empty.png` present — a file that only merged an hour earlier, so auto-deploy from `main` is working. The config now names it, the three action `runtime_url`s name it, and **`bulk-price-editor-8` is released**.

## Verified the way that actually proves it

**With no dev server running at all**, the app loads in the admin from Railway. The Dev Console lists all six extensions:

| Handle | Type |
|---|---|
| `campaign-started`, `campaign-ended`, `campaign-held` | Flow Trigger |
| `start-campaign`, `end-campaign`, `capture-baselines` | Flow Action |

A **stale dev preview was overriding the released version** and had to be cleaned first. Worth knowing: a dev preview outlives the CLI session that created it, and while it is active the app serves from a tunnel that no longer exists — which looks exactly like a broken deploy.

## The help page

Drops its "not available yet" notice, because it is available. The test that enforced the notice now enforces the pair that made it necessary: the page describes six things, and six extensions exist. Delete one and the page becomes a promise again.

## What is still true and worth saying

`automatically_update_urls_on_dev` is still true, so the next `shopify app dev` rewrites these URLs to its tunnel and leaves it in the file. There is a comment at the top of `shopify.app.toml` telling you to check before deploying, and the real fix — a second app record for production — is written down rather than pretended away.

## Verification

- 1,149 unit tests, lint and build clean
- App version `bulk-price-editor-8` released
- App loads from Railway in the admin with no local process running

Refs #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)