### PR TITLE
Check compare-at against the real Shopify API

### DIFF
--- a/scripts/test-pricing-rules.ts
+++ b/scripts/test-pricing-rules.ts
@@ -34,11 +34,26 @@ type Client = NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>;
 
 /** The price Shopify itself reports. Never the mirror — that is the thing under test. */
 async function livePrice(client: Client, variantGid: string): Promise<string> {
-  const result = await client.request<{ productVariant: { price: string } }>(
-    `query PricingRulesPrice($id: ID!) { productVariant(id: $id) { price } }`,
+  return (await live(client, variantGid)).price;
+}
+
+/** Price and compare-at together, as Shopify reports them. */
+async function live(
+  client: Client,
+  variantGid: string,
+): Promise<{ price: string; compareAt: string | null }> {
+  const result = await client.request<{
+    productVariant: { price: string; compareAtPrice: string | null };
+  }>(
+    `query PricingRulesPrice($id: ID!) {
+       productVariant(id: $id) { price compareAtPrice }
+     }`,
     { id: variantGid },
   );
-  return result.data?.productVariant?.price ?? "";
+  return {
+    price: result.data?.productVariant?.price ?? "",
+    compareAt: result.data?.productVariant?.compareAtPrice ?? null,
+  };
 }
 
 async function createProbe(client: Client, price: string) {
@@ -169,6 +184,37 @@ async function main() {
   console.log(`   live price: ${charmedPrice}`);
   await runCampaign(shop.id, charmed.id, client, { revert: true });
   check("reverted to the baseline", await livePrice(client, probe.variantGid), "200.00");
+
+
+  // ------------------------------------------------- 4. compare-at strike-through
+  console.log("4. a sale that looks like a sale");
+  const struck = await createCampaign(shop.id, {
+    name: `Struck ${Date.now()}`,
+    priority: 930,
+    rule: { kind: "percent-change", percent: -25 },
+    // The baseline goes into compare-at, which is what puts the line through the old
+    // price on the storefront. Without it a sale is just a lower number.
+    compareAtPolicy: { kind: "set-to-baseline" },
+    compareAtViolationPolicy: "clear",
+    rounding: { default: "none", byCurrency: {} },
+    ast: scoped,
+    schedule: { kind: "manual" },
+  } as never);
+  created.push(struck.id);
+
+  await runCampaign(shop.id, struck.id, client, {});
+  const onSale = await live(client, probe.variantGid);
+  check("the sale price", onSale.price, "150.00");
+  check("compare-at carries the baseline", onSale.compareAt, "200.00");
+  check("compare-at is above the price, or it is not a strike-through",
+    Number(onSale.compareAt) > Number(onSale.price), true);
+
+  await runCampaign(shop.id, struck.id, client, { revert: true });
+  const ended = await live(client, probe.variantGid);
+  check("price back to the baseline", ended.price, "200.00");
+  // The sale is over, so the strike-through must go with it. A compare-at left behind
+  // shows a permanent fake discount, which is the thing regulators care about.
+  check("compare-at cleared when the sale ended", ended.compareAt, null);
 
   // ------------------------------------------------------------------- clean up
   for (const id of created) {


### PR DESCRIPTION
A sale that does not show a strike-through is just a lower number. `set-to-baseline` is what puts the line through the old price, and nothing had ever confirmed Shopify ends up holding it.

Four assertions on a variant at 200.00 with −25%, all passing:

| | |
|---|---|
| price | **150.00** |
| compare-at | **200.00**, the baseline |
| ordering | compare-at above price, or it is not a strike-through at all |
| after revert | price **200.00**, compare-at back to **null** |

### The last one is the one worth having

A compare-at left behind after the sale ends shows a permanent *"was 200.00"* against a price that is now simply the normal price — a fake discount sitting on the storefront indefinitely, and precisely what was/now pricing rules exist to stop. It is cleared.

The ordering check is not redundant with the first two. It is the property that makes them a strike-through rather than two numbers that happen to be right, and it survives someone changing the discount in this test later.

Extends `scripts/test-pricing-rules.ts`, which now covers practice mode, guardrails, rounding and compare-at against real Shopify.

`npm run typecheck` clean, `npm run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)