### PR TITLE
Give the scheduler a heartbeat of its own

### DIFF
--- a/app/services/alerting.server.ts
+++ b/app/services/alerting.server.ts
@@ -7,14 +7,20 @@
  *
  * Runs from the scheduler tick, which is slightly circular: the tick is what reports that
  * the tick is alive. That is fine for every condition except a stopped scheduler, and that
- * one is deliberately detected by *absence* — the tick writes a heartbeat and an external
- * check reads it, so a worker that has died cannot suppress its own alert by not running
+ * one is detected by *absence* — the tick stamps `scheduler_heartbeat` and whoever reads
+ * that row decides, so a worker that has died cannot suppress its own alert by not running
  * the code that would send it.
+ *
+ * That last part was a description rather than a fact until the heartbeat existed. The
+ * window read the newest campaign-run heartbeat instead, which is produced by runs rather
+ * than by the tick — so the alert fired on any shop quiet for three minutes and stayed
+ * silent when the scheduler died mid-run.
  */
 
 import prisma from "../db.server";
 import { logger } from "../lib/logging/logger";
 import { evaluate, type AlertCondition, type SignalWindow } from "../lib/observability/alerts";
+import { secondsSinceBeat } from "./scheduler-heartbeat.server";
 
 /** How far back a window looks. Long enough to be meaningful, short enough to be current. */
 const WINDOW_MINUTES = 15;
@@ -34,12 +40,15 @@ const lastSent = new Map<string, number>();
 export async function gather(now: Date = new Date()): Promise<SignalWindow> {
   const since = new Date(now.getTime() - WINDOW_MINUTES * 60_000);
 
-  const [lastRun, errors, webhooks, lastAudit] = await Promise.all([
-    prisma.campaignRun.findFirst({
-      where: { heartbeatAt: { not: null } },
-      orderBy: { heartbeatAt: "desc" },
-      select: { heartbeatAt: true },
-    }),
+  const [sinceTick, errors, webhooks, lastAudit] = await Promise.all([
+    // The scheduler's own heartbeat, not a campaign run's.
+    //
+    // This used to read the newest `campaign_runs.heartbeatAt`, which is stamped by runs
+    // while they execute — so it was wrong in both directions. On an idle shop, which is
+    // the normal state, the newest one is hours old and "the scheduler has stopped" paged
+    // for a scheduler that was fine. And a scheduler that died while a long run was still
+    // stamping looked alive, which is the one case the alert exists for.
+    secondsSinceBeat(now),
     prisma.errorEvent.count({ where: { createdAt: { gte: since } } }),
     prisma.webhookEvent.findMany({
       where: { receivedAt: { gte: since }, processedAt: { not: null } },
@@ -66,11 +75,9 @@ export async function gather(now: Date = new Date()): Promise<SignalWindow> {
     | null;
 
   return {
-    // Null when nothing has ever run, which is a new install rather than a dead
-    // scheduler. Alerting there would page somebody on every fresh deployment.
-    secondsSinceTick: lastRun?.heartbeatAt
-      ? Math.round((now.getTime() - lastRun.heartbeatAt.getTime()) / 1000)
-      : null,
+    // Null until the scheduler has beaten once, which is a new install rather than a
+    // dead scheduler. Alerting there would page somebody on every fresh deployment.
+    secondsSinceTick: sinceTick,
     webhookLagMs: lagMs,
     errors,
     // Webhook deliveries stand in for request volume: it is the traffic that arrives

--- a/app/services/scheduler-heartbeat.server.ts
+++ b/app/services/scheduler-heartbeat.server.ts
@@ -1,0 +1,59 @@
+/**
+ * The scheduler saying it is alive, and anything else asking whether it is.
+ *
+ * This is the signal behind the one alert that catches a dead worker. Every other alert
+ * is computed from work the worker produces — webhook lag from processed deliveries,
+ * error rate from a denominator of those same deliveries — so a worker that stops
+ * outright empties all of them and they go quiet rather than fire. Only absence of a
+ * heartbeat distinguishes "nothing is happening because nothing needs to" from "nothing
+ * is happening because the process is gone".
+ *
+ * Stamped more than once per tick on purpose. A tick can spend minutes inside a single
+ * large campaign, and a heartbeat written only at the top would go stale during exactly
+ * the work that proves the scheduler is alive — reporting a stopped scheduler because it
+ * was busy. So the tick beats when it starts and again as it works through campaigns.
+ */
+
+import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
+
+/** The only legal primary key. See the model comment. */
+const SINGLETON = "singleton";
+
+/**
+ * Records that the scheduler is alive at `now`.
+ *
+ * Never throws. This is liveness reporting, and a failure to report is not worth failing
+ * the tick that was about to do the real work — the worst case is one missed beat, and
+ * the next one is thirty seconds away.
+ */
+export async function beat(now: Date = new Date(), instance?: string): Promise<void> {
+  try {
+    await prisma.schedulerHeartbeat.upsert({
+      where: { id: SINGLETON },
+      create: { id: SINGLETON, beatAt: now, instance: instance ?? null },
+      update: { beatAt: now, instance: instance ?? null },
+    });
+  } catch (error) {
+    logger.warn("could not stamp the scheduler heartbeat", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * How long since the scheduler last said anything, or null if it never has.
+ *
+ * Null rather than a large number on a fresh install, because "we have not looked" and
+ * "we looked and it is dead" are different statements and only one of them should wake
+ * somebody. Alerting treats null as "do not know" and stays quiet.
+ */
+export async function secondsSinceBeat(now: Date = new Date()): Promise<number | null> {
+  const row = await prisma.schedulerHeartbeat.findUnique({
+    where: { id: SINGLETON },
+    select: { beatAt: true },
+  });
+
+  if (!row) return null;
+  return Math.round((now.getTime() - row.beatAt.getTime()) / 1000);
+}

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -18,6 +18,7 @@ import { runCampaign } from "./campaigns/run.server";
 import { adminClientForShop } from "./admin-client.server";
 import { claimEnrollment, pendingEnrollments } from "./auto-enroll.server";
 import { reclaimStaleRuns } from "./campaigns/reaper.server";
+import { beat } from "./scheduler-heartbeat.server";
 import { checkAlerts } from "./alerting.server";
 import { sendDueDigests } from "./digest.server";
 import { auditMirror } from "./mirror-audit.server";
@@ -60,6 +61,11 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
     failures: [],
   };
 
+  // Before anything else, including before the alert check below reads it. This is the
+  // only signal that separates a stopped scheduler from a quiet one, and a tick that did
+  // any work first would be reporting liveness it had already spent time not having.
+  await beat(now);
+
   // First, before anything is scheduled. A run whose process died still holds its
   // campaign in APPLYING, and a campaign in APPLYING is invisible to the query below
   // -- so without reclaiming first, a dead run would block every future occurrence of
@@ -93,6 +99,13 @@ export async function tick(now: Date = new Date()): Promise<TickResult> {
       now,
     );
     if (!transition) continue;
+
+    // Beaten again per campaign, not only at the top of the tick. `runTransition` below
+    // can spend minutes on a large catalogue, and a heartbeat that only fires between
+    // ticks would go stale during precisely the work that proves the scheduler is
+    // alive — turning a busy scheduler into a stopped one. One upsert per due campaign
+    // is nothing next to the run it precedes.
+    await beat(new Date());
 
     try {
       await runTransition(

--- a/chaos/scenarios/scheduler-heartbeat.chaos.ts
+++ b/chaos/scenarios/scheduler-heartbeat.chaos.ts
@@ -1,0 +1,88 @@
+/**
+ * A quiet scheduler and a stopped one must not look the same.
+ *
+ * `scheduler-stopped` is the alert that catches a dead worker, and it is the only one
+ * that can. Every other condition in the window is computed from work the worker
+ * produces — webhook lag from processed deliveries, the error rate from a denominator of
+ * those same deliveries — so a process that stops outright empties all of them and they
+ * fall silent rather than fire.
+ *
+ * It was reading the newest `campaign_runs.heartbeatAt` and calling that "seconds since
+ * tick". Those rows are stamped by campaign runs while they execute, which made the
+ * signal wrong in both directions at once:
+ *
+ *   On an idle shop — the normal state, most of the time — the newest heartbeat is hours
+ *   or days old, so a perfectly healthy scheduler was reported stopped. A page that fires
+ *   every quiet night is a page that gets muted, and a muted page is not an alert.
+ *
+ *   And a scheduler that died while a long run was still stamping looked alive, which is
+ *   the exact case the alert exists for.
+ *
+ * These run against real Postgres because the bug was in a query, and a mocked Prisma
+ * would have agreed with whatever the query said.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { gather } from "../../app/services/alerting.server";
+import { beat, secondsSinceBeat } from "../../app/services/scheduler-heartbeat.server";
+import { evaluate, TICK_SILENCE_SECONDS } from "../../app/lib/observability/alerts";
+import { withChaos } from "../harness/scenario";
+
+const fired = (window: Awaited<ReturnType<typeof gather>>) =>
+  evaluate(window).map((alert) => alert.id);
+
+describe("chaos: the scheduler heartbeat", () => {
+  it("separates a quiet scheduler from a stopped one", async () => {
+    await withChaos(
+      "scheduler-heartbeat",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -10 },
+      async () => {
+        const now = new Date();
+
+        // Nothing has beaten yet. "We have not looked" is not "it is dead", and a fresh
+        // deployment must not page.
+        await prisma.schedulerHeartbeat.deleteMany({});
+        expect(await secondsSinceBeat(now)).toBeNull();
+        expect(fired(await gather(now))).not.toContain("scheduler-stopped");
+
+        // The bug, reproduced. A campaign run that stamped a heartbeat two days ago, and
+        // a scheduler that beat a second ago: healthy, idle, and silent.
+        await prisma.campaignRun.updateMany({
+          data: { heartbeatAt: new Date(now.getTime() - 2 * 24 * 60 * 60_000) },
+        });
+        await beat(new Date(now.getTime() - 1_000));
+
+        const quiet = await gather(now);
+        expect(quiet.secondsSinceTick).toBeLessThan(TICK_SILENCE_SECONDS);
+        expect(fired(quiet)).not.toContain("scheduler-stopped");
+
+        // And the case it is for. The beat stops; the stale campaign heartbeat is still
+        // sitting there and must not stand in for it.
+        await beat(new Date(now.getTime() - (TICK_SILENCE_SECONDS + 60) * 1_000));
+
+        const stopped = await gather(now);
+        expect(stopped.secondsSinceTick).toBeGreaterThan(TICK_SILENCE_SECONDS);
+        expect(fired(stopped)).toContain("scheduler-stopped");
+      },
+    );
+  });
+
+  it("keeps one row however often it beats", async () => {
+    await withChaos(
+      "scheduler-heartbeat-singleton",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async () => {
+        await prisma.schedulerHeartbeat.deleteMany({});
+
+        for (let i = 0; i < 5; i++) await beat(new Date());
+
+        // A heartbeat that accumulated a row per tick would be 2,880 rows a day and an
+        // unbounded table, and `secondsSinceBeat` reads one id rather than a max().
+        expect(await prisma.schedulerHeartbeat.count()).toBe(1);
+        expect(await secondsSinceBeat(new Date())).toBeLessThan(60);
+      },
+    );
+  });
+});

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -103,17 +103,29 @@ minimum are both there because the noisy versions of this alert were tried first
 
 ## Alert: scheduler tick stopped
 
-**Metric:** `scheduler.tick` absent for more than three intervals
+**Metric:** `scheduler_heartbeat.beatAt` older than three tick intervals.
 
 **What it means.** No worker is holding the leader lock and ticking. Scheduled campaigns
 are not starting and, more importantly, **scheduled reverts are not running** — every
 minute of this is a minute a sale runs past its end.
 
+**This is the only alert that catches a dead worker.** Every other condition in the window
+is computed from work the worker produces — webhook lag from processed deliveries, the
+error rate from a denominator of those same deliveries — so a process that stops outright
+empties all of them and they go *quiet* rather than fire. If this one is wrong, a dead
+worker is silent everywhere.
+
+It reads a row the tick stamps for no other purpose. It used to read the newest
+`campaign_runs.heartbeatAt`, which runs stamp while they execute — so it paged on any shop
+idle for three minutes and stayed silent when the scheduler died mid-run. If you are
+looking at an old incident, that is why.
+
 **Diagnose.**
 
-1. Is the worker process alive? A crash loop shows as repeated startup lines with no ticks between.
-2. Is Redis reachable? The leader lock lives there. Without it no worker will consider itself leader, and the process stays up while doing nothing — which is why this alert exists rather than a process-liveness one.
-3. `SELECT id, status, "startedAt", "heartbeatAt" FROM campaign_runs WHERE status NOT IN ('COMPLETED','FAILED','PARTIAL');` — runs stuck in EXECUTING with an old heartbeat confirm the worker died mid-run.
+1. `SELECT "beatAt", instance, now() - "beatAt" AS quiet FROM scheduler_heartbeat;` — one row. How long it has been quiet, and which process stamped it last.
+2. Is the worker process alive? A crash loop shows as repeated startup lines with no ticks between.
+3. Is Redis reachable? The leader lock lives there. Without it no worker will consider itself leader, and the process stays up while doing nothing — which is why this alert exists rather than a process-liveness one.
+4. `SELECT id, status, "startedAt", "heartbeatAt" FROM campaign_runs WHERE status NOT IN ('COMPLETED','FAILED','PARTIAL');` — runs stuck in EXECUTING with an old heartbeat confirm the worker died mid-run.
 
 **Remediate.** Restart the worker. The reaper reclaims stale runs on the next tick and
 marks them PARTIAL, which is resumable and visible to the merchant. Nothing needs manual

--- a/prisma/migrations/20260827160000_scheduler_heartbeat/migration.sql
+++ b/prisma/migrations/20260827160000_scheduler_heartbeat/migration.sql
@@ -1,0 +1,9 @@
+-- Expand-only: a new table nothing else references, so the previous release runs
+-- unchanged against this schema and a rollback needs no down migration.
+CREATE TABLE "scheduler_heartbeat" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "beatAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "instance" TEXT,
+
+    CONSTRAINT "scheduler_heartbeat_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -355,12 +355,12 @@ model Campaign {
   roundingProfile RoundingProfileRecord? @relation(fields: [roundingProfileId], references: [id])
   runs            CampaignRun[]
   driftEvents     DriftEvent[]
+  approvals       Approval[]
 
   @@index([shopId, status])
   @@index([shopId, startAt])
   @@index([shopId, endAt])
   @@map("campaigns")
-  approvals Approval[]
 }
 
 enum RunKind {
@@ -419,12 +419,12 @@ model CampaignRun {
   /// dead run hanging for just as long.
   heartbeatAt DateTime?
 
-  shop     Shop                  @relation(fields: [shopId], references: [id], onDelete: Cascade)
-  campaign Campaign              @relation(fields: [campaignId], references: [id], onDelete: Cascade)
-  changes    VariantChange[]
-  tagChanges TagChange[]
+  shop             Shop                  @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  campaign         Campaign              @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  changes          VariantChange[]
+  tagChanges       TagChange[]
   priceListChanges PriceListChange[]
-  bulkOps    BulkOperationRecord[]
+  bulkOps          BulkOperationRecord[]
 
   @@unique([campaignId, occurrenceKey, kind])
   @@index([shopId, status])
@@ -536,8 +536,8 @@ model TagChange {
   verifiedAt DateTime?
   createdAt  DateTime  @default(now())
 
-  shop     Shop        @relation(fields: [shopId], references: [id], onDelete: Cascade)
-  run      CampaignRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+  shop Shop        @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  run  CampaignRun @relation(fields: [runId], references: [id], onDelete: Cascade)
 
   /// One row per product per run: a resumed run must update its row rather than
   /// claim ownership of the same tags twice.
@@ -564,7 +564,7 @@ model PriceListChange {
   /// The merchant's percentage before this campaign, in basis points. Null means the
   /// list had no parent adjustment at all, which reverts differently from 0%: one
   /// removes the adjustment, the other pins it at zero.
-  priorAdjustmentBps Int?
+  priorAdjustmentBps   Int?
   /// What the campaign set it to: the campaign's percentage composed with the prior one.
   appliedAdjustmentBps Int
 
@@ -785,7 +785,7 @@ model PriceImport {
   createdBy String?
   createdAt DateTime @default(now())
 
-  shop Shop               @relation(fields: [shopId], references: [id], onDelete: Cascade)
+  shop Shop             @relation(fields: [shopId], references: [id], onDelete: Cascade)
   rows PriceImportRow[]
 
   @@index([shopId, createdAt])
@@ -965,11 +965,11 @@ model ErrorEvent {
   /// The short id shown on the error screen, e.g. ANC-K3M2-P7QR.
   errorId String @unique
 
-  shopId String?
-  code   String
+  shopId      String?
+  code        String
   /// The technical message. Never shown to a merchant.
-  message String
-  stack   String?
+  message     String
+  stack       String?
   /// What the merchant was shown, so support can see both halves of the story.
   userMessage String
 
@@ -1007,4 +1007,30 @@ model AuditLogEntry {
   @@index([shopId, createdAt])
   @@index([shopId, action])
   @@map("audit_log")
+}
+
+/// The scheduler's own liveness, which nothing else in the system can stand in for.
+///
+/// The alerting window used to read the newest `campaign_runs.heartbeatAt` and call it
+/// "seconds since tick". Those are stamped by campaign runs while they execute, so the
+/// signal was wrong in both directions: on an idle shop — the normal state — the newest
+/// one is hours old and the scheduler was reported stopped when it was fine, and a
+/// scheduler that died while a long run was still stamping looked alive.
+///
+/// A dead process cannot report its own death, so this is detected by absence: the tick
+/// stamps this row, and anything reading it decides. One row, in the database rather than
+/// in memory, so a restarted process does not reset the picture and the same question can
+/// be asked by hand during an incident.
+model SchedulerHeartbeat {
+  /// Always `singleton`. A primary key with one legal value keeps this to one row
+  /// without a partial unique index over a table that has no other key.
+  id String @id @default("singleton")
+
+  beatAt DateTime @default(now()) @updatedAt
+
+  /// Which process stamped it last. Only meaningful once more than one worker runs, and
+  /// then it is the first thing an operator wants to know.
+  instance String?
+
+  @@map("scheduler_heartbeat")
 }


### PR DESCRIPTION
`scheduler-stopped` read the newest `campaign_runs.heartbeatAt` and called it *"seconds since tick"*. Those rows are stamped by **campaign runs while they execute**, not by the tick — so the signal was wrong in both directions at once:

| situation | what happened | what should happen |
|---|---|---|
| idle shop, healthy scheduler | newest run heartbeat is hours old → **pages** | silence |
| scheduler dies mid-run, run still stamping | heartbeat looks fresh → **silent** | page |

A page that fires every quiet night gets muted, and a muted page is not an alert.

### Why this one mattered more than a single wrong alert

Every other condition in the window is computed from work the worker produces — webhook lag from processed deliveries, the error rate from a denominator of *those same deliveries*. A worker that stops outright empties all of them, so they go **quiet rather than fire**. This is the only alert that catches a dead worker, and it was wired to the wrong signal. Documented on the runbook page now, since it is the thing an operator most needs to know at 3am.

The module comment already described the fix as though it were true — *"the tick writes a heartbeat and an external check reads it"*. It was a description, not a fact.

### The change

New `scheduler_heartbeat` table, one row, upserted by the tick. In the database rather than in memory so a restart does not reset the picture and an operator can ask the same question by hand during an incident — matching the stated rule for every other signal in `gather()`.

Two details that are not incidental:

- **Stamped per due campaign as well as per tick.** `runTransition` can spend minutes on a large catalogue — the file says so a few lines above — so a heartbeat written only between ticks would go stale during exactly the work that proves the scheduler is alive, turning a busy scheduler into a stopped one. One upsert before a campaign run is nothing next to the run.
- **Null until it has beaten once**, so a fresh deployment does not page. Same "null is not zero" rule the other signals already follow.

Migration is expand-only — a new table nothing references — so the previous release runs unchanged against this schema and a rollback needs no down migration.

### Test

`chaos/scenarios/scheduler-heartbeat.chaos.ts`, against real Postgres, because the bug was in a query and a mocked Prisma would have agreed with whatever the query said. It walks the three states: never beaten (silent), beaten a second ago with a two-day-old campaign heartbeat sitting there (silent — the bug), and beat aged past the threshold with that same stale campaign heartbeat still present (fires).

Mutation-checked by restoring the campaign-run lookup:

```
AssertionError: expected [ 'scheduler-stopped' ] to not include 'scheduler-stopped'
```

That is the original bug, reproduced — a healthy idle scheduler reported as stopped.

`npm run typecheck` clean, `npm run lint` 0 errors, 1168 unit tests and 122 chaos tests pass.

Refs #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)