### PR TITLE
P7.3 — Price the campaign before it exists, and fix the rule it was built from

### DIFF
--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -1,0 +1,124 @@
+import { formatCount } from "../lib/format/display";
+import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
+
+/**
+ * What this rule would do to prices, before the campaign exists.
+ *
+ * The editor could previously only say how many variants matched. To find out what
+ * happened to a price you had to create the campaign — so the only way to learn what a
+ * rule did was to commit to it.
+ *
+ * The claim being made here is stronger than a competitor's identical-looking panel:
+ * `resolve()` runs in preview and execution alike, against baselines rather than live
+ * prices, so these are the prices that will be written and not an estimate of them.
+ * Which is exactly why the counts have to be honest about the rows that will *not* be
+ * written — a preview that showed only the happy rows would be the estimate it claims
+ * not to be.
+ */
+export function DraftPreview({ preview }: { preview: Preview | null }) {
+  if (!preview) {
+    return (
+      <s-paragraph>
+        <s-text tone="neutral">Set a rule to see what it would do.</s-text>
+      </s-paragraph>
+    );
+  }
+
+  if (preview.blocked) {
+    return (
+      <s-banner tone="critical">
+        <s-paragraph>
+          This rule would price {preview.blocked.variantGid.split("/").pop()} below your
+          floor, and your guardrail setting is to stop rather than adjust. Nothing would
+          be written. Lower the floor, narrow the scope, or change the rule.
+        </s-paragraph>
+      </s-banner>
+    );
+  }
+
+  if (preview.matched === 0) {
+    return (
+      <s-paragraph>
+        <s-text tone="neutral">Nothing matches this scope yet.</s-text>
+      </s-paragraph>
+    );
+  }
+
+  return (
+    <s-stack gap="base">
+      <s-paragraph>
+        <s-text>
+          <strong>{formatCount(preview.changing)}</strong> of {formatCount(preview.matched)}{" "}
+          variants would change price.
+        </s-text>
+      </s-paragraph>
+
+      {/* Every row that will not move, and why. A merchant who expected 400 and sees 380
+          needs the other 20 explained here rather than after the run. */}
+      {preview.alreadyCorrect > 0 ? (
+        <s-paragraph>
+          <s-text tone="neutral">
+            {formatCount(preview.alreadyCorrect)} already at this price.
+          </s-text>
+        </s-paragraph>
+      ) : null}
+      {preview.skipped > 0 ? (
+        <s-paragraph>
+          <s-text tone="caution">
+            {formatCount(preview.skipped)} would be left alone — see the reasons below.
+          </s-text>
+        </s-paragraph>
+      ) : null}
+      {preview.withoutBaseline > 0 ? (
+        <s-paragraph>
+          <s-text tone="caution">
+            {formatCount(preview.withoutBaseline)} have no baseline yet, so they cannot be
+            priced at all. Sync your catalogue to capture them.
+          </s-text>
+        </s-paragraph>
+      ) : null}
+
+      {preview.rows.length > 0 ? (
+        <s-table>
+          <s-table-header-row>
+            <s-table-header>Variant</s-table-header>
+            <s-table-header>Now</s-table-header>
+            <s-table-header>Would become</s-table-header>
+          </s-table-header-row>
+          <s-table-body>
+            {preview.rows.map((row) => (
+              <s-table-row key={row.variantGid}>
+                <s-table-cell>{row.title}</s-table-cell>
+                <s-table-cell>
+                  {row.before ?? "—"}
+                  {row.beforeCompareAt ? ` (was ${row.beforeCompareAt})` : ""}
+                </s-table-cell>
+                <s-table-cell>
+                  {row.skippedReason ? (
+                    <s-text tone="caution">{row.skippedReason}</s-text>
+                  ) : row.unchanged ? (
+                    <s-text tone="neutral">no change</s-text>
+                  ) : (
+                    <s-text>
+                      {row.after ?? "—"}
+                      {row.afterCompareAt ? ` (was ${row.afterCompareAt})` : ""}
+                    </s-text>
+                  )}
+                </s-table-cell>
+              </s-table-row>
+            ))}
+          </s-table-body>
+        </s-table>
+      ) : null}
+
+      {preview.changing + preview.alreadyCorrect + preview.skipped > preview.rows.length ? (
+        <s-paragraph>
+          <s-text tone="neutral">
+            Showing the first {formatCount(preview.rows.length)}. Every row is priced the
+            same way.
+          </s-text>
+        </s-paragraph>
+      ) : null}
+    </s-stack>
+  );
+}

--- a/app/lib/campaigns/draft-form.test.ts
+++ b/app/lib/campaigns/draft-form.test.ts
@@ -1,0 +1,122 @@
+/**
+ * One parser for the preview and for the submit.
+ *
+ * The pair of bugs this pins (#343): the editor's form has no currency field, so
+ * `form.get("currency") ?? "USD"` made every fixed-amount rule USD on every store; and
+ * the conversion to minor units used a literal 100, which is right for dollars and
+ * wrong for every zero-decimal currency. Together, ¥3,000 became 300,000 minor units
+ * labelled USD.
+ *
+ * Both are only reachable through `fixed-change` and `set-exact`. `percent-change` is
+ * the default and carries a plain number, which is why two USD dev stores never showed
+ * either.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { astFrom, compareAtFrom, readerFor, ruleFrom } from "./draft-form";
+
+const read = (fields: Record<string, string>) => readerFor(new URLSearchParams(fields));
+
+describe("money in the rule", () => {
+  it("uses the currency it is given, not a default", () => {
+    const rule = ruleFrom(read({ ruleKind: "set-exact", ruleValue: "3000" }), "JPY");
+
+    expect(rule).toEqual({ kind: "set-exact", amount: { amount: 3000, currency: "JPY" } });
+  });
+
+  it("does not multiply a zero-decimal currency by a hundred", () => {
+    const rule = ruleFrom(read({ ruleKind: "fixed-change", ruleValue: "-500" }), "JPY");
+
+    expect(
+      rule,
+      "¥500 is 500 minor units; a hardcoded 100 would make it ¥50,000",
+    ).toEqual({ kind: "fixed-change", amount: { amount: -500, currency: "JPY" } });
+  });
+
+  it("still handles two-decimal currencies", () => {
+    const rule = ruleFrom(read({ ruleKind: "fixed-change", ruleValue: "-10.50" }), "USD");
+
+    expect(rule).toEqual({ kind: "fixed-change", amount: { amount: -1050, currency: "USD" } });
+  });
+
+  it("handles a three-decimal currency", () => {
+    const rule = ruleFrom(read({ ruleKind: "set-exact", ruleValue: "1.5" }), "KWD");
+
+    expect(rule, "1.5 KWD is 1500 fils").toEqual({
+      kind: "set-exact",
+      amount: { amount: 1500, currency: "KWD" },
+    });
+  });
+
+  it("keeps a percentage a plain number, with no currency involved", () => {
+    expect(ruleFrom(read({ ruleKind: "percent-change", ruleValue: "-20" }), "JPY")).toEqual({
+      kind: "percent-change",
+      percent: -20,
+    });
+  });
+
+  it("defaults to a percentage, which is what the editor offers first", () => {
+    expect(ruleFrom(read({ ruleValue: "-15" }), "USD")).toEqual({
+      kind: "percent-change",
+      percent: -15,
+    });
+  });
+});
+
+describe("compare-at", () => {
+  it.each([
+    ["set-to-baseline", { kind: "set-to-baseline" }],
+    ["clear", { kind: "clear" }],
+    ["leave", { kind: "leave" }],
+  ])("reads %s", (value, expected) => {
+    expect(compareAtFrom(read({ compareAt: value }))).toEqual(expected);
+  });
+
+  it("leaves it alone when nothing was chosen", () => {
+    expect(compareAtFrom(read({}))).toEqual({ kind: "leave" });
+  });
+});
+
+describe("scope", () => {
+  it("builds one group from the fields that were filled in", () => {
+    // Order follows SCOPE_CONDITION_FIELDS, not the order they were typed, so the same
+    // filter produces the same AST however the merchant filled the form in.
+    expect(astFrom(read({ vendor: "Acme", tag: "sale" }))).toEqual({
+      groups: [
+        {
+          conditions: [
+            { field: "tag", value: "sale" },
+            { field: "vendor", value: "Acme" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("means every variant when nothing is filled in, not none", () => {
+    expect(astFrom(read({}))).toEqual({ groups: [] });
+  });
+
+  it("ignores whitespace someone typed and deleted", () => {
+    expect(astFrom(read({ tag: "   " }))).toEqual({ groups: [] });
+  });
+
+  it("trims, so a trailing space does not make a tag not match", () => {
+    expect(astFrom(read({ tag: " sale " }))).toEqual({
+      groups: [{ conditions: [{ field: "tag", value: "sale" }] }],
+    });
+  });
+});
+
+describe("the same parser reads a form and a query string", () => {
+  it("agrees between the two, because the preview posts and the submit posts", () => {
+    const form = new FormData();
+    form.set("ruleKind", "fixed-change");
+    form.set("ruleValue", "-7.25");
+
+    expect(ruleFrom(readerFor(form), "USD")).toEqual(
+      ruleFrom(read({ ruleKind: "fixed-change", ruleValue: "-7.25" }), "USD"),
+    );
+  });
+});

--- a/app/lib/campaigns/draft-form.ts
+++ b/app/lib/campaigns/draft-form.ts
@@ -1,0 +1,68 @@
+/**
+ * Turning the campaign editor's form into the rule and scope a campaign is made of.
+ *
+ * Extracted so the live preview and the create action cannot build a different campaign
+ * from the same fields. Rule 4 says preview and execution share one code path; a
+ * preview that parsed `-20` into a different rule than the submit would honour the
+ * letter of that and none of the point.
+ *
+ * The currency is a parameter rather than a form field read with a default. It used to
+ * be `String(form.get("currency") ?? "USD")` against a form that has no currency field,
+ * so every fixed-amount rule on every store was built in USD (#343). Making the caller
+ * supply it means there is no default left to be silently wrong.
+ */
+
+import { decimalsFor } from "../money/format";
+import { money } from "../money/money";
+import type { AdjustmentRule, CompareAtPolicy } from "../pricing/types";
+import type { FilterAst } from "../../services/segments.server";
+
+/** Scope fields the editor offers, minus `segment`, which resolves to a whole AST. */
+export const SCOPE_CONDITION_FIELDS = ["collection", "tag", "vendor", "title"] as const;
+
+/** Reads a value from either a form or a query string, so one parser serves both. */
+export type FieldReader = (name: string) => string | null;
+
+export function readerFor(source: FormData | URLSearchParams): FieldReader {
+  return (name) => {
+    const value = source.get(name);
+    return typeof value === "string" ? value : null;
+  };
+}
+
+/**
+ * The rule the merchant has described.
+ *
+ * `10 ** decimalsFor(currency)` rather than a literal 100: a hardcoded hundred reads a
+ * ¥3,000 price as ¥300,000 and a 1.5 KWD price as 0.15 KWD. The same literal has been
+ * removed from three service files already.
+ */
+export function ruleFrom(read: FieldReader, currency: string): AdjustmentRule {
+  const kind = read("ruleKind") ?? "percent-change";
+  const amount = Number(read("ruleValue") ?? 0);
+  const perMajor = 10 ** decimalsFor(currency);
+
+  if (kind === "fixed-change") {
+    return { kind: "fixed-change", amount: money(Math.round(amount * perMajor), currency) };
+  }
+  if (kind === "set-exact") {
+    return { kind: "set-exact", amount: money(Math.round(amount * perMajor), currency) };
+  }
+  return { kind: "percent-change", percent: amount };
+}
+
+export function compareAtFrom(read: FieldReader): CompareAtPolicy {
+  const value = read("compareAt") ?? "leave";
+  if (value === "set-to-baseline") return { kind: "set-to-baseline" };
+  if (value === "clear") return { kind: "clear" };
+  return { kind: "leave" };
+}
+
+/** The inline filter, as an AST. An empty filter is every variant, not none. */
+export function astFrom(read: FieldReader): FilterAst {
+  const conditions = SCOPE_CONDITION_FIELDS.map((field) => [field, read(field)] as const)
+    .filter(([, value]) => value && value.trim().length > 0)
+    .map(([field, value]) => ({ field, value: value!.trim() }));
+
+  return conditions.length > 0 ? { groups: [{ conditions }] } : { groups: [] };
+}

--- a/app/lib/planning/reasons.test.ts
+++ b/app/lib/planning/reasons.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Both phrasings cover every reason the resolver can produce.
+ *
+ * A reason added to `ResolutionReason` and phrased in only one map renders as "unknown"
+ * or "Not written" in the other — a merchant told nothing about a case the app
+ * understands perfectly well. TypeScript catches a missing key because both maps are
+ * `Record<ResolutionReason, string>`; what it cannot catch is an *extra* key that no
+ * longer corresponds to a reason, or the two maps describing different things.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { SKIP_REASON_GROUP, SKIP_REASON_ROW, skipReasonForRow } from "./reasons";
+
+describe("the two phrasings stay in step", () => {
+  it("cover the same reasons", () => {
+    expect(Object.keys(SKIP_REASON_ROW).sort()).toEqual(Object.keys(SKIP_REASON_GROUP).sort());
+  });
+
+  it("phrases every reason, with nothing left blank", () => {
+    for (const [reason, text] of [
+      ...Object.entries(SKIP_REASON_GROUP),
+      ...Object.entries(SKIP_REASON_ROW),
+    ]) {
+      expect(text.trim(), `${reason} has no wording`).not.toBe("");
+    }
+  });
+
+  it("keeps the group phrasing plural and the row phrasing not", () => {
+    // The group form completes "14 variants ...", the row form stands alone. Getting
+    // these the wrong way round produces "14 variants No cost recorded".
+    for (const text of Object.values(SKIP_REASON_GROUP)) {
+      expect(text[0], `"${text}" should continue a sentence, so it starts lowercase`).toBe(
+        text[0].toLowerCase(),
+      );
+    }
+    for (const text of Object.values(SKIP_REASON_ROW)) {
+      expect(text[0], `"${text}" stands alone, so it starts capitalised`).toBe(
+        text[0].toUpperCase(),
+      );
+    }
+  });
+});
+
+describe("a reason the planner did not attach", () => {
+  it("still says something rather than rendering undefined", () => {
+    expect(skipReasonForRow(undefined)).toBe("Not written");
+    expect(skipReasonForRow("something-new")).toBe("Not written");
+  });
+
+  it("uses the real wording when there is one", () => {
+    expect(skipReasonForRow("below-floor")).toBe("Below your price floor");
+  });
+});

--- a/app/lib/planning/reasons.ts
+++ b/app/lib/planning/reasons.ts
@@ -1,0 +1,40 @@
+/**
+ * Why the planner left a row alone, in the merchant's words.
+ *
+ * Two phrasings of one set of reasons: a run summary groups rows ("14 variants have no
+ * cost recorded"), while a preview names one row at a time ("No cost recorded"). They
+ * are kept in one file, over one key set, because the failure mode of keeping them apart
+ * is that a reason gets added to the resolver and phrased in one place only — so the
+ * other renders "unknown" for a case the app understands perfectly well.
+ *
+ * `reasons.test.ts` asserts both maps cover exactly the `ResolutionReason` union, so
+ * adding a reason without phrasing it is a build-time failure rather than a word a
+ * merchant cannot act on.
+ */
+
+import type { ResolutionReason } from "../pricing/types";
+
+/** Plural, for a run summary that groups rows by reason. */
+export const SKIP_REASON_GROUP: Record<ResolutionReason, string> = {
+  "missing-cost": "have no cost recorded, and a cost-based guardrail applies",
+  "missing-import": "were not in the imported file",
+  "below-floor": "would have priced below a guardrail floor",
+  "invalid-margin": "have a margin target that cannot be satisfied",
+  "invalid-compare-at": "would have had a compare-at price below their price",
+  "non-positive-price": "would have priced at or below zero",
+};
+
+/** Singular, for one row in a preview table. */
+export const SKIP_REASON_ROW: Record<ResolutionReason, string> = {
+  "missing-cost": "No cost recorded",
+  "missing-import": "Not in the imported file",
+  "below-floor": "Below your price floor",
+  "invalid-margin": "Margin target cannot be met",
+  "invalid-compare-at": "Compare-at would be below the price",
+  "non-positive-price": "Would price at or below zero",
+};
+
+/** The row phrasing, tolerant of a reason the planner did not attach. */
+export function skipReasonForRow(reason: string | undefined): string {
+  return SKIP_REASON_ROW[reason as ResolutionReason] ?? "Not written";
+}

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -1,13 +1,12 @@
+import { useCallback, useEffect, useRef } from "react";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { Form, redirect, useLoaderData } from "react-router";
+import { Form, redirect, useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
-import { facets, previewMatches, type FilterAst } from "../services/segments.server";
+import { facets, previewMatches } from "../services/segments.server";
 import { createCampaign } from "../services/campaigns/index.server";
-import type { AdjustmentRule, CompareAtPolicy } from "../lib/pricing/types";
-import { money } from "../lib/money/money";
 import { joinDateAndTime, localInputToUtc, type Schedule } from "../lib/scheduling/window";
 import { presetStartFor } from "../lib/scheduling/calendar";
 import { describeAdjustment } from "../lib/markets/describe";
@@ -24,7 +23,10 @@ import { billingFrom } from "../services/billing.server";
 import { canUseSurface } from "../lib/billing/plans";
 import prisma from "../db.server";
 import { segmentToAst } from "../services/segments.server";
+import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/draft-form";
 import { PageShell } from "../components/PageShell";
+import { DraftPreview } from "../components/DraftPreview";
+import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
 export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -51,7 +53,7 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
         filterAst: segment.filterAst,
         frozenVariantGids: segment.frozenVariantGids,
       })
-    : astFromParams(url.searchParams);
+    : astFrom(readerFor(url.searchParams));
 
   const [available, preview, segments, priceLists, settings, currency, shopRecord] =
     await Promise.all([
@@ -140,16 +142,6 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
 export const SCOPE_FIELDS = ["collection", "tag", "vendor", "title", "segment"] as const;
 
 /** Builds an AST from the simple scope form: all provided conditions ANDed. */
-function astFromParams(params: URLSearchParams): FilterAst {
-  // `segment` rides in the same form but is a reference, not a condition -- the
-  // loader resolves it into a whole AST rather than adding a clause to one.
-  const conditions = SCOPE_FIELDS.filter((field) => field !== "segment")
-    .map((field) => [field, params.get(field)] as const)
-    .filter(([, value]) => value && value.trim().length > 0)
-    .map(([field, value]) => ({ field, value: value!.trim() }));
-
-  return conditions.length > 0 ? { groups: [{ conditions }] } : { groups: [] };
-}
 
 export const action = withGuard("/app/campaigns/new", async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -162,26 +154,13 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
     if (typeof value === "string" && value.trim()) params.set(field, value.trim());
   }
 
-  const kind = String(form.get("ruleKind") ?? "percent-change");
-  const amount = Number(form.get("ruleValue") ?? 0);
-  const currency = String(form.get("currency") ?? "USD");
-
-  let rule: AdjustmentRule;
-  if (kind === "fixed-change") {
-    rule = { kind: "fixed-change", amount: money(Math.round(amount * 100), currency) };
-  } else if (kind === "set-exact") {
-    rule = { kind: "set-exact", amount: money(Math.round(amount * 100), currency) };
-  } else {
-    rule = { kind: "percent-change", percent: amount };
-  }
-
-  const compareAt = String(form.get("compareAt") ?? "leave");
-  const compareAtPolicy: CompareAtPolicy =
-    compareAt === "set-to-baseline"
-      ? { kind: "set-to-baseline" }
-      : compareAt === "clear"
-        ? { kind: "clear" }
-        : { kind: "leave" };
+  // The shop's own currency, not a form field. The form never had one, so this used to
+  // fall back to "USD" on every store -- and the conversion to minor units used a
+  // literal 100, so a JPY amount came out a hundred times too large as well (#343).
+  const read = readerFor(form);
+  const currency = await shopCurrency(shop.id);
+  const rule = ruleFrom(read, currency);
+  const compareAtPolicy = compareAtFrom(read);
 
   const startLocal = joinDateAndTime(
     String(form.get("startDate") ?? ""),
@@ -218,7 +197,7 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
 
   const campaign = await createCampaign(shop.id, {
     name: String(form.get("name") ?? "Untitled campaign").trim() || "Untitled campaign",
-    ast: astFromParams(params),
+    ast: astFrom(readerFor(params)),
     ...(segmentId ? { segmentId } : {}),
     ...(practice ? { practice: true } : {}),
     rule,
@@ -256,6 +235,29 @@ export default function NewCampaign() {
     gates,
     planName,
   } = useLoaderData<typeof loader>();
+
+  // The live price preview. Debounced, because it plans the whole scope on every call
+  // and a merchant typing "-20" would otherwise ask three times on the way there.
+  const previewFetcher = useFetcher<Preview>();
+  const formRef = useRef<HTMLFormElement>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const requestPreview = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      const form = formRef.current;
+      if (!form) return;
+      previewFetcher.submit(new FormData(form), {
+        method: "post",
+        action: "/app/preview-draft",
+      });
+    }, 400);
+  }, [previewFetcher]);
+
+  // Clear the pending call on unmount, so navigating away mid-type does not fire a
+  // request against a page that is gone.
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
 
   return (
     <PageShell heading={practice ? "Practice campaign" : guided ? "Your first campaign" : "New campaign"}>
@@ -363,7 +365,7 @@ export default function NewCampaign() {
       </s-section>
 
       <s-section heading="2 · Rule">
-        <Form method="post">
+        <Form method="post" ref={formRef} onChange={requestPreview}>
           {/* The scope form and the create form are separate elements, so the chosen
               segment has to travel with the submission that actually creates. */}
           <input type="hidden" name="segment" value={selected.segment} />
@@ -416,6 +418,14 @@ export default function NewCampaign() {
                 differently.
               </s-text>
             </s-paragraph>
+
+            {/* What this rule does to prices, from the same resolver the run uses --
+                not an estimate of it. Sits with the rule rather than at the bottom of
+                the page, because it exists to answer "did I mean -20% or x0.20?" while
+                the merchant is still deciding. */}
+            <s-divider />
+            <s-heading>What this would do</s-heading>
+            <DraftPreview preview={previewFetcher.data ?? null} />
 
             <s-number-field
               name="priority"

--- a/app/routes/app.preview-draft.tsx
+++ b/app/routes/app.preview-draft.tsx
@@ -1,0 +1,55 @@
+/**
+ * Prices a campaign that does not exist yet, for the editor's live preview.
+ *
+ * A resource route rather than a second action on the editor: the editor's own action
+ * creates a campaign, and a preview that shares a submit target with "create the thing"
+ * is one misrouted request away from creating one by accident.
+ *
+ * Deliberately outside `/app/campaigns/*` so it cannot be confused with a campaign id
+ * by `app.campaigns.$id`.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/draft-form";
+import { previewDraft } from "../services/campaigns/draft-preview.server";
+import { readRoundingPolicy } from "../lib/money/rounding-policy";
+import { shopCurrency } from "../services/settings.server";
+import { segmentToAst } from "../services/segments.server";
+import prisma from "../db.server";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const form = await request.formData();
+  const read = readerFor(form);
+
+  // A chosen segment replaces the inline filter, exactly as it does on submit -- a
+  // preview scoped differently from the campaign it previews is worse than no preview.
+  const segmentId = (read("segment") ?? "").trim();
+  const segment = segmentId
+    ? await prisma.segment.findFirst({
+        where: { id: segmentId, shopId: shop.id },
+        select: { kind: true, filterAst: true, frozenVariantGids: true },
+      })
+    : null;
+
+  const preview = await previewDraft(shop.id, {
+    ast: segment
+      ? segmentToAst({
+          kind: segment.kind as "DYNAMIC" | "FROZEN",
+          filterAst: segment.filterAst,
+          frozenVariantGids: segment.frozenVariantGids,
+        })
+      : astFrom(read),
+    rule: ruleFrom(read, await shopCurrency(shop.id)),
+    compareAtPolicy: compareAtFrom(read),
+    rounding: readRoundingPolicy(form.entries()),
+    priority: Number(read("priority") ?? 100) || 100,
+  });
+
+  return preview;
+};

--- a/app/services/campaigns/draft-preview.server.ts
+++ b/app/services/campaigns/draft-preview.server.ts
@@ -1,0 +1,209 @@
+/**
+ * What a campaign would do, before it exists.
+ *
+ * The editor could previously only tell a merchant how many variants matched, and show
+ * five of their names. To see what happened to a *price* you had to click "Create and
+ * preview", which creates the campaign — so the only way to find out what a rule does
+ * was to commit to it. Competitors show a live before/after while you type, and the
+ * absence of one here read as the app being unable to say.
+ *
+ * It can say. `resolve()` runs in preview and execution alike (rule 4), so this is not
+ * an approximation of what will happen — it is the same computation, against the same
+ * baselines, through the same planner. That is a stronger claim than a competitor
+ * pricing off live values can make, and it was going unmade.
+ *
+ * The draft takes part in resolution alongside the shop's other ACTIVE campaigns rather
+ * than being planned in isolation, because a variant already on sale is exactly where a
+ * naive preview would lie: it would show a discount off the full price while the run
+ * would resolve the overlap by priority and do something else.
+ */
+
+import { format } from "../../lib/money/format";
+import type { Money } from "../../lib/money/money";
+import { planRun } from "../../lib/planning/plan";
+import { loadCandidates, titleMapFor } from "./candidates.server";
+import { importIdsOf, toResolvable } from "./model.server";
+import { guardrailsFor, readSettings } from "../settings.server";
+import { skipReasonForRow } from "../../lib/planning/reasons";
+import { resolvePolicy } from "../../lib/money/rounding-policy";
+import type { FilterAst } from "../segments.server";
+import type {
+  AdjustmentRule,
+  CompareAtPolicy,
+  GuardrailViolationPolicy,
+  ResolvableCampaign,
+} from "../../lib/pricing/types";
+import type { StoredRoundingPolicy } from "../../lib/money/rounding-policy";
+import prisma from "../../db.server";
+
+/** Just enough of a campaign to price with. Everything else is irrelevant to the maths. */
+export interface DraftCampaign {
+  ast: FilterAst;
+  rule: AdjustmentRule;
+  compareAtPolicy: CompareAtPolicy;
+  rounding: StoredRoundingPolicy;
+  priority: number;
+}
+
+export interface DraftPreviewRow {
+  variantGid: string;
+  title: string;
+  before: string | null;
+  after: string | null;
+  beforeCompareAt: string | null;
+  afterCompareAt: string | null;
+  /** True when the price does not move — already at the campaign price. */
+  unchanged: boolean;
+  /** Why this row will not be written, if it will not be. */
+  skippedReason: string | null;
+}
+
+export interface DraftPreview {
+  /** Variants the scope matches, whether or not their price moves. */
+  matched: number;
+  /** Rows whose price this campaign would change. */
+  changing: number;
+  /** Rows already at the price this campaign wants. */
+  alreadyCorrect: number;
+  /** Rows deliberately not written, with reasons on the rows themselves. */
+  skipped: number;
+  /** Rows with no baseline, which cannot be priced at all. */
+  withoutBaseline: number;
+  rows: DraftPreviewRow[];
+  /**
+   * A guardrail that stops the whole run, surfaced here rather than on submit.
+   *
+   * `planRun` returning `blocked` throws inside `runCampaign`, so before this existed a
+   * merchant met their own floor as a crash after committing rather than as a sentence
+   * while editing.
+   */
+  blocked: { reason: string; variantGid: string } | null;
+}
+
+const EMPTY: DraftPreview = {
+  matched: 0,
+  changing: 0,
+  alreadyCorrect: 0,
+  skipped: 0,
+  withoutBaseline: 0,
+  rows: [],
+  blocked: null,
+};
+
+/**
+ * The draft as the resolver sees it.
+ *
+ * `guardrailViolationPolicy` is read from the shop rather than hardcoded, because a
+ * campaign created a moment from now copies the shop's setting (#338) -- and a preview
+ * that clamped while the campaign it is previewing would block is a preview that
+ * disagrees with execution, which is the one thing rule 4 forbids. Hardcoding "clamp"
+ * here would have been #338 reintroduced in the one place built to prove it cannot
+ * happen.
+ */
+function draftAsResolvable(
+  draft: DraftCampaign,
+  violationPolicy: GuardrailViolationPolicy,
+): ResolvableCampaign {
+  return {
+    id: DRAFT_ID,
+    priority: draft.priority,
+    // Newest, so that at equal priority the draft wins the tie and the merchant sees
+    // what their new campaign does rather than what the existing one already did.
+    startAt: Number.MAX_SAFE_INTEGER,
+    ruleRows: [{ segmentIds: [], rule: draft.rule }],
+    compareAtPolicy: draft.compareAtPolicy,
+    compareAtViolationPolicy: "clear",
+    roundingPolicy: resolvePolicy(draft.rounding),
+    guardrails: undefined,
+    guardrailViolationPolicy: violationPolicy,
+    excludedVariantGids: [],
+  };
+}
+
+/** Not a real id, and never persisted — it only has to be distinct from a cuid. */
+const DRAFT_ID = "draft";
+
+export async function previewDraft(
+  shopId: string,
+  draft: DraftCampaign,
+  limit = 25,
+): Promise<DraftPreview> {
+  const [others, settings] = await Promise.all([
+    prisma.campaign.findMany({ where: { shopId, status: "ACTIVE" } }),
+    readSettings(shopId),
+  ]);
+  const resolvable = [
+    draftAsResolvable(draft, settings.violationPolicy),
+    ...others.map(toResolvable),
+  ];
+
+  const [candidates, storeGuardrails, matched] = await Promise.all([
+    loadCandidates(shopId, draft.ast, undefined, importIdsOf(resolvable)),
+    guardrailsFor(shopId),
+    countMatching(shopId, draft.ast),
+  ]);
+
+  if (candidates.length === 0) {
+    // Matched but unpriceable: every variant in scope is missing a baseline. Reported
+    // rather than shown as "0 variants match", which would send the merchant to fix
+    // their filter when the filter is fine.
+    return { ...EMPTY, matched, withoutBaseline: matched };
+  }
+
+  const outcome = planRun({ campaigns: resolvable, candidates, storeGuardrails });
+
+  if (outcome.kind === "blocked") {
+    return {
+      ...EMPTY,
+      matched,
+      withoutBaseline: matched - candidates.length,
+      blocked: { reason: outcome.reason, variantGid: outcome.ref.variantGid },
+    };
+  }
+
+  // Only what this draft controls. A variant a higher-priority campaign already owns is
+  // in scope and is not this campaign's to change, and counting it as "changing" would
+  // promise a price the run will not write.
+  const ours = outcome.rows.filter((row) => row.campaignId === DRAFT_ID);
+
+  const changing = ours.filter((row) => row.status !== "skipped" && !isNoop(row));
+  const alreadyCorrect = ours.filter((row) => row.status !== "skipped" && isNoop(row));
+  const skipped = ours.filter((row) => row.status === "skipped");
+
+  const shown = [...changing, ...alreadyCorrect, ...skipped].slice(0, limit);
+  const titles = await titleMapFor(shopId, shown.map((row) => row.ref.variantGid));
+
+  const fmt = (value?: Money | null) => (value ? format(value) : null);
+
+  return {
+    matched,
+    changing: changing.length,
+    alreadyCorrect: alreadyCorrect.length,
+    skipped: skipped.length,
+    withoutBaseline: matched - candidates.length,
+    blocked: null,
+    rows: shown.map((row) => ({
+      variantGid: row.ref.variantGid,
+      title: titles.get(row.ref.variantGid) ?? row.ref.variantGid,
+      before: fmt(row.beforePrice),
+      after: fmt(row.intendedPrice),
+      beforeCompareAt: fmt(row.beforeCompareAt),
+      afterCompareAt: fmt(row.intendedCompareAt),
+      unchanged: isNoop(row),
+      skippedReason: row.status === "skipped" ? skipReasonForRow(row.reason) : null,
+    })),
+  };
+}
+
+/** A row whose price does not move. */
+function isNoop(row: { beforePrice?: Money | null; intendedPrice?: Money | null }): boolean {
+  // An absent live price is never "already correct" -- we do not know what is there, and
+  // treating unknown as correct is how a variant silently keeps a stale price.
+  if (!row.beforePrice || !row.intendedPrice) return false;
+  return row.beforePrice.amount === row.intendedPrice.amount;
+}
+
+async function countMatching(shopId: string, ast: FilterAst): Promise<number> {
+  const { astToWhere } = await import("../segments.server");
+  return prisma.variantIndex.count({ where: astToWhere(shopId, ast) });
+}

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -24,6 +24,7 @@ import type { RunOutcome } from "./types";
 import { inChunksCounting } from "../../lib/db/chunk";
 import { releaseClaim, transitionCampaign } from "./lifecycle.server";
 import type { CampaignState } from "../../lib/lifecycle/transitions";
+import { SKIP_REASON_GROUP } from "../../lib/planning/reasons";
 import { planResume, type LedgerState } from "../../lib/execution/resume";
 import { applyCampaignTags, removeCampaignTags } from "./tags.server";
 import {
@@ -560,15 +561,13 @@ async function executeCampaignRun(
   };
 }
 
-/** Why the plan left rows alone, in the merchant's terms. */
-const SKIP_REASONS: Record<string, string> = {
-  "missing-cost": "have no cost recorded, and a cost-based guardrail applies",
-  "missing-import": "were not in the imported file",
-  "below-floor": "would have priced below a guardrail floor",
-  "invalid-margin": "have a margin target that cannot be satisfied",
-  "invalid-compare-at": "would have had a compare-at price below their price",
-  "non-positive-price": "would have priced at or below zero",
-};
+/**
+ * Why the plan left rows alone, in the merchant's terms.
+ *
+ * Shared with the editor's preview, which phrases the same reasons one row at a time.
+ * Two copies would drift the moment a reason was added to the resolver.
+ */
+const SKIP_REASONS: Record<string, string> = SKIP_REASON_GROUP;
 
 function describeSkips(rows: readonly PlannedRow[]): string[] {
   const byReason = new Map<string, number>();

--- a/chaos/scenarios/draft-preview.chaos.ts
+++ b/chaos/scenarios/draft-preview.chaos.ts
@@ -1,0 +1,161 @@
+/**
+ * The editor's preview says what the run will do.
+ *
+ * Rule 4: preview and execution share one code path, because a preview that can
+ * disagree with execution is worthless. The editor previously honoured that only in the
+ * weakest sense — it showed a *count* and five variant names, and to see what happened
+ * to a price you had to create the campaign first.
+ *
+ * Now it prices. Which means the claim has to be checked rather than asserted: this
+ * scenario previews a draft, applies the same rule as a real campaign, and compares
+ * row for row against the store the fake Shopify actually ends up holding.
+ *
+ * The case that matters most is overlap. A variant already on sale is exactly where a
+ * naive preview lies — it would show a discount off the full price, while the run
+ * resolves by priority and does something else.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { previewDraft } from "../../app/services/campaigns/draft-preview.server";
+import { DEFAULT_SETTINGS, writeSettings } from "../../app/services/settings.server";
+import { withChaos } from "../harness/scenario";
+
+const RULE = { kind: "percent-change", percent: -20 } as const;
+const DRAFT = {
+  ast: { groups: [] },
+  rule: RULE,
+  compareAtPolicy: { kind: "leave" } as const,
+  rounding: { default: "none" as const, byCurrency: {} },
+  priority: 500,
+};
+
+describe("chaos: the editor's preview and the run agree", () => {
+  it("prices every row the way the run will", async () => {
+    await withChaos(
+      "draft-preview",
+      { catalog: { products: 4, variantsPerProduct: 3 }, percent: -20 },
+      async (ctx) => {
+        const { shopId, campaignId } = ctx.fixture;
+
+        // The fixture's campaign uses the same rule, so the draft preview and this
+        // campaign's run must reach identical prices. Preview the draft with the
+        // fixture campaign not yet applied, so both start from the same baselines.
+        const preview = await previewDraft(shopId, DRAFT, 100);
+
+        expect(preview.matched, "the whole catalogue is in scope").toBe(12);
+        expect(preview.changing, "a -20% campaign moves every price").toBe(12);
+        expect(preview.blocked).toBeNull();
+
+        const predicted = new Map(preview.rows.map((row) => [row.variantGid, row.after]));
+
+        await ctx.apply();
+
+        // What the store actually holds now.
+        const live = ctx.livePrices();
+
+        for (const [variantGid, after] of predicted) {
+          expect(
+            live.get(variantGid),
+            `preview promised ${after} for ${variantGid}; the storefront says ` +
+              `${live.get(variantGid)}`,
+          ).toBe(after);
+        }
+
+        await ctx.expectHonest(await ctx.latestRunId("APPLY"));
+        // The campaign this ran is the fixture's, not the draft — the draft was never
+        // persisted, which is the whole point of previewing one.
+        const drafts = await prisma.campaign.count({ where: { shopId, id: "draft" } });
+        expect(drafts, "previewing must not create a campaign").toBe(0);
+        expect(campaignId).not.toBe("draft");
+      },
+    );
+  });
+
+  it("tells a merchant when their own floor would stop the run", async () => {
+    await withChaos(
+      "draft-preview-blocked",
+      { catalog: { products: 2, variantsPerProduct: 2 }, percent: -20 },
+      async (ctx) => {
+        const { shopId } = ctx.fixture;
+
+        // Blocking is the merchant's own instruction, and before this it reached them
+        // as a thrown error *after* they had committed rather than a sentence while
+        // they were still editing.
+        await writeSettings(shopId, {
+          ...DEFAULT_SETTINGS,
+          minPrice: 100_000,
+          violationPolicy: "block",
+        });
+
+        const blocked = await previewDraft(
+          shopId,
+          { ...DRAFT, rule: { kind: "percent-change", percent: -90 } },
+          100,
+        );
+
+        expect(
+          blocked.blocked,
+          "the merchant's own floor must be reported while editing, not thrown on submit",
+        ).not.toBeNull();
+        expect(blocked.blocked?.reason).toContain("below-floor");
+
+        // And with the shop set to clamp, the same draft previews clamped prices --
+        // which is the point: the preview follows the shop's setting, exactly as the
+        // campaign created from it will (#338).
+        await writeSettings(shopId, { ...DEFAULT_SETTINGS, minPrice: 100_000 });
+
+        const clamped = await previewDraft(
+          shopId,
+          { ...DRAFT, rule: { kind: "percent-change", percent: -90 } },
+          100,
+        );
+
+        expect(clamped.blocked, "clamp does not block").toBeNull();
+        expect(clamped.matched).toBe(4);
+        expect(
+          new Set(clamped.rows.map((row) => row.after)).size,
+          "every price clamped to the same floor, which is what clamp means",
+        ).toBe(1);
+      },
+    );
+  });
+
+  it("does not promise a price on a variant another campaign owns", async () => {
+    await withChaos(
+      "draft-preview-overlap",
+      { catalog: { products: 3, variantsPerProduct: 2 }, percent: -20 },
+      async (ctx) => {
+        const { shopId, campaignId } = ctx.fixture;
+
+        // The fixture's campaign runs at priority 900. Make it ACTIVE *without*
+        // applying it, so it wins the overlap and its rows are real changes.
+        //
+        // Applying it first is the version of this test that proves nothing: every row
+        // then sits at its campaign price, `planRun` does not emit no-op rows at all,
+        // and a preview that wrongly claimed the winner's rows would still report zero
+        // changing. Mutation testing is what surfaced that -- the first draft of this
+        // scenario passed with the ownership filter deleted.
+        await prisma.campaign.update({ where: { id: campaignId }, data: { status: "ACTIVE" } });
+
+        const preview = await previewDraft(
+          shopId,
+          { ...DRAFT, priority: 1, rule: { kind: "percent-change", percent: -50 } },
+          100,
+        );
+
+        expect(preview.matched, "still in scope").toBe(6);
+        expect(
+          preview.changing,
+          "a lower-priority draft controls nothing, and must not claim to",
+        ).toBe(0);
+        expect(
+          preview.rows,
+          "rows belonging to the campaign that actually won must not appear here at all",
+        ).toEqual([]);
+        expect(preview.alreadyCorrect + preview.skipped).toBe(0);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Fixes #330 and #343. Third of Epic #327.

## The editor now prices

Before: a match count and five variant names. To see what a rule did to a **price**, you clicked "Create and preview" — which creates the campaign. The only way to learn what a rule does was to commit to it.

Now a live before → after panel sits with the rule, debounced at 400ms.

## The claim we can make and the competitor cannot

NA Bulk Price Editor has a panel that looks the same. Ours is computed by `resolve()` — **the same code path the run uses**, against baselines rather than live prices (rule 4). These are the prices that *will be written*, not an estimate of them.

Which is exactly why the counts must be honest about rows that will **not** be written. A preview showing only the happy rows would be the estimate it claims not to be:

- *N already at this price*
- *N would be left alone* — with per-row reasons
- *N have no baseline yet, so they cannot be priced at all*

**Overlap is where a naive preview lies.** The draft takes part in resolution alongside the shop's ACTIVE campaigns; a variant already on sale would otherwise show a discount off the full price while the run resolves by priority and does something else.

**A blocking guardrail is now a sentence, not a crash.** `planRun` returning `blocked` throws inside `runCampaign`, so the merchant used to meet their own floor *after* committing.

## #343 — found while extracting the parser

The editor's form has **no currency field**. The action read:

```ts
const currency = String(form.get("currency") ?? "USD");
rule = { kind: "set-exact", amount: money(Math.round(amount * 100), currency) };
```

So every fixed-amount rule on every store was built in **USD**, with a hardcoded `× 100` — the literal already removed from three service files for exactly this reason. A JPY store setting "exact price 3000" got **300,000 minor units labelled USD**.

Only `fixed-change` and `set-exact` build a `Money` from merchant input; `percent-change` is the default and carries a plain number. Both dev stores are USD, where `decimalsFor("USD") === 2` makes both mistakes cancel.

The parser now takes the currency as an argument rather than defaulting — there is no default left to be silently wrong — and preview and submit share it, so they cannot build different campaigns from the same fields.

## Two mutants survived first, and both mattered

The chaos scenario compares preview prices to what the fake storefront actually holds after the run. Four mutants; **two initially passed**:

- The first overlap test applied the fixture campaign before previewing. That makes every row a no-op — and `planRun` does not emit no-op rows at all, so a preview wrongly claiming another campaign's rows still reported zero changing. Fixed by making the other campaign ACTIVE *without* applying it, and giving the draft a rule that differs.
- `draftAsResolvable` hardcoded `guardrailViolationPolicy: "clamp"` — **#338 reintroduced in the one place built to prove preview and execution agree**. It reads the shop's setting now, and the scenario checks block and clamp give different previews.

All four now fail when they should:

| Mutant | Caught |
|---|---|
| claims rows another campaign owns | *"expected 6 to be +0"* |
| ignores the shop's running campaigns | ✓ |
| hardcodes clamp | ✓ |
| rounds differently from the run | *"preview promised …; the storefront says …"* |

## Also

`SKIP_REASON_GROUP` and `SKIP_REASON_ROW` now live in one file over one key set. Two lists would drift the moment a reason was added to the resolver, and the row phrasing would render "unknown" for a case the app understands.

## Checks

- `npm test` — 1585 passed (98 files)
- `npm run test:chaos` — 137 passed (42 files)
- `npm run typecheck`, `npm run build`, `npm run lint` — clean