### PR TITLE
Check practice mode, guardrails and rounding against the real Shopify API

### DIFF
--- a/scripts/test-pricing-rules.ts
+++ b/scripts/test-pricing-rules.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env tsx
+/**
+ * Practice mode, guardrails and rounding, against the real Shopify API.
+ *
+ * All three are covered by unit tests and by chaos scenarios, and both of those talk to a
+ * fake. The fake is written from the same understanding as the code, so it agrees with
+ * the code about anything the code has wrong — which is how a trigger that Shopify
+ * refuses outright passed every test in the repo.
+ *
+ * So each check here reads the price back out of Shopify rather than out of the mirror or
+ * the ledger, and asserts on that. What the merchant's storefront says is the only
+ * authority that matters.
+ *
+ *   npx tsx scripts/test-pricing-rules.ts --shop <domain>
+ */
+
+import prisma from "../app/db.server";
+import { chooseShop, shopArg } from "../app/lib/seed/target-shop";
+import { adminClientForShop } from "../app/services/admin-client.server";
+import { createCampaign } from "../app/services/campaigns/model.server";
+import { runCampaign } from "../app/services/campaigns/run.server";
+import { captureBaselines } from "../app/services/baselines.server";
+
+const TAG = "anchor-pricing-rules-test";
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = actual === expected;
+  if (!ok) failures++;
+  console.log(`   ${ok ? "PASS" : "FAIL"}  ${label}: ${actual}${ok ? "" : ` (expected ${expected})`}`);
+}
+
+type Client = NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>;
+
+/** The price Shopify itself reports. Never the mirror — that is the thing under test. */
+async function livePrice(client: Client, variantGid: string): Promise<string> {
+  const result = await client.request<{ productVariant: { price: string } }>(
+    `query Price($id: ID!) { productVariant(id: $id) { price } }`,
+    { id: variantGid },
+  );
+  return result.data?.productVariant?.price ?? "";
+}
+
+async function createProbe(client: Client, price: string) {
+  const result = await client.request<{
+    productSet: { product: { id: string; variants: { nodes: Array<{ id: string }> } } };
+  }>(
+    `mutation Create($input: ProductSetInput!) {
+       productSet(synchronous: true, input: $input) {
+         product { id variants(first: 1) { nodes { id } } }
+         userErrors { message }
+       }
+     }`,
+    {
+      input: {
+        title: `Pricing rules probe ${Date.now()}`,
+        status: "ACTIVE",
+        tags: [TAG],
+        productOptions: [{ name: "Size", values: [{ name: "M" }] }],
+        variants: [{ optionValues: [{ optionName: "Size", name: "M" }], price }],
+      },
+    },
+  );
+
+  const product = result.data?.productSet?.product;
+  if (!product) throw new Error("could not create the probe product");
+  return { productGid: product.id, variantGid: product.variants.nodes[0]!.id };
+}
+
+async function waitForMirror(shopId: string, variantGid: string) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    const row = await prisma.variantIndex.findUnique({
+      where: { shopId_variantGid: { shopId, variantGid } },
+    });
+    if (row) return row;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error("the products/create webhook never mirrored the probe");
+}
+
+async function main() {
+  const installed = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { domain: true },
+  });
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { domain: chooseShop(installed, shopArg(process.argv.slice(2))).domain },
+  });
+
+  const client = await adminClientForShop(shop.domain);
+  if (!client) throw new Error("No usable session");
+
+  const probe = await createProbe(client, "200.00");
+  console.log(`shop: ${shop.domain}\nprobe: ${probe.variantGid} at 200.00\n`);
+  await waitForMirror(shop.id, probe.variantGid);
+  await captureBaselines(shop.id, {
+    variantGids: [probe.variantGid],
+    source: "INSTALL_CAPTURE",
+  });
+
+  const scoped = { groups: [{ conditions: [{ field: "tag" as const, value: TAG }] }] };
+  const created: string[] = [];
+
+  // ------------------------------------------------- 1. practice mode writes nothing
+  console.log("1. a practice campaign writes nothing");
+  const practice = await createCampaign(shop.id, {
+    name: `Practice ${Date.now()}`,
+    priority: 900,
+    rule: { kind: "percent-change", percent: -50 },
+    compareAtPolicy: { kind: "leave" },
+    rounding: { default: "none", byCurrency: {} },
+    ast: scoped,
+    schedule: { kind: "manual", practice: true },
+  } as never);
+  created.push(practice.id);
+
+  let refused = false;
+  try {
+    await runCampaign(shop.id, practice.id, client, {});
+  } catch {
+    // Refused in `runCampaign` itself rather than only in the UI, which is the point.
+    refused = true;
+  }
+  check("applying a practice campaign is refused", refused, true);
+  check("the live price is untouched", await livePrice(client, probe.variantGid), "200.00");
+
+  // ------------------------------------------------- 2. a floor clamps the price
+  console.log("2. a guardrail floor clamps rather than pricing through it");
+  const floored = await createCampaign(shop.id, {
+    name: `Floored ${Date.now()}`,
+    priority: 910,
+    // -50% would be 100.00; the floor is above that and must win.
+    rule: { kind: "percent-change", percent: -50 },
+    compareAtPolicy: { kind: "leave" },
+    rounding: { default: "none", byCurrency: {} },
+    // `Money.amount` is a number of minor units, not a bigint. Writing 15000n here
+    // compared bigint against number in the read-back, failed a row whose price was
+    // exactly right, and left the campaign PARTIAL — worth the comment, because the
+    // `as never` below is what let it past the compiler.
+    guardrails: { minPrice: { amount: 15000, currency: "USD" } },
+    ast: scoped,
+    schedule: { kind: "manual" },
+  } as never);
+  created.push(floored.id);
+
+  await runCampaign(shop.id, floored.id, client, {});
+  check("Shopify holds the floor, not the computed price", await livePrice(client, probe.variantGid), "150.00");
+  await runCampaign(shop.id, floored.id, client, { revert: true });
+  check("reverted to the baseline", await livePrice(client, probe.variantGid), "200.00");
+
+  // ------------------------------------------------- 3. charm rounding
+  console.log("3. charm rounding reaches the storefront");
+  const charmed = await createCampaign(shop.id, {
+    name: `Charmed ${Date.now()}`,
+    priority: 920,
+    // -13% of 200.00 is 174.00, which only ends .99 if rounding actually applied.
+    rule: { kind: "percent-change", percent: -13 },
+    compareAtPolicy: { kind: "leave" },
+    rounding: { default: "charm99", byCurrency: {} },
+    ast: scoped,
+    schedule: { kind: "manual" },
+  } as never);
+  created.push(charmed.id);
+
+  await runCampaign(shop.id, charmed.id, client, {});
+  const charmedPrice = await livePrice(client, probe.variantGid);
+  check("the live price ends .99", charmedPrice.endsWith(".99"), true);
+  console.log(`   live price: ${charmedPrice}`);
+  await runCampaign(shop.id, charmed.id, client, { revert: true });
+  check("reverted to the baseline", await livePrice(client, probe.variantGid), "200.00");
+
+  // ------------------------------------------------------------------- clean up
+  for (const id of created) {
+    await prisma.campaign.delete({ where: { id } }).catch(() => {});
+  }
+  await client.request(
+    `mutation Delete($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
+    { input: { id: probe.productGid } },
+  );
+  console.log("\ncleaned up");
+
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exitCode = failures === 0 ? 0 : 1;
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
All three are already covered by unit tests and chaos scenarios — and both of those talk to a fake. The fake is written from the same understanding as the code, so **it agrees with the code about anything the code has wrong.** That is exactly how a Flow trigger Shopify refuses outright passed every test in the repo (#302).

So each check here reads the price back out of **Shopify**, not out of the mirror or the ledger. What the storefront says is the only authority that matters.

| behaviour | assertion | result |
|---|---|---|
| practice mode | applying is refused inside `runCampaign`, not only in the UI, and the live price is untouched | 200.00, unchanged |
| guardrails | a floor of 150.00 against a rule computing 100.00 — Shopify must hold the floor | 150.00, then 200.00 after revert |
| rounding | `charm99` on −13% of 200.00, which is 174.00 and only ends .99 if rounding applied | **173.99** |

Follows the repo convention for live scripts: a probe product it creates and deletes, `--shop` required via `chooseShop` (so it satisfies the contract test from #303), and it reverts everything it applies.

### It found something

Writing it turned up a reproducible problem in the revert path, filed as **#308**: a campaign whose apply failed read-back reverts to `COMPLETED` with zero rows written, leaving the sale price live on the storefront. Not fixed here — it is in core execution and deserves a careful read rather than a guess.

One thing worth recording about the process: the first run of this script reported a guardrail bug that was not real. `Money.amount` is a number of minor units and I wrote `15000n`, so the read-back compared bigint against number and failed a row whose price was exactly right. The `as never` on the campaign input is what let it past the compiler; the corrected line now carries a comment saying so.

`npm run typecheck` clean, `npm run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)