### PR TITLE
Trace the enqueue, not just the run

### DIFF
--- a/app/worker/queue-runtime.server.ts
+++ b/app/worker/queue-runtime.server.ts
@@ -109,7 +109,26 @@ export function redisRuntime(handler: Handler, options: RedisRuntimeOptions): Qu
       const queue = queues.get(name);
       if (!queue) throw new Error(`No such queue: ${name}`);
 
-      await queue.add(name, ref, jobOptionsFor(QUEUE_POLICIES[name]));
+      // Spanned, not only counted. The execution side has had a span since it was
+      // written, so a trace showed a job appearing from nowhere and taking however long
+      // it took — with no record of when it was asked for. The interesting number in a
+      // backlog is the gap between those two, and a counter cannot express a gap.
+      //
+      // Same attributes as the execution span so the two line up in a trace view.
+      await span(
+        `enqueue ${name}`,
+        {
+          "queue.name": name,
+          "shop.id": ref.shopId,
+          ...(ref.campaignId ? { "campaign.id": ref.campaignId } : {}),
+          ...(ref.runId ? { "run.id": ref.runId } : {}),
+          ...(ref.revert === undefined ? {} : { "job.revert": ref.revert }),
+        },
+        async () => {
+          await queue.add(name, ref, jobOptionsFor(QUEUE_POLICIES[name]));
+        },
+      );
+
       metric("queue.enqueued", 1, { queue: name });
     },
 

--- a/app/worker/queue-runtime.test.ts
+++ b/app/worker/queue-runtime.test.ts
@@ -6,6 +6,9 @@
  * so the fallback has to actually run the work rather than drop it.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { inlineRuntime, runtimeFor } from "./queue-runtime.server";
@@ -77,5 +80,31 @@ describe("picking a runtime", () => {
     await runtime.enqueue("sync", { shopId: "s1" });
 
     expect(seen).toEqual(["sync"]);
+  });
+});
+
+describe("both ends of a job's life are traced", () => {
+  /**
+   * `span()` is a no-op when OTel is off, which it is in tests, so there is nothing to
+   * observe at runtime — the check is over the source, the way `built-for-shopify`
+   * checks that every webhook route authenticates.
+   *
+   * Execution has been spanned since it was written. Enqueue was only counted, so a
+   * trace showed a job appearing from nowhere and taking however long it took, with no
+   * record of when it was asked for. The interesting number in a backlog is the gap
+   * between the two, and a counter cannot express a gap.
+   */
+  const source = readFileSync(join(process.cwd(), "app/worker/queue-runtime.server.ts"), "utf8");
+
+  it("spans the enqueue as well as the run", () => {
+    expect(source, "the enqueue is not spanned").toMatch(/span\(\s*`enqueue \$\{name\}`/);
+    expect(source, "the run is not spanned").toMatch(/span\(\s*`job \$\{name\}`/);
+  });
+
+  it("gives both spans the same attributes, so a trace lines them up", () => {
+    for (const attribute of ['"queue.name"', '"shop.id"', '"campaign.id"', '"run.id"']) {
+      const uses = source.split(attribute).length - 1;
+      expect(uses, `${attribute} appears on only one of the two spans`).toBeGreaterThanOrEqual(2);
+    }
   });
 });


### PR DESCRIPTION
#47 asks for worker job spans covering **enqueue → start → finish**. Execution has been spanned since it was written; enqueue was only counted.

So a trace showed a job appearing from nowhere and taking however long it took, with no record of when it was *asked for*. The interesting number in a backlog is the gap between those two, and a counter cannot express a gap.

Same attributes as the execution span — `queue.name`, `shop.id`, `campaign.id`, `run.id`, `job.revert` — so the two line up in a trace view rather than being two unrelated entries that happen to mention the same queue.

### The test

`span()` is a no-op when OTel is off, which it is in tests, so there is nothing to observe at runtime. The check is over the source, following the precedent in `built-for-shopify.test.ts` where every webhook route is checked for `authenticate.webhook`.

It asserts both spans exist **and** that they carry the same attributes — a pair that disagrees is no more useful than one that is missing.

Mutation-checked by removing the enqueue span:

```
the enqueue is not spanned: expected '/**\n * Connecting the job classes to…' to match /span\(\s*`enqueue \$\{name\}`/
```

`npm run typecheck` clean, `npm run lint` 0 errors, 1408 unit tests pass.

Refs #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)