### PR TITLE
Measure webhook lag, and record the mirror drill

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -9,6 +9,8 @@ Regenerate with:
 npx tsx scripts/measure-import.ts 2000 --variants 50 --shop anchor-perf --label 100k
 npx tsx scripts/measure-import.ts --max-variant-product --shop anchor-perf --label e12
 npx tsx scripts/measure-admin.ts --shop anchor-perf
+npx tsx scripts/measure-webhook-lag.ts --shop anchor-perf --edits 20
+npx tsx scripts/drill-mirror.ts --shop anchor-perf
 ```
 
 ## Import (#66)
@@ -48,9 +50,55 @@ Deep paging costs about 11× the first page and flattens out rather than degradi
 curve between offset 15,250 and 101,100 is 195 ms to 285 ms, which is a long way from the
 quadratic behaviour a naive `OFFSET` on an unindexed sort would give.
 
+## Webhook lag: a price edit reaching the mirror (#4)
+
+| | Measured | Budget |
+|---|---|---|
+| p50 | **1,518 ms** | — |
+| p95 | **1,772 ms** | 30,000 ms |
+| max | 1,772 ms | — |
+| Delivered | **20 of 20** | all |
+
+Measured the way a merchant produces it: the price is edited through the Admin API
+*without* recording a write intent, so the resulting webhook is indistinguishable from
+somebody typing in the Shopify admin, and the mirror is then polled until it agrees. Every
+price is put back afterwards, and the restoring webhook is waited for too, so a slow one
+cannot be charged to the next measurement.
+
+This is the number that decides whether planning against the mirror is safe. A campaign
+scoped a minute after somebody edits a price is planning against whatever the mirror knew
+then — so it is the width of the window in which the app can be wrong about a store, not a
+vanity metric. At under two seconds the window is narrow enough that the drift path, not
+this, is what catches a real conflict.
+
+## Mirror-corruption drill (#4)
+
+| | |
+|---|---|
+| Clean audit first | 60 checked, 0 diverged |
+| Corrupted | **3,064 of 102,132** rows (3%) |
+| Dirty audit | 400 sampled, **18 diverged, 18 healed** |
+| Alerted at | **4.50%**, against a 0.5% threshold |
+| Restored afterwards | 3,046 rows the sample never reached |
+
+`mirror-audit.chaos.ts` proves the same behaviour against the fake. This proves it against
+a real store and a real Shopify, which is a different claim: the harness cannot tell you
+that the live read path, the session, the rate limiter and the healing write all work
+together on a catalogue of a hundred thousand variants.
+
+**The shape of the drill is the lesson.** The audit samples randomly, so an early version
+that corrupted twenty rows out of 102,132 and sampled twenty found nothing — which looked
+like a broken audit and was a broken drill. It corrupts a *fraction* instead, chosen well
+over the alert threshold so the alert must fire rather than might.
+
 ## What these numbers do not cover
 
 Concurrency. Every measurement here is one request at a time against an otherwise idle
 store, so they are a floor rather than a forecast. A merchant paging the catalogue while a
 100K campaign runs is a different question, and the honest answer is that it has not been
 measured.
+
+Webhook lag under load, likewise. Twenty sequential edits on an idle store is the best
+case; the number that would matter during an incident is lag while a bulk import is
+draining the same queue. `webhook.lag_ms` is emitted every tick now, so the panel will
+answer that once there is traffic to look at.

--- a/scripts/measure-webhook-lag.ts
+++ b/scripts/measure-webhook-lag.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env tsx
+/**
+ * How long a merchant's price edit takes to reach the mirror.
+ *
+ * The NFR is p95 under 30 seconds, and it is the number that decides whether planning a
+ * campaign against the mirror is safe. A campaign scoped a minute after somebody edits a
+ * price is planning against whatever the mirror knew then — so this is not a vanity
+ * metric, it is the width of the window in which the app can be wrong about a store.
+ *
+ * Measured the way a merchant produces it: edit the price through the Admin API without
+ * recording a write intent, so the resulting webhook is indistinguishable from a person
+ * doing it in the Shopify admin, then poll the mirror until it agrees.
+ *
+ * Every price is put back afterwards, including on failure.
+ *
+ *   npx tsx scripts/measure-webhook-lag.ts --shop anchor-perf [--edits 20]
+ */
+
+import prisma from "../app/db.server";
+import { chooseShop, shopArg } from "../app/lib/seed/target-shop";
+import { adminClientForShop } from "../app/services/admin-client.server";
+
+type Client = NonNullable<Awaited<ReturnType<typeof adminClientForShop>>>;
+
+const POLL_MS = 250;
+const GIVE_UP_MS = 120_000;
+
+function numberArg(args: readonly string[], flag: string, fallback: number): number {
+  const at = args.indexOf(flag);
+  if (at === -1) return fallback;
+  const value = Number(args[at + 1]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function percentile(sorted: readonly number[], q: number): number {
+  if (sorted.length === 0) return NaN;
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))]!;
+}
+
+async function setPrice(client: Client, productGid: string, variantGid: string, price: string) {
+  const result = await client.request<{
+    productVariantsBulkUpdate: { userErrors: Array<{ message: string }> };
+  }>(
+    `mutation LagSetPrice($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+       productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+         userErrors { message }
+       }
+     }`,
+    { productId: productGid, variants: [{ id: variantGid, price }] },
+  );
+
+  const errors = result.data?.productVariantsBulkUpdate?.userErrors ?? [];
+  if (errors.length) throw new Error(errors.map((e) => e.message).join("; "));
+}
+
+/** Waits for the mirror to hold `expected`, returning how long that took. */
+async function waitForMirror(
+  shopId: string,
+  variantGid: string,
+  expected: bigint,
+): Promise<number | null> {
+  const started = Date.now();
+
+  while (Date.now() - started < GIVE_UP_MS) {
+    const row = await prisma.variantIndex.findUnique({
+      where: { shopId_variantGid: { shopId, variantGid } },
+      select: { price: true },
+    });
+    if (row?.price === expected) return Date.now() - started;
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+  }
+
+  return null;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const installed = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { domain: true },
+  });
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { domain: chooseShop(installed, shopArg(args)).domain },
+  });
+
+  const client = await adminClientForShop(shop.domain);
+  if (!client) throw new Error("No usable session");
+
+  const edits = numberArg(args, "--edits", 20);
+  const variants = await prisma.variantIndex.findMany({
+    where: { shopId: shop.id, deletedAt: null, price: { not: null } },
+    select: { variantGid: true, productGid: true, price: true, title: true },
+    orderBy: { variantGid: "asc" },
+    take: edits,
+  });
+
+  if (variants.length === 0) throw new Error("no mirrored variants to edit");
+  console.log(`${shop.domain}: measuring ${variants.length} edits\n`);
+
+  const lags: number[] = [];
+  let lost = 0;
+
+  for (const [index, variant] of variants.entries()) {
+    const original = variant.price!;
+    // A pound up, then back. Small enough to be obviously a test edit if anybody looks
+    // at the store, large enough that the mirror cannot match by rounding.
+    const bumped = original + 100n;
+
+    try {
+      await setPrice(client, variant.productGid, variant.variantGid, minorToDecimal(bumped));
+      const lag = await waitForMirror(shop.id, variant.variantGid, bumped);
+
+      if (lag === null) {
+        lost++;
+        console.log(`  ${index + 1}/${variants.length}  never arrived within ${GIVE_UP_MS / 1000}s`);
+      } else {
+        lags.push(lag);
+        console.log(`  ${index + 1}/${variants.length}  ${lag} ms`);
+      }
+    } finally {
+      await setPrice(client, variant.productGid, variant.variantGid, minorToDecimal(original));
+      // Let the restoring webhook land before the next edit, so a slow one is not
+      // attributed to the following measurement.
+      await waitForMirror(shop.id, variant.variantGid, original);
+    }
+  }
+
+  const sorted = [...lags].sort((a, b) => a - b);
+  console.log("");
+  console.log(`delivered   ${lags.length} of ${variants.length}${lost ? ` (${lost} never arrived)` : ""}`);
+  if (sorted.length) {
+    console.log(`p50         ${percentile(sorted, 0.5)} ms`);
+    console.log(`p95         ${percentile(sorted, 0.95)} ms   budget 30000 ms`);
+    console.log(`max         ${sorted[sorted.length - 1]} ms`);
+  }
+
+  const met = lost === 0 && sorted.length > 0 && percentile(sorted, 0.95) < 30_000;
+  console.log(met ? "\nPASS  p95 within the 30s budget" : "\nFAIL  budget not met");
+  process.exitCode = met ? 0 : 1;
+}
+
+/** Minor units to the decimal string Shopify's price field expects. */
+function minorToDecimal(minor: bigint): string {
+  const negative = minor < 0n;
+  const abs = negative ? -minor : minor;
+  const whole = abs / 100n;
+  const cents = abs % 100n;
+  return `${negative ? "-" : ""}${whole}.${cents.toString().padStart(2, "0")}`;
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
Epic 2's definition of done has three clauses. Import had recorded numbers; the other two were asserted rather than measured — which on a perf claim is the same as not done.

### A price edit reaching the mirror

| | Measured | Budget |
|---|---|---|
| p50 | 1,518 ms | — |
| **p95** | **1,772 ms** | 30,000 ms |
| Delivered | **20 of 20** | all |

On the 102,132-variant store, measured the way a merchant produces it: edited through the Admin API **without recording a write intent**, so the resulting webhook is indistinguishable from somebody typing in the Shopify admin. Prices are put back afterwards and the restoring webhook waited for, so a slow one is not charged to the next measurement.

That number is the width of the window in which the app can be wrong about a store — a campaign scoped a minute after an edit plans against whatever the mirror knew then. Under two seconds, drift detection rather than staleness is what catches a real conflict.

### The mirror drill, against real Shopify

| | |
|---|---|
| Corrupted | **3,064 of 102,132** rows (3%) |
| Dirty audit | 400 sampled, **18 diverged, 18 healed** |
| Alerted at | **4.50%** against a 0.5% threshold |
| Restored | 3,046 rows the sample never reached |

`mirror-audit.chaos.ts` proves the same behaviour against the fake. This proves the live read path, the session, the rate limiter and the healing write work together at a hundred thousand variants, which the harness cannot.

The shape of the drill is itself the lesson, and it is written down: the audit samples randomly, so an early version that corrupted twenty rows of 102,132 and sampled twenty found nothing — which looked like a broken audit and was a broken drill.

### Also

`docs/perf/README.md` carries both, with the commands to regenerate, and its "what these numbers do not cover" section now says plainly that **lag under load** is still unmeasured — twenty sequential edits on an idle store is the best case, and the number that would matter during an incident is lag while a bulk import drains the same queue. `webhook.lag_ms` is emitted every tick since #305, so the panel will answer that once there is traffic.

`npm run typecheck` clean, `npm run lint` 0 errors. The new script satisfies the `chooseShop` contract from #303.

Refs #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)