### PR TITLE
/healthz reports whether the scheduler is alive

### DIFF
--- a/app/routes/healthz.tsx
+++ b/app/routes/healthz.tsx
@@ -16,11 +16,24 @@
  * body and deliberately does not fail the check, because taking the web service down for
  * it would turn a partial outage into a total one.
  *
+ * **It also reports the scheduler, and deliberately does not fail on it.** The worker is a
+ * separate service, so the web process being healthy says nothing about whether anything
+ * is ticking — and until this reported it, "is the worker running?" could only be answered
+ * by someone with database access. That is the wrong shape for the one condition that
+ * detects a dead worker: `scheduler-stopped` is detected by *absence*, which needs an
+ * external reader. This is that reader.
+ *
+ * Failing the check on it would be worse than useless: it would take the web service down
+ * because a *different* service stopped, turning "scheduled reverts are late" into "the
+ * app is gone".
+ *
  * Unauthenticated on purpose: it is called by the platform before any session exists, and
- * it returns no shop data — only whether two dependencies answered.
+ * it returns no shop data — only whether its dependencies answered.
  */
 
 import prisma from "../db.server";
+import { TICK_SILENCE_SECONDS } from "../lib/observability/alerts";
+import { secondsSinceBeat } from "../services/scheduler-heartbeat.server";
 
 interface Check {
   ok: boolean;
@@ -60,8 +73,39 @@ async function checkRedis(): Promise<Check> {
   }
 }
 
+/**
+ * Whether the scheduler has beaten recently enough.
+ *
+ * `null` seconds means it has never beaten — a worker that has not started rather than one
+ * that has stopped. Reported as `"never"` rather than as stale, because on a fresh
+ * deployment those are very different things and only one of them is a problem.
+ */
+async function checkScheduler(): Promise<Check & { secondsSinceTick: number | null }> {
+  try {
+    const seconds = await secondsSinceBeat();
+    if (seconds === null) {
+      return { ok: false, detail: "never — the worker has not started", secondsSinceTick: null };
+    }
+    return {
+      ok: seconds <= TICK_SILENCE_SECONDS,
+      detail: seconds <= TICK_SILENCE_SECONDS ? undefined : `quiet for ${seconds}s`,
+      secondsSinceTick: seconds,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+      secondsSinceTick: null,
+    };
+  }
+}
+
 export async function loader() {
-  const [database, redis] = await Promise.all([checkDatabase(), checkRedis()]);
+  const [database, redis, scheduler] = await Promise.all([
+    checkDatabase(),
+    checkRedis(),
+    checkScheduler(),
+  ]);
 
   // Only the database can fail the check. Without it nothing works; without Redis the
   // queue runs inline and campaigns still apply.
@@ -69,9 +113,10 @@ export async function loader() {
 
   return new Response(
     JSON.stringify({
-      status: database.ok ? (redis.ok ? "ok" : "degraded") : "unhealthy",
+      status: database.ok ? (redis.ok && scheduler.ok ? "ok" : "degraded") : "unhealthy",
       database,
       redis,
+      scheduler,
     }),
     { status, headers: { "content-type": "application/json" } },
   );

--- a/chaos/scenarios/healthz-scheduler.chaos.ts
+++ b/chaos/scenarios/healthz-scheduler.chaos.ts
@@ -1,0 +1,73 @@
+/**
+ * `/healthz` answering "is the worker running?" from outside.
+ *
+ * The worker is a separate service, so a healthy web process says nothing about whether
+ * anything is ticking. Until this was reported, the only way to find out was a database
+ * query — which is the wrong shape for the one condition that detects a dead worker.
+ * `scheduler-stopped` is detected by *absence*, and absence needs an external reader.
+ *
+ * The two failure modes to keep apart are "never started" and "stopped". On a fresh
+ * deployment the first is expected and the second is an incident, and a check that
+ * reported them identically would cry wolf on every first boot.
+ *
+ * And it must never fail the check. Taking the web service down because a *different*
+ * service stopped turns "scheduled reverts are late" into "the app is gone" — Railway
+ * holds a deploy at "deploying" until this answers, so a 503 here would also stop a fixed
+ * release from ever replacing a broken one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { loader } from "../../app/routes/healthz";
+import { TICK_SILENCE_SECONDS } from "../../app/lib/observability/alerts";
+import { beat } from "../../app/services/scheduler-heartbeat.server";
+import { withChaos } from "../harness/scenario";
+
+type Health = {
+  status: string;
+  database: { ok: boolean };
+  scheduler: { ok: boolean; detail?: string; secondsSinceTick: number | null };
+};
+
+async function health(): Promise<{ body: Health; status: number }> {
+  const response = await loader();
+  return { body: (await response.json()) as Health, status: response.status };
+}
+
+describe("chaos: healthz reports the scheduler", () => {
+  it("tells a worker that never started from one that stopped", async () => {
+    await withChaos(
+      "healthz-scheduler",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async () => {
+        // Never started.
+        await prisma.schedulerHeartbeat.deleteMany({});
+
+        const fresh = await health();
+        expect(fresh.body.scheduler.ok).toBe(false);
+        expect(fresh.body.scheduler.secondsSinceTick).toBeNull();
+        expect(fresh.body.scheduler.detail, "a fresh deploy must say so").toMatch(/never/i);
+        expect(fresh.status, "a missing worker must not fail the web healthcheck").toBe(200);
+
+        // Running.
+        await beat(new Date());
+        const running = await health();
+        expect(running.body.scheduler.ok).toBe(true);
+        expect(running.body.scheduler.secondsSinceTick).toBeLessThanOrEqual(TICK_SILENCE_SECONDS);
+        expect(running.body.status).toBe("ok");
+
+        // Stopped: beaten once, then silent for longer than the threshold.
+        await beat(new Date(Date.now() - (TICK_SILENCE_SECONDS + 60) * 1_000));
+        const stopped = await health();
+        expect(stopped.body.scheduler.ok).toBe(false);
+        expect(stopped.body.scheduler.detail, "a stopped worker says how long").toMatch(/quiet for/);
+        expect(stopped.body.status, "degraded, because the database is still fine").toBe("degraded");
+        expect(
+          stopped.status,
+          "a stopped worker must never take the web service down with it",
+        ).toBe(200);
+      },
+    );
+  });
+});


### PR DESCRIPTION
The worker is a separate service, so a healthy web process says nothing about whether anything is ticking. Until now the only way to answer **"is the worker running?"** was a database query.

That is the wrong shape for the one condition that detects a dead worker: `scheduler-stopped` is detected by *absence*, and absence needs a reader outside the process that died. `/healthz` is that reader.

### Prompted by a real question

The worker service exists in Railway with its variables set and **has never had an active deployment** — Railway says "There is no active deployment for this service". Nothing the app served would have told you that. Now:

```json
{"status":"degraded","database":{"ok":true},"redis":{"ok":true},
 "scheduler":{"ok":false,"detail":"never — the worker has not started","secondsSinceTick":null}}
```

### Two failure modes, kept apart

| | reports |
|---|---|
| never started | `secondsSinceTick: null`, and says so in words |
| stopped | the seconds, and how long it has been quiet |

On a fresh deploy the first is expected and the second is an incident. A check reporting them identically would cry wolf on every first boot.

### It never fails the check

Taking the web service down because a *different* service stopped turns "scheduled reverts are late" into "the app is gone". And since Railway holds a deploy at "deploying" until this answers, a 503 here would also stop a fixed release from ever replacing a broken one. It degrades — exactly as a missing Redis already does.

Mutation-checked both ways:

```
a missing worker must not fail the web healthcheck: expected 503 to be 200
a fresh deploy must say so: expected 'quiet for a while' to match /never/i
```

`npm run typecheck` clean, `npm run lint` 0 errors, 1417 unit and 127 chaos tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)