### PR TITLE
Give every alert its own runbook page

### DIFF
--- a/app/lib/observability/alerts.test.ts
+++ b/app/lib/observability/alerts.test.ts
@@ -155,14 +155,21 @@ describe("every alert leads somewhere", () => {
    */
   const runbook = readFileSync(join(process.cwd(), "docs/runbooks.md"), "utf8");
 
+  const anchorOf = (heading: string) =>
+    heading
+      .trim()
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, "")
+      .replace(/\s+/g, "-");
+
   const anchors = new Set(
-    [...runbook.matchAll(/^##\s+(.+)$/gm)].map(([, heading]) =>
-      heading
-        .trim()
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, "")
-        .replace(/\s+/g, "-"),
-    ),
+    [...runbook.matchAll(/^##\s+(.+)$/gm)].map(([, heading]) => anchorOf(heading)),
+  );
+
+  // Only the `## Alert:` pages. The runbook also carries `## Watch:` sections and
+  // procedures like stuck-run recovery, and no alert should be pointing at those.
+  const alertSections = new Set(
+    [...runbook.matchAll(/^##\s+(Alert:.+)$/gm)].map(([, heading]) => anchorOf(heading)),
   );
 
   // Every condition at once, so a new alert is covered without anybody remembering to add
@@ -195,4 +202,30 @@ describe("every alert leads somewhere", () => {
       ).toContain(anchor);
     });
   }
+
+  /**
+   * One page per alert, and no page without an alert.
+   *
+   * "The anchor resolves" is too weak, and the gap is not hypothetical: `webhook-lag`
+   * pointed at the mirror-divergence runbook and `error-spike` at stuck-run recovery.
+   * Both anchors existed, so every assertion above passed — and the operator woken at 3am
+   * by an error spike read a page about a different incident. Worse than a broken link,
+   * which at least announces itself.
+   *
+   * The runbook also carried an `## Alert:` page for budget saturation, which `NOT_ALERTS`
+   * records as deliberately *not* an alert: a documented promise of a page that never
+   * comes.
+   *
+   * A bijection catches all three, and nothing weaker catches any of them.
+   */
+  it("gives every alert its own page, and every page an alert", () => {
+    const claimed = all.map((alert) => alert.runbook.split("#")[1]);
+
+    expect(
+      new Set(claimed).size,
+      "two alerts share one runbook page, so one of them describes the wrong incident",
+    ).toBe(claimed.length);
+
+    expect(new Set(claimed)).toEqual(alertSections);
+  });
 });

--- a/app/lib/observability/alerts.ts
+++ b/app/lib/observability/alerts.ts
@@ -105,7 +105,7 @@ export function evaluate(window: SignalWindow): AlertCondition[] {
       because:
         "The catalogue mirror is stale, and a campaign planned against a stale mirror prices " +
         "the wrong products.",
-      runbook: "docs/runbooks.md#alert-mirror-divergence-above-05",
+      runbook: "docs/runbooks.md#alert-webhooks-more-than-five-minutes-behind",
     });
   }
 
@@ -132,7 +132,7 @@ export function evaluate(window: SignalWindow): AlertCondition[] {
       because:
         "More than one request in twenty is failing. Whatever it is, it is affecting " +
         "merchants right now rather than one unlucky one.",
-      runbook: "docs/runbooks.md#stuck-run-recovery",
+      runbook: "docs/runbooks.md#alert-errors-spiking",
     });
   }
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -35,6 +35,72 @@ always meant something real.
 
 ---
 
+## Alert: webhooks more than five minutes behind
+
+**Metric:** `webhook.lag_ms` — the largest `processedAt - receivedAt` across deliveries
+processed in the last fifteen minutes.
+
+**What it means.** Shopify reached us and we were slow to act on it, so the mirror is
+behind the store. A campaign planned against a stale mirror prices the wrong products: a
+variant created ten minutes ago is not in scope, and one that just moved collection is
+scoped by where it used to be.
+
+**Read the metric carefully.** It measures *our* processing, not Shopify's delivery, and
+it is computed only over events that already have a `processedAt`. That has a consequence
+worth knowing at 3am: **if the worker stops outright, nothing gets a `processedAt`, the
+sample is empty, and this alert goes quiet instead of firing.** The same emptiness zeroes
+the denominator behind *errors spiking*, which needs twenty deliveries before it will
+speak. A worker that is dead rather than slow is caught by **scheduler tick stopped**, and
+by that alert alone — so read sudden silence across all three as a stopped worker until
+something proves otherwise.
+
+**Diagnose.**
+
+1. `SELECT status, count(*) FROM webhook_events WHERE "receivedAt" > now() - interval '1 hour' GROUP BY status;` — a large `RECEIVED` next to a small `PROCESSED` is a worker accepting deliveries and not draining them.
+2. `SELECT topic, count(*), max(now() - "receivedAt") AS oldest FROM webhook_events WHERE "processedAt" IS NULL GROUP BY topic ORDER BY oldest DESC;` — one topic backed up while the others move points at that handler rather than at the worker.
+3. `SELECT "failureReason", count(*) FROM webhook_events WHERE status = 'FAILED' AND "receivedAt" > now() - interval '1 hour' GROUP BY 1 ORDER BY 2 DESC;` — a repeated reason means the handler is throwing and `attempts` is climbing.
+
+**Remediate.** If the queue is draining and merely slow, let it. Restarting mid-drain
+costs the in-flight batch and buys nothing, because delivery is at-least-once and the
+unique constraint on `webhookId` makes the replay safe rather than fast. If it is not
+draining, restart the worker and watch `PROCESSED` climb. Once lag is back under a minute,
+run a catalogue re-sync for any shop that ran a campaign during the window — the mirror
+caught up, but anything planned against it while it was stale did not.
+
+**Do not** clear the backlog by deleting rows. `webhook_events` is how a lost change is
+found afterwards, and a mirror divergence with no delivery history is unexplainable.
+
+---
+
+## Alert: errors spiking
+
+**Metric:** `error_events` in the last fifteen minutes over deliveries processed in the
+same window, firing above 5% — and only once the window holds at least twenty deliveries,
+so one failure on a quiet night is not a 33% error rate.
+
+**What it means.** More than one in twenty is failing. Whatever it is, it is reaching
+merchants now rather than one unlucky merchant. It says nothing yet about *what* is
+failing; the first job is to find out whether this is one cause, one shop, or one route.
+
+**Diagnose.** Start with the shape, not the stack.
+
+1. `SELECT code, count(*) FROM error_events WHERE "createdAt" > now() - interval '1 hour' GROUP BY 1 ORDER BY 2 DESC;` — one code dominating is a single cause. A flat spread is usually infrastructure underneath all of them.
+2. `SELECT "shopId", count(*) FROM error_events WHERE "createdAt" > now() - interval '1 hour' GROUP BY 1 ORDER BY 2 DESC LIMIT 10;` — concentrated on one shop is that shop's data or its rate-limit budget, and is not an outage.
+3. `SELECT route, method, count(*) FROM error_events WHERE "createdAt" > now() - interval '1 hour' GROUP BY 1,2 ORDER BY 3 DESC;` — one route is a deploy; every route is the database or Shopify.
+4. Pick one `errorId` and read its `message`, `stack` and `userMessage` together. `userMessage` is what the merchant was actually told, which decides whether this needs a status note as well as a fix.
+
+**Remediate.** A dominant `SHOPIFY_UNAVAILABLE` is Shopify's, and the retry policy is
+already handling it — confirm it recovers rather than acting. Anything correlated with a
+release should be rolled back before it is diagnosed. If the errors are concentrated in
+execution, check for runs stuck mid-flight before restarting anything: see
+[Stuck run recovery](#stuck-run-recovery), because a restart with rows already in the
+ledger and unsettled is the case that procedure exists for.
+
+**Do not** raise the threshold to stop the paging. The 5% floor and the twenty-delivery
+minimum are both there because the noisy versions of this alert were tried first.
+
+---
+
 ## Alert: scheduler tick stopped
 
 **Metric:** `scheduler.tick` absent for more than three intervals
@@ -131,7 +197,7 @@ single poison job, its failure is in `error_events` with the job id.
 
 ---
 
-## Alert: a shop's budget saturated
+## Watch: a shop's budget saturated
 
 **Metric:** `budget.saturation`
 


### PR DESCRIPTION
Closes the "Runbook written per alert" criterion on #161.

### Two alerts linked to the wrong incident

| alert | pointed at | now |
|---|---|---|
| `webhook-lag` | `#alert-mirror-divergence-above-05` | `#alert-webhooks-more-than-five-minutes-behind` |
| `error-spike` | `#stuck-run-recovery` | `#alert-errors-spiking` |

Both anchors resolved, so the existing "every alert leads somewhere" test passed. The operator woken at 3am by an error spike would have followed the link and read a page about stuck runs. That is worse than a dead link, which at least announces itself.

The runbook also carried `## Alert: a shop's budget saturated` — but `NOT_ALERTS` in the code records budget saturation as deliberately **not** an alert ("Normal during a large campaign… Worth a graph, not a page"). The page promised a page that never arrives. Retitled `## Watch:`; the content was right, only the heading was wrong.

### The two new pages

Written from what the code actually measures, not from the alert titles. The load-bearing detail, which is not visible from either:

> `webhook.lag_ms` is the max `processedAt - receivedAt` over deliveries **that already have a `processedAt`**. If the worker stops outright, nothing gets one, the sample is empty, and this alert goes *quiet* instead of firing. The same emptiness zeroes the denominator behind *errors spiking*, which needs twenty deliveries before it will speak. A worker that is dead rather than slow is caught by **scheduler tick stopped** and by that alert alone.

So: sudden silence across all three reads as a stopped worker. Each page carries real SQL against `webhook_events` / `error_events` (grouped by status, topic, `failureReason`; by `code`, `shopId`, `route`) to separate one cause from one shop from one route.

### The test

Existing coverage checked that each anchor resolved to *some* heading, which is exactly why this drifted. Now a bijection: every alert claims a **distinct** `## Alert:` page, and every `## Alert:` page is claimed. `## Watch:` pages and procedures are excluded, so an alert pointing at one fails.

Mutation-checked, each failing:
- point `webhook-lag` back at mirror-divergence → *"two alerts share one runbook page"*, 5 vs 6
- retitle the budget page back to `## Alert:` → unclaimed page
- point `error-spike` at `#stuck-run-recovery` → not an alert page

`npm run typecheck` clean, `npm run lint` 0 errors, 1161 unit tests pass.

The remaining #161 criteria (chaos scenarios against staging, confirming each alert routes to a human, rehearsing restore) need staging with alerting live, which does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)