### PR TITLE
Fix Flow actions reading the wrong field keys

### DIFF
--- a/app/lib/flow/manifest.test.ts
+++ b/app/lib/flow/manifest.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The manifest and the code that reads it, held together.
+ *
+ * The bug this exists to stop: all three action routes read `properties["campaign id"]`
+ * while their manifests declared `campaign-id`. Every Flow action received an empty id,
+ * found no campaign, and returned 200 — so Flow reported success and no price ever moved.
+ * Nothing failed. That is why it survived: there is no error to notice.
+ *
+ * The strong assertion is the set equality below. Checking only that each declared key is
+ * read would have passed the broken code the moment somebody added a correct lookup
+ * alongside the wrong one; requiring the two sets to be equal catches a stale spelling.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { parseFlowManifest } from "./manifest";
+
+const EXTENSIONS = join(process.cwd(), "extensions");
+const ROUTES = join(process.cwd(), "app", "routes");
+
+function manifests() {
+  return readdirSync(EXTENSIONS, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(EXTENSIONS, entry.name, "shopify.extension.toml"))
+    .map((path) => parseFlowManifest(readFileSync(path, "utf8")));
+}
+
+describe("parsing a manifest", () => {
+  const toml = `
+# A comment that mentions handle = "not-this"
+
+[[extensions]]
+name = "End a price campaign"
+handle = "end-campaign"
+type = "flow_action"
+runtime_url = "https://example.test/flow/actions/end-campaign"
+
+[settings]
+
+  [[settings.fields]]
+  type = "single_line_text_field"
+  key = "campaign-id"
+  name = "Campaign ID"
+
+  [[settings.fields]]
+  type = "single_line_text_field"
+  key = "reason"
+`;
+
+  it("reads the handle, type and every field key", () => {
+    expect(parseFlowManifest(toml)).toEqual({
+      handle: "end-campaign",
+      type: "flow_action",
+      fieldKeys: ["campaign-id", "reason"],
+    });
+  });
+
+  it("does not mistake a field's own type for the extension's", () => {
+    // `type = "single_line_text_field"` appears twice above and must not win.
+    expect(parseFlowManifest(toml).type).toBe("flow_action");
+  });
+
+  it("ignores commented-out lines", () => {
+    expect(parseFlowManifest(toml).handle).toBe("end-campaign");
+  });
+});
+
+describe("every action route reads the keys its manifest declares", () => {
+  const actions = manifests().filter((manifest) => manifest.type === "flow_action");
+
+  // A glob that quietly matched nothing would make every assertion below vacuous.
+  it("found the action manifests", () => {
+    expect(actions.map((action) => action.handle).sort()).toEqual([
+      "capture-baselines",
+      "end-campaign",
+      "start-campaign",
+    ]);
+  });
+
+  it.each(actions)("$handle", (manifest) => {
+    expect(manifest.fieldKeys.length).toBeGreaterThan(0);
+
+    const source = readFileSync(join(ROUTES, `flow.actions.${manifest.handle}.tsx`), "utf8");
+    const read = [...source.matchAll(/properties\?\.\["([^"]+)"\]/g)].map((match) => match[1]);
+
+    expect(read.length).toBeGreaterThan(0);
+    expect(new Set(read)).toEqual(new Set(manifest.fieldKeys));
+  });
+});
+
+describe("every trigger key exists on TriggerPayload", () => {
+  const triggers = manifests().filter((manifest) => manifest.type === "flow_trigger");
+  const server = readFileSync(join(process.cwd(), "app", "services", "flow.server.ts"), "utf8");
+  const payload = server.slice(
+    server.indexOf("export interface TriggerPayload"),
+    server.indexOf("export function containsPrice"),
+  );
+
+  it("found the trigger manifests", () => {
+    expect(triggers.map((trigger) => trigger.handle).sort()).toEqual([
+      "campaign-ended",
+      "campaign-held",
+      "campaign-started",
+    ]);
+  });
+
+  it.each(triggers)("$handle", (manifest) => {
+    for (const key of manifest.fieldKeys) {
+      // Spaced keys are quoted in the interface; a bare identifier like `outcome` is not.
+      expect(payload).toMatch(new RegExp(`(^|\\s)"?${key}"?\\??:`, "m"));
+    }
+  });
+});

--- a/app/lib/flow/manifest.ts
+++ b/app/lib/flow/manifest.ts
@@ -1,0 +1,60 @@
+/**
+ * Reading the field keys back out of a Flow extension manifest.
+ *
+ * Flow keys an action's `properties` by the field `key` in the extension TOML, and a
+ * trigger's payload by its field keys — and the two use different alphabets. Trigger keys
+ * are alphabetic characters and spaces ("campaign id"); action keys are identifiers
+ * ("campaign-id"). Nothing connects the manifest to the code that reads it, so a route
+ * looking up the wrong spelling gets `undefined` and carries on: the action returns 200,
+ * Flow shows a green tick, and nothing happened.
+ *
+ * This exists so a test can hold the two together. It is deliberately a few lines of
+ * line-oriented parsing rather than a TOML dependency — it only ever reads manifests this
+ * repo writes, and it tracks the current table so a field's own `type = ` is not mistaken
+ * for the extension's.
+ */
+
+export interface FlowManifest {
+  /** `handle` — also the route filename and the last segment of `runtime_url`. */
+  handle: string;
+  /** `flow_action` or `flow_trigger`. */
+  type: string;
+  /** Every `key` under `[[settings.fields]]`, in declaration order. */
+  fieldKeys: string[];
+}
+
+const HEADER = /^\[\[?([^\]]+?)\]?\]$/;
+const PAIR = /^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"(.*)"$/;
+
+export function parseFlowManifest(toml: string): FlowManifest {
+  let section = "";
+  let handle = "";
+  let type = "";
+  const fieldKeys: string[] = [];
+
+  for (const raw of toml.split("\n")) {
+    const line = raw.trim();
+    // Whole-line comments only. Values here never carry a trailing `#`, and stripping one
+    // blindly would corrupt any that later did.
+    if (line === "" || line.startsWith("#")) continue;
+
+    const header = line.match(HEADER);
+    if (header) {
+      section = header[1];
+      continue;
+    }
+
+    const pair = line.match(PAIR);
+    if (!pair) continue;
+    const [, key, value] = pair;
+
+    if (section === "extensions") {
+      if (key === "handle") handle = value;
+      if (key === "type") type = value;
+    } else if (section === "settings.fields" && key === "key") {
+      fieldKeys.push(value);
+    }
+  }
+
+  return { handle, type, fieldKeys };
+}

--- a/app/routes/flow.actions.capture-baselines.tsx
+++ b/app/routes/flow.actions.capture-baselines.tsx
@@ -40,18 +40,30 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   const segmentId = String(
-    (payload as { properties?: Record<string, unknown> }).properties?.["segment id"] ?? "",
+    (payload as { properties?: Record<string, unknown> }).properties?.["segment-id"] ?? "",
   );
+
+  // `segment-id` is required in the manifest, so an empty one means the request did not
+  // carry what we asked for — a renamed field key, a hand-built call. Falling through
+  // would hand `undefined` to recapture, which means *every* baseline in the shop rather
+  // than one segment. The widest possible write is the worst available default, so this
+  // refuses instead of guessing.
+  if (!segmentId) {
+    logger.warn("Flow asked to capture baselines without a segment; refused", {
+      shopId: shop.id,
+    });
+    return new Response(null, { status: 200 });
+  }
 
   // The confirmation phrase is generated from the plan and handed straight back. That
   // reads like defeating the check and is not: the check exists to make a *person* stop
   // and read the warning, and the warning it produces is about live campaigns — which is
   // the condition already refused above. What remains is the scope, which the automation
   // named deliberately.
-  const plan = await planRecapture(shop.id, { segmentId: segmentId || undefined });
+  const plan = await planRecapture(shop.id, { segmentId });
 
   const result = await recapture(shop.id, {
-    segmentId: segmentId || undefined,
+    segmentId,
     confirmation: plan.confirmationPhrase ?? undefined,
     actor: "shopify-flow",
   });

--- a/app/routes/flow.actions.end-campaign.tsx
+++ b/app/routes/flow.actions.end-campaign.tsx
@@ -24,7 +24,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   if (!shop) return new Response("Unknown shop", { status: 404 });
 
   const campaignId = String(
-    (payload as { properties?: Record<string, unknown> }).properties?.["campaign id"] ?? "",
+    (payload as { properties?: Record<string, unknown> }).properties?.["campaign-id"] ?? "",
   );
 
   const campaign = await prisma.campaign.findFirst({

--- a/app/routes/flow.actions.start-campaign.tsx
+++ b/app/routes/flow.actions.start-campaign.tsx
@@ -30,7 +30,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   if (!shop) return new Response("Unknown shop", { status: 404 });
 
   const campaignId = String(
-    (payload as { properties?: Record<string, unknown> }).properties?.["campaign id"] ?? "",
+    (payload as { properties?: Record<string, unknown> }).properties?.["campaign-id"] ?? "",
   );
 
   const campaign = await prisma.campaign.findFirst({


### PR DESCRIPTION
Every Flow action route read `properties["campaign id"]` / `["segment id"]`, but the manifests declare `campaign-id` / `segment-id`. Flow keys an action's `properties` by the **manifest field key** ([docs](https://shopify.dev/docs/apps/build/flow/actions/endpoints)), so all three actions received an empty string, matched nothing, and returned 200. Flow showed success and no price ever moved.

Triggers were correct — their keys really are spaced words. The distinction was applied on the trigger side and not the action side.

### The dangerous one

`capture-baselines` did not just no-op. An empty segment id fell through `segmentId || undefined` into `recapture`, where `undefined` means *every* baseline in the shop rather than one segment — silently resetting the reference prices every future campaign computes from. That is the write its own file comment calls "the most expensive thing in this codebase". It now refuses instead of widening.

### How it was found

Building the #177 workflow (`inventory < 10` → end campaign) in Flow against a Plus dev store. The tasks register and the action config renders correctly; reading the route to see what it would do with the campaign id showed it would do nothing with it.

### The test

`app/lib/flow/manifest.ts` parses the extension TOMLs (table-aware, so a field's own `type =` is not mistaken for the extension's). The test asserts each action route's `properties?.["…"]` lookups equal its manifest's declared keys **as set equality in both directions** — checking only "each declared key is read" would pass the broken code the moment a correct lookup was added beside the wrong one. Trigger keys are pinned against `TriggerPayload`.

Mutation-checked three ways, each failing the suite:
- reintroduce the original `"campaign id"` → 1 failure
- rename a manifest key to `campaign_id` → 1 failure
- make the parser ignore which table it is in → 4 failures

`npm run typecheck` clean, `npm run lint` 0 errors, 1160 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)