### PR TITLE
Drift holds the campaign that priced the variant, not whichever is running

### DIFF
--- a/app/services/drift.server.ts
+++ b/app/services/drift.server.ts
@@ -112,13 +112,36 @@ export async function checkForDrift(
 
   if (await isOurEcho(shopId, variantGid, incomingPrice, incomingCompareAt)) return false;
 
-  // Only meaningful while a campaign controls this variant.
-  const activeCampaign = await prisma.campaign.findFirst({
-    where: { shopId, status: "ACTIVE" },
-    orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
-    select: { id: true, name: true },
+  // The campaign that controls *this variant*, which is the one that last priced it and
+  // is still running.
+  //
+  // This used to take any ACTIVE campaign on the shop, highest priority first, with no
+  // reference to the variant at all — while the doc above claimed the opposite. So a
+  // merchant editing one product by hand stopped whichever unrelated campaign happened to
+  // be running, and the drift event named a variant that campaign had never priced. On a
+  // store running several campaigns at once, which is what this product is for, the
+  // highest-priority one absorbed every hand edit in the catalogue.
+  //
+  // The ledger answers it exactly: a VERIFIED base-surface row is us having written this
+  // variant, and its run carries the campaign. Newest first, because a variant repriced by
+  // a later campaign is controlled by that one.
+  const controlling = await prisma.variantChange.findFirst({
+    where: {
+      shopId,
+      variantGid,
+      surfaceKind: "BASE",
+      status: "VERIFIED",
+      run: { campaign: { status: "ACTIVE" } },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { run: { select: { campaignId: true, campaign: { select: { name: true } } } } },
   });
-  if (!activeCampaign) return false;
+  if (!controlling) return false;
+
+  const activeCampaign = {
+    id: controlling.run.campaignId,
+    name: controlling.run.campaign.name,
+  };
 
   // Collapse repeats: one open event per variant, updated rather than duplicated.
   const existing = await prisma.driftEvent.findFirst({

--- a/chaos/scenarios/drift-scope.chaos.ts
+++ b/chaos/scenarios/drift-scope.chaos.ts
@@ -1,0 +1,154 @@
+/**
+ * Drift holds the campaign that controls the variant, and no other.
+ *
+ * `checkForDrift` documents itself as narrow: "it means the price changed *while a
+ * campaign controls the variant*. Outside a campaign a price change is just the merchant
+ * running their store, and flagging that would make the queue useless noise."
+ *
+ * The implementation did not do that. It took any ACTIVE campaign on the shop, ordered by
+ * priority, and never looked at the variant — so a merchant editing one product by hand
+ * stopped whichever unrelated campaign happened to be running, and the drift event named
+ * a variant that campaign had never priced. On a store running several campaigns at once,
+ * which is the whole premise of this product, the highest-priority campaign absorbed every
+ * hand edit in the catalogue.
+ *
+ * Found on a real store: a campaign was left HELD with no drift event to explain it,
+ * because the campaign the event belonged to had been deleted and taken the event with it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { checkForDrift } from "../../app/services/drift.server";
+import { withChaos } from "../harness/scenario";
+
+/** A VERIFIED ledger row is the record of us having priced this variant. */
+async function recordPriced(
+  shopId: string,
+  campaignId: string,
+  variantGid: string,
+  price: bigint,
+) {
+  const run = await prisma.campaignRun.create({
+    data: {
+      shopId,
+      campaignId,
+      kind: "APPLY",
+      status: "COMPLETED",
+      occurrenceKey: `drift-scope-${campaignId}-${variantGid}`,
+    },
+  });
+
+  await prisma.variantChange.create({
+    data: {
+      runId: run.id,
+      shopId,
+      variantGid,
+      surfaceKind: "BASE",
+      priceListGid: "",
+      currency: "USD",
+      beforePrice: price + 1000n,
+      intendedPrice: price,
+      status: "VERIFIED",
+    },
+  });
+}
+
+describe("chaos: drift holds only the campaign that priced the variant", () => {
+  it("leaves an unrelated campaign alone when another product is edited by hand", async () => {
+    await withChaos(
+      "drift-scope",
+      { catalog: { products: 4, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const shopId = chaos.fixture.shopId;
+        const [ours, theirs] = chaos.fixture.variantGids;
+        expect(theirs, "the fixture needs at least two variants").toBeDefined();
+
+        // The campaign under test controls `ours` and nothing else. It is deliberately
+        // the *lower* priority of the two, because the old query sorted by priority and
+        // would have picked the other one.
+        const mine = await prisma.campaign.update({
+          where: { id: chaos.fixture.campaignId },
+          data: { status: "ACTIVE", priority: 100 },
+          select: { id: true },
+        });
+        await recordPriced(shopId, mine.id, ours!, 5000n);
+
+        // A second, higher-priority campaign that has priced nothing at all.
+        const bystander = await prisma.campaign.create({
+          data: {
+            shopId,
+            name: "Bystander",
+            status: "ACTIVE",
+            priority: 999,
+            ruleRows: [] as never,
+            surfaces: { base: true, priceLists: [] } as never,
+            compareAtPolicy: { kind: "leave" } as never,
+            compareAtViolationPolicy: "clear",
+            guardrails: {} as never,
+            guardrailViolationPolicy: "clamp",
+            schedule: { kind: "manual" } as never,
+          },
+          select: { id: true },
+        });
+
+        // Both variants need a surface entry, which is what "the price we last saw" means.
+        for (const gid of [ours!, theirs!]) {
+          await prisma.priceSurfaceEntry.upsert({
+            where: {
+              shopId_variantGid_surfaceKind_priceListGid: {
+                shopId,
+                variantGid: gid,
+                surfaceKind: "BASE",
+                priceListGid: "",
+              },
+            },
+            create: {
+              shopId,
+              variantGid: gid,
+              surfaceKind: "BASE",
+              priceListGid: "",
+              livePrice: 5000n,
+              currency: "USD",
+            },
+            update: { livePrice: 5000n },
+          });
+        }
+
+        // The merchant edits a variant NOTHING has priced.
+        const flaggedOther = await checkForDrift(shopId, theirs!, 4200n, null);
+
+        expect(flaggedOther, "an unpriced variant is the merchant running their store").toBe(
+          false,
+        );
+        expect(
+          (await prisma.campaign.findUniqueOrThrow({ where: { id: bystander.id } })).status,
+          "the bystander priced nothing and must not be held",
+        ).toBe("ACTIVE");
+        expect(
+          (await prisma.campaign.findUniqueOrThrow({ where: { id: mine.id } })).status,
+          "this campaign does not cover that variant either",
+        ).toBe("ACTIVE");
+
+        // Now the merchant edits the variant this campaign actually priced.
+        const flaggedOurs = await checkForDrift(shopId, ours!, 4200n, null);
+
+        expect(flaggedOurs, "a variant under a campaign's control is real drift").toBe(true);
+        expect(
+          (await prisma.campaign.findUniqueOrThrow({ where: { id: mine.id } })).status,
+          "the campaign that priced it is the one that stops",
+        ).toBe("HELD");
+        expect(
+          (await prisma.campaign.findUniqueOrThrow({ where: { id: bystander.id } })).status,
+          "the higher-priority bystander is still not involved",
+        ).toBe("ACTIVE");
+
+        const event = await prisma.driftEvent.findFirstOrThrow({
+          where: { shopId, variantGid: ours! },
+          select: { campaignId: true },
+        });
+        expect(event.campaignId, "the event names the campaign that priced it").toBe(mine.id);
+      },
+    );
+  });
+});


### PR DESCRIPTION
`checkForDrift` documents itself as narrow:

> *"Drift is deliberately narrow: it means the price changed **while a campaign controls the variant**. Outside a campaign a price change is just the merchant running their store, and flagging that would make the queue useless noise."*

The implementation did the opposite:

```ts
// Only meaningful while a campaign controls this variant.
const activeCampaign = await prisma.campaign.findFirst({
  where: { shopId, status: "ACTIVE" },
  orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
});
```

Any ACTIVE campaign on the shop, highest priority first, **with no reference to the variant at all.**

### What that does to a merchant

- Editing one product by hand stops whichever unrelated campaign happens to be running.
- The drift event names a variant that campaign never priced — a merchant-visible message about the wrong object, which is precisely what the error convention exists to prevent.
- On a store running several campaigns at once — the premise of this product — the highest-priority campaign absorbs every hand edit in the catalogue.
- And it produces exactly the noise the doc says it avoids: a variant no campaign covers is the merchant running their store, and it was flagged whenever anything else was live.

### The fix

The ledger already answers the question exactly: a `VERIFIED` base-surface `variant_changes` row is us having written that variant, and its run carries the campaign. Newest first, so a variant repriced by a later campaign is controlled by that one.

### How it surfaced

Not from reading the code. On a real dev store a campaign sat `HELD` with **zero drift events** to explain it. The event had belonged to a different campaign and was deleted along with it — leaving a stopped campaign and no reason. That is the shape of the bug: the hold and the explanation were attached to different campaigns.

### Test

`chaos/scenarios/drift-scope.chaos.ts`, real Postgres, two ACTIVE campaigns. The one under test is deliberately the **lower** priority, because the old query sorted by priority and would have picked the other. It asserts:

- editing a variant nothing has priced flags nothing and holds neither campaign
- editing the variant this campaign priced holds **that** campaign
- the higher-priority bystander stays ACTIVE throughout
- the drift event names the campaign that priced it

Mutation-checked by restoring the original query:

```
an unpriced variant is the merchant running their store: expected true to be false
```

`npm run typecheck` clean, `npm run lint` 0 errors, 1405 unit and 124 chaos tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)