### PR TITLE
P7.2 — Full width, with the aside rebuilt rather than dropped

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * The page shell, and the aside it has to rebuild.
+ *
+ * Polaris renders `s-page`'s `aside` slot **only** at `inlineSize="base"`. Going full
+ * width therefore deletes every aside — silently, with no error and no empty box.
+ * Nineteen sections across thirteen routes are in that slot, and four of them are on
+ * the campaign page, including the one holding apply, revert, resume and cancel.
+ *
+ * So these assertions are about a merchant losing a button, not about layout taste.
+ *
+ * Server rendering rather than a DOM: Polaris web components are custom elements the
+ * server passes through as written, which is exactly what needs asserting about
+ * `inlineSize` and about where the aside content ended up.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PageShell } from "./PageShell";
+
+const render = (node: React.ReactElement) => renderToStaticMarkup(node);
+
+describe("full width", () => {
+  it("asks for the whole screen rather than the default column", () => {
+    const html = render(
+      <PageShell heading="Prices">
+        <s-section>rows</s-section>
+      </PageShell>,
+    );
+
+    expect(html).toContain('inlineSize="large"');
+  });
+
+  it("keeps the heading", () => {
+    expect(render(<PageShell heading="Diagnostics">{null}</PageShell>)).toContain(
+      'heading="Diagnostics"',
+    );
+  });
+});
+
+describe("the aside survives going full width", () => {
+  const html = render(
+    <PageShell heading="Campaign">
+      <s-section heading="Preview">main content</s-section>
+      <s-section slot="aside" heading="Actions">
+        <s-button>Apply</s-button>
+      </s-section>
+    </PageShell>,
+  );
+
+  it("still renders the aside content", () => {
+    expect(html, "an aside dropped here is a button a merchant cannot press").toContain(
+      "Apply",
+    );
+  });
+
+  it("still renders the main content", () => {
+    expect(html).toContain("main content");
+  });
+
+  it("puts it in a second column rather than leaving it to the slot", () => {
+    expect(html).toContain("<s-grid");
+  });
+
+  it("drops the slot, which now names a slot no ancestor provides", () => {
+    expect(html).not.toContain('slot="aside"');
+  });
+
+  it("keeps main content ahead of the aside, so narrow screens read in order", () => {
+    expect(html.indexOf("main content")).toBeLessThan(html.indexOf("Apply"));
+  });
+});
+
+describe("pages without an aside", () => {
+  const html = render(
+    <PageShell heading="Activity">
+      <s-section>just rows</s-section>
+    </PageShell>,
+  );
+
+  it("do not pay for a two-column grid", () => {
+    expect(html).not.toContain("<s-grid");
+  });
+
+  it("still render their content", () => {
+    expect(html).toContain("just rows");
+  });
+});
+
+describe("asides that a page renders conditionally", () => {
+  // Three of the nineteen sit inside a ternary — `{count > 0 ? <s-section slot="aside">`
+  // — so they arrive as a direct child only when the condition holds. A partition that
+  // missed them would drop an aside on exactly the pages that had something to say.
+  it("are found when the condition holds", () => {
+    const show = true;
+    const html = render(
+      <PageShell heading="Diagnostics">
+        <s-section>main</s-section>
+        {show ? <s-section slot="aside">by kind</s-section> : null}
+      </PageShell>,
+    );
+
+    expect(html).toContain("by kind");
+    expect(html).toContain("<s-grid");
+  });
+
+  it("leave no empty column when the condition does not hold", () => {
+    const show = false;
+    const html = render(
+      <PageShell heading="Diagnostics">
+        <s-section>main</s-section>
+        {show ? <s-section slot="aside">by kind</s-section> : null}
+      </PageShell>,
+    );
+
+    expect(html).not.toContain("<s-grid");
+  });
+});
+
+describe("the column collapses before it gets unreadable", () => {
+  it("uses a container query, because the admin iframe is not the window", () => {
+    const html = render(
+      <PageShell heading="X">
+        <s-section>main</s-section>
+        <s-section slot="aside">side</s-section>
+      </PageShell>,
+    );
+
+    expect(html).toMatch(/@container[^"]*inline-size/);
+  });
+});

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -1,0 +1,66 @@
+import { Children, cloneElement, isValidElement, type ReactNode } from "react";
+
+/**
+ * Every page in the app, at the full width of the screen.
+ *
+ * `s-page` defaults to `inlineSize="base"`, a ~660px column. On a 1300px viewport that
+ * left roughly half the screen empty while the tables inside it wrapped — which is a
+ * strange thing for an app whose whole job is showing a merchant thousands of rows.
+ *
+ * The catch that makes this more than one attribute: Polaris renders the `aside` slot
+ * **only** when `inlineSize` is `"base"`. Nineteen sections across thirteen routes use
+ * it, and four of them are on the campaign page — including the one holding apply,
+ * revert, resume and cancel. Setting `inlineSize="large"` and nothing else would have
+ * deleted the apply button with no error and no empty box, which is the kind of
+ * failure nobody finds until a merchant reports it.
+ *
+ * So the aside is rebuilt here rather than abandoned. Children marked `slot="aside"`
+ * are partitioned out and rendered in a second column, and the routes keep writing
+ * exactly what they wrote before. The alternative — hand-editing nineteen JSX blocks
+ * out of their pages and into a prop — is the same change with far more opportunity to
+ * drop one.
+ *
+ * The column collapses under 900px so the aside falls below the content rather than
+ * being squeezed into something unreadable. It is a container query, not a media
+ * query: the app renders in an admin iframe whose width is not the window's.
+ */
+export function PageShell({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: ReactNode;
+}) {
+  const all = Children.toArray(children);
+  const isAside = (child: ReactNode) =>
+    isValidElement(child) && (child.props as { slot?: string }).slot === "aside";
+
+  const aside = all.filter(isAside);
+  const main = all.filter((child) => !isAside(child));
+
+  if (aside.length === 0) {
+    return (
+      <s-page heading={heading} inlineSize="large">
+        {main}
+      </s-page>
+    );
+  }
+
+  return (
+    <s-page heading={heading} inlineSize="large">
+      <s-grid
+        gap="base"
+        gridTemplateColumns="@container (inline-size <= 900px) minmax(0, 1fr), minmax(0, 1fr) minmax(0, 22rem)"
+      >
+        <s-stack gap="base">{main}</s-stack>
+        <s-stack gap="base">
+          {aside.map((child) =>
+            // The slot is meaningless now that these are ordinary grid children, and
+            // leaving it on would have them looking for a slot no ancestor provides.
+            isValidElement(child) ? cloneElement(child, { slot: undefined } as never) : child,
+          )}
+        </s-stack>
+      </s-grid>
+    </s-page>
+  );
+}

--- a/app/lib/ui/page-width.test.ts
+++ b/app/lib/ui/page-width.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Nothing gets to render a page the narrow way again.
+ *
+ * `s-page` defaults to `inlineSize="base"` — a ~660px column that left half a 1300px
+ * screen empty. Every route goes through `PageShell` instead, which asks for the full
+ * width and rebuilds the `aside` slot that Polaris only renders at `base`.
+ *
+ * The failure this guards is quiet and specific: a route that writes `<s-page>` itself
+ * either gets the old narrow column, or — if it also copies `inlineSize="large"` — gets
+ * a page whose asides silently do not render. On the campaign page that is the apply
+ * button disappearing with no error.
+ *
+ * Read from the routes directory rather than a list, so a route added next month is
+ * covered without anyone remembering this file exists.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROUTES_DIR = join(process.cwd(), "app", "routes");
+
+/** Route modules that render something. Redirect stubs and resource routes have no JSX. */
+function renderingRoutes(): Array<{ name: string; source: string }> {
+  return readdirSync(ROUTES_DIR)
+    .filter((f) => f.endsWith(".tsx"))
+    .map((name) => ({ name, source: readFileSync(join(ROUTES_DIR, name), "utf8") }))
+    .filter(({ source }) => source.includes("export default function"));
+}
+
+describe("every page is full width", () => {
+  it("finds routes to check, so this cannot pass by checking nothing", () => {
+    expect(renderingRoutes().length).toBeGreaterThan(15);
+  });
+
+  it("routes the page through PageShell rather than s-page", () => {
+    const direct = renderingRoutes()
+      .filter(({ source }) => source.includes("<s-page"))
+      .map(({ name }) => name);
+
+    expect(
+      direct,
+      "these render s-page directly, so they get the default narrow column — and if " +
+        "they set inlineSize themselves, their asides stop rendering with no error",
+    ).toEqual([]);
+  });
+
+  it("keeps the aside rebuild in one place", () => {
+    const shell = readFileSync(join(process.cwd(), "app", "components", "PageShell.tsx"), "utf8");
+
+    expect(shell).toContain('inlineSize="large"');
+    expect(
+      shell,
+      "PageShell is the only thing that may render s-page, because it is the only thing " +
+        "that also rebuilds the aside",
+    ).toContain("<s-page");
+  });
+});
+
+describe("routes that use the aside slot", () => {
+  it("still have somewhere for it to land", () => {
+    const withAside = renderingRoutes().filter(({ source }) => source.includes('slot="aside"'));
+
+    // Not a nice-to-have: four of these are on the campaign page, one of them holding
+    // apply, revert, resume and cancel.
+    expect(withAside.length, "the asides this guards should still exist").toBeGreaterThan(5);
+
+    for (const { name, source } of withAside) {
+      expect(source, `${name} uses slot="aside" but does not render inside PageShell`).toContain(
+        "PageShell",
+      );
+    }
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -16,6 +16,7 @@ import { OnboardingCard } from "../components/OnboardingCard";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { onboarding } from "../lib/onboarding/steps";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -215,7 +216,7 @@ export default function Dashboard() {
   const neverSynced = syncedAt === null;
 
   return (
-    <s-page heading="Anchor">
+    <PageShell heading="Anchor">
       {result ? (
         <s-banner tone={result.ok ? "success" : "critical"}>
           <s-paragraph>{result.message}</s-paragraph>
@@ -467,7 +468,7 @@ export default function Dashboard() {
           <s-link href="/app/imports/recapture">Recapture baselines…</s-link>
         </s-section>
       ) : null}
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -21,6 +21,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { downloadCsv } from "../lib/reporting/csv";
 import { describeActor } from "../lib/audit/actor";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 const FILTER_FIELDS = ["actor", "action", "from", "to"] as const;
 
@@ -66,7 +67,7 @@ export default function Activity() {
     });
 
   return (
-    <s-page heading="Activity">
+    <PageShell heading="Activity">
       <s-section>
         <FilterForm fields={FILTER_FIELDS}>
           <s-stack gap="base">
@@ -156,7 +157,7 @@ export default function Activity() {
           </s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -40,6 +40,7 @@ import {
 } from "../lib/lifecycle/transitions";
 import { transitionHistory } from "../services/campaigns/lifecycle.server";
 import { approvalFor, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/campaigns/$id", async ({ request, params }: LoaderFunctionArgs) => {
   const { admin, session } = await authenticate.admin(request);
@@ -279,7 +280,7 @@ export default function CampaignDetail() {
   const canApply = !practice && !preview.blocked && canTransition(state, "APPLYING");
 
   return (
-    <s-page heading={preview.name}>
+    <PageShell heading={preview.name}>
       {result ? (
         <s-banner tone={result.ok ? "success" : "critical"}>
           <s-paragraph>{result.message}</s-paragraph>
@@ -676,7 +677,7 @@ export default function CampaignDetail() {
           </>
         ) : null}
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -12,6 +12,7 @@ import {
   needsAttention,
   type CampaignState,
 } from "../lib/lifecycle/transitions";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/campaigns", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -61,7 +62,7 @@ export default function CampaignList() {
   const { campaigns, attentionCount } = useLoaderData<typeof loader>();
 
   return (
-    <s-page heading="Campaigns">
+    <PageShell heading="Campaigns">
       {attentionCount > 0 ? (
         <s-banner tone="warning">
           <s-paragraph>
@@ -134,7 +135,7 @@ export default function CampaignList() {
           campaign still covers a variant, that campaign&rsquo;s price stays in place.
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.campaigns.calendar.tsx
+++ b/app/routes/app.campaigns.calendar.tsx
@@ -9,6 +9,7 @@ import { addDays } from "../lib/scheduling/calendar";
 import { CalendarGrid } from "../components/CalendarGrid";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/campaigns/calendar", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -50,7 +51,7 @@ export default function Calendar() {
   const heading = view === "week" ? `Week of ${on}` : monthName(on);
 
   return (
-    <s-page heading="Calendar">
+    <PageShell heading="Calendar">
       <s-section heading={heading}>
         <s-paragraph>
           <s-text>
@@ -114,7 +115,7 @@ export default function Calendar() {
           ))}
         </s-section>
       ) : null}
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -24,6 +24,7 @@ import { billingFrom } from "../services/billing.server";
 import { canUseSurface } from "../lib/billing/plans";
 import prisma from "../db.server";
 import { segmentToAst } from "../services/segments.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -257,7 +258,7 @@ export default function NewCampaign() {
   } = useLoaderData<typeof loader>();
 
   return (
-    <s-page heading={practice ? "Practice campaign" : guided ? "Your first campaign" : "New campaign"}>
+    <PageShell heading={practice ? "Practice campaign" : guided ? "Your first campaign" : "New campaign"}>
       {practice ? (
         <s-banner tone="info">
           <s-paragraph>
@@ -579,7 +580,7 @@ export default function NewCampaign() {
           discounting the discount.
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.imports.baselines.tsx
+++ b/app/routes/app.imports.baselines.tsx
@@ -26,6 +26,7 @@ import { actorFor } from "../lib/audit/actor";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/imports/baselines", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -85,7 +86,7 @@ export default function ImportBaselines() {
   };
 
   return (
-    <s-page heading="Import baselines">
+    <PageShell heading="Import baselines">
       {data ? (
         <s-banner tone={data.ok ? "success" : "critical"}>
           <s-paragraph>{data.message}</s-paragraph>
@@ -164,7 +165,7 @@ export default function ImportBaselines() {
           </s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.imports.costs.tsx
+++ b/app/routes/app.imports.costs.tsx
@@ -30,6 +30,7 @@ import { linesOf } from "../lib/reporting/lines";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/imports/costs", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -101,7 +102,7 @@ export default function ImportCosts() {
     : [];
 
   return (
-    <s-page heading="Import costs">
+    <PageShell heading="Import costs">
       {data ? (
         <s-banner tone={data.ok ? "success" : "critical"}>
           <s-paragraph>{data.message}</s-paragraph>
@@ -193,7 +194,7 @@ export default function ImportCosts() {
           ) : null}
         </s-section>
       ) : null}
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.imports.prices.tsx
+++ b/app/routes/app.imports.prices.tsx
@@ -26,6 +26,7 @@ import { actorFor } from "../lib/audit/actor";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import prisma from "../db.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/imports/prices", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -107,7 +108,7 @@ export default function ImportPrices() {
     : [];
 
   return (
-    <s-page heading="Import prices">
+    <PageShell heading="Import prices">
       {fetcher.data ? (
         <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
           <s-paragraph>{fetcher.data.message}</s-paragraph>
@@ -175,7 +176,7 @@ export default function ImportPrices() {
           </s-unordered-list>
         </s-section>
       ) : null}
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.imports.recapture.tsx
+++ b/app/routes/app.imports.recapture.tsx
@@ -23,6 +23,7 @@ import { actorFor } from "../lib/audit/actor";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/imports/recapture", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -89,7 +90,7 @@ export default function Recapture() {
   const data = fetcher.data;
 
   return (
-    <s-page heading="Recapture baselines">
+    <PageShell heading="Recapture baselines">
       {data ? (
         <s-banner tone={data.ok ? "success" : "critical"}>
           <s-paragraph>{data.message}</s-paragraph>
@@ -201,7 +202,7 @@ export default function Recapture() {
           <s-text>The Baselines page shows every version of every variant.</s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -9,6 +9,7 @@ import { formatMoney, money } from "../lib/money/money";
 import { FilterForm } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 const PAGE_SIZE = 50;
 
@@ -100,7 +101,7 @@ export default function Catalog() {
     });
 
   return (
-    <s-page heading="Catalogue">
+    <PageShell heading="Catalogue">
       <s-section>
         <FilterForm fields={["q"]}>
           <s-stack direction="inline" gap="base">
@@ -195,7 +196,7 @@ export default function Catalog() {
           </s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.prices.baselines.tsx
+++ b/app/routes/app.prices.baselines.tsx
@@ -29,6 +29,7 @@ import { baselinesCsv } from "../lib/reporting/baselines-csv";
 import { downloadCsv } from "../lib/reporting/csv";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 const FILTER_FIELDS = ["q", "vendor", "source", "diverged", "variant"] as const;
 
@@ -74,7 +75,7 @@ export default function Baselines() {
     });
 
   return (
-    <s-page heading="Baselines">
+    <PageShell heading="Baselines">
       <s-section>
         <FilterForm fields={FILTER_FIELDS}>
           <s-stack gap="base">
@@ -204,7 +205,7 @@ export default function Baselines() {
           </s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.prices.costs.tsx
+++ b/app/routes/app.prices.costs.tsx
@@ -28,6 +28,7 @@ import { facets, type FilterAst } from "../services/segments.server";
 import { actorFor } from "../lib/audit/actor";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/prices/costs", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -112,7 +113,7 @@ export default function Costs() {
   const coverage = variants === 0 ? 0 : Math.round((withCost / variants) * 100);
 
   return (
-    <s-page heading="Costs">
+    <PageShell heading="Costs">
       {violationCount > 0 ? (
         <s-banner tone="critical">
           <s-heading>A cost change has put live prices below your floor</s-heading>
@@ -222,7 +223,7 @@ export default function Costs() {
           </s-unordered-list>
         ) : null}
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.prices.drift.tsx
+++ b/app/routes/app.prices.drift.tsx
@@ -7,6 +7,7 @@ import { ensureShop } from "../services/shop.server";
 import { pendingDrift, resolveDrift, type DriftResolution } from "../services/drift.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/prices/drift", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -41,7 +42,7 @@ export default function DriftQueue() {
   const busy = fetcher.state !== "idle";
 
   return (
-    <s-page heading="Price drift">
+    <PageShell heading="Price drift">
       {fetcher.data ? (
         <s-banner tone="success">
           <s-paragraph>{fetcher.data.message}</s-paragraph>
@@ -118,7 +119,7 @@ export default function DriftQueue() {
           </s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -14,6 +14,7 @@ import { ReconciliationTable } from "../components/ReconciliationTable";
 import { FilterForm } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 /** Filters that ride in the query string, so a merchant can bookmark a view. */
 export const RECONCILE_FIELDS = ["q", "surface", "campaign", "state"] as const;
@@ -78,7 +79,7 @@ export default function Reconciliation() {
   const busy = fetcher.state !== "idle";
 
   return (
-    <s-page heading="What is live, and why">
+    <PageShell heading="What is live, and why">
       <s-section>
         <s-paragraph>
           <s-text>
@@ -197,7 +198,7 @@ export default function Reconciliation() {
           Export this page (CSV)
         </s-button>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -15,6 +15,7 @@ import {
   readRoundingPolicy,
   ROUNDING_LABELS,
 } from "../lib/money/rounding-policy";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -132,7 +133,7 @@ export default function Settings() {
   const costCoverage = variants === 0 ? 0 : Math.round((withCost / variants) * 100);
 
   return (
-    <s-page heading="Settings">
+    <PageShell heading="Settings">
       {fetcher.data ? (
         <s-banner tone="success">
           <s-paragraph>{fetcher.data.message}</s-paragraph>
@@ -381,7 +382,7 @@ export default function Settings() {
           </s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.settings.diagnostics.tsx
+++ b/app/routes/app.settings.diagnostics.tsx
@@ -18,6 +18,7 @@ import { isErrorId } from "../lib/errors/error-id";
 import { EmptyState } from "../components/AsyncState";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/settings/diagnostics", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -59,7 +60,7 @@ export default function Debug() {
   const { query, invalidQuery, match, recent, byCode } = useLoaderData<typeof loader>();
 
   return (
-    <s-page heading="Diagnostics">
+    <PageShell heading="Diagnostics">
       <s-section heading="Look up an error">
         <s-paragraph>
           <s-text>
@@ -180,7 +181,7 @@ export default function Debug() {
           ))}
         </s-section>
       ) : null}
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.settings.feedback.tsx
+++ b/app/routes/app.settings.feedback.tsx
@@ -18,6 +18,7 @@ import { actorFor } from "../lib/audit/actor";
 import { FeedbackForm } from "../components/FeedbackForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/settings/feedback", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -60,7 +61,7 @@ export default function FeedbackPage() {
   const { sent, timeZone } = useLoaderData<typeof loader>();
 
   return (
-    <s-page heading="Feedback">
+    <PageShell heading="Feedback">
       <FeedbackForm route="/app/settings/feedback" />
 
       {sent.length > 0 ? (
@@ -93,7 +94,7 @@ export default function FeedbackPage() {
           </s-table>
         </s-section>
       ) : null}
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.settings.plan.tsx
+++ b/app/routes/app.settings.plan.tsx
@@ -20,6 +20,7 @@ import { PLAN_ORDER, PLANS } from "../lib/billing/plans";
 import { formatMinorUnits } from "../lib/money/format";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/settings/plan", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -70,7 +71,7 @@ export default function PlanPage() {
     useLoaderData<typeof loader>();
 
   return (
-    <s-page heading="Plan">
+    <PageShell heading="Plan">
       {exempt ? (
         <s-banner tone="info">
           <s-paragraph>
@@ -179,7 +180,7 @@ export default function PlanPage() {
           </>
         ) : null}
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -24,6 +24,7 @@ import { facets } from "../services/segments.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
+import { PageShell } from "../components/PageShell";
 
 export const loader = withGuard("/app/settings/segments", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -152,7 +153,7 @@ export default function Segments() {
   const busy = fetcher.state !== "idle";
 
   return (
-    <s-page heading="Segments">
+    <PageShell heading="Segments">
       {result ? (
         <s-banner tone={result.ok ? "success" : "critical"}>
           <s-paragraph>{result.message}</s-paragraph>
@@ -319,7 +320,7 @@ export default function Segments() {
           </s-text>
         </s-paragraph>
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }
 


### PR DESCRIPTION
Fixes #329. Second of Epic #327.

## The problem

Every page rendered in a **~660px column on a 1300px viewport** — half the screen empty while the tables inside it wrapped. `s-page` defaults to `inlineSize="base"`; `large` is full width.

## Why that one attribute isn't the change

From Polaris's own types:

> **This slot is only rendered when `inlineSize` is "base".**

That's the `aside` slot. **19 sections across 13 routes** use it — four on the campaign page, including the one holding **apply, revert, resume and cancel**.

Setting `inlineSize="large"` and stopping there deletes the apply button with no error, no empty box, and nothing in the console. A merchant would find it before we did.

## The approach

`PageShell` rebuilds the aside instead of abandoning it: children marked `slot="aside"` are partitioned into a second column, and **every route keeps writing exactly what it wrote before**. The per-route diff is `<s-page heading=…>` → `<PageShell heading=…>`.

The alternative — hand-editing 19 JSX blocks out of their pages and into a prop — is the same change with far more opportunity to drop one. And the one most likely to be dropped is the biggest, which is Actions.

Three of the 19 sit inside a ternary (`{count > 0 ? <s-section slot="aside">`), so they're a child only when the condition holds. `Children.toArray` sees them; a partition that didn't would have failed on exactly the pages that had something to say.

The column collapses under 900px so the aside falls below rather than being squeezed. **Container query, not media query** — this renders in an admin iframe whose width is not the window's.

## Tests

Both read the routes directory rather than a list, so a route added next month is covered without anyone remembering these files exist.

- **`PageShell.test.tsx`** — content survives, main stays ahead of aside so narrow screens read in order, no grid is paid for when there's no aside, conditional asides are found and absent ones leave no empty column.
- **`page-width.test.ts`** — nothing may render `s-page` directly. A route that does either gets the old narrow column, or copies `inlineSize="large"` and silently loses its asides.

**Mutation-tested:**

| Mutant | Caught by |
|---|---|
| `PageShell` drops the aside | *"an aside dropped here is a button a merchant cannot press"* |
| back to `inlineSize="base"` | both width tests |
| a route renders `s-page` itself | *"expected [ 'app.activity.tsx' ] to deeply equal []"* |

## Checks

- `npm test` — 1556 passed (96 files)
- `npm run test:chaos` — 134 passed (41 files)
- `npm run typecheck`, `npm run build`, `npm run lint` — clean (4 pre-existing warnings)

Visual verification in the admin follows once this is on `main` — in particular that the campaign page's Actions column is where a merchant expects it.