### PR TITLE
Close the two remaining places a job or a webhook can silently do nothing

### DIFF
--- a/app/lib/compliance/deploy-config.test.ts
+++ b/app/lib/compliance/deploy-config.test.ts
@@ -43,6 +43,48 @@ function environmentKeys(): Set<string> {
   return keys;
 }
 
+describe("the webhooks the manifest subscribes to", () => {
+  /**
+   * A declared topic with no route, or a route no topic reaches.
+   *
+   * Both fail silently and in opposite directions. Shopify posts a declared `uri` and
+   * gets a 404 — deliveries fail, the subscription is eventually disabled, and the first
+   * symptom is a mirror that has quietly stopped tracking the store. A route with no
+   * subscription is worse in the other direction: the handler is written, reviewed and
+   * tested, and simply never runs, while everybody believes the topic is covered.
+   *
+   * Neither is visible by reading, and `shopify.app.toml` is rewritten by the CLI on
+   * every `shopify app dev`, so this is a file that drifts without anybody editing it.
+   *
+   * The compliance topics route is exempt from the uri-to-filename rule below because
+   * Shopify addresses all three of `customers/data_request`, `customers/redact` and
+   * `shop/redact` at one uri.
+   */
+  const manifest = readFileSync(join(ROOT, "shopify.app.toml"), "utf8");
+
+  const declared = [...manifest.matchAll(/^\s*uri\s*=\s*"([^"]+)"/gm)].map(([, uri]) => uri);
+
+  /** `/webhooks/app/uninstalled` -> `webhooks.app.uninstalled.tsx`, the flat-route form. */
+  const routeFileFor = (uri: string) => `${uri.replace(/^\//, "").replace(/\//g, ".")}.tsx`;
+
+  const routeFiles = readdirSync(join(ROOT, "app/routes")).filter(
+    (file) => file.startsWith("webhooks.") && file.endsWith(".tsx"),
+  );
+
+  it("declares at least one webhook, so the checks below mean something", () => {
+    expect(declared.length).toBeGreaterThan(0);
+    expect(routeFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(declared)("%s is served by a route", (uri) => {
+    expect(routeFiles).toContain(routeFileFor(uri));
+  });
+
+  it("has no webhook route that nothing is subscribed to", () => {
+    expect(new Set(routeFiles)).toEqual(new Set(declared.map(routeFileFor)));
+  });
+});
+
 describe("the Railway runbook", () => {
   it("documents every environment variable the app reads", () => {
     // Variables the platform or the image sets, which nobody has to be told about.

--- a/app/worker/handlers.server.ts
+++ b/app/worker/handlers.server.ts
@@ -31,6 +31,15 @@ export async function handleJob(name: QueueName, ref: JobRef): Promise<void> {
     case "verification":
     case "webhooks":
       return;
+    default: {
+      // Exhaustiveness, not defensiveness. Without it, adding a name to `QUEUE_NAMES`
+      // compiles: the runtime gives it a Queue and a Worker, this switch falls straight
+      // through, and every job on it is marked complete having done nothing. Silence is
+      // the worst outcome available here, so `never` turns it into a build failure and
+      // the throw covers a name arriving from outside TypeScript.
+      const unhandled: never = name;
+      throw new Error(`No handler for queue ${String(unhandled)}`);
+    }
   }
 }
 


### PR DESCRIPTION
Both are the shape of the bug fixed in #297: two halves of a contract with nothing holding them together, where a mismatch produces **silence** rather than an error. Neither is a live defect today; both are one edit away.

### 1. A new queue gets a Worker and no handler

`handleJob` switches on `QueueName` with no `default`. Add a name to `QUEUE_NAMES` and it compiles: `queue-runtime.server.ts` gives it a `Queue` and a `Worker`, the switch falls straight through, and every job on it is marked **complete** having done nothing.

`QUEUE_POLICIES` is a `Record<QueueName, …>` so it already fails to typecheck — but the handler did not, and the three deliberate no-op cases (`planning`, `verification`, `webhooks`) make a fall-through look intentional to a reader. A `never` assignment closes it:

```
app/worker/handlers.server.ts(40,13): error TS2322:
  Type '"reconciliation"' is not assignable to type 'never'.
```

### 2. A webhook topic with no route, or a route with no topic

Nothing checked that the `uri`s in `shopify.app.toml` correspond to routes. The two directions fail differently and both quietly:

- **Declared, no route** — Shopify posts and gets a 404. Deliveries fail, the subscription is eventually disabled, and the first symptom is a catalogue mirror that has silently stopped tracking the store.
- **Route, not declared** — the handler is written, reviewed, tested, and never runs, while everybody believes the topic is covered.

`built-for-shopify.test.ts` already asserts every webhook route calls `authenticate.webhook`, so the routes were checked for *safety* but never for being *reached*. And `shopify.app.toml` is rewritten by the CLI on every `shopify app dev` — this is a file that drifts without anybody editing it.

The test asserts the set of declared uris and the set of `webhooks.*.tsx` routes map onto each other exactly. The compliance route is naturally covered: Shopify addresses all three of `customers/data_request`, `customers/redact` and `shop/redact` at one uri, and that uri has one route.

### Mutation-checked

- rename one declared uri to `/webhooks/app/uninstalled_v2` → 2 failures (`is served by a route`, `has no webhook route that nothing is subscribed to`)
- add `"reconciliation"` to `QUEUE_NAMES` → build fails at `handlers.server.ts:40` as above

`npm run typecheck` clean, `npm run lint` 0 errors, 1168 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)