### PR TITLE
Emit the two metrics the runbooks were already sending people to

### DIFF
--- a/app/lib/observability/metrics-contract.test.ts
+++ b/app/lib/observability/metrics-contract.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Metrics that are declared, metrics that are emitted, and metrics a runbook promises.
+ *
+ * Three lists that have to agree and had no reason to. `budget.saturation` and
+ * `webhook.lag_ms` were both declared in the registry and named in runbook pages, and
+ * neither was ever emitted — so an operator following a page at 3am went looking for a
+ * graph that did not exist. One of the two was named by a runbook page written earlier
+ * the same day, which is how quickly this drifts.
+ *
+ * A dead declaration is the quieter half: it costs nothing at runtime and makes the
+ * dashboard look complete when it is not.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+/** Every `metric("name", …)` call in the app. */
+function emitted(): Set<string> {
+  const names = new Set<string>();
+
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(join(ROOT, dir), { withFileTypes: true })) {
+      const path = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!/\.(ts|tsx)$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) continue;
+
+      const source = readFileSync(join(ROOT, path), "utf8");
+      for (const [, name] of source.matchAll(/\bmetric\(\s*"([a-z0-9_.]+)"/g)) names.add(name);
+    }
+  };
+
+  walk("app");
+  return names;
+}
+
+/** The registry in `otel.server.ts`, which decides each metric's instrument type. */
+function declared(): Set<string> {
+  const source = readFileSync(join(ROOT, "app/lib/observability/otel.server.ts"), "utf8");
+  const table = source.slice(source.indexOf("{"), source.indexOf("};") + 1);
+  return new Set([...table.matchAll(/"([a-z0-9_]+\.[a-z0-9_]+)":\s*"(counter|gauge|histogram)"/g)].map(
+    ([, name]) => name,
+  ));
+}
+
+/** Metric names a runbook page tells somebody to go and look at. */
+function promised(): Set<string> {
+  const runbook = readFileSync(join(ROOT, "docs/runbooks.md"), "utf8");
+  return new Set(
+    [...runbook.matchAll(/`([a-z0-9_]+\.[a-z0-9_]+)`/g)]
+      .map(([, name]) => name)
+      // Table and column names also arrive in backticks and are not metrics.
+      .filter((name) => !/^(scheduler_heartbeat|variant_changes|error_events|webhook_events)\./.test(name)),
+  );
+}
+
+describe("the three lists of metric names agree", () => {
+  const isEmitted = emitted();
+  const isDeclared = declared();
+  const isPromised = promised();
+
+  it("found all three, so the checks below are not vacuous", () => {
+    expect(isEmitted.size).toBeGreaterThan(5);
+    expect(isDeclared.size).toBeGreaterThan(5);
+    expect(isPromised.size).toBeGreaterThan(2);
+  });
+
+  it.each([...isDeclared])("%s is emitted somewhere", (name) => {
+    expect(
+      isEmitted.has(name),
+      `${name} is declared in the otel registry and never emitted, so the dashboard has ` +
+        `a panel that will always be empty`,
+    ).toBe(true);
+  });
+
+  it.each([...isPromised])("%s is emitted, because a runbook sends somebody to it", (name) => {
+    expect(
+      isEmitted.has(name),
+      `a runbook page names ${name}, but nothing emits it — whoever follows that page ` +
+        `during an incident will go looking for a graph that does not exist`,
+    ).toBe(true);
+  });
+
+  it("declares every metric it emits, so the instrument type is never guessed", () => {
+    for (const name of isEmitted) {
+      expect(isDeclared, `${name} is emitted but not in the registry`).toContain(name);
+    }
+  });
+});

--- a/app/services/alerting.server.ts
+++ b/app/services/alerting.server.ts
@@ -19,6 +19,7 @@
 
 import prisma from "../db.server";
 import { logger } from "../lib/logging/logger";
+import { metric } from "../lib/telemetry/metrics";
 import { evaluate, type AlertCondition, type SignalWindow } from "../lib/observability/alerts";
 import { secondsSinceBeat } from "./scheduler-heartbeat.server";
 
@@ -149,6 +150,12 @@ export async function checkAlerts(
   try {
     const window = await gather(now);
     if (options.queueDepth !== undefined) window.executionQueueDepth = options.queueDepth;
+
+    // Reported whether or not it crosses the alert threshold. An SLO panel needs the
+    // ordinary values to have any idea what abnormal looks like, and this one was named
+    // in the runbook before anything emitted it — so an operator following the page went
+    // looking for a graph that did not exist.
+    if (window.webhookLagMs !== null) metric("webhook.lag_ms", window.webhookLagMs);
 
     const fired = evaluate(window);
     let sent = 0;

--- a/app/services/campaigns/execute.server.ts
+++ b/app/services/campaigns/execute.server.ts
@@ -25,6 +25,7 @@ import { readBackVerdict } from "../../lib/execution/read-back";
 import type { PlannedRow } from "../../lib/planning/types";
 import { selectWritePath } from "../../lib/planning/write-path";
 import { RateLimitBudget } from "../../lib/shopify/budget";
+import { metric } from "../../lib/telemetry/metrics";
 
 export interface ExecuteOutcome {
   rows: ExecutedRow[];
@@ -37,6 +38,15 @@ export interface ExecuteOutcome {
 
 export interface ExecuteContext {
   client: AdminClient;
+  /**
+   * Whose rate-limit budget this run is spending.
+   *
+   * Carried only so `budget.saturation` can be reported per shop, which is the only way
+   * the number means anything: saturation is a property of one merchant's bucket, and an
+   * average across shops would hide the one that is exhausted behind the ones that are
+   * idle. RFC §11 lists it as an SLO panel for that reason.
+   */
+  shopId: string;
   productOf: (variantGid: string) => string;
   verifySampleRate?: number;
   /** Overrides the automatic choice. Only used by tests and diagnostics. */
@@ -73,13 +83,28 @@ export async function executeRows(
   const path = context.forcePath ?? decision.path;
 
   if (path === "sync") {
+    const budget = new RateLimitBudget();
     const result = await executeSync(rows, {
       client: context.client,
-      budget: new RateLimitBudget(),
+      budget,
       productOf: context.productOf,
       verifySampleRate: context.verifySampleRate ?? 1,
       onProgress: context.onProgress,
     });
+
+    // Reported after the run rather than during it: the interesting number is how much
+    // of the merchant's bucket this campaign left behind, and sampling mid-run would
+    // mostly record the sleep the budget manager had just finished taking.
+    //
+    // Only the sync path. The bulk path spends no rate-limit budget at all, so reporting
+    // a saturation for it would draw a flat line that means "we did not look" while
+    // reading as "nothing was used".
+    const usable = budget.usableMaximum();
+    if (usable > 0) {
+      const saturation = Math.min(1, Math.max(0, 1 - budget.available() / usable));
+      metric("budget.saturation", saturation, { shop: context.shopId });
+    }
+
     return { ...result, path: "sync" };
   }
 

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -332,6 +332,7 @@ export async function runCampaign(
 
   const result = await executeRows(writable, {
     client,
+    shopId,
     productOf: (gid) => products.get(gid) ?? gid,
     verifySampleRate: options.verifySampleRate ?? 1,
     forcePath: options.forcePath,


### PR DESCRIPTION
`budget.saturation` and `webhook.lag_ms` were both **declared** in the otel registry and **named in runbook pages** — and neither was ever emitted.

Whoever followed either page during an incident would have gone looking for a graph that does not exist. One of the two was named by a runbook page written earlier the same day (#298), which is how quickly this drifts.

Both are SLO panels RFC §11 asks for, so the fix is to emit them, not to stop promising them.

### `webhook.lag_ms`

Already computed for the alert. Now reported every tick whether or not it crosses the threshold — a panel needs the ordinary values to give the abnormal ones any meaning.

### `budget.saturation`

Per shop, which is the only way the number means anything: saturation is a property of one merchant's bucket, and an average across shops hides the exhausted one behind the idle ones. That needed `shopId` on `ExecuteContext`.

Two deliberate choices:

- **After the run, not during it.** Mid-run sampling would mostly record the sleep the budget manager had just finished taking.
- **Sync path only.** The bulk path spends no rate-limit budget at all — the runbook says so — and a saturation for it would draw a flat line that reads as "nothing was used" when it means "we did not look".

### The test

Three lists that have to agree and had no reason to: **declared** in the registry, **emitted** by `metric(...)`, and **promised** by a runbook page. Checked in both directions, so a dead declaration fails as loudly as a broken promise — a dead declaration is the quieter half, since it costs nothing at runtime and makes the dashboard look complete when it is not.

Mutation-checked by removing each emit, which reproduces the exact state before this commit:

```
a runbook page names webhook.lag_ms, but nothing emits it — whoever follows that page
during an incident will go looking for a graph that does not exist
```

`npm run typecheck` clean, `npm run lint` 0 errors, 1212 unit and 123 chaos tests pass.

Refs #45, #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)