### PR TITLE
A failed row leaves the mirror saying unknown, not saying the old price

### DIFF
--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -858,7 +858,37 @@ async function recordResults(
  */
 async function refreshMirror(shopId: string, rows: ExecutedRows): Promise<void> {
   for (const executed of rows) {
-    if (executed.status === "failed" || !executed.row.intendedPrice) continue;
+    if (!executed.row.intendedPrice) continue;
+
+    // A failed row leaves the mirror saying "unknown", not saying the old price.
+    //
+    // Read-back failed, so we genuinely do not know what is live: the write may have
+    // landed and been misreported, or not landed at all. Skipping the update left the
+    // mirror asserting the *pre-run* price, which is a definite claim and a wrong one —
+    // and the planner believes it. `isNoop` then compares a revert's target against that
+    // stale value, finds them equal, drops the row, and the revert writes nothing while
+    // reporting clean. A storefront stays on sale and the campaign says it is over.
+    //
+    // Null is the honest answer and the one the planner handles correctly: `isNoop`
+    // never treats an absent live price as already-correct, so the row is written. Drift
+    // detection already reads null as "we have not looked" and stays quiet, and the
+    // nightly audit heals it from Shopify.
+    if (executed.status === "failed") {
+      await prisma.priceSurfaceEntry.updateMany({
+        where: {
+          shopId,
+          variantGid: executed.row.ref.variantGid,
+          surfaceKind: "BASE",
+          priceListGid: "",
+        },
+        data: { livePrice: null, liveCompareAt: null, syncedAt: new Date() },
+      });
+      await prisma.variantIndex.updateMany({
+        where: { shopId, variantGid: executed.row.ref.variantGid },
+        data: { price: null, compareAt: null, syncedAt: new Date() },
+      });
+      continue;
+    }
 
     await prisma.priceSurfaceEntry.updateMany({
       where: {

--- a/chaos/scenarios/revert-after-failed-row.chaos.ts
+++ b/chaos/scenarios/revert-after-failed-row.chaos.ts
@@ -1,0 +1,139 @@
+/**
+ * A revert must not be defeated by a mirror that says the wrong thing.
+ *
+ * Observed on a real store: a campaign applied, one row failed read-back, and the revert
+ * that followed reported `clean: true` with `verified: 0`, wrote nothing, and moved the
+ * campaign to COMPLETED — while the storefront kept the sale price. The campaign said it
+ * was over and the merchant was still discounted, which is the failure this product
+ * exists to prevent.
+ *
+ * The chain:
+ *
+ *   `refreshMirror` skipped failed rows, so the mirror kept the *pre-run* price. That
+ *   reads like caution — do not record what you could not verify — but the effect is the
+ *   opposite: the mirror goes on making a definite claim, and the claim is wrong.
+ *
+ *   `planRun` believes it. `isNoop` compares the revert's target against that stale live
+ *   price, finds them equal, and drops the row before it is ever written.
+ *
+ * So the revert had nothing to do. Null is the honest value, and `isNoop` already refuses
+ * to treat an absent live price as already-correct.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { planRun } from "../../app/lib/planning/plan";
+import { withChaos } from "../harness/scenario";
+
+describe("chaos: reverting after a row failed read-back", () => {
+  it("still plans a write for the row whose live price is unknown", async () => {
+    await withChaos(
+      "revert-after-failed-row",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const shopId = chaos.fixture.shopId;
+        const variantGid = chaos.fixture.variantGids[0]!;
+        const baseline = chaos.fixture.baseline.get(variantGid)!;
+
+        // The state a failed row used to leave behind: the mirror still asserting the
+        // price from before the run, while Shopify holds the sale price.
+        await prisma.priceSurfaceEntry.updateMany({
+          where: { shopId, variantGid, surfaceKind: "BASE", priceListGid: "" },
+          data: { livePrice: BigInt(baseline) },
+        });
+
+        const stale = await plannedFor(shopId, variantGid, baseline);
+        expect(
+          stale,
+          "a mirror asserting the pre-run price makes the revert look like a no-op",
+        ).toBe(false);
+
+        // What the fix records instead: we do not know what is live.
+        await prisma.priceSurfaceEntry.updateMany({
+          where: { shopId, variantGid, surfaceKind: "BASE", priceListGid: "" },
+          data: { livePrice: null },
+        });
+
+        const unknown = await plannedFor(shopId, variantGid, baseline);
+        expect(
+          unknown,
+          "an unknown live price must be written, not assumed already correct",
+        ).toBe(true);
+      },
+    );
+  });
+
+  it("leaves the mirror saying unknown after a real read-back failure", async () => {
+    await withChaos(
+      "revert-after-failed-row-live",
+      { catalog: { products: 3, variantsPerProduct: 1 }, percent: -20 },
+      async (chaos) => {
+        const shopId = chaos.fixture.shopId;
+        const variantGid = chaos.fixture.variantGids[0]!;
+
+        const before = await prisma.priceSurfaceEntry.findFirstOrThrow({
+          where: { shopId, variantGid, surfaceKind: "BASE", priceListGid: "" },
+          select: { livePrice: true },
+        });
+        expect(before.livePrice, "the fixture starts with a known live price").not.toBeNull();
+
+        // Shopify stores something other than what we asked for, on this variant only.
+        // That is a read-back failure for real rather than a hand-written ledger row.
+        chaos.fake.distortStoredPrice = (requested, gid) =>
+          gid === variantGid ? String(Number(requested) + 1) : requested;
+
+        // The harness's own apply, so this goes through the real run path.
+        const outcome = await chaos.apply();
+        expect(outcome.clean, "a distorted row must not report clean").toBe(false);
+
+        const row = await prisma.variantChange.findFirstOrThrow({
+          where: { shopId, variantGid, surfaceKind: "BASE" },
+          orderBy: { createdAt: "desc" },
+          select: { status: true },
+        });
+        expect(row.status, "the distorted row is the one that failed").toBe("FAILED");
+
+        const after = await prisma.priceSurfaceEntry.findFirstOrThrow({
+          where: { shopId, variantGid, surfaceKind: "BASE", priceListGid: "" },
+          select: { livePrice: true },
+        });
+        expect(
+          after.livePrice,
+          "read-back failed, so the mirror must say unknown rather than the old price",
+        ).toBeNull();
+
+        const index = await prisma.variantIndex.findFirstOrThrow({
+          where: { shopId, variantGid },
+          select: { price: true },
+        });
+        expect(index.price, "both copies of the live price say unknown").toBeNull();
+      },
+    );
+  });
+});
+
+/**
+ * Whether a revert — resolving with no campaign at all — would write this variant.
+ *
+ * Reverting is `resolve(without C)`, and with a single campaign that leaves nothing, so
+ * the target is the baseline. Passing no campaigns models exactly that.
+ */
+async function plannedFor(
+  shopId: string,
+  variantGid: string,
+  baseline: number,
+): Promise<boolean> {
+  const { loadCandidates } = await import("../../app/services/campaigns/candidates.server");
+  const candidates = await loadCandidates(shopId, { groups: [] }, [variantGid], []);
+
+  const outcome = planRun({ campaigns: [], candidates, storeGuardrails: {} });
+  if (outcome.kind !== "ok") throw new Error(`planning was ${outcome.kind}`);
+
+  const row = outcome.rows.find((r) => r.ref.variantGid === variantGid);
+  // A row that is absent was dropped as a no-op; a skipped one was declined for a reason.
+  if (!row || row.status === "skipped") return false;
+
+  expect(row.intendedPrice?.amount, "a revert targets the baseline").toBe(baseline);
+  return true;
+}


### PR DESCRIPTION
Closes #308, and the root cause is not where I expected when I filed it.

Observed on a real store: a campaign applied, one row failed read-back, and the revert that followed reported `clean: true` with `verified: 0`, wrote nothing, and moved the campaign to **COMPLETED** — while the storefront kept the sale price. The campaign said it was over and the merchant was still discounted. That is the failure this product exists to prevent.

### The chain

Every link looks careful, which is why it took a while to see.

```ts
// refreshMirror
if (executed.status === "failed" || !executed.row.intendedPrice) continue;
```

Skipping a failed row reads as caution — *do not record what you could not verify*. The effect is the opposite: the mirror goes on making a **definite claim**, the pre-run price, and that claim is now wrong. Shopify may well hold the sale price; we simply did not confirm it.

```ts
// isNoop
if (!candidate.livePrice) return false;
if (!equals(resolution.price, candidate.livePrice)) return false;
```

`planRun` believes the mirror. The revert's target is the baseline, the stale mirror also says the baseline, so the row is a no-op and is **dropped before anything is written**.

The revert then had nothing to do, and reported that honestly.

### The fix

Null is the honest value, and the rest of the system already handles it:

- `isNoop` never treats an absent live price as already-correct → the row is written
- drift detection reads `livePrice === null` as "we have not looked" → no false drift
- the nightly mirror audit heals it from Shopify

Both copies of the live price are set, for the reason `refreshMirror`'s own comment gives about the audit comparing against `variant_index`.

### Tests

Two scenarios, because the bug spans two components:

1. over `planRun` — a mirror asserting the pre-run price makes the revert a no-op; an unknown one makes it a write
2. end to end — `distortStoredPrice` makes the fake store something other than what was asked, so a row fails read-back through the **real** run path, and the test asserts what the mirror is left holding

Mutation-checked by restoring the skip:

```
read-back failed, so the mirror must say unknown rather than the old price: expected 9700n to be null
```

`npm run typecheck` clean, `npm run lint` 0 errors, 1405 unit and 126 chaos tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)