### PR TITLE
Check never-below-cost against whatever cost data the store has

### DIFF
--- a/scripts/test-pricing-rules.ts
+++ b/scripts/test-pricing-rules.ts
@@ -216,6 +216,54 @@ async function main() {
   // shows a permanent fake discount, which is the thing regulators care about.
   check("compare-at cleared when the sale ended", ended.compareAt, null);
 
+
+  // ------------------------------------------- 5. never below cost, if cost exists
+  console.log("5. a campaign may not price below cost");
+
+  // Cost per item lives on the inventory item, and writing it needs `write_inventory`
+  // — a scope this app deliberately does not hold (#249). So this cannot set up its own
+  // fixture: it checks real cost data if the store has any, and says so plainly if not.
+  // Reporting a pass on a store with no costs would be the test lying about coverage.
+  const priced = await prisma.baseline.findFirst({
+    where: { shopId: shop.id, supersededAt: null, cost: { not: null } },
+    select: { variantGid: true, basePrice: true, cost: true },
+  });
+
+  if (!priced) {
+    console.log(
+      "   SKIP  no variant on this store has a cost per item, so there is nothing to " +
+        "check. Set one in the Shopify admin (Products → variant → Cost per item), " +
+        "re-sync, and run again.",
+    );
+  } else {
+    const floor = Number(priced.cost) / 100;
+    const campaign = await createCampaign(shop.id, {
+      name: `Below cost ${Date.now()}`,
+      priority: 940,
+      // Deep enough that the rule alone would land under cost, so the guardrail is what
+      // decides the answer rather than the arithmetic happening to stay above it.
+      rule: { kind: "percent-change", percent: -90 },
+      compareAtPolicy: { kind: "leave" },
+      rounding: { default: "none", byCurrency: {} },
+      guardrails: { neverBelowCost: true },
+      ast: { groups: [{ conditions: [{ field: "variantGid" as const, value: priced.variantGid }] }] },
+      schedule: { kind: "manual" },
+    } as never);
+    created.push(campaign.id);
+
+    await runCampaign(shop.id, campaign.id, client, {});
+    const held = await live(client, priced.variantGid);
+    check("Shopify never holds a price below cost", Number(held.price) >= floor, true);
+    console.log(`   cost ${floor.toFixed(2)}, live ${held.price}`);
+
+    await runCampaign(shop.id, campaign.id, client, { revert: true });
+    check(
+      "reverted to its baseline",
+      (await livePrice(client, priced.variantGid)),
+      (Number(priced.basePrice) / 100).toFixed(2),
+    );
+  }
+
   // ------------------------------------------------------------------- clean up
   for (const id of created) {
     await prisma.campaign.delete({ where: { id } }).catch(() => {});


### PR DESCRIPTION
The guardrail with money attached. `neverBelowCost` derives its floor from cost per item, and the code is explicit about why it matters:

> *"Never silently treat cost as zero — that would let a campaign price below cost while reporting success."*

### It cannot set up its own fixture, and should not be able to

Cost lives on the inventory item, and writing it needs `write_inventory` — a scope this app **deliberately does not hold** (#249 established the minimal set). Widening the app's permissions so a test can be convenient is the wrong trade, so the script does not.

Instead it checks real cost data when the store has some, and prints a **SKIP naming the exact setup step** when it does not:

```
5. a campaign may not price below cost
   SKIP  no variant on this store has a cost per item, so there is nothing to check.
         Set one in the Shopify admin (Products → variant → Cost per item), re-sync,
         and run again.
```

`anchor-flow` has no costs today, so it skips — and that is the point. A pass there would be the test lying about what it covered, which is the failure mode this whole set of live checks exists to avoid.

The discount is −90% rather than something near the floor, so when it does run, the guardrail is what decides the answer rather than the arithmetic happening to stay above cost anyway.

Note that the clamping machinery itself is already proven live by section 2, where an absolute `minPrice` floor holds at 150.00 against a rule computing 100.00. What is unverified is specifically the cost-derived floor.

`npm run typecheck` clean, `npm run lint` 0 errors. The other four sections still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)