### PR TITLE
Fix the aside column: a comma inside the responsive value

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -118,14 +118,32 @@ describe("asides that a page renders conditionally", () => {
 });
 
 describe("the column collapses before it gets unreadable", () => {
-  it("uses a container query, because the admin iframe is not the window", () => {
-    const html = render(
-      <PageShell heading="X">
-        <s-section>main</s-section>
-        <s-section slot="aside">side</s-section>
-      </PageShell>,
-    );
+  const html = render(
+    <PageShell heading="X">
+      <s-section>main</s-section>
+      <s-section slot="aside">side</s-section>
+    </PageShell>,
+  );
 
-    expect(html).toMatch(/@container[^"]*inline-size/);
+  const columns = /gridTemplateColumns="([^"]+)"/i.exec(html)?.[1] ?? "";
+
+  it("uses a container query, because the admin iframe is not the window", () => {
+    expect(columns).toMatch(/^@container[^)]*inline-size/);
+  });
+
+  it("carries exactly one comma, which is the separator and not part of a value", () => {
+    // This is the assertion that was missing, and its absence let a broken value
+    // through: `minmax(0, 1fr)` reads its own comma as the branch separator, so the
+    // value stops parsing and Polaris falls back to `none` -- one column, aside
+    // stacked underneath, indistinguishable from a deliberate layout.
+    expect(
+      columns.split(",").length - 1,
+      `"${columns}" has a comma inside a value, so Polaris cannot parse it`,
+    ).toBe(1);
+  });
+
+  it("asks for two columns when there is room", () => {
+    const [, wide] = columns.split(",");
+    expect(wide.trim().split(/\s+/), "wide viewports get content plus an aside").toHaveLength(2);
   });
 });

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -50,7 +50,12 @@ export function PageShell({
     <s-page heading={heading} inlineSize="large">
       <s-grid
         gap="base"
-        gridTemplateColumns="@container (inline-size <= 900px) minmax(0, 1fr), minmax(0, 1fr) minmax(0, 22rem)"
+        // One comma only. Polaris splits a responsive value on the comma to separate
+        // "when the query matches" from "otherwise", so a `minmax(0, 1fr)` in here
+        // takes its own comma as that separator and the whole value stops parsing --
+        // which silently falls back to `none` and stacks the aside underneath, looking
+        // exactly like a layout choice rather than a broken string.
+        gridTemplateColumns="@container (inline-size <= 900px) 1fr, 1fr 22rem"
       >
         <s-stack gap="base">{main}</s-stack>
         <s-stack gap="base">


### PR DESCRIPTION
Follow-up to #341 (#329). Found by looking at the deployed page.

## What shipped

```
gridTemplateColumns="@container (inline-size <= 900px) minmax(0, 1fr), minmax(0, 1fr) minmax(0, 22rem)"
```

Polaris splits a responsive value **on the comma** to separate *when the query matches* from *otherwise*. The comma inside `minmax(0, 1fr)` was read as that separator, so the whole value stopped parsing, `gridTemplateColumns` fell back to `none`, and children stacked in a single column.

**It looked deliberate.** The aside rendered full width underneath the content instead of beside it — no error, no console warning, nothing that reads as broken unless you knew a second column was supposed to be there.

## The test passed for the wrong reason

```ts
expect(html).toMatch(/@container[^"]*inline-size/);
```

An unparseable string satisfies that perfectly. Now it asserts the value carries **exactly one comma** — the separator, not part of a value — and that the wide branch names two tracks. Putting the old string back fails both:

```
AssertionError: "@container (inline-size <= 900px) minmax(0, 1fr), minmax(0, 1fr) minmax(0, 22rem)"
has a comma inside a value, so Polaris cannot parse it: expected 4 to be 1
```

## The fix

`@container (inline-size <= 900px) 1fr, 1fr 22rem` — comma-free by construction. `1fr` rather than `minmax(0, 1fr)` because the value cannot contain a comma; the existing table cell budget already keeps wide tables from blowing out a column.

## Also confirmed from the same look

`inlineSize="large"` **is** working — `/app/prices/live` (no aside) went from ~966px to ~1210px of content, filters spanning the full width. The width half of #329 landed correctly; only the two-column value was wrong.

## Checks

- `npm test` — 1558 passed (96 files)
- `npm run typecheck` — clean