### PR TITLE
The shop-error-spike scenario cleans up the shop it creates

### DIFF
--- a/chaos/scenarios/shop-error-spike.chaos.ts
+++ b/chaos/scenarios/shop-error-spike.chaos.ts
@@ -75,6 +75,7 @@ describe("chaos: one shop failing inside a healthy platform", () => {
         // reason that has nothing to do with the code.
         await prisma.errorEvent.deleteMany({ where: { errorId: { startsWith: "ANC-SPIKE-" } } });
         await prisma.webhookEvent.deleteMany({ where: { webhookId: { startsWith: "spike-" } } });
+        await prisma.shop.deleteMany({ where: { domain: { startsWith: "busy-" } } });
         const shop = await prisma.shop.findUniqueOrThrow({
           where: { id: chaos.fixture.shopId },
           select: { id: true, domain: true },
@@ -126,6 +127,12 @@ describe("chaos: one shop failing inside a healthy platform", () => {
 
         await prisma.errorEvent.deleteMany({ where: { errorId: { startsWith: "ANC-SPIKE-" } } });
         await prisma.webhookEvent.deleteMany({ where: { webhookId: { startsWith: "spike-" } } });
+        // Including the shop itself. Leaving it behind put sixteen `busy-…` rows in the
+        // database over an afternoon, and a `shop` table full of fixtures makes a real
+        // question — "which stores are installed?" — harder to answer than it should be.
+        // Earlier runs are cleaned too, so a database that already collected some
+        // recovers on the next run rather than needing somebody to notice.
+        await prisma.shop.deleteMany({ where: { domain: { startsWith: "busy-" } } });
       },
     );
   });


### PR DESCRIPTION
The scenario needs a second, busier shop so the global and per-shop denominators differ — without one they are identical and the test cannot tell a per-shop rate from a global one (mutation testing caught exactly that when it was written).

It created that shop and never deleted it. An afternoon of runs left **sixteen `busy-…` rows** in the `shop` table.

That matters more than tidiness: `chooseShop` reads that table to decide which store a script may write to, and "which stores are installed?" is the first question anybody asks of it. A table full of fixtures makes both worse.

Cleaned at both ends of the scenario, so a database that has already collected some recovers on the next run rather than needing somebody to notice. Seventeen rows went on the run that verified it — the table is back to the four real shops.

`npm run typecheck` clean, chaos suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)