### PR TITLE
Give the worker a Railway config without a healthcheck

### DIFF
--- a/app/lib/compliance/deploy-config.test.ts
+++ b/app/lib/compliance/deploy-config.test.ts
@@ -43,6 +43,48 @@ function environmentKeys(): Set<string> {
   return keys;
 }
 
+describe("the worker's Railway config", () => {
+  /**
+   * Railway applies a repo's config file to every service built from it, and
+   * `railway.json` carries `healthcheckPath: "/healthz"`. The worker serves no HTTP, so
+   * it inherited a healthcheck it could never answer — build succeeded, deploy succeeded,
+   * then `Network > Healthcheck` failed after the timeout and the deployment was marked
+   * FAILED. The worker had never once run.
+   *
+   * Nothing in that error names the healthcheck as the wrong setting for this service
+   * rather than a broken app, which is why it is worth a test rather than a paragraph.
+   */
+  const web = JSON.parse(readFileSync(join(ROOT, "railway.json"), "utf8"));
+  const worker = JSON.parse(readFileSync(join(ROOT, "railway.worker.json"), "utf8"));
+
+  it("gives the web service a healthcheck", () => {
+    expect(web.deploy?.healthcheckPath, "the web service must be health-checked").toBe(
+      "/healthz",
+    );
+  });
+
+  it("gives the worker none, because it serves no HTTP", () => {
+    expect(
+      worker.deploy?.healthcheckPath,
+      "a healthcheck on the worker can never pass, so every deploy fails",
+    ).toBeUndefined();
+  });
+
+  it("starts the worker as a worker", () => {
+    expect(worker.deploy?.startCommand).toBe("npm run worker");
+  });
+
+  it("builds both from the same Dockerfile", () => {
+    // The pair that must never disagree about a price is exactly this pair: the worker
+    // writes what the web process previewed.
+    expect(worker.build).toEqual(web.build);
+  });
+
+  it("restarts the worker on failure, like the web service", () => {
+    expect(worker.deploy?.restartPolicyType).toBe(web.deploy?.restartPolicyType);
+  });
+});
+
 describe("the webhooks the manifest subscribes to", () => {
   /**
    * A declared topic with no route, or a route no topic reaches.

--- a/docs/deploying-to-railway.md
+++ b/docs/deploying-to-railway.md
@@ -4,7 +4,18 @@ Two services from one repository, per [D5](decisions.md). The worker is the only
 that writes prices, so it restarts and scales on its own — a slow campaign must never tie
 up a request thread, and a web deploy must never interrupt a run mid-write.
 
-Both services build the **same image**. They differ only in their start command. Building
+Both services build the **same image**. They differ in their start command and in which
+config file they read — and the second one is not optional.
+
+`railway.json` carries `healthcheckPath: "/healthz"`, and Railway applies a repo's config
+file to *every* service built from it. The worker serves no HTTP, so it inherited a
+healthcheck it can never answer: build succeeded, deploy succeeded, then
+`Network > Healthcheck` failed after the 120-second timeout and the deployment was marked
+FAILED. Nothing about that error names the healthcheck as the *wrong setting for this
+service* rather than a broken app, which is what makes it worth writing down.
+
+So the worker points at `railway.worker.json`, which is the same build with no healthcheck
+and the worker's start command. Building
 twice would let them drift, and the pair that must never disagree about a price is exactly
 this pair: the worker writes what the web process previewed.
 
@@ -17,6 +28,7 @@ this pair: the worker writes what the web process previewed.
 | Start command | `npm run docker-start` (the image default) | `npm run worker` |
 | Public domain | yes | **no** |
 | Healthcheck | `/healthz` | none — it serves no HTTP |
+| Config-as-code | `railway.json` (the default) | **`railway.worker.json`** — set it under Settings → Config-as-code |
 | Runs migrations | **yes** | no |
 | Replicas | scale freely | **exactly one** |
 

--- a/railway.worker.json
+++ b/railway.worker.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "npm run worker",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}


### PR DESCRIPTION
**The worker service has never once run.** Its deployments fail, and the reason is in this repo rather than in the dashboard.

Railway applies a repo's config file to **every** service built from it, and `railway.json` carries:

```json
"deploy": { "healthcheckPath": "/healthz", "healthcheckTimeout": 120, ... }
```

The worker serves no HTTP, so it inherited a check it can never answer.

### The failure is the confusing kind

```
✓ Initialization   (00:44)
✓ Build            (00:43)
✓ Deploy           (00:05)
✗ Network › Healthcheck   (01:32)   Healthcheck failure
FAILED
```

Everything that could indicate a broken application succeeded. Only the healthcheck failed, and nothing in that output says *"this setting is wrong for this service"* rather than *"your app is broken"* — so it sends you to the logs and the start command instead of to a config file.

The runbook already said the worker should have **"none — it serves no HTTP"**. Nothing enforced it, and the config file quietly said otherwise.

### The fix

`railway.worker.json` — the same build, the worker's start command, no healthcheck. The worker points at it under **Settings → Config-as-code**.

Deliberately a second file rather than removing the healthcheck from the shared one. The web service is currently working, and taking its healthcheck away to fix a *different* service would let a broken release replace a good one — Railway holds a deploy at "deploying" until `/healthz` answers, which is the whole point of having it there.

### Tested

Both files are asserted against each other: the web service must have the healthcheck, the worker must not, their `build` blocks must be identical, and the restart policy must match. The pair that must never disagree about a price is exactly this pair — the worker writes what the web process previewed.

Mutation-checked by putting the healthcheck back on the worker:

```
a healthcheck on the worker can never pass, so every deploy fails: expected '/healthz' to be undefined
```

`npm run typecheck` clean, `npm run lint` 0 errors, 1422 unit tests pass.

### After merging

Set the worker's **Config-as-code** path to `railway.worker.json` and redeploy — the runbook table now lists it alongside the start command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)