### PR TITLE
Chunk IN lists below Postgres's bind-variable ceiling

### DIFF
--- a/app/lib/db/chunk.test.ts
+++ b/app/lib/db/chunk.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Splitting `IN` lists.
+ *
+ * The bug this exists for was not "no chunking" — Prisma chunks long `IN` lists by
+ * itself. It was that Prisma chunks at exactly the ceiling and then adds the query's
+ * other bind variables on top, so a campaign of 62,535 variants died on `received
+ * 32769` before a single price was written.
+ *
+ * So the properties worth pinning are the ones that make that impossible to
+ * reintroduce: every element is covered exactly once and in order, and a full batch
+ * plus a generous number of other binds still sits under the ceiling.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { BIND_VARIABLE_CEILING, IN_CHUNK, chunk, inChunks, inChunksCounting } from "./chunk";
+
+const ids = (n: number) => Array.from({ length: n }, (_, i) => `gid://v/${i}`);
+
+describe("chunk", () => {
+  it("leaves room for the rest of the where clause", () => {
+    expect(
+      IN_CHUNK,
+      "a full batch plus other filters must not approach the ceiling",
+    ).toBeLessThan(BIND_VARIABLE_CEILING / 2);
+  });
+
+  it("returns nothing for an empty list, so callers do not query for nothing", () => {
+    expect(chunk([])).toEqual([]);
+  });
+
+  it("keeps a short list in one batch", () => {
+    expect(chunk(ids(3), 5)).toEqual([ids(3)]);
+  });
+
+  it("splits exactly at the boundary rather than one either side", () => {
+    expect(chunk(ids(10), 5)).toHaveLength(2);
+    expect(chunk(ids(11), 5)).toHaveLength(3);
+    expect(chunk(ids(9), 5).map((b) => b.length)).toEqual([5, 4]);
+  });
+
+  it("covers every element exactly once, in order", () => {
+    const source = ids(23);
+    expect(chunk(source, 5).flat()).toEqual(source);
+  });
+
+  it("refuses a size that would loop forever", () => {
+    expect(() => chunk(ids(3), 0)).toThrow(/at least 1/);
+  });
+});
+
+describe("inChunks", () => {
+  it("never sends a batch bigger than the size", async () => {
+    const sizes: number[] = [];
+    await inChunks(ids(62_535), async (batch) => {
+      sizes.push(batch.length);
+      return batch;
+    });
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(IN_CHUNK);
+  });
+
+  it("returns every row, in batch order", async () => {
+    const source = ids(12);
+    const rows = await inChunks(source, async (batch) => batch.map((id) => id.toUpperCase()), 5);
+    expect(rows).toEqual(source.map((id) => id.toUpperCase()));
+  });
+
+  it("does not query at all for an empty list", async () => {
+    let calls = 0;
+    const rows = await inChunks([], async () => {
+      calls++;
+      return [];
+    });
+    expect(calls).toBe(0);
+    expect(rows).toEqual([]);
+  });
+
+  it("keeps a single batch to one round trip", async () => {
+    let calls = 0;
+    await inChunks(ids(IN_CHUNK), async (batch) => {
+      calls++;
+      return batch;
+    });
+    expect(calls, "a list that fits must not pay for batching").toBe(1);
+  });
+});
+
+describe("inChunksCounting", () => {
+  it("sums the counts rather than reporting the last batch's", async () => {
+    const result = await inChunksCounting(ids(12), async (batch) => ({ count: batch.length }), 5);
+    expect(result.count, "an updateMany across batches must report the total").toBe(12);
+  });
+
+  it("counts zero for an empty list without calling the mutation", async () => {
+    let calls = 0;
+    const result = await inChunksCounting([], async () => {
+      calls++;
+      return { count: 1 };
+    });
+    expect(calls).toBe(0);
+    expect(result.count).toBe(0);
+  });
+});

--- a/app/lib/db/chunk.ts
+++ b/app/lib/db/chunk.ts
@@ -1,0 +1,77 @@
+/**
+ * Splitting `IN` lists so a query cannot outgrow Postgres.
+ *
+ * A prepared statement may carry at most 32,767 bind variables, and every element of
+ * an `IN (...)` list is one. A campaign scoped to 62,535 variants therefore could not
+ * be planned at all: `loadCandidates` asked for its baselines in one statement and
+ * Postgres refused the whole query with `P2035`, before a single price was written.
+ *
+ * Prisma does chunk long `IN` lists on its own, which is why this went unnoticed --
+ * but it chunks at exactly 32,767 elements and then adds the where clause's *other*
+ * binds on top, so the statement it sends is over the limit by however many other
+ * columns the query filters on. The observed failure was `received 32769`: the chunk,
+ * plus `shopId` and `surfaceKind`.
+ *
+ * So the chunk size here is deliberately far below the ceiling rather than just under
+ * it. The gap is not tuning slack -- it is room for a caller to add another filter to
+ * a query years from now without silently reintroducing this.
+ */
+
+/** Postgres's hard limit on bind variables in one prepared statement. */
+export const BIND_VARIABLE_CEILING = 32_767;
+
+/**
+ * Elements per `IN` list.
+ *
+ * Small enough that no realistic where clause can reach the ceiling, large enough
+ * that a 100,000-variant catalogue is twenty round trips rather than four hundred.
+ */
+export const IN_CHUNK = 5_000;
+
+/** Splits `items` into consecutive batches of at most `size`. */
+export function chunk<T>(items: readonly T[], size: number = IN_CHUNK): T[][] {
+  if (size < 1) throw new Error(`chunk size must be at least 1, got ${size}`);
+  if (items.length <= size) return items.length === 0 ? [] : [[...items]];
+
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) batches.push(items.slice(i, i + size));
+  return batches;
+}
+
+/**
+ * Runs `query` once per batch and concatenates the rows.
+ *
+ * Sequential rather than parallel: these run inside campaign planning, where twenty
+ * concurrent statements against the same tables would contend with the run that is
+ * writing prices at the same moment. Nothing here is latency-critical enough to trade
+ * that away.
+ */
+export async function inChunks<T, R>(
+  items: readonly T[],
+  query: (batch: T[]) => Promise<R[]>,
+  size: number = IN_CHUNK,
+): Promise<R[]> {
+  const batches = chunk(items, size);
+  if (batches.length === 0) return [];
+  if (batches.length === 1) return query(batches[0]);
+
+  const rows: R[] = [];
+  for (const batch of batches) rows.push(...(await query(batch)));
+  return rows;
+}
+
+/**
+ * Runs `mutate` once per batch, summing whatever count each returns.
+ *
+ * Separate from `inChunks` because `updateMany` returns a count rather than rows, and
+ * flattening counts as if they were rows would quietly report the wrong number.
+ */
+export async function inChunksCounting<T>(
+  items: readonly T[],
+  mutate: (batch: T[]) => Promise<{ count: number }>,
+  size: number = IN_CHUNK,
+): Promise<{ count: number }> {
+  let count = 0;
+  for (const batch of chunk(items, size)) count += (await mutate(batch)).count;
+  return { count };
+}

--- a/app/services/baselines.server.ts
+++ b/app/services/baselines.server.ts
@@ -13,6 +13,7 @@
  */
 
 import prisma from "../db.server";
+import { inChunks } from "../lib/db/chunk";
 import type { BaselineSource } from "@prisma/client";
 
 export interface CaptureResult {
@@ -46,12 +47,11 @@ export async function captureBaselines(
 ): Promise<CaptureResult> {
   const result: CaptureResult = { captured: 0, alreadyCurrent: 0, superseded: 0 };
 
-  const entries = await prisma.priceSurfaceEntry.findMany({
-    where: {
-      shopId,
-      ...(options.variantGids ? { variantGid: { in: options.variantGids } } : {}),
-    },
-  });
+  const entries = options.variantGids
+    ? await inChunks(options.variantGids, (batch) =>
+        prisma.priceSurfaceEntry.findMany({ where: { shopId, variantGid: { in: batch } } }),
+      )
+    : await prisma.priceSurfaceEntry.findMany({ where: { shopId } });
 
   const existing = await prisma.baseline.findMany({
     where: { shopId, supersededAt: null },

--- a/app/services/campaigns/candidates.server.ts
+++ b/app/services/campaigns/candidates.server.ts
@@ -7,6 +7,7 @@
  */
 
 import prisma from "../../db.server";
+import { inChunks } from "../../lib/db/chunk";
 import { money, type Money } from "../../lib/money/money";
 import type { Baseline } from "../../lib/pricing/types";
 import type { PlanCandidate } from "../../lib/planning/types";
@@ -19,10 +20,12 @@ export async function productMapFor(
 ): Promise<Map<string, string>> {
   if (variantGids.length === 0) return new Map();
 
-  const rows = await prisma.variantIndex.findMany({
-    where: { shopId, variantGid: { in: variantGids } },
-    select: { variantGid: true, productGid: true },
-  });
+  const rows = await inChunks(variantGids, (batch) =>
+    prisma.variantIndex.findMany({
+      where: { shopId, variantGid: { in: batch } },
+      select: { variantGid: true, productGid: true },
+    }),
+  );
 
   return new Map(rows.map((row) => [row.variantGid, row.productGid]));
 }
@@ -34,10 +37,12 @@ export async function titleMapFor(
 ): Promise<Map<string, string>> {
   if (variantGids.length === 0) return new Map();
 
-  const rows = await prisma.variantIndex.findMany({
-    where: { shopId, variantGid: { in: variantGids } },
-    select: { variantGid: true, title: true },
-  });
+  const rows = await inChunks(variantGids, (batch) =>
+    prisma.variantIndex.findMany({
+      where: { shopId, variantGid: { in: batch } },
+      select: { variantGid: true, title: true },
+    }),
+  );
 
   return new Map(rows.map((row) => [row.variantGid, row.title ?? row.variantGid]));
 }
@@ -71,13 +76,18 @@ export async function loadCandidates(
 ): Promise<PlanCandidate[]> {
   if (onlyVariantGids?.length === 0) return [];
 
-  const variants = await prisma.variantIndex.findMany({
-    where: {
-      ...astToWhere(shopId, ast),
-      ...(onlyVariantGids ? { variantGid: { in: onlyVariantGids } } : {}),
-    },
-    select: { variantGid: true, currency: true, cost: true },
-  });
+  const scope = astToWhere(shopId, ast);
+  const variants = onlyVariantGids
+    ? await inChunks(onlyVariantGids, (batch) =>
+        prisma.variantIndex.findMany({
+          where: { ...scope, variantGid: { in: batch } },
+          select: { variantGid: true, currency: true, cost: true },
+        }),
+      )
+    : await prisma.variantIndex.findMany({
+        where: scope,
+        select: { variantGid: true, currency: true, cost: true },
+      });
   if (variants.length === 0) return [];
 
   const gids = variants.map((v) => v.variantGid);
@@ -85,12 +95,16 @@ export async function loadCandidates(
   const imported = await importedPricesByVariant(importIds, gids);
 
   const [baselines, entries] = await Promise.all([
-    prisma.baseline.findMany({
-      where: { shopId, supersededAt: null, surfaceKind: "BASE", variantGid: { in: gids } },
-    }),
-    prisma.priceSurfaceEntry.findMany({
-      where: { shopId, surfaceKind: "BASE", variantGid: { in: gids } },
-    }),
+    inChunks(gids, (batch) =>
+      prisma.baseline.findMany({
+        where: { shopId, supersededAt: null, surfaceKind: "BASE", variantGid: { in: batch } },
+      }),
+    ),
+    inChunks(gids, (batch) =>
+      prisma.priceSurfaceEntry.findMany({
+        where: { shopId, surfaceKind: "BASE", variantGid: { in: batch } },
+      }),
+    ),
   ]);
 
   const baselineBy = new Map(baselines.map((b) => [b.variantGid, b]));
@@ -143,10 +157,12 @@ async function importedPricesByVariant(
 ): Promise<Map<string, Map<string, bigint>>> {
   if (importIds.length === 0 || variantGids.length === 0) return new Map();
 
-  const rows = await prisma.priceImportRow.findMany({
-    where: { importId: { in: [...importIds] }, variantGid: { in: [...variantGids] } },
-    select: { importId: true, variantGid: true, price: true },
-  });
+  const rows = await inChunks([...variantGids], (batch) =>
+    prisma.priceImportRow.findMany({
+      where: { importId: { in: [...importIds] }, variantGid: { in: batch } },
+      select: { importId: true, variantGid: true, price: true },
+    }),
+  );
 
   const byVariant = new Map<string, Map<string, bigint>>();
   for (const row of rows) {

--- a/app/services/campaigns/rollback-report.server.ts
+++ b/app/services/campaigns/rollback-report.server.ts
@@ -19,6 +19,7 @@
  */
 
 import prisma from "../../db.server";
+import { inChunks } from "../../lib/db/chunk";
 import { format } from "../../lib/money/format";
 import { money } from "../../lib/money/money";
 import { planRun } from "../../lib/planning/plan";
@@ -146,14 +147,18 @@ async function mirrorState(
   if (variantGids.length === 0) return new Map();
 
   const [entries, index] = await Promise.all([
-    prisma.priceSurfaceEntry.findMany({
-      where: { shopId, variantGid: { in: variantGids }, surfaceKind: "BASE", priceListGid: "" },
-      select: { variantGid: true, livePrice: true, currency: true },
-    }),
-    prisma.variantIndex.findMany({
-      where: { shopId, variantGid: { in: variantGids } },
-      select: { variantGid: true, deletedAt: true, currency: true },
-    }),
+    inChunks(variantGids, (batch) =>
+      prisma.priceSurfaceEntry.findMany({
+        where: { shopId, variantGid: { in: batch }, surfaceKind: "BASE", priceListGid: "" },
+        select: { variantGid: true, livePrice: true, currency: true },
+      }),
+    ),
+    inChunks(variantGids, (batch) =>
+      prisma.variantIndex.findMany({
+        where: { shopId, variantGid: { in: batch } },
+        select: { variantGid: true, deletedAt: true, currency: true },
+      }),
+    ),
   ]);
 
   const tombstones = new Map(index.map((row) => [row.variantGid, row.deletedAt !== null]));

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -21,6 +21,7 @@ import { astToWhere } from "../segments.server";
 import { AppError } from "../../lib/errors/app-error";
 import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
+import { inChunksCounting } from "../../lib/db/chunk";
 import { transitionCampaign } from "./lifecycle.server";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
@@ -799,14 +800,16 @@ async function recordResults(
 
   const now = new Date();
   for (const [status, gids] of byStatus) {
-    await prisma.variantChange.updateMany({
-      where: { runId, shopId, variantGid: { in: gids } },
-      data: {
-        status,
-        appliedAt: status === "FAILED" ? null : now,
-        verifiedAt: status === "VERIFIED" ? now : null,
-      },
-    });
+    await inChunksCounting(gids, (batch) =>
+      prisma.variantChange.updateMany({
+        where: { runId, shopId, variantGid: { in: batch } },
+        data: {
+          status,
+          appliedAt: status === "FAILED" ? null : now,
+          verifiedAt: status === "VERIFIED" ? now : null,
+        },
+      }),
+    );
   }
 
   // Failure reasons differ per row, so those are written individually -- but only

--- a/chaos/scenarios/bind-variable-ceiling.chaos.ts
+++ b/chaos/scenarios/bind-variable-ceiling.chaos.ts
@@ -1,0 +1,128 @@
+/**
+ * A campaign larger than Postgres will accept in one statement.
+ *
+ * `loadCandidates` asked for a campaign's baselines with one `variantGid IN (...)`
+ * per query. Postgres allows 32,767 bind variables in a prepared statement, so a
+ * campaign scoped to more variants than that could not be planned at all — it died
+ * with `P2035` before a single price was written, and the merchant saw a raw Prisma
+ * assertion rather than anything from the error taxonomy.
+ *
+ * It hid because Prisma chunks long `IN` lists on its own. It chunks at exactly
+ * 32,767 elements and then adds the query's other binds on top, so the ceiling is
+ * breached by however many other columns the where clause filters on — two, here.
+ * That is why nothing under 32,767 variants ever showed it, and why every scale test
+ * up to that point had passed.
+ *
+ * This runs against real Postgres because that is the only thing that enforces the
+ * limit: a fake, a mock or a unit test would accept any list length and agree that
+ * the code works.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { IN_CHUNK } from "../../app/lib/db/chunk";
+import {
+  loadCandidates,
+  productMapFor,
+  titleMapFor,
+} from "../../app/services/campaigns/candidates.server";
+import { captureBaselines } from "../../app/services/baselines.server";
+import { withChaos } from "../harness/scenario";
+
+/** Comfortably past the ceiling, and past a whole number of chunks. */
+const OVER_CEILING = 34_000;
+
+const TYPE = "Ceiling";
+
+/** Bulk-inserted directly: this scenario is about statement size, not about syncing. */
+async function seedWide(shopId: string, count: number): Promise<string[]> {
+  const gids = Array.from({ length: count }, (_, i) => `gid://shopify/ProductVariant/9${i}`);
+
+  for (let i = 0; i < count; i += 5_000) {
+    const slice = gids.slice(i, i + 5_000);
+
+    await prisma.variantIndex.createMany({
+      data: slice.map((variantGid, n) => ({
+        shopId,
+        variantGid,
+        productGid: `gid://shopify/Product/9${i + n}`,
+        title: `Wide ${i + n}`,
+        price: BigInt(10_000 + n),
+        currency: "USD",
+        productType: TYPE,
+      })),
+      skipDuplicates: true,
+    });
+
+    await prisma.priceSurfaceEntry.createMany({
+      data: slice.map((variantGid, n) => ({
+        shopId,
+        variantGid,
+        surfaceKind: "BASE" as const,
+        priceListGid: "",
+        currency: "USD",
+        livePrice: BigInt(10_000 + n),
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  return gids;
+}
+
+describe("chaos: a campaign wider than one prepared statement", () => {
+  it("plans a scope past the bind-variable ceiling", async () => {
+    await withChaos(
+      "bind-variable-ceiling",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -15 },
+      async (ctx) => {
+        expect(
+          OVER_CEILING,
+          "the scope must exceed what one statement can bind, or this proves nothing",
+        ).toBeGreaterThan(32_767);
+
+        const gids = await seedWide(ctx.fixture.shopId, OVER_CEILING);
+
+        // Capture takes the same oversized list, and had the same ceiling.
+        const capture = await captureBaselines(ctx.fixture.shopId, {
+          variantGids: gids,
+          source: "INSTALL_CAPTURE",
+        });
+        expect(capture.captured).toBe(OVER_CEILING);
+
+        // The planner's own load: baselines and mirrored live values for the scope.
+        const candidates = await loadCandidates(ctx.fixture.shopId, {
+          groups: [{ conditions: [{ field: "productType", value: TYPE }] }],
+        });
+        expect(
+          candidates.length,
+          "every variant in scope must be planned, not the first chunk of them",
+        ).toBe(OVER_CEILING);
+
+        // Nothing may be lost or duplicated at a chunk seam.
+        expect(new Set(candidates.map((c) => c.ref.variantGid)).size).toBe(OVER_CEILING);
+
+        // A baseline that lands in a later chunk must be the one used for that variant,
+        // not one smeared from the first batch.
+        const last = candidates.find((c) => c.ref.variantGid === gids[OVER_CEILING - 1]);
+        expect(last?.baseline.price.amount).toBe(10_000 + ((OVER_CEILING - 1) % 5_000));
+
+        // The lookups the ledger and the rollback report use take the same list.
+        const [titles, products] = await Promise.all([
+          titleMapFor(ctx.fixture.shopId, gids),
+          productMapFor(ctx.fixture.shopId, gids),
+        ]);
+        expect(titles.size).toBe(OVER_CEILING);
+        expect(products.size).toBe(OVER_CEILING);
+        expect(titles.get(gids[OVER_CEILING - 1])).toBe(`Wide ${OVER_CEILING - 1}`);
+      },
+    );
+  });
+
+  it("chunks below the ceiling with room for other filters", () => {
+    // The queries above filter on shopId and surfaceKind as well as the gid list, and
+    // the next one to gain a filter must not silently reintroduce the bug.
+    expect(IN_CHUNK + 1_000).toBeLessThan(32_767);
+  });
+});


### PR DESCRIPTION
Fixes #324.

## The bug

A campaign scoped to more than ~32,765 variants could not be planned at all:

```
Invalid `prisma.baseline.findMany()` invocation in candidates.server.ts:88
Assertion violation on the database:
  too many bind variables in prepared statement, expected maximum of 32767, received 32769
```

Found running Epic 5's *"a 50K-row run completes verified-clean"* against **62,535
variants** on `anchor-perf`. A 12,369-variant campaign on the same store applies clean,
so this is purely scale.

## Why it hid

Prisma already chunks long `IN` lists — at exactly 32,767 elements, and then the where
clause's other binds go on top. `received 32769` is one full Prisma chunk plus `shopId`
and `surfaceKind`. Nothing below the ceiling could show it, and the code read as though
chunking were handled.

That is why `IN_CHUNK` is 5,000 rather than something just under the limit. The gap is
not tuning slack — it is room for one of these queries to gain another filter later
without silently reintroducing this.

## Scope

The unbounded lists on the base campaign path:

| file | query |
|---|---|
| `candidates.server.ts` | planner scope, baselines, mirror, imported prices |
| `run.server.ts` | per-status ledger update after execution |
| `rollback-report.server.ts` | mirror state for every row a campaign wrote |
| `baselines.server.ts` | capture over an explicit variant list |

Sites that are bounded by a page or a webhook payload are left alone. The market and
B2B surface paths have the same shape and follow in a separate PR.

## Proof

`chaos/scenarios/bind-variable-ceiling.chaos.ts` seeds 34,000 variants in **real
Postgres** and plans them — real Postgres because it is the only thing that enforces
the limit; a fake or a mock would accept any list length and agree the code works.

It asserts every variant is planned (not the first chunk), that nothing is lost or
duplicated at a seam, and that a baseline landing in a later chunk is the one used for
that variant rather than one smeared from the first batch.

**Mutation test** — raising `IN_CHUNK` to 40,000 puts the list back in one statement:

```
× plans a scope past the bind-variable ceiling
  Assertion violation on the database: too many bind variables in prepared
  statement, expected maximum of 32767, received 32768
  code: 'P2035'
```

Same error as production. The test fails for the right reason.

## Checks

- `npm test` — 1435 passed
- `npm run test:chaos` — 129 passed (40 files)
- `npm run typecheck`, `npm run lint` — clean (4 pre-existing warnings)

The live 62,535-variant run against `anchor-perf` follows once this lands; it also hits
#325, which is filed separately.