### PR TITLE
Honour the floor-violation policy, and give the claim back when a run never starts

### DIFF
--- a/app/services/campaigns/lifecycle.server.ts
+++ b/app/services/campaigns/lifecycle.server.ts
@@ -86,6 +86,81 @@ export async function transitionCampaign(
   return { changed: true, from, to };
 }
 
+/** The two states that mean "a run has claimed this campaign and may be writing". */
+const CLAIM_STATES: ReadonlySet<CampaignState> = new Set<CampaignState>(["APPLYING", "REVERTING"]);
+
+/**
+ * Puts a campaign back where it was when a run claimed it and then never started.
+ *
+ * `runCampaign` moves the campaign to APPLYING before it plans, so that an illegal
+ * action is refused before a price moves. But planning can fail -- a guardrail blocks
+ * the run, the catalogue is too large for one statement, the shop's session expired --
+ * and until this existed, every one of those left the campaign claiming to be applying
+ * forever. `PRICES_MAY_BE_LIVE` includes APPLYING, so the whole app then believed the
+ * storefront might be carrying this campaign's prices when the ledger was empty. Revert
+ * was refused (APPLYING -> REVERTING is not a legal edge) and the merchant's only way
+ * out was to press apply again, which is the one action that sounds most dangerous.
+ *
+ * The guardrail case is not exotic: `planRun` returning `blocked` *throws*, so a floor
+ * price doing exactly its job stranded the campaign every single time.
+ *
+ * This is deliberately not `transitionCampaign`. APPLYING -> DRAFT is not a legal
+ * transition and should not become one: it is not the campaign progressing, it is a
+ * claim being given back, and the difference matters when reading an audit trail six
+ * months later. Adding those edges to the state machine would also let any caller move
+ * a genuinely-running campaign back to DRAFT, which is precisely the corruption the
+ * machine exists to prevent.
+ *
+ * Refuses when the campaign is not in a claim state, or when a run is still executing,
+ * because in either case something may have been written and the honest answer is
+ * PARTIAL rather than "nothing happened".
+ */
+export async function releaseClaim(
+  shopId: string,
+  campaignId: string,
+  to: CampaignState,
+  options: TransitionOptions,
+): Promise<TransitionResult> {
+  const campaign = await prisma.campaign.findFirstOrThrow({
+    where: { id: campaignId, shopId },
+    select: { status: true },
+  });
+
+  const from = campaign.status as CampaignState;
+
+  // Someone else already moved it on -- a concurrent run finishing, a cancel. Their
+  // state is newer than ours and must not be clobbered.
+  if (!CLAIM_STATES.has(from)) return { changed: false, from, to };
+
+  const executing = await prisma.campaignRun.count({
+    where: { campaignId, status: { in: ["PLANNING", "QUEUED", "EXECUTING", "VERIFYING"] } },
+  });
+  if (executing > 0) {
+    // A run is live. Releasing now would tell the merchant nothing is happening while
+    // prices are being written, which is worse than the stuck state this fixes.
+    logger.info("campaign claim not released, a run is still live", {
+      campaignId,
+      from,
+      executing,
+    });
+    return { changed: false, from, to };
+  }
+
+  const updated = await prisma.campaign.updateMany({
+    where: { id: campaignId, shopId, status: from },
+    data: { status: to },
+  });
+
+  if (updated.count === 0) return { changed: false, from, to };
+
+  await recordTransition(shopId, campaignId, from, to, {
+    ...options,
+    reason: `claim released without running: ${options.reason}`,
+  });
+
+  return { changed: true, from, to };
+}
+
 /**
  * Records the move.
  *

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -17,11 +17,32 @@ import {
 } from "../../lib/money/rounding-policy";
 import type {
   CompareAtPolicy,
+  GuardrailViolationPolicy,
   Guardrails,
   ResolvableCampaign,
 } from "../../lib/pricing/types";
 import { segmentToAst, type FilterAst } from "../segments.server";
+import { readSettings } from "../settings.server";
 import type { CampaignInput } from "./types";
+
+/**
+ * Narrows a stored policy string to the union the resolver expects.
+ *
+ * The column is a plain `String` with a `"clamp"` default, so anything could be in it
+ * -- an older row, a hand-edited record, a value from a future version rolled back.
+ * Unknown values fall back to `clamp` rather than throwing: refusing to resolve a
+ * campaign because its policy string is unfamiliar would take a merchant's live prices
+ * out of our reach entirely, and clamp is the option that keeps a price valid.
+ */
+function asViolationPolicy(stored: string): GuardrailViolationPolicy {
+  return stored === "skip" || stored === "block" ? stored : "clamp";
+}
+
+/** The shop's floor-violation setting, for a campaign being created now. */
+async function violationPolicyFor(shopId: string): Promise<GuardrailViolationPolicy> {
+  const settings = await readSettings(shopId);
+  return settings.violationPolicy;
+}
 
 export async function createCampaign(shopId: string, input: CampaignInput) {
   return prisma.campaign.create({
@@ -37,7 +58,15 @@ export async function createCampaign(shopId: string, input: CampaignInput) {
       compareAtPolicy: input.compareAtPolicy as never,
       compareAtViolationPolicy: "clear",
       guardrails: (input.guardrails ?? {}) as never,
-      guardrailViolationPolicy: "clamp",
+      // The shop's answer to "when a price would breach a floor", not a literal.
+      // It was hardcoded here and again in `toResolvable`, so the setting the merchant
+      // picked -- including "leave those variants alone" and "refuse the run" -- was
+      // silently replaced by "write the floor price anyway" (#338).
+      //
+      // Copied onto the campaign rather than read live at resolution time, so changing
+      // the store default does not retroactively change what a running campaign does
+      // to prices already on a storefront.
+      guardrailViolationPolicy: await violationPolicyFor(shopId),
       // Rounding and scope ride along in the schedule blob so the shape can evolve
       // without a migration; parseSchedule ignores the extra keys.
       schedule: {
@@ -138,6 +167,7 @@ export function toResolvable(
     | "ruleRows"
     | "compareAtPolicy"
     | "guardrails"
+    | "guardrailViolationPolicy"
     | "schedule"
     | "createdAt"
     | "excludedVariantGids"
@@ -158,7 +188,10 @@ export function toResolvable(
     compareAtViolationPolicy: "clear",
     roundingPolicy: roundingFor(schedule.rounding),
     guardrails: (campaign.guardrails ?? undefined) as unknown as Guardrails | undefined,
-    guardrailViolationPolicy: "clamp",
+    // Read from the campaign, not hardcoded. See #338: every layer below this
+    // implemented `skip` and `block` correctly and none of them could ever be reached,
+    // because this line threw the answer away.
+    guardrailViolationPolicy: asViolationPolicy(campaign.guardrailViolationPolicy),
     // Variants reverted out of this campaign individually. Carried into resolution
     // rather than filtered out beforehand, so an excluded variant falls through to
     // whatever else still controls it instead of jumping to full price.

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -22,7 +22,8 @@ import { AppError } from "../../lib/errors/app-error";
 import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
 import { inChunksCounting } from "../../lib/db/chunk";
-import { transitionCampaign } from "./lifecycle.server";
+import { releaseClaim, transitionCampaign } from "./lifecycle.server";
+import type { CampaignState } from "../../lib/lifecycle/transitions";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
 import {
@@ -35,6 +36,18 @@ import { metric } from "../../lib/telemetry/metrics";
 
 export interface RunOptions {
   revert?: boolean;
+  /**
+   * The state the caller moved this campaign out of when it claimed it.
+   *
+   * Only the scheduler needs this. It claims a campaign with its own conditional
+   * update -- that update *is* how two overlapping ticks avoid both running the same
+   * transition -- so by the time `runCampaign` looks, the original state is gone. If
+   * planning then fails, this is the only record of where to put the campaign back.
+   *
+   * A manual apply leaves it unset: the campaign is still in its pre-claim state when
+   * `runCampaign` reads it.
+   */
+  claimedFrom?: CampaignState;
   /**
    * Fraction of applied rows to read back. Defaults to full verification, which
    * suits the catalogue sizes the sync path handles; the bulk path compares every row
@@ -85,6 +98,46 @@ export interface RunOptions {
 }
 
 export async function runCampaign(
+  shopId: string,
+  campaignId: string,
+  client: AdminClient,
+  options: RunOptions = {},
+): Promise<RunOutcome> {
+  // The campaign is moved to APPLYING before anything is planned, so that an illegal
+  // action is refused before a price moves. Planning can then fail -- a guardrail
+  // blocks the run, a session expires, a catalogue outgrows one statement -- and until
+  // this wrapper existed every one of those left the campaign claiming to be applying
+  // forever, with an empty ledger behind it and revert refused.
+  //
+  // The guardrail case is the common one, not an exotic one: `planRun` returning
+  // `blocked` throws, so a floor price doing exactly its job stranded the campaign.
+  //
+  // Read before the claim, because afterwards the original state is gone. When the
+  // scheduler claimed the campaign itself -- its `updateMany` from SCHEDULED is how two
+  // overlapping ticks avoid both running the same transition -- this reads APPLYING and
+  // only the scheduler knows what it took, so it passes `claimedFrom`.
+  const before = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: { status: true },
+  });
+  const releaseTo = (options.claimedFrom ?? before?.status) as CampaignState | undefined;
+
+  try {
+    return await executeCampaignRun(shopId, campaignId, client, options);
+  } catch (error) {
+    // Only release to a state that is not itself a claim. A campaign that was already
+    // APPLYING when this was called -- a resume, a second worker -- has nowhere to be
+    // put back to, and `releaseClaim` additionally refuses while any run is still live.
+    if (releaseTo && releaseTo !== "APPLYING" && releaseTo !== "REVERTING") {
+      await releaseClaim(shopId, campaignId, releaseTo, {
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+    throw error;
+  }
+}
+
+async function executeCampaignRun(
   shopId: string,
   campaignId: string,
   client: AdminClient,

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -15,6 +15,7 @@ import {
   type Transition,
 } from "../lib/scheduling/window";
 import { runCampaign } from "./campaigns/run.server";
+import type { CampaignState } from "../lib/lifecycle/transitions";
 import { adminClientForShop } from "./admin-client.server";
 import { claimEnrollment, pendingEnrollments } from "./auto-enroll.server";
 import { reclaimStaleRuns } from "./campaigns/reaper.server";
@@ -273,6 +274,14 @@ async function runTransition(
   // Claim the campaign before running. Two ticks overlapping — a slow run, a second
   // worker that briefly held the lock — would otherwise both start the same
   // transition. The status change is the claim.
+  // Read the state we are about to take it out of, so a run that fails before it
+  // starts can be put back there. `updateMany` reports how many rows it changed, not
+  // what they were.
+  const before = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: { status: true },
+  });
+
   const claimed = await prisma.campaign.updateMany({
     where: {
       id: campaignId,
@@ -286,6 +295,7 @@ async function runTransition(
   await runCampaign(shopId, campaignId, client, {
     revert: transition === "revert",
     occurrenceKey,
+    claimedFrom: before?.status as CampaignState | undefined,
   });
 }
 

--- a/chaos/scenarios/stranded-claim.chaos.ts
+++ b/chaos/scenarios/stranded-claim.chaos.ts
@@ -1,0 +1,205 @@
+/**
+ * A campaign that fails before its run starts must not be left claiming to be applying.
+ *
+ * `runCampaign` moves the campaign to APPLYING before anything is planned, so that an
+ * illegal action is refused before a price moves. Planning can then fail, and until
+ * this was fixed every such failure left the campaign in APPLYING forever: the ledger
+ * empty, no run row, revert refused because APPLYING -> REVERTING is not a legal edge,
+ * and the dashboard reporting a run in progress that no worker was working on.
+ *
+ * `PRICES_MAY_BE_LIVE` includes APPLYING, so the whole app believed the storefront
+ * might be carrying this campaign's prices. That is a state the product exists to make
+ * impossible: clean, or visibly partial, never a claim nobody can act on.
+ *
+ * The trigger used here is a blocking guardrail, deliberately, because it is the
+ * ordinary case rather than an exotic one. `planRun` returning `blocked` *throws*, so a
+ * merchant's floor price doing exactly its job stranded the campaign every time. It was
+ * found via a much rarer failure (#324, a catalogue too large for one statement), but
+ * fixing only that would have left the common path broken.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { createCampaign } from "../../app/services/campaigns/model.server";
+import { DEFAULT_SETTINGS, writeSettings } from "../../app/services/settings.server";
+import { withChaos } from "../harness/scenario";
+
+describe("chaos: a run that never starts gives the campaign back", () => {
+  it("leaves a guardrail-blocked campaign actionable instead of stuck applying", async () => {
+    await withChaos(
+      "stranded-claim",
+      { catalog: { products: 3, variantsPerProduct: 2 }, percent: -20 },
+      async (ctx) => {
+        const { shopId, campaignId } = ctx.fixture;
+
+        const before = await prisma.campaign.findUniqueOrThrow({
+          where: { id: campaignId },
+          select: { status: true },
+        });
+
+        // A floor above every price in the catalogue, set to block rather than clamp.
+        // Blocking is the merchant saying "do not quietly do something else" -- which
+        // is exactly why it must not quietly break the campaign either.
+        //
+        // The policy goes on the campaign because that is where resolution reads it
+        // (#338): a campaign copies the shop's setting when it is created, so changing
+        // the shop default afterwards must not retroactively change a running campaign.
+        // The fixture's campaign already exists, so set it directly.
+        await writeSettings(shopId, { ...DEFAULT_SETTINGS, minPrice: 100_000 });
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { guardrailViolationPolicy: "block" },
+        });
+
+        await expect(ctx.apply()).rejects.toThrow(/guardrail/i);
+
+        const after = await prisma.campaign.findUniqueOrThrow({
+          where: { id: campaignId },
+          select: { status: true },
+        });
+
+        expect(
+          after.status,
+          "a campaign that never ran must go back where it was, not sit in APPLYING",
+        ).toBe(before.status);
+
+        // Nothing was written, and nothing pretends to have been.
+        const runs = await prisma.campaignRun.count({ where: { campaignId } });
+        expect(runs, "no run started, so no run row should exist").toBe(0);
+
+        const ledger = await prisma.variantChange.count({ where: { shopId } });
+        expect(ledger, "ledger before write (I4) -- nothing planned means nothing ledgered").toBe(0);
+
+        // The audit trail says what happened, so the state change is explainable.
+        const entry = await prisma.auditLogEntry.findFirst({
+          where: { shopId, entityId: campaignId, action: "campaign.transition" },
+          orderBy: { createdAt: "desc" },
+        });
+        const reason = (entry?.after as { reason?: string } | null)?.reason ?? "";
+        expect(reason, "the release must be distinguishable from a normal transition").toMatch(
+          /claim released without running/,
+        );
+      },
+    );
+  });
+
+  it("recovers: with the guardrail lifted, the same campaign applies cleanly", async () => {
+    await withChaos(
+      "stranded-claim-recovers",
+      { catalog: { products: 3, variantsPerProduct: 2 }, percent: -20 },
+      async (ctx) => {
+        const { shopId, campaignId } = ctx.fixture;
+
+        await writeSettings(shopId, { ...DEFAULT_SETTINGS, minPrice: 100_000 });
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { guardrailViolationPolicy: "block" },
+        });
+        await expect(ctx.apply()).rejects.toThrow(/guardrail/i);
+
+        // The point of releasing the claim: the merchant fixes the floor and retries.
+        // Before the fix this second apply was the *only* way out, and revert was not
+        // available at all.
+        await writeSettings(shopId, DEFAULT_SETTINGS);
+
+        const outcome = await ctx.apply();
+        expect(outcome.clean, "the retry must be an ordinary clean run").toBe(true);
+        expect(outcome.verified).toBe(6);
+
+        const after = await prisma.campaign.findUniqueOrThrow({
+          where: { id: campaignId },
+          select: { status: true },
+        });
+        expect(after.status).toBe("ACTIVE");
+
+        await ctx.expectHonest(await ctx.latestRunId("APPLY"));
+      },
+    );
+  });
+});
+
+describe("chaos: the floor-violation policy reaches the resolver", () => {
+  it("copies the shop's setting onto a campaign when it is created", async () => {
+    await withChaos(
+      "violation-policy-copied",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (ctx) => {
+        const { shopId } = ctx.fixture;
+
+        await writeSettings(shopId, { ...DEFAULT_SETTINGS, violationPolicy: "skip" });
+
+        const created = await createCampaign(shopId, {
+          name: "Reads the setting",
+          rule: { kind: "percent-change", percent: -10 },
+          compareAtPolicy: { kind: "leave" },
+          rounding: { default: "none", byCurrency: {} },
+          ast: { groups: [] },
+          schedule: { kind: "manual" },
+        } as never);
+
+        expect(
+          created.guardrailViolationPolicy,
+          "a merchant who chose skip must not get a campaign that clamps",
+        ).toBe("skip");
+      },
+    );
+  });
+
+  it("does not retroactively change a campaign when the shop default changes", async () => {
+    await withChaos(
+      "violation-policy-frozen",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (ctx) => {
+        const { shopId } = ctx.fixture;
+
+        await writeSettings(shopId, { ...DEFAULT_SETTINGS, violationPolicy: "block" });
+        const created = await createCampaign(shopId, {
+          name: "Created under block",
+          rule: { kind: "percent-change", percent: -10 },
+          compareAtPolicy: { kind: "leave" },
+          rounding: { default: "none", byCurrency: {} },
+          ast: { groups: [] },
+          schedule: { kind: "manual" },
+        } as never);
+
+        // Changing the store default must not reach back into a campaign that may
+        // already have prices on a storefront.
+        await writeSettings(shopId, { ...DEFAULT_SETTINGS, violationPolicy: "clamp" });
+
+        const after = await prisma.campaign.findUniqueOrThrow({
+          where: { id: created.id },
+          select: { guardrailViolationPolicy: true },
+        });
+        expect(after.guardrailViolationPolicy).toBe("block");
+      },
+    );
+  });
+
+  it("falls back to clamp on a policy string it does not recognise", async () => {
+    await withChaos(
+      "violation-policy-unknown",
+      { catalog: { products: 2, variantsPerProduct: 1 }, percent: -10 },
+      async (ctx) => {
+        const { shopId, campaignId } = ctx.fixture;
+
+        // An older row, a rolled-back release, a hand-edited record. Refusing to
+        // resolve would put the merchant's live prices out of our reach entirely,
+        // which is worse than the safest valid answer.
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { guardrailViolationPolicy: "obliterate" },
+        });
+        await writeSettings(shopId, { ...DEFAULT_SETTINGS, minPrice: 100_000 });
+
+        const outcome = await ctx.apply();
+        expect(outcome.clean, "an unknown policy must not stop the run").toBe(true);
+        expect(outcome.verified).toBe(2);
+
+        // Clamped to the floor, not blocked and not skipped.
+        const live = [...ctx.livePrices().values()];
+        expect(new Set(live).size, "every price clamped to the same floor").toBe(1);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Fixes #338 and #325. They land together on purpose — the first makes a code path live, and the second stops that path stranding the campaign.

## #338 — the merchant's floor-violation setting did nothing

Settings offers **"When a price would breach a floor: clamp / skip / block"**. `writeSettings` validates it, persists it, and audits every change. `resolver.ts` implements all three branches; `plan.ts:107` handles a blocked plan; `run.server.ts` handles it again.

The value never arrived. It was dropped three times:

| Where | What it did |
|---|---|
| `toGuardrails` | carries `neverBelowCost`, `minMarginPercent`, `minPrice`, `missingCostPolicy` — not `violationPolicy` |
| `createCampaign` | `guardrailViolationPolicy: "clamp"` — a literal |
| `toResolvable` | ignored even the stored column and hardcoded `"clamp"` again |

**The two wrong answers were the same wrong answer.** `skip` means *leave those variants alone*; `block` means *refuse the run*. Both are the merchant saying **do not write a price here**, and both wrote one anyway — at the floor, a number they never asked for and never previewed under that setting.

It hid because the unit tests construct a `ResolvableCampaign` directly and set the policy themselves. They exercised branches that no real campaign could reach: the blocked branches of `plan.ts` and `run.server.ts` were dead code.

Two deliberate choices:

- **Copied at creation, not read live.** Changing the store default must not reach back into a campaign that may already have prices on a storefront.
- **Unknown stored values fall back to `clamp`, not a throw.** Refusing to resolve a campaign over an unfamiliar policy string would put the merchant's live prices out of reach entirely; clamp is the option that still produces a valid price.

## #325 — a run that never started left the campaign stuck in APPLYING

The campaign moves to APPLYING before planning, so an illegal action is refused before a price moves. Planning can then fail — and every such failure left it there forever:

```
campaign: {"status":"APPLYING"}     ← long after the process exited
RUN: null                           ← no run row was ever created
REVERT THREW: This campaign is applying, so that action does not apply to it.
```

`PRICES_MAY_BE_LIVE` includes APPLYING, so the whole app believed the storefront might carry prices that were never written. Revert was refused (APPLYING → REVERTING is not a legal edge). The only escape was pressing apply again — the one action that sounds most dangerous.

**`releaseClaim` is deliberately not `transitionCampaign`.** APPLYING → DRAFT is not a legal transition and should not become one: this is not the campaign progressing, it is a claim being given back, and the distinction matters when reading an audit trail later. Adding those edges would also let any caller move a genuinely *running* campaign back to DRAFT. It refuses unless the campaign is in a claim state and no run is live, and its audit reason reads `claim released without running`.

The scheduler claims campaigns itself — that conditional update is how two overlapping ticks avoid both running the same transition — so it now passes `claimedFrom`, because by the time `runCampaign` looks, the original state is gone.

## Proof

`chaos/scenarios/stranded-claim.chaos.ts`, 5 scenarios against real Postgres. **Four mutants, each caught by the test that should catch it:**

| Mutant | Caught by |
|---|---|
| `toResolvable` hardcodes clamp | run no longer throws — *"promise resolved instead of rejecting"* |
| `createCampaign` hardcodes clamp | the copy test and the don't-retroactively-change test |
| wrapper never releases | *"expected 'APPLYING' to be 'DRAFT'"* |
| fallback trusts the stored string | unknown-policy test |

Worth noting from mutant 3: the *recovery* test still passed with the release removed — confirming that retry-apply really was the only way out.

## Checks

- `npm test` — 1435 passed
- `npm run test:chaos` — 134 passed (41 files)
- `npm run typecheck`, `npm run lint` — clean (4 pre-existing warnings)

## Not fixed here

`compareAtViolationPolicy` is hardcoded identically in both places (`"clear"`). It is not merchant-settable anywhere, so it is an unused column rather than a broken promise — noted in #338, left alone.