### PR TITLE
Alert when one shop is failing inside a healthy platform

### DIFF
--- a/app/lib/observability/alerts.test.ts
+++ b/app/lib/observability/alerts.test.ts
@@ -28,6 +28,7 @@ const quiet: SignalWindow = {
   divergenceRate: 0,
   executionQueueDepth: 0,
   unpriceableVariants: 0,
+  shopRates: null,
 };
 
 const ids = (window: Partial<SignalWindow>) =>
@@ -76,6 +77,7 @@ describe("what a missing signal means", () => {
         divergenceRate: null,
         executionQueueDepth: null,
         unpriceableVariants: null,
+        shopRates: null,
       }),
     ).toEqual([]);
   });
@@ -122,6 +124,7 @@ describe("every alert is actionable", () => {
       divergenceRate: 0.5,
       executionQueueDepth: 5_000,
       unpriceableVariants: 400,
+      shopRates: [{ shopId: "shop-1", errors: 40, requests: 100 }],
     });
 
     expect(all.length).toBeGreaterThan(0);
@@ -138,6 +141,67 @@ describe("every alert is actionable", () => {
     for (const entry of NOT_ALERTS) {
       expect(entry.because.length).toBeGreaterThan(20);
     }
+  });
+});
+
+describe("one shop failing while the rest are fine", () => {
+  const quiet = {
+    secondsSinceTick: 10,
+    webhookLagMs: 1_000,
+    errors: 0,
+    requests: 500,
+    divergenceRate: 0,
+    executionQueueDepth: 0,
+    unpriceableVariants: 0,
+  };
+
+  const ids = (window: Parameters<typeof evaluate>[0]) => evaluate(window).map((a) => a.id);
+
+  it("fires when one shop is failing inside a healthy global rate", () => {
+    // The incident the global rate cannot see. 30 failures out of 60 for this shop is
+    // total failure for that merchant, and 30 out of 5,000 platform-wide is 0.6% — well
+    // under the global floor, so `error-spike` stays silent and should.
+    const window = {
+      ...quiet,
+      errors: 30,
+      requests: 5_000,
+      shopRates: [{ shopId: "unlucky", errors: 30, requests: 60 }],
+    };
+
+    expect(ids(window)).toContain("shop-error-spike");
+    expect(ids(window)).not.toContain("error-spike");
+  });
+
+  it("ignores a shop too quiet for its rate to mean anything", () => {
+    // Three deliveries and one failure is 33%, and says nothing at all.
+    expect(
+      ids({ ...quiet, shopRates: [{ shopId: "quiet", errors: 1, requests: 3 }] }),
+    ).not.toContain("shop-error-spike");
+  });
+
+  it("does not fire for a shop with errors below the rate", () => {
+    expect(
+      ids({ ...quiet, shopRates: [{ shopId: "busy", errors: 1, requests: 100 }] }),
+    ).not.toContain("shop-error-spike");
+  });
+
+  it("says nothing when nobody has looked", () => {
+    expect(ids({ ...quiet, shopRates: null })).not.toContain("shop-error-spike");
+  });
+
+  it("fires once for the worst shop rather than once per shop", () => {
+    // Three shops failing is one incident to a human, and three pages is three chances to
+    // mute the channel.
+    const fired = evaluate({
+      ...quiet,
+      shopRates: [
+        { shopId: "a", errors: 30, requests: 60 },
+        { shopId: "b", errors: 50, requests: 60 },
+        { shopId: "c", errors: 40, requests: 60 },
+      ],
+    }).filter((a) => a.id === "shop-error-spike");
+
+    expect(fired).toHaveLength(1);
   });
 });
 
@@ -182,12 +246,13 @@ describe("every alert leads somewhere", () => {
     divergenceRate: 0.5,
     executionQueueDepth: 5_000,
     unpriceableVariants: 400,
+    shopRates: [{ shopId: "shop-1", errors: 40, requests: 100 }],
   });
 
   it("fires every condition, so this file cannot silently stop covering one", () => {
     // If a condition is added and this number is not, the assertions below stop being
     // exhaustive without failing — which is the same rot they exist to prevent.
-    expect(all.length).toBe(6);
+    expect(all.length).toBe(7);
   });
 
   for (const alert of all) {

--- a/app/lib/observability/alerts.ts
+++ b/app/lib/observability/alerts.ts
@@ -46,6 +46,22 @@ export interface SignalWindow {
    * check cannot see it.
    */
   unpriceableVariants: number | null;
+  /**
+   * Errors and requests broken down by shop, or null when nobody has looked.
+   *
+   * The global rate above cannot see the incident this is for. One shop whose every
+   * campaign is failing — a revoked token, a poisoned catalogue, one market misconfigured
+   * — is a handful of errors against everybody else's traffic, so it stays under the
+   * global floor and nothing fires while that merchant's prices are stuck. RFC §11 asked
+   * for per-shop spikes for exactly this reason.
+   */
+  shopRates: ShopRate[] | null;
+}
+
+export interface ShopRate {
+  shopId: string;
+  errors: number;
+  requests: number;
 }
 
 /** How long the scheduler may go quiet before it is presumed stopped. */
@@ -56,6 +72,16 @@ export const WEBHOOK_LAG_MS = 5 * 60_000;
 
 /** Errors as a fraction of requests. Above this is a spike, not background noise. */
 export const ERROR_RATE = 0.05;
+
+/**
+ * Requests a single shop must have produced before its rate means anything.
+ *
+ * Higher than the global minimum of twenty, and deliberately so: a per-shop denominator
+ * is small by construction, and a quiet shop with three deliveries and one failure is a
+ * 33% error rate that says nothing. This is the number that decides whether the alert is
+ * useful or is the reason somebody mutes the channel.
+ */
+export const SHOP_SAMPLE_MINIMUM = 25;
 
 /**
  * Variants the audit could not make priceable. The healthy value is zero.
@@ -133,6 +159,27 @@ export function evaluate(window: SignalWindow): AlertCondition[] {
         "More than one request in twenty is failing. Whatever it is, it is affecting " +
         "merchants right now rather than one unlucky one.",
       runbook: "docs/runbooks.md#alert-errors-spiking",
+    });
+  }
+
+  // Per shop, and separate from the global rate rather than replacing it. The two catch
+  // different incidents: the global one is the platform failing everybody a little, this
+  // one is one merchant failing completely while the average stays healthy.
+  const worst = (window.shopRates ?? [])
+    .filter((shop) => shop.requests >= SHOP_SAMPLE_MINIMUM)
+    .filter((shop) => shop.errors / shop.requests > ERROR_RATE)
+    .sort((a, b) => b.errors / b.requests - a.errors / a.requests)[0];
+
+  if (worst) {
+    firing.push({
+      id: "shop-error-spike",
+      severity: "page",
+      title: "One shop is failing while the rest are fine",
+      because:
+        "More than one request in twenty is failing for a single shop, which the global " +
+        "error rate cannot see. That merchant's prices are the ones stuck, and they are " +
+        "stuck for a reason particular to them rather than to the platform.",
+      runbook: "docs/runbooks.md#alert-one-shop-is-failing",
     });
   }
 

--- a/app/services/alerting.server.ts
+++ b/app/services/alerting.server.ts
@@ -40,7 +40,8 @@ const lastSent = new Map<string, number>();
 export async function gather(now: Date = new Date()): Promise<SignalWindow> {
   const since = new Date(now.getTime() - WINDOW_MINUTES * 60_000);
 
-  const [sinceTick, errors, webhooks, lastAudit] = await Promise.all([
+  const [sinceTick, errors, webhooks, delivered, lastAudit, errorsByShop, deliveriesByShop] =
+    await Promise.all([
     // The scheduler's own heartbeat, not a campaign run's.
     //
     // This used to read the newest `campaign_runs.heartbeatAt`, which is stamped by runs
@@ -50,15 +51,39 @@ export async function gather(now: Date = new Date()): Promise<SignalWindow> {
     // stamping looked alive, which is the one case the alert exists for.
     secondsSinceBeat(now),
     prisma.errorEvent.count({ where: { createdAt: { gte: since } } }),
+    // Sampled, and only ever used for the worst lag. The cap is why the count below is a
+    // separate query rather than this array's length.
     prisma.webhookEvent.findMany({
       where: { receivedAt: { gte: since }, processedAt: { not: null } },
       select: { receivedAt: true, processedAt: true },
       take: 500,
     }),
+    // The real denominator.
+    //
+    // This used to be `webhooks.length`, which is capped at 500 — while `errors` above is
+    // an uncapped count. Past five hundred deliveries in a window the denominator stops
+    // growing and the numerator does not, so the error rate climbs with traffic and the
+    // alert fires because the platform is *busy*. A rate whose two halves are measured
+    // differently is not a rate.
+    prisma.webhookEvent.count({
+      where: { receivedAt: { gte: since }, processedAt: { not: null } },
+    }),
     prisma.auditLogEntry.findFirst({
       where: { action: "mirror.audited" },
       orderBy: { createdAt: "desc" },
       select: { after: true },
+    }),
+    // Counted rather than listed. The global pair above samples 500 deliveries because it
+    // only needs the worst lag; a rate needs the whole denominator or it is not a rate.
+    prisma.errorEvent.groupBy({
+      by: ["shopId"],
+      where: { createdAt: { gte: since }, shopId: { not: null } },
+      _count: { _all: true },
+    }),
+    prisma.webhookEvent.groupBy({
+      by: ["shopId"],
+      where: { receivedAt: { gte: since }, processedAt: { not: null }, shopId: { not: null } },
+      _count: { _all: true },
     }),
   ]);
 
@@ -69,6 +94,10 @@ export async function gather(now: Date = new Date()): Promise<SignalWindow> {
         ),
       )
     : null;
+
+  const deliveries = new Map(
+    deliveriesByShop.map((group) => [group.shopId!, group._count._all] as const),
+  );
 
   const audit = (lastAudit?.after ?? null) as
     | { rate?: number; unpriceable?: number }
@@ -83,13 +112,21 @@ export async function gather(now: Date = new Date()): Promise<SignalWindow> {
     // Webhook deliveries stand in for request volume: it is the traffic that arrives
     // whether or not a merchant has the app open, so it does not fall to zero overnight
     // and turn every error into a spike.
-    requests: webhooks.length,
+    requests: delivered,
     divergenceRate: typeof audit?.rate === "number" ? audit.rate : null,
     // Null until an audit has run, for the same reason as the tick: "we have not looked"
     // and "we looked and found none" are different statements, and only one of them is
     // worth staying asleep over.
     unpriceableVariants: typeof audit?.unpriceable === "number" ? audit.unpriceable : null,
     executionQueueDepth: null,
+    // Only shops that produced errors can be spiking, so the error groups drive the list
+    // and the delivery counts supply each denominator. A shop with deliveries and no
+    // errors is healthy and does not need a row.
+    shopRates: errorsByShop.map((group) => ({
+      shopId: group.shopId!,
+      errors: group._count._all,
+      requests: deliveries.get(group.shopId!) ?? 0,
+    })),
   };
 }
 

--- a/chaos/scenarios/shop-error-spike.chaos.ts
+++ b/chaos/scenarios/shop-error-spike.chaos.ts
@@ -1,0 +1,132 @@
+/**
+ * One shop failing while the platform looks healthy.
+ *
+ * `evaluate` is pure and unit-tested, so the part that can still be wrong is the query
+ * that feeds it — which is exactly where the scheduler-heartbeat bug lived. A per-shop
+ * rate needs two groupings that agree with each other: errors keyed by shop, and
+ * deliveries keyed by shop, in the same window. Get the denominator from the wrong place
+ * and the alert either never fires or fires constantly, and a unit test with a
+ * hand-written window would agree with either.
+ *
+ * So this runs against real Postgres and writes real rows.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { gather } from "../../app/services/alerting.server";
+import { evaluate, SHOP_SAMPLE_MINIMUM } from "../../app/lib/observability/alerts";
+import { withChaos } from "../harness/scenario";
+
+async function deliveries(shopId: string, shopDomain: string, count: number, at: Date) {
+  for (let i = 0; i < count; i++) {
+    await prisma.webhookEvent.create({
+      data: {
+        webhookId: `spike-${shopId}-${i}-${at.getTime()}`,
+        shopId,
+        shopDomain,
+        topic: "products/update",
+        payload: {},
+        status: "PROCESSED",
+        receivedAt: at,
+        processedAt: at,
+      },
+    });
+  }
+}
+
+async function failures(shopId: string, count: number, at: Date) {
+  for (let i = 0; i < count; i++) {
+    await prisma.errorEvent.create({
+      data: {
+        errorId: `ANC-SPIKE-${shopId}-${i}-${at.getTime()}`,
+        shopId,
+        code: "SHOPIFY_REJECTED",
+        message: "Shopify refused the write",
+        userMessage: "Shopify would not accept this price. Check the market's minimum.",
+      },
+    });
+  }
+}
+
+/** Comfortably over `SHOP_SAMPLE_MINIMUM`, so this shop's own rate is meaningful. */
+const FAILING_SHOP_DELIVERIES = 35;
+/** 30/35 is catastrophic for this shop; 30/635 is a quiet afternoon for the platform. */
+const FAILING_SHOP_ERRORS = 30;
+/** Enough to push the platform's true delivery count well past the 500-row lag sample. */
+const BUSY_SHOP_DELIVERIES = 600;
+
+describe("chaos: one shop failing inside a healthy platform", () => {
+  it("fires per-shop without firing the global rate", async () => {
+    await withChaos(
+      "shop-error-spike",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        // If somebody raises the minimum past these numbers the scenario stops testing
+        // what it claims to, silently — the shop would be below the sample floor and the
+        // alert would correctly not fire, which looks like a pass.
+        expect(FAILING_SHOP_DELIVERIES).toBeGreaterThan(SHOP_SAMPLE_MINIMUM);
+
+        const now = new Date();
+
+        // Rows from earlier runs of this scenario live in the same database and land in
+        // the same fifteen-minute window, so without this the global error count climbs
+        // by 25 every run until the platform-is-healthy assertion below fails for a
+        // reason that has nothing to do with the code.
+        await prisma.errorEvent.deleteMany({ where: { errorId: { startsWith: "ANC-SPIKE-" } } });
+        await prisma.webhookEvent.deleteMany({ where: { webhookId: { startsWith: "spike-" } } });
+        const shop = await prisma.shop.findUniqueOrThrow({
+          where: { id: chaos.fixture.shopId },
+          select: { id: true, domain: true },
+        });
+
+        // A second, much busier shop with nothing wrong with it. It exists so the global
+        // denominator and this shop's differ — without it the two are identical and the
+        // test cannot tell a per-shop rate from a global one. Mutation testing caught
+        // exactly that: swapping the denominator for the global count passed happily.
+        const other = await prisma.shop.create({
+          data: { domain: `busy-${Date.now()}.myshopify.com` },
+          select: { id: true, domain: true },
+        });
+        await deliveries(other.id, other.domain, BUSY_SHOP_DELIVERIES, now);
+
+        // The failing shop is quiet by comparison: enough traffic for its rate to count,
+        // nowhere near enough to move the platform's.
+        //
+        // The numbers are chosen so the two denominators disagree about whether the
+        // *global* alert should fire. 30 failures against the true 635 deliveries is
+        // 4.7% and stays quiet; against the capped 500-row sample it is 6% and pages.
+        // Anything nearer the threshold passes under both and proves nothing.
+        await deliveries(shop.id, shop.domain, FAILING_SHOP_DELIVERIES, now);
+
+        const healthy = await gather(now);
+        expect(evaluate(healthy).map((a) => a.id)).not.toContain("shop-error-spike");
+
+        // Now this one shop starts failing. Its own rate is catastrophic; the global rate
+        // is still nowhere near the 5% floor, which is the whole point of the alert.
+        await failures(shop.id, FAILING_SHOP_ERRORS, now);
+
+        const window = await gather(now);
+        const mine = window.shopRates?.find((rate) => rate.shopId === shop.id);
+
+        expect(mine, "the shop is missing from shopRates entirely").toBeDefined();
+        expect(mine!.errors).toBe(FAILING_SHOP_ERRORS);
+        // Exactly this shop's deliveries, not the platform's. The busy shop above has 600
+        // of its own, so any denominator drawn from the global pool fails here.
+        expect(
+          mine!.requests,
+          "the denominator did not come from this shop's own deliveries",
+        ).toBe(FAILING_SHOP_DELIVERIES);
+
+        expect(evaluate(window).map((a) => a.id)).toContain("shop-error-spike");
+        expect(
+          evaluate(window).map((a) => a.id),
+          "the platform is healthy, so the global rate must stay quiet",
+        ).not.toContain("error-spike");
+
+        await prisma.errorEvent.deleteMany({ where: { errorId: { startsWith: "ANC-SPIKE-" } } });
+        await prisma.webhookEvent.deleteMany({ where: { webhookId: { startsWith: "spike-" } } });
+      },
+    );
+  });
+});

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -191,6 +191,35 @@ surface row. Six code paths write both, and the invariant only holds because eac
 does; the fix is in whichever one stopped, not in healing harder. `git log -S
 "priceSurfaceEntry" -- app/services` is the fastest way to see which one changed.
 
+## Alert: one shop is failing
+
+**Metric:** `error_events` over processed webhook deliveries, **per shop**, in the last
+fifteen minutes — above 5% and only once that shop has produced at least 25 deliveries.
+
+**What it means.** One merchant is failing while the platform is fine. The global *errors
+spiking* alert cannot see this: a single shop's failures are a handful against everybody
+else's traffic, so the average stays healthy and nothing fires while that merchant's
+prices sit wrong.
+
+**Diagnose.** The shop id is the whole lead — start there, not in the aggregate.
+
+1. `SELECT code, count(*) FROM error_events WHERE "shopId" = $1 AND "createdAt" > now() - interval '1 hour' GROUP BY 1 ORDER BY 2 DESC;` — a single dominant code is the usual shape here, and it is usually one of the three below.
+2. `NO_SESSION` or `UNAUTHENTICATED` — the token is gone. The merchant uninstalled and reinstalled, or revoked access. `SELECT shop, "isOnline", expires FROM "Session" WHERE shop = $1;` confirms it. Nothing is retryable until they reinstall.
+3. `SHOPIFY_REJECTED` concentrated on one shop is their data, not ours: a price below a market's minimum, a variant Shopify will not accept a price for. The ledger row carries the reason Shopify gave.
+4. `SHOPIFY_THROTTLED` on one shop alone means we are competing with something else on that shop's budget — another app, or two of our own runs. Check for overlapping runs before assuming Shopify.
+
+**Remediate.** Depends entirely on the code, which is why step 1 comes first. A token
+problem needs the merchant, and the app already tells them so — confirm the message they
+are seeing says *reinstall* rather than something generic. Data rejections are per-row and
+already ledgered; the run reports them and the merchant can act. Only throttling is ours
+to fix, and the fix is fewer concurrent runs on that shop, never more.
+
+**Do not** treat this as a platform incident until at least a second shop appears. One
+shop failing alone is almost never the platform, and the global alert is the one that
+would say so.
+
+---
+
 ## Alert: queue depth rising
 
 **Metric:** `queue.depth`, per queue


### PR DESCRIPTION
RFC §11 asks for **per-shop error spikes**. Only the global rate was implemented, and it cannot see the incident this is for.

One shop whose every campaign is failing — a revoked token, a poisoned catalogue, one market misconfigured — is a handful of errors against everybody else's traffic. The average stays healthy, nothing fires, and that merchant's prices sit wrong. `error_events.shopId` was already populated; nothing read it.

- Fires **once for the worst shop**, not once per shop. Three shops failing is one incident to a human, and three pages is three chances to mute the channel.
- Per-shop sample floor of **25**, higher than the global 20, because a per-shop denominator is small by construction and a quiet shop with three deliveries and one failure is a 33% error rate that says nothing.
- Its own runbook page, which leads with the shop id and the three codes that actually show up here (`NO_SESSION`, `SHOPIFY_REJECTED`, `SHOPIFY_THROTTLED`) — and says not to treat it as a platform incident until a second shop appears.

### Writing the test found a bug in the *existing* global alert

`errors` is an uncapped `count()`. `requests` was `webhooks.length` — an array capped at `take: 500`, because that query exists to find the worst lag, not to count anything.

Past five hundred deliveries in a window the denominator stops growing and the numerator does not. **The global error rate therefore climbs with traffic and pages because the platform is busy.** The denominator is now its own count. A rate whose two halves are measured differently is not a rate.

### Mutation testing earned its keep twice

The first chaos scenario had one shop — so the global and per-shop denominators were *identical*, and swapping one for the other passed happily. It now runs a second, busier shop.

Then the numbers had to be chosen so the two denominators actually disagree about the global alert: 30 failures against the true 635 deliveries is 4.7% and quiet; against the capped 500 it is 6% and pages. Anything nearer the threshold passes under both and proves nothing.

| mutation | result |
|---|---|
| per-shop denominator from the global pool | *"the denominator did not come from this shop's own deliveries: expected 630 to be 30"* |
| global denominator back to the capped sample | *"the platform is healthy, so the global rate must stay quiet"* |
| drop the per-shop sample floor | *"ignores a shop too quiet for its rate to mean anything"* |
| fire once per shop instead of once | *"fires once for the worst shop rather than once per shop"* |
| point it at another alert's runbook | *"two alerts share one runbook page"* (caught by #298's bijection) |

The scenario also cleans its own rows: they land in the same fifteen-minute window on every run, so without it the global error count climbed by 25 each time until the assertion failed for a reason unrelated to the code.

`npm run typecheck` clean, `npm run lint` 0 errors, 1192 unit and 123 chaos tests pass.

Refs #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)