### PR TITLE
Generate the Prisma client in the image, not at boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,20 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 COPY . .
 
+# Generate the Prisma client into the image, not at boot.
+#
+# `npm run docker-start` runs `prisma generate && prisma migrate deploy` before starting,
+# so the web service produced its own client on every boot and the image never needed one.
+# The worker starts with `tsx scripts/worker.ts` and runs neither — so it imported
+# `db.server.ts`, found no generated client, and crashed on every deploy with
+# "@prisma/client did not initialize yet". Build succeeded, deploy succeeded, process died.
+#
+# Generating here is also the right split on its own terms. `generate` produces code and
+# belongs to the build; `migrate` changes a database and belongs to exactly one service at
+# deploy time. Bundling them into one `setup` script is what tied a build step to the web
+# service's start command.
+RUN npx prisma generate
+
 RUN npm run build
 
 # The default is the web service. The worker overrides it with `npm run worker`.

--- a/app/lib/compliance/deploy-config.test.ts
+++ b/app/lib/compliance/deploy-config.test.ts
@@ -178,6 +178,27 @@ describe("the Railway runbook", () => {
     expect(scripts.worker).not.toContain("migrate");
   });
 
+  it("generates the Prisma client in the image, not at boot", () => {
+    // The worker starts with `tsx scripts/worker.ts` and runs neither `generate` nor
+    // `migrate`. With the client generated only by the web service's start command, the
+    // worker imported `db.server.ts`, found nothing, and crashed on every deploy with
+    // "@prisma/client did not initialize yet" — after a successful build and deploy.
+    //
+    // `generate` produces code and belongs to the build. `migrate` changes a database and
+    // belongs to one service at deploy time. The test below still holds the second rule.
+    const dockerfile = readFileSync(join(ROOT, "Dockerfile"), "utf8");
+
+    expect(
+      dockerfile,
+      "nothing generates the Prisma client at build time, so the worker starts without one",
+    ).toMatch(/RUN\s+npx\s+prisma\s+generate/);
+
+    // Before the build, since the build may import generated types.
+    const generateAt = dockerfile.search(/RUN\s+npx\s+prisma\s+generate/);
+    const buildAt = dockerfile.search(/RUN\s+npm\s+run\s+build/);
+    expect(generateAt, "generate must come before the build").toBeLessThan(buildAt);
+  });
+
   it("ships the worker's runtime dependencies in the production image", () => {
     // The worker starts through `tsx`. As a dev dependency it would build cleanly under
     // `npm ci --omit=dev` and then fail to start — in the deployed environment, which is


### PR DESCRIPTION
The worker crashed on every deploy:

```
Error: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again.
    at new PrismaClient (/app/node_modules/.prisma/client/default.js:43:11)
    at <anonymous> (/app/app/db.server.ts:14:39)
```

After a **successful build and a successful deploy** — the combination that sends you looking at the application rather than at the image.

### Why only the worker

```
docker-start:  npm run setup && npm run start
setup:         prisma generate && prisma migrate deploy
worker:        tsx scripts/worker.ts
```

The web service produced its own client on every boot, so the image never needed one. The worker runs neither `generate` nor `migrate`, imported `db.server.ts`, and found nothing.

### The distinction the Dockerfile missed

Its comment already gets the migrate half right — only the web service migrates, because *"two services racing the same migration on deploy is a lock fight at best and a half-applied schema at worst"*.

But `generate` is not the same kind of thing. It **produces code** and belongs to the build. `migrate` **changes a database** and belongs to exactly one service at deploy time. Bundling both into one `setup` script is what tied a build step to the web service's start command.

Generated before `npm run build`, since the build may import generated types.

`docker-start` is left alone deliberately: changing the working service's boot path to fix a broken one is the same mistake as the healthcheck in #320, and `generate` is idempotent so the extra boot-time run costs only seconds.

### Mutation-checked

```
nothing generates the Prisma client at build time, so the worker starts without one
generate must come before the build: expected 1345 to be less than 1326
```

The existing "keeps the worker off the migration path" test still holds — the worker must still never migrate.

`npm run typecheck` clean, `npm run lint` 0 errors, 1423 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)