### PR TITLE
Check overlapping campaigns against the real Shopify API

### DIFF
--- a/app/types/admin.types.d.ts
+++ b/app/types/admin.types.d.ts
@@ -10671,8 +10671,22 @@ export type CollectionDuplicateUserError = DisplayableError & {
 
 /** Possible error codes that can be returned by `CollectionDuplicateUserError`. */
 export enum CollectionDuplicateUserErrorCode {
+  /** The collection title must not be blank. */
+  Blank = 'BLANK',
   /** The collection was not found. Please check the collection ID and try again. */
-  CollectionNotFound = 'COLLECTION_NOT_FOUND'
+  CollectionNotFound = 'COLLECTION_NOT_FOUND',
+  /** The duplicated collection isn't valid. */
+  Invalid = 'INVALID',
+  /** The URL handle generated from the new title is already in use. Please choose a different title. */
+  Taken = 'TAKEN',
+  /** The collection title or URL handle is too long. */
+  TooLong = 'TOO_LONG',
+  /** The shop has reached its limit of collection sources with conditions. */
+  TooManyConditionBackedSources = 'TOO_MANY_CONDITION_BACKED_SOURCES',
+  /** The shop has reached its limit of collections with sub-collection exclusions. */
+  TooManySubCollectionExclusionCollections = 'TOO_MANY_SUB_COLLECTION_EXCLUSION_COLLECTIONS',
+  /** The shop has reached its limit of collections with sub-collection inclusions. */
+  TooManySubCollectionInclusionCollections = 'TOO_MANY_SUB_COLLECTION_INCLUSION_COLLECTIONS'
 }
 
 /** An auto-generated type which holds one Collection and a cursor during pagination. */
@@ -61154,7 +61168,9 @@ export type QueryRoot = {
   /**
    * Returns a paginated list of [`Metaobject`](https://shopify.dev/docs/api/admin-graphql/latest/objects/Metaobject) entries for a specific type. Metaobjects are custom data structures that extend Shopify's data model with merchant or app-specific data types.
    *
-   * Filter results using the query parameter with a search syntax for metaobject fields. Use `fields.{key}:{value}` to filter by field values, supporting any field previously marked as filterable. The `sortKey` parameter accepts `id`, `type`, `updated_at`, or `display_name` to control result ordering.
+   * Filter results using the query parameter with a search syntax for metaobject fields. Use `fields.{key}:{value}` to filter by field values, supporting any field previously marked as filterable.
+   *
+   * Results are ordered by metaobject ID in ascending order by default. The `sortKey` parameter accepts `id`, `type`, `updated_at`, or `display_name` to control result ordering. Pass `reverse: true` to invert the order.
    *
    * Learn more about [querying metaobjects by field value](https://shopify.dev/docs/apps/build/custom-data/metafields/query-by-metafield-value).
    */

--- a/scripts/test-pricing-rules.ts
+++ b/scripts/test-pricing-rules.ts
@@ -35,7 +35,7 @@ type Client = NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>;
 /** The price Shopify itself reports. Never the mirror — that is the thing under test. */
 async function livePrice(client: Client, variantGid: string): Promise<string> {
   const result = await client.request<{ productVariant: { price: string } }>(
-    `query Price($id: ID!) { productVariant(id: $id) { price } }`,
+    `query PricingRulesPrice($id: ID!) { productVariant(id: $id) { price } }`,
     { id: variantGid },
   );
   return result.data?.productVariant?.price ?? "";
@@ -45,7 +45,7 @@ async function createProbe(client: Client, price: string) {
   const result = await client.request<{
     productSet: { product: { id: string; variants: { nodes: Array<{ id: string }> } } };
   }>(
-    `mutation Create($input: ProductSetInput!) {
+    `mutation PricingRulesCreate($input: ProductSetInput!) {
        productSet(synchronous: true, input: $input) {
          product { id variants(first: 1) { nodes { id } } }
          userErrors { message }
@@ -175,7 +175,7 @@ async function main() {
     await prisma.campaign.delete({ where: { id } }).catch(() => {});
   }
   await client.request(
-    `mutation Delete($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
+    `mutation PricingRulesDelete($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
     { input: { id: probe.productGid } },
   );
   console.log("\ncleaned up");

--- a/scripts/test-resolution.ts
+++ b/scripts/test-resolution.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+/**
+ * Overlapping campaigns, against the real Shopify API.
+ *
+ * This is the product's central claim, and the one the help centre states plainly: "one
+ * winner per product, never stacked", and "reverting recomputes rather than restoring
+ * saved numbers — if another campaign still covers a variant, that campaign's price stays
+ * in place".
+ *
+ * Both are property-tested against the resolver and exercised in chaos scenarios, and
+ * both of those talk to a fake. So this asserts them against the price Shopify itself
+ * reports, which is the only place a merchant's customer ever looks.
+ *
+ * The discounts are deliberately chosen so no two possible answers collide: -10% and -40%
+ * of 200.00 are 180.00 and 120.00, and a stacked result would be 108.00 — three distinct
+ * numbers, so the assertion cannot pass by coincidence.
+ *
+ *   npx tsx scripts/test-resolution.ts --shop <domain>
+ */
+
+import prisma from "../app/db.server";
+import { chooseShop, shopArg } from "../app/lib/seed/target-shop";
+import { adminClientForShop } from "../app/services/admin-client.server";
+import { createCampaign } from "../app/services/campaigns/model.server";
+import { runCampaign } from "../app/services/campaigns/run.server";
+import { captureBaselines } from "../app/services/baselines.server";
+
+const TAG = "anchor-resolution-test";
+let failures = 0;
+
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = actual === expected;
+  if (!ok) failures++;
+  console.log(`   ${ok ? "PASS" : "FAIL"}  ${label}: ${actual}${ok ? "" : ` (expected ${expected})`}`);
+}
+
+type Client = NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>;
+
+async function livePrice(client: Client, variantGid: string): Promise<string> {
+  const result = await client.request<{ productVariant: { price: string } }>(
+    `query Price($id: ID!) { productVariant(id: $id) { price } }`,
+    { id: variantGid },
+  );
+  return result.data?.productVariant?.price ?? "";
+}
+
+async function createProbe(client: Client, price: string) {
+  const result = await client.request<{
+    productSet: { product: { id: string; variants: { nodes: Array<{ id: string }> } } };
+  }>(
+    `mutation Create($input: ProductSetInput!) {
+       productSet(synchronous: true, input: $input) {
+         product { id variants(first: 1) { nodes { id } } }
+         userErrors { message }
+       }
+     }`,
+    {
+      input: {
+        title: `Resolution probe ${Date.now()}`,
+        status: "ACTIVE",
+        tags: [TAG],
+        productOptions: [{ name: "Size", values: [{ name: "M" }] }],
+        variants: [{ optionValues: [{ optionName: "Size", name: "M" }], price }],
+      },
+    },
+  );
+
+  const product = result.data?.productSet?.product;
+  if (!product) throw new Error("could not create the probe product");
+  return { productGid: product.id, variantGid: product.variants.nodes[0]!.id };
+}
+
+async function main() {
+  const installed = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { domain: true },
+  });
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { domain: chooseShop(installed, shopArg(process.argv.slice(2))).domain },
+  });
+
+  const client = await adminClientForShop(shop.domain);
+  if (!client) throw new Error("No usable session");
+
+  const probe = await createProbe(client, "200.00");
+  console.log(`shop: ${shop.domain}\nprobe: ${probe.variantGid} at 200.00\n`);
+
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    const row = await prisma.variantIndex.findUnique({
+      where: { shopId_variantGid: { shopId: shop.id, variantGid: probe.variantGid } },
+    });
+    if (row) break;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  await captureBaselines(shop.id, {
+    variantGids: [probe.variantGid],
+    source: "INSTALL_CAPTURE",
+  });
+
+  const scoped = { groups: [{ conditions: [{ field: "tag" as const, value: TAG }] }] };
+  const base = {
+    compareAtPolicy: { kind: "leave" },
+    rounding: { default: "none", byCurrency: {} },
+    ast: scoped,
+    schedule: { kind: "manual" },
+  };
+
+  const quiet = await createCampaign(shop.id, {
+    ...base,
+    name: `Background 10 ${Date.now()}`,
+    priority: 100,
+    rule: { kind: "percent-change", percent: -10 },
+  } as never);
+
+  const loud = await createCampaign(shop.id, {
+    ...base,
+    name: `Flash 40 ${Date.now()}`,
+    priority: 900,
+    rule: { kind: "percent-change", percent: -40 },
+  } as never);
+
+  // ------------------------------------------- 1. the lower-priority campaign alone
+  console.log("1. one campaign covering the variant");
+  await runCampaign(shop.id, quiet.id, client, {});
+  check("priced by the only campaign", await livePrice(client, probe.variantGid), "180.00");
+
+  // ------------------------------------------- 2. the higher-priority one takes over
+  console.log("2. a higher-priority campaign covers the same variant");
+  await runCampaign(shop.id, loud.id, client, {});
+  // 108.00 would be the two stacked. It must not appear.
+  check("exactly one winner, not both", await livePrice(client, probe.variantGid), "120.00");
+
+  // --------------------------- 3. ending the winner recomputes, it does not restore
+  console.log("3. ending the winner while the other still covers it");
+  await runCampaign(shop.id, loud.id, client, { revert: true });
+  // The claim: not 200.00 (the baseline, which a restore would give) and not 120.00.
+  check(
+    "falls back to the remaining campaign, not to the baseline",
+    await livePrice(client, probe.variantGid),
+    "180.00",
+  );
+
+  // ------------------------------------------- 4. ending the last one reaches baseline
+  console.log("4. ending the last campaign");
+  await runCampaign(shop.id, quiet.id, client, { revert: true });
+  check("back to the baseline", await livePrice(client, probe.variantGid), "200.00");
+
+  // ------------------------------------------------------------------- clean up
+  for (const id of [quiet.id, loud.id]) {
+    await prisma.campaign.delete({ where: { id } }).catch(() => {});
+  }
+  await client.request(
+    `mutation Delete($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
+    { input: { id: probe.productGid } },
+  );
+  console.log("\ncleaned up");
+
+  console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+  process.exitCode = failures === 0 ? 0 : 1;
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/test-resolution.ts
+++ b/scripts/test-resolution.ts
@@ -38,7 +38,7 @@ type Client = NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>;
 
 async function livePrice(client: Client, variantGid: string): Promise<string> {
   const result = await client.request<{ productVariant: { price: string } }>(
-    `query Price($id: ID!) { productVariant(id: $id) { price } }`,
+    `query ResolutionPrice($id: ID!) { productVariant(id: $id) { price } }`,
     { id: variantGid },
   );
   return result.data?.productVariant?.price ?? "";
@@ -48,7 +48,7 @@ async function createProbe(client: Client, price: string) {
   const result = await client.request<{
     productSet: { product: { id: string; variants: { nodes: Array<{ id: string }> } } };
   }>(
-    `mutation Create($input: ProductSetInput!) {
+    `mutation ResolutionCreate($input: ProductSetInput!) {
        productSet(synchronous: true, input: $input) {
          product { id variants(first: 1) { nodes { id } } }
          userErrors { message }
@@ -151,7 +151,7 @@ async function main() {
     await prisma.campaign.delete({ where: { id } }).catch(() => {});
   }
   await client.request(
-    `mutation Delete($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
+    `mutation ResolutionDelete($input: ProductDeleteInput!) { productDelete(input: $input) { deletedProductId } }`,
     { input: { id: probe.productGid } },
   );
   console.log("\ncleaned up");


### PR DESCRIPTION
The product's central claim, and the one the help centre states plainly:

> *"one winner per product, never stacked"*
> *"reverting recomputes rather than restoring saved numbers — if another campaign still covers a variant, that campaign's price stays in place"*

Both are property-tested against the resolver and exercised in chaos scenarios. Both of those talk to a fake. Neither had ever been asserted against **the price Shopify itself reports**, which is the only place a merchant's customer looks.

### Four steps on one variant at 200.00

| step | live price | |
|---|---|---|
| −10% alone | **180.00** | |
| −40% at higher priority | **120.00** | not 108.00, which is the two stacked |
| end the winner, −10% still covers it | **180.00** | not 200.00, which a restore would give |
| end the last one | **200.00** | |

All pass.

**The third row is the differentiator.** A product that restored a saved number would answer 200.00 there — quietly undoing a sale the merchant is still running. That is the failure the whole baseline design exists to avoid, and it is now checked against the real API rather than against our own model of it.

The discounts are chosen so no two possible answers collide: 180.00, 120.00 and 108.00 are three distinct numbers, so a passing assertion cannot be a coincidence.

Follows the live-script convention: a probe product it creates and deletes, `--shop` required via `chooseShop` (satisfying the contract test from #303), everything it applies is reverted.

`npm run typecheck` clean, `npm run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)