### PR TITLE
Send trigger counts as strings, because Flow has no integer type

### DIFF
--- a/app/lib/flow/manifest.test.ts
+++ b/app/lib/flow/manifest.test.ts
@@ -55,6 +55,10 @@ runtime_url = "https://example.test/flow/actions/end-campaign"
       handle: "end-campaign",
       type: "flow_action",
       fieldKeys: ["campaign-id", "reason"],
+      fields: [
+        { key: "campaign-id", type: "single_line_text_field" },
+        { key: "reason", type: "single_line_text_field" },
+      ],
     });
   });
 
@@ -88,6 +92,54 @@ describe("every action route reads the keys its manifest declares", () => {
 
     expect(read.length).toBeGreaterThan(0);
     expect(new Set(read)).toEqual(new Set(manifest.fieldKeys));
+  });
+});
+
+describe("every trigger field's declared type matches what the payload sends", () => {
+  /**
+   * The bug this exists to stop, found by firing a real trigger at Shopify:
+   *
+   *   Type error for field 'products reverted': 18 is not a String.
+   *
+   * Flow's trigger schema has no integer type — `number_integer` is rejected — so every
+   * field in these manifests is `single_line_text_field`. `TriggerPayload` typed the
+   * three counts as `number`, so Shopify refused the whole trigger, and `fireTrigger`
+   * swallows that deliberately: a campaign must not fail because an automation could not
+   * be told about it. All three triggers silently never fired.
+   *
+   * Nothing in the repo could catch it. The mismatch is between a TOML file and a
+   * TypeScript interface, and only Shopify validates the pair — which is the argument for
+   * asserting it here, statically, rather than hoping somebody runs a live trigger again.
+   */
+  const triggers = manifests().filter((manifest) => manifest.type === "flow_trigger");
+  const server = readFileSync(join(process.cwd(), "app", "services", "flow.server.ts"), "utf8");
+  const payload = server.slice(
+    server.indexOf("export interface TriggerPayload"),
+    server.indexOf("export function containsPrice"),
+  );
+
+  it("declares every trigger field as text, because Flow has no integer type", () => {
+    const declared = triggers.flatMap((trigger) => trigger.fields);
+    expect(declared.length).toBeGreaterThan(0);
+    for (const field of declared) {
+      expect(field.type, `${field.key} is ${field.type}`).toBe("single_line_text_field");
+    }
+  });
+
+  it.each(triggers)("$handle sends a string for every field", (manifest) => {
+    for (const field of manifest.fields) {
+      // The declared TS type for this key, whatever it is.
+      const declaration = new RegExp(`"?${field.key}"?\\??:\\s*([^;]+);`).exec(payload);
+      expect(declaration, `${field.key} is not on TriggerPayload`).not.toBeNull();
+
+      const tsType = declaration![1].trim();
+      // A union of string literals is still a string on the wire; a number is not.
+      expect(
+        /^(string|"(?:[^"]*")(?:\s*\|\s*"[^"]*")*)$/.test(tsType),
+        `${manifest.handle}.${field.key} is declared ${field.type} but typed ${tsType} — ` +
+          `Shopify will refuse the trigger and fireTrigger will swallow the refusal`,
+      ).toBe(true);
+    }
   });
 });
 

--- a/app/lib/flow/manifest.ts
+++ b/app/lib/flow/manifest.ts
@@ -14,12 +14,20 @@
  * for the extension's.
  */
 
+export interface FlowField {
+  key: string;
+  /** The declared field type, e.g. `single_line_text_field`. */
+  type: string;
+}
+
 export interface FlowManifest {
   /** `handle` — also the route filename and the last segment of `runtime_url`. */
   handle: string;
   /** `flow_action` or `flow_trigger`. */
   type: string;
-  /** Every `key` under `[[settings.fields]]`, in declaration order. */
+  /** Every field under `[[settings.fields]]`, in declaration order. */
+  fields: FlowField[];
+  /** Just the keys, for the callers that only care about those. */
   fieldKeys: string[];
 }
 
@@ -30,7 +38,8 @@ export function parseFlowManifest(toml: string): FlowManifest {
   let section = "";
   let handle = "";
   let type = "";
-  const fieldKeys: string[] = [];
+  const fields: FlowField[] = [];
+  let pendingType = "";
 
   for (const raw of toml.split("\n")) {
     const line = raw.trim();
@@ -51,10 +60,16 @@ export function parseFlowManifest(toml: string): FlowManifest {
     if (section === "extensions") {
       if (key === "handle") handle = value;
       if (key === "type") type = value;
-    } else if (section === "settings.fields" && key === "key") {
-      fieldKeys.push(value);
+    } else if (section === "settings.fields") {
+      // A field's own `type` precedes its `key` in the generated scaffold, so the type is
+      // stashed and claimed by the next key rather than looked up afterwards.
+      if (key === "type") pendingType = value;
+      if (key === "key") {
+        fields.push({ key: value, type: pendingType });
+        pendingType = "";
+      }
     }
   }
 
-  return { handle, type, fieldKeys };
+  return { handle, type, fields, fieldKeys: fields.map((field) => field.key) };
 }

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -978,7 +978,7 @@ async function fireCampaignTrigger(
         "campaign id": campaignId,
         "campaign name": campaignName,
         outcome: result.clean ? "clean" : "partial",
-        "products reverted": result.verified,
+        "products reverted": String(result.verified),
       });
       return;
     }
@@ -986,7 +986,7 @@ async function fireCampaignTrigger(
     await fireTriggerForShop(shopId, "campaign-started", {
       "campaign id": campaignId,
       "campaign name": campaignName,
-      "products affected": outcome.counts.planned,
+      "products affected": String(outcome.counts.planned),
     });
   } catch (error) {
     const { logger } = await import("../../lib/logging/logger");

--- a/app/services/flow.server.ts
+++ b/app/services/flow.server.ts
@@ -50,9 +50,24 @@ export interface TriggerPayload {
    */
   "campaign id": string;
   "campaign name": string;
-  "products affected"?: number;
-  "products reverted"?: number;
-  "products drifted"?: number;
+  /**
+   * Counts are strings, and that is not a style choice.
+   *
+   * Every field in the trigger manifests is `single_line_text_field`, because Flow's
+   * trigger schema has no integer type — `number_integer` is rejected outright. Sending
+   * a number against a text field makes Shopify refuse the whole trigger:
+   *
+   *   Type error for field 'products reverted': 18 is not a String.
+   *
+   * `fireTrigger` swallows that by design — a campaign must not fail because an
+   * automation could not be told about it — so all three triggers silently never fired
+   * and every workflow downstream of them was dead. Nothing in the repo could see it:
+   * the mismatch is between a TOML file and a TypeScript type, and only Shopify
+   * validates the pair.
+   */
+  "products affected"?: string;
+  "products reverted"?: string;
+  "products drifted"?: string;
   outcome?: "clean" | "partial" | "failed";
 }
 

--- a/app/services/flow.test.ts
+++ b/app/services/flow.test.ts
@@ -16,8 +16,23 @@ describe("refusing to send a price", () => {
       containsPrice({
         "campaign id": "c1",
         "campaign name": "Summer sale",
-        "products affected": 412,
+        "products affected": "412",
         outcome: "clean",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not mistake a count for a price now that counts are strings", () => {
+    // Counts travel as strings because Flow trigger fields are all text. A bare integer
+    // string is not money-shaped — the detector wants two decimal places — so widening
+    // these to strings did not quietly start blocking every trigger it was meant to send.
+    expect(
+      containsPrice({
+        "campaign id": "c1",
+        "campaign name": "Summer sale",
+        "products affected": "412",
+        "products reverted": "0",
+        "products drifted": "1299",
       }),
     ).toBe(false);
   });
@@ -54,8 +69,8 @@ describe("refusing to send a price", () => {
     expect(
       containsPrice({
         "campaign id": "gid://shopify/Campaign/12345",
-        "products affected": 412,
-        "products reverted": 0,
+        "products affected": "412",
+        "products reverted": "0",
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
Found by doing the thing #177 asks for — applying and reverting a real campaign on a real store. Shopify answered:

```
WARN  Flow rejected a trigger handle=campaign-ended error=Errors validating schema:
  Type error for field 'products reverted': 18 is not a String.
```

Every field in the three trigger manifests is `single_line_text_field` — Flow's trigger schema has no integer type and rejects `number_integer` outright — while `TriggerPayload` typed the three counts as `number`. Shopify refused the **whole** trigger.

And `fireTrigger` swallows a refusal on purpose:

> *A trigger is a notification about work that has already happened, and failing a campaign because an automation could not be told about it would be the tail wagging the dog.*

That is the right call, and it is also why this survived: **all three triggers silently never fired**, so every merchant workflow downstream of campaign started, ended, or held was dead, and nothing anywhere said so.

### Why no test caught it

The mismatch is between a TOML file and a TypeScript interface. Only Shopify validates the pair. #297's test already pinned the field *keys* — this pins the *types*, statically, so the next person does not need to run a live trigger to find out.

The assertion allows `string` and unions of string literals (`outcome` is `"clean" | "partial" | "failed"`, which is a string on the wire) and rejects anything else.

### Counts as strings do not trip the price detector

`containsPrice` refuses any payload that looks like money, and widening these fields to strings could have started blocking the very triggers it exists to send. It wants two decimal places and a bare integer string has none — now asserted rather than assumed, including `"1299"`.

### Verified live, same operation before and after

| | |
|---|---|
| before | 18-row revert → `Flow rejected a trigger … 18 is not a String` |
| after | identical 18-row revert → no rejection, Shopify accepts it |

Prices restored exactly to baseline both times (62995, 78595, 60000 minor units), 18/18 verified, `run.verified_clean_rate=1`.

### Mutation-checked

- restore `"products reverted"?: number` → *"campaign-ended.products reverted is declared single_line_text_field but typed number — Shopify will refuse the trigger and fireTrigger will swallow the refusal"*
- declare one manifest field `number_integer` → *"campaign id is number_integer: expected 'number_integer' to be 'single_line_text_field'"*

`npm run typecheck` clean, `npm run lint` 0 errors, 1173 unit tests pass.

Refs #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)