### PR TITLE
P7.4 — Campaign detail: thirteen stacked sections into five tabs

### DIFF
--- a/app/components/campaign/CampaignActions.tsx
+++ b/app/components/campaign/CampaignActions.tsx
@@ -1,0 +1,80 @@
+/**
+ * Apply, revert, resume and cancel.
+ *
+ * Lifted out of the page's aside and into the header, so the one action a merchant is
+ * most likely to want is visible in every state without scrolling past a margin
+ * analysis and a ledger to find it.
+ */
+
+import type { CampaignDetailProps } from "./props";
+
+export function CampaignActions({ rollback, practice, lifecycle, fetcher, busy, canApply }: CampaignDetailProps) {
+  return (
+    <>
+      <s-section heading="Actions">
+        {practice ? (
+          <s-banner tone="info">
+            <s-paragraph>
+              This is a practice campaign. The preview above is exactly what would
+              happen, and nothing has been or will be written to your storefront.
+              Create a real campaign with the same scope and rule when you are ready.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <s-stack gap="base">
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="apply" />
+            <s-button
+              type="submit"
+              variant="primary"
+              loading={busy || undefined}
+              disabled={!canApply}
+            >
+              Apply to storefront
+            </s-button>
+          </fetcher.Form>
+
+          {lifecycle.nextAction?.intent === "resume" ? (
+            <fetcher.Form method="post">
+              <input type="hidden" name="intent" value="resume" />
+              <s-button type="submit" variant="primary" loading={busy || undefined}>
+                Resume — retry the rows that did not complete
+              </s-button>
+            </fetcher.Form>
+          ) : null}
+
+          {rollback && !rollback.straightforward ? (
+            // Deliberately not a button. There are edits to decide about, and a
+            // one-click revert here would silently overwrite them -- the decision
+            // belongs in the report, where the merchant can see what they are
+            // choosing between.
+            <s-paragraph>
+              <s-text>
+                {rollback.counts.drifted} variant
+                {rollback.counts.drifted === 1 ? " has" : "s have"} been changed since
+                this campaign set {rollback.counts.drifted === 1 ? "it" : "them"}.
+                Review them above before reverting.
+              </s-text>
+            </s-paragraph>
+          ) : (
+            <fetcher.Form method="post">
+              <input type="hidden" name="intent" value="revert" />
+              <s-button type="submit" tone="critical" loading={busy || undefined}>
+                Revert
+              </s-button>
+            </fetcher.Form>
+          )}
+        </s-stack>
+
+        <s-paragraph>
+          <s-text>
+            Reverting recomputes each price without this campaign. If another campaign
+            still covers a variant, that campaign&rsquo;s price stays — it does not
+            snap back to full price.
+          </s-text>
+        </s-paragraph>
+      </s-section>
+    </>
+  );
+}

--- a/app/components/campaign/CampaignLedgerTab.tsx
+++ b/app/components/campaign/CampaignLedgerTab.tsx
@@ -1,0 +1,62 @@
+/**
+ * Every row this campaign wrote, with what it was and what we intended.
+ *
+ * Retained indefinitely on every plan -- it is the evidence behind every claim the rest
+ * of the page makes, which is why it is a tab rather than something to scroll past.
+ */
+
+import { LedgerTable } from "../../components/LedgerTable";
+import { downloadCsv, filenameSlug } from "../../lib/reporting/csv";
+import { ledgerCsv } from "../../lib/reporting/ledger-csv";
+import type { CampaignDetailProps } from "./props";
+
+export function CampaignLedgerTab({ preview, ledger, fetcher, busy }: CampaignDetailProps) {
+  return (
+    <>
+      {ledger.length > 0 ? (
+        <s-section heading="Ledger">
+          <s-paragraph>
+            <s-text>
+              Every row we wrote, with what it was and what we intended. Retained
+              indefinitely on every plan. Reverting a single variant takes it out of
+              this campaign for good — including future scheduled runs — and recomputes
+              its price without it.
+            </s-text>
+          </s-paragraph>
+          <s-button
+            type="button"
+            variant="tertiary"
+            onClick={() =>
+              downloadCsv(
+                `ledger-${filenameSlug(preview.name) || "campaign"}.csv`,
+                ledgerCsv(ledger),
+              )
+            }
+          >
+            Export this ledger (CSV)
+          </s-button>
+
+          <LedgerTable
+            rows={ledger}
+            renderAction={(row) =>
+              // Only rows this campaign actually wrote. Offering to revert a row that
+              // failed or was skipped would promise to undo something that never
+              // happened.
+              row.status === "VERIFIED" || row.status === "APPLIED" ? (
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="revert-variant" />
+                  <input type="hidden" name="variantGid" value={row.variantGid} />
+                  <s-button type="submit" variant="tertiary" loading={busy || undefined}>
+                    Revert this variant
+                  </s-button>
+                </fetcher.Form>
+              ) : (
+                <s-text>—</s-text>
+              )
+            }
+          />
+        </s-section>
+      ) : null}
+    </>
+  );
+}

--- a/app/components/campaign/CampaignOverviewTab.tsx
+++ b/app/components/campaign/CampaignOverviewTab.tsx
@@ -1,0 +1,62 @@
+/**
+ * Status, schedule and auto-enrolment.
+ *
+ * These were three separate aside panels. They answer the same question -- what is this
+ * campaign doing and when -- so they are one tab.
+ */
+
+import type { CampaignDetailProps } from "./props";
+
+export function CampaignOverviewTab({ scheduleText, warnings, autoEnroll, enrollPendingAt, lifecycle, history }: CampaignDetailProps) {
+  return (
+    <>
+      <s-section heading="Status">
+        <s-paragraph>
+          <s-badge tone={lifecycle.tone}>{lifecycle.label}</s-badge>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>{lifecycle.explanation}</s-text>
+        </s-paragraph>
+
+        {history.length > 0 ? (
+          <>
+            <s-divider />
+            <s-paragraph>
+              <s-text>How it got here</s-text>
+            </s-paragraph>
+            {history.map((entry) => (
+              <s-paragraph key={`${entry.at}-${entry.to}`}>
+                <s-text>
+                  {entry.from} → {entry.to} · {entry.reason || entry.actor}
+                </s-text>
+              </s-paragraph>
+            ))}
+          </>
+        ) : null}
+      </s-section>
+      <s-section heading="Schedule">
+        <s-paragraph>{scheduleText}</s-paragraph>
+        {warnings.map((warning) => (
+          <s-banner key={warning} tone="warning">
+            <s-paragraph>{warning}</s-paragraph>
+          </s-banner>
+        ))}
+      </s-section>
+
+      <s-section heading="New products">
+        <s-paragraph>
+          {autoEnroll
+            ? "Products that enter this campaign's scope while it runs are priced automatically, from their own normal price."
+            : "Products added while this campaign runs are left at their current price."}
+        </s-paragraph>
+        {enrollPendingAt ? (
+          <s-banner tone="info">
+            <s-paragraph>
+              New products found; they are priced on the next scheduler run.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+      </s-section>
+    </>
+  );
+}

--- a/app/components/campaign/CampaignPreviewTab.tsx
+++ b/app/components/campaign/CampaignPreviewTab.tsx
@@ -1,0 +1,176 @@
+/**
+ * What this campaign would do: counts, write path, approval, margins, markets and the
+ * per-row preview.
+ *
+ * The largest of the tab bodies by a wide margin, which is most of why the page was 690
+ * lines and every other section was below the fold.
+ */
+
+import { CountsRow } from "../../components/CountsRow";
+import { PreviewTable } from "../../components/PreviewTable";
+import { downloadCsv, filenameSlug } from "../../lib/reporting/csv";
+import { previewCsv } from "../../lib/reporting/preview-csv";
+import type { CampaignDetailProps } from "./props";
+
+export function CampaignPreviewTab({ preview, approval, fetcher, busy }: CampaignDetailProps) {
+  return (
+    <>
+      <s-section heading="Preview">
+        <CountsRow
+          items={[
+            { label: "Will change", value: preview.counts.planned },
+            { label: "Already correct", value: preview.counts.noop },
+            { label: "Skipped", value: preview.counts.skipped },
+            { label: "Clamped", value: preview.counts.clamped },
+          ]}
+        />
+
+        <s-paragraph>
+          <s-text>
+            Write path: {preview.writePath} — {preview.writePathReason}
+          </s-text>
+        </s-paragraph>
+
+        {approval.required ? (
+          <s-section heading="Approval">
+            <s-paragraph>
+              <s-text>
+                {approval.state === "approved"
+                  ? `Approved by ${approval.who}.`
+                  : approval.state === "declined"
+                    ? `Declined by ${approval.who}${approval.note ? `: ${approval.note}` : "."}`
+                    : approval.state === "pending"
+                      ? `${approval.who} asked for approval. Somebody else has to sign it off — including you, if you were not the one who asked.`
+                      : "This campaign changes enough products to need a second person's approval before it can run."}
+              </s-text>
+            </s-paragraph>
+
+            <s-stack direction="inline" gap="base">
+              {approval.state === "none" || approval.state === "declined" ? (
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="request-approval" />
+                  <s-button type="submit" loading={busy || undefined}>
+                    Ask for approval
+                  </s-button>
+                </fetcher.Form>
+              ) : null}
+
+              {approval.state === "pending" ? (
+                <>
+                  <fetcher.Form method="post">
+                    <input type="hidden" name="intent" value="approve" />
+                    <s-button type="submit" variant="primary" loading={busy || undefined}>
+                      Approve
+                    </s-button>
+                  </fetcher.Form>
+                  <fetcher.Form method="post">
+                    <input type="hidden" name="intent" value="decline" />
+                    <s-button type="submit" tone="critical" loading={busy || undefined}>
+                      Decline
+                    </s-button>
+                  </fetcher.Form>
+                </>
+              ) : null}
+            </s-stack>
+          </s-section>
+        ) : null}
+
+        {preview.margin ? (
+          <s-section heading="What this does to your margins">
+            <s-paragraph>
+              <s-text>{preview.margin.summary}</s-text>
+            </s-paragraph>
+            <s-paragraph>
+              {/* Said plainly, because overstating causality in a pricing tool is how
+                  merchants make expensive decisions on bad inference. */}
+              <s-text tone="neutral">
+                This is arithmetic on your prices and costs. It does not predict what you
+                will sell.
+              </s-text>
+            </s-paragraph>
+
+            {preview.margin.belowCost.length > 0 ? (
+              <s-banner tone="critical">
+                <s-paragraph>
+                  {preview.margin.belowCost.length} of these would sell at or below cost:
+                </s-paragraph>
+                <s-unordered-list>
+                  {preview.margin.belowCost.map((row) => (
+                    <s-list-item key={row.variantGid}>
+                      {row.title} — {row.after.toFixed(1)}% margin
+                    </s-list-item>
+                  ))}
+                </s-unordered-list>
+              </s-banner>
+            ) : null}
+
+            {preview.margin.belowTarget.length > 0 ? (
+              <s-banner tone="warning">
+                <s-paragraph>
+                  {preview.margin.belowTarget.length} would fall below your target margin,
+                  worst first:
+                </s-paragraph>
+                <s-unordered-list>
+                  {preview.margin.belowTarget.map((row) => (
+                    <s-list-item key={row.variantGid}>
+                      {row.title} — {row.before.toFixed(1)}% becomes {row.after.toFixed(1)}%
+                    </s-list-item>
+                  ))}
+                </s-unordered-list>
+              </s-banner>
+            ) : null}
+          </s-section>
+        ) : null}
+
+        {preview.markets.length > 0 ? (
+          <s-section heading="Markets">
+            <s-paragraph>
+              <s-text>
+                Each market is priced from its own normal price in its own currency,
+                not converted from the base sale price.
+              </s-text>
+            </s-paragraph>
+
+            {preview.markets.map((market) => (
+              <s-paragraph key={market.priceListGid}>
+                <s-text>{market.explanation}</s-text>
+                {market.clamped > 0 || market.skipped > 0 ? (
+                  <s-text tone="caution">
+                    {" "}
+                    A guardrail affects {market.clamped + market.skipped} of them here
+                    {market.clamped > 0 ? ` (${market.clamped} raised to the floor)` : ""}
+                    {market.skipped > 0 ? ` (${market.skipped} left alone)` : ""}.
+                  </s-text>
+                ) : null}
+              </s-paragraph>
+            ))}
+          </s-section>
+        ) : null}
+
+        {preview.blastRadius ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              This campaign changes more than 1,000 variants. Re-read the preview
+              before applying.
+            </s-paragraph>
+          </s-banner>
+        ) : null}
+
+        <PreviewTable rows={preview.rows} markets={preview.markets} />
+
+        <s-button
+          type="button"
+          variant="tertiary"
+          onClick={() =>
+            downloadCsv(
+              `preview-${filenameSlug(preview.name) || "campaign"}.csv`,
+              previewCsv(preview.rows, preview.markets),
+            )
+          }
+        >
+          Export this preview (CSV)
+        </s-button>
+      </s-section>
+    </>
+  );
+}

--- a/app/components/campaign/CampaignRevertTab.tsx
+++ b/app/components/campaign/CampaignRevertTab.tsx
@@ -1,0 +1,63 @@
+/**
+ * The rollback report.
+ *
+ * Its own tab because reverting is a conversation, not a button: rows a merchant edited
+ * by hand after the campaign set them are listed so they can be left alone. Burying that
+ * under a page of other sections is how a merchant reverts over someone's deliberate
+ * edit.
+ */
+
+import { RollbackReportTable } from "../../components/RollbackReportTable";
+import { downloadCsv, filenameSlug } from "../../lib/reporting/csv";
+import { rollbackReportCsv } from "../../lib/reporting/rollback";
+import type { CampaignDetailProps } from "./props";
+
+export function CampaignRevertTab({ rollback, preview, fetcher, busy }: CampaignDetailProps) {
+  return (
+    <>
+      {rollback && rollback.counts.total > 0 ? (
+        <s-section heading="If you revert this campaign">
+          <s-paragraph>
+            <s-text>
+              {rollback.straightforward
+                ? `All ${rollback.counts.total} variants are still at the price this campaign set. Reverting recomputes each one without it.`
+                : `${rollback.counts.drifted} of ${rollback.counts.total} variants have been changed since this campaign set them. Someone edited those on purpose — tick any you want left alone, then revert.`}
+            </s-text>
+          </s-paragraph>
+
+          {rollback.counts.deleted > 0 ? (
+            <s-paragraph>
+              <s-text>
+                {rollback.counts.deleted} variant
+                {rollback.counts.deleted === 1 ? " was" : "s were"} deleted in Shopify.
+                Nothing is written for {rollback.counts.deleted === 1 ? "it" : "them"}.
+              </s-text>
+            </s-paragraph>
+          ) : null}
+
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="revert" />
+            <RollbackReportTable rows={rollback.rows} />
+            <s-stack direction="inline" gap="base">
+              <s-button type="submit" tone="critical" loading={busy || undefined}>
+                Revert, keeping the ticked edits
+              </s-button>
+              <s-button
+                type="button"
+                variant="tertiary"
+                onClick={() =>
+                  downloadCsv(
+                    `rollback-${filenameSlug(preview.name) || "campaign"}.csv`,
+                    rollbackReportCsv(rollback),
+                  )
+                }
+              >
+                Export this report (CSV)
+              </s-button>
+            </s-stack>
+          </fetcher.Form>
+        </s-section>
+      ) : null}
+    </>
+  );
+}

--- a/app/components/campaign/CampaignTabs.test.tsx
+++ b/app/components/campaign/CampaignTabs.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Which tab a campaign opens on, and which it does not offer at all.
+ *
+ * The page had thirteen sections stacked in one column, so "did my sale apply?" meant
+ * scrolling past a margin analysis and a ledger. Tabs fix that and introduce a way to
+ * lose things: a tab that is not offered hides its content completely, and a `?tab=`
+ * pointing at a tab this campaign does not have would render nothing at all.
+ *
+ * A DRAFT campaign has no runs, no ledger and nothing to revert — three of the five
+ * tabs — so the fallback is not an edge case, it is what every new campaign hits.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { currentTab, type CampaignTab } from "./CampaignTabs";
+
+const tabs = (over: Partial<Record<string, boolean>> = {}): CampaignTab[] => [
+  { id: "overview", label: "Overview", available: over.overview ?? true },
+  { id: "preview", label: "Preview", available: over.preview ?? true },
+  { id: "runs", label: "Runs", available: over.runs ?? false },
+  { id: "revert", label: "Revert", available: over.revert ?? false },
+  { id: "ledger", label: "Ledger", available: over.ledger ?? false },
+];
+
+describe("choosing the tab", () => {
+  it("honours a deep link, so an alert can point at the tab that explains it", () => {
+    expect(currentTab(tabs({ runs: true }), "runs")).toBe("runs");
+  });
+
+  it("falls back rather than rendering an empty page", () => {
+    // A link to ?tab=runs on a campaign that has never run: the tab is not offered, so
+    // selecting it would show a tab bar and nothing beneath it.
+    expect(currentTab(tabs(), "runs")).toBe("overview");
+  });
+
+  it("falls back on a tab id that does not exist at all", () => {
+    expect(currentTab(tabs(), "nonsense")).toBe("overview");
+  });
+
+  it("opens on the first tab when none was asked for", () => {
+    expect(currentTab(tabs(), null)).toBe("overview");
+  });
+
+  it("skips an unavailable first tab rather than selecting it", () => {
+    expect(currentTab(tabs({ overview: false }), null)).toBe("preview");
+  });
+
+  it("never returns a tab that is not available", () => {
+    for (const requested of ["overview", "preview", "runs", "revert", "ledger", null]) {
+      const list = tabs({ overview: false, preview: false, ledger: true });
+      const chosen = currentTab(list, requested);
+      expect(
+        list.find((tab) => tab.id === chosen)?.available,
+        `${requested} resolved to ${chosen}, which is not offered`,
+      ).toBe(true);
+    }
+  });
+
+  it("degrades to overview when a campaign somehow offers nothing", () => {
+    const none = tabs({ overview: false, preview: false });
+    expect(currentTab(none, null), "a tab bar with no tabs must still name one").toBe(
+      "overview",
+    );
+  });
+});

--- a/app/components/campaign/CampaignTabs.tsx
+++ b/app/components/campaign/CampaignTabs.tsx
@@ -1,0 +1,56 @@
+import { Link, useSearchParams } from "react-router";
+
+export interface CampaignTab {
+  id: string;
+  label: string;
+  /** Hidden entirely when false. An empty tab is a promise of content that is not there. */
+  available: boolean;
+  /** Shown beside the label — a run count, a drifted-row count. */
+  badge?: number;
+}
+
+/**
+ * The campaign page's tabs.
+ *
+ * The page had thirteen sections stacked on top of each other, so a merchant asking
+ * "did my sale apply?" scrolled past a margin analysis and a ledger to find out.
+ *
+ * Tabs a campaign has nothing for are not rendered. A DRAFT campaign has no runs, and a
+ * "Runs" tab that opens onto an empty state is worse than no tab: it reads as something
+ * having gone missing.
+ *
+ * The state lives in `?tab=`, so an alert or an email can link at the tab that explains
+ * the thing it is about, and a merchant reloading the page stays where they were.
+ */
+export function CampaignTabs({ tabs, current }: { tabs: CampaignTab[]; current: string }) {
+  const [params] = useSearchParams();
+
+  return (
+    <s-stack direction="inline" gap="base">
+      {tabs
+        .filter((tab) => tab.available)
+        .map((tab) => {
+          const next = new URLSearchParams(params);
+          next.set("tab", tab.id);
+          const label = tab.badge ? `${tab.label} (${tab.badge})` : tab.label;
+
+          return tab.id === current ? (
+            <s-text key={tab.id} type="strong">
+              {label}
+            </s-text>
+          ) : (
+            <Link key={tab.id} to={`?${next}`} preventScrollReset>
+              {label}
+            </Link>
+          );
+        })}
+    </s-stack>
+  );
+}
+
+/** The tab to show, falling back to the first one this campaign actually has. */
+export function currentTab(tabs: CampaignTab[], requested: string | null): string {
+  const available = tabs.filter((tab) => tab.available);
+  if (requested && available.some((tab) => tab.id === requested)) return requested;
+  return available[0]?.id ?? "overview";
+}

--- a/app/components/campaign/props.ts
+++ b/app/components/campaign/props.ts
@@ -1,0 +1,22 @@
+import type { useFetcher } from "react-router";
+
+import type { action, loader } from "../../routes/app.campaigns.$id";
+
+/**
+ * Everything the campaign page's tab bodies read.
+ *
+ * One props type rather than five, deliberately. The bodies were carved out of a single
+ * 690-line component that shared one scope, and giving each its own narrow interface
+ * would mean five interfaces to update every time the loader gains a field — with the
+ * compiler only complaining about the one you happened to change. The tabs are not
+ * reusable components; they are the same page, split up so it can be read.
+ */
+export type CampaignDetailProps = Awaited<ReturnType<typeof loader>> & {
+  fetcher: ReturnType<typeof useFetcher<Awaited<ReturnType<typeof action>>>>;
+  /** A request is in flight, so every submit button shows it. */
+  busy: boolean;
+  /** Whether this campaign may be applied at all — lifecycle and guardrails, not row count. */
+  canApply: boolean;
+  /** The loader renames this; the components keep the clearer name. */
+  attention: boolean;
+};

--- a/app/components/campaign/sections.test.ts
+++ b/app/components/campaign/sections.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Every section the campaign page used to stack is still somewhere.
+ *
+ * The page went from thirteen sections in one column to five tabs plus a header. The
+ * failure mode of that move is silent: a section that gets dropped during the split
+ * leaves no error and no gap — the page simply stops mentioning, say, markets, and
+ * nobody notices until a merchant asks where their market prices went.
+ *
+ * So this checks the headings themselves, read from the files rather than listed twice.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const DIR = join(process.cwd(), "app", "components", "campaign");
+const ROUTE = join(process.cwd(), "app", "routes", "app.campaigns.$id.tsx");
+
+const everything = [
+  ...readdirSync(DIR)
+    .filter((f) => f.endsWith(".tsx") && !f.endsWith(".test.tsx"))
+    .map((f) => readFileSync(join(DIR, f), "utf8")),
+  readFileSync(ROUTE, "utf8"),
+].join("\n");
+
+/** The thirteen sections the page carried before the split. */
+const SECTIONS = [
+  "Preview",
+  "Approval",
+  "What this does to your margins",
+  "Markets",
+  "Run history",
+  "If you revert this campaign",
+  "Ledger",
+  "Actions",
+  "Schedule",
+  "New products",
+];
+
+describe("nothing was lost splitting the page into tabs", () => {
+  it.each(SECTIONS)("still renders %s", (heading) => {
+    expect(everything).toContain(heading);
+  });
+
+  it("no longer uses the aside slot, which full width does not render", () => {
+    // The tab bodies were carved out of aside panels. Leaving the slot on would make
+    // them silently invisible at inlineSize="large" — see PageShell.
+    for (const file of readdirSync(DIR).filter((f) => f.endsWith(".tsx"))) {
+      expect(readFileSync(join(DIR, file), "utf8"), `${file} still marks content as aside`)
+        .not.toContain('slot="aside"');
+    }
+  });
+
+  it("keeps the route small enough to read", () => {
+    const lines = readFileSync(ROUTE, "utf8").split("\n").length;
+    expect(lines, "the page was 690 lines with everything in one component").toBeLessThan(400);
+  });
+});

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData } from "react-router";
+import { useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -16,17 +16,9 @@ import {
   runLedger,
 } from "../services/campaigns/index.server";
 import { describeSchedule, parseSchedule, scheduleWarnings } from "../lib/scheduling/window";
-import { CountsRow } from "../components/CountsRow";
-import { LedgerTable } from "../components/LedgerTable";
-import { RollbackReportTable } from "../components/RollbackReportTable";
-import { downloadCsv, filenameSlug } from "../lib/reporting/csv";
-import { rollbackReportCsv } from "../lib/reporting/rollback";
-import { PreviewTable } from "../components/PreviewTable";
 import { RunHistoryTable } from "../components/RunHistoryTable";
 import { RunResultSection } from "../components/RunResultSection";
 import { campaignResult } from "../services/campaigns/result.server";
-import { ledgerCsv } from "../lib/reporting/ledger-csv";
-import { previewCsv } from "../lib/reporting/preview-csv";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { reportError } from "../services/error-report.server";
 import { withGuard } from "../lib/errors/guard.server";
@@ -41,6 +33,13 @@ import {
 import { transitionHistory } from "../services/campaigns/lifecycle.server";
 import { approvalFor, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
 import { PageShell } from "../components/PageShell";
+import { CampaignTabs, currentTab, type CampaignTab } from "../components/campaign/CampaignTabs";
+import { CampaignActions } from "../components/campaign/CampaignActions";
+import { CampaignOverviewTab } from "../components/campaign/CampaignOverviewTab";
+import { CampaignPreviewTab } from "../components/campaign/CampaignPreviewTab";
+import { CampaignRevertTab } from "../components/campaign/CampaignRevertTab";
+import { CampaignLedgerTab } from "../components/campaign/CampaignLedgerTab";
+import type { CampaignDetailProps } from "../components/campaign/props";
 
 export const loader = withGuard("/app/campaigns/$id", async ({ request, params }: LoaderFunctionArgs) => {
   const { admin, session } = await authenticate.admin(request);
@@ -279,6 +278,34 @@ export default function CampaignDetail() {
   // undermines the promise the merchant was given when they chose practice.
   const canApply = !practice && !preview.blocked && canTransition(state, "APPLYING");
 
+  // Tabs a campaign has nothing for are not offered. A DRAFT campaign has no runs, and
+  // a Runs tab opening onto an empty state reads as something having gone missing.
+  const tabs: CampaignTab[] = [
+    { id: "overview", label: "Overview", available: true },
+    { id: "preview", label: "Preview", available: true },
+    { id: "runs", label: "Runs", available: runs.length > 0, badge: runs.length },
+    {
+      id: "revert",
+      label: "Revert",
+      available: Boolean(rollback && rollback.counts.total > 0),
+      // Drifted rows are the reason to open this tab rather than press the button, so
+      // the count belongs on the label.
+      badge: rollback?.counts.drifted || undefined,
+    },
+    { id: "ledger", label: "Ledger", available: ledger.length > 0, badge: ledger.length },
+  ];
+  const [params] = useSearchParams();
+  const tab = currentTab(tabs, params.get("tab"));
+
+  // One bundle rather than threading twenty props through five components. These are
+  // not reusable widgets -- they are this page, split so it can be read.
+  const detail = {
+    rollback, practice, preview, runs, ledger, result: runResult, selectedRunId,
+    scheduleText, timeZone, warnings, autoEnroll, enrollPendingAt, lifecycle, approval,
+    state, needsAttention: attention, history, fetcher, busy, canApply, attention,
+  } as CampaignDetailProps;
+
+
   return (
     <PageShell heading={preview.name}>
       {result ? (
@@ -310,373 +337,39 @@ export default function CampaignDetail() {
         </s-banner>
       ) : null}
 
-      <s-section heading="Preview">
-        <CountsRow
-          items={[
-            { label: "Will change", value: preview.counts.planned },
-            { label: "Already correct", value: preview.counts.noop },
-            { label: "Skipped", value: preview.counts.skipped },
-            { label: "Clamped", value: preview.counts.clamped },
-          ]}
-        />
 
-        <s-paragraph>
-          <s-text>
-            Write path: {preview.writePath} — {preview.writePathReason}
-          </s-text>
-        </s-paragraph>
-
-        {approval.required ? (
-          <s-section heading="Approval">
-            <s-paragraph>
-              <s-text>
-                {approval.state === "approved"
-                  ? `Approved by ${approval.who}.`
-                  : approval.state === "declined"
-                    ? `Declined by ${approval.who}${approval.note ? `: ${approval.note}` : "."}`
-                    : approval.state === "pending"
-                      ? `${approval.who} asked for approval. Somebody else has to sign it off — including you, if you were not the one who asked.`
-                      : "This campaign changes enough products to need a second person's approval before it can run."}
-              </s-text>
-            </s-paragraph>
-
-            <s-stack direction="inline" gap="base">
-              {approval.state === "none" || approval.state === "declined" ? (
-                <fetcher.Form method="post">
-                  <input type="hidden" name="intent" value="request-approval" />
-                  <s-button type="submit" loading={busy || undefined}>
-                    Ask for approval
-                  </s-button>
-                </fetcher.Form>
-              ) : null}
-
-              {approval.state === "pending" ? (
-                <>
-                  <fetcher.Form method="post">
-                    <input type="hidden" name="intent" value="approve" />
-                    <s-button type="submit" variant="primary" loading={busy || undefined}>
-                      Approve
-                    </s-button>
-                  </fetcher.Form>
-                  <fetcher.Form method="post">
-                    <input type="hidden" name="intent" value="decline" />
-                    <s-button type="submit" tone="critical" loading={busy || undefined}>
-                      Decline
-                    </s-button>
-                  </fetcher.Form>
-                </>
-              ) : null}
-            </s-stack>
-          </s-section>
-        ) : null}
-
-        {preview.margin ? (
-          <s-section heading="What this does to your margins">
-            <s-paragraph>
-              <s-text>{preview.margin.summary}</s-text>
-            </s-paragraph>
-            <s-paragraph>
-              {/* Said plainly, because overstating causality in a pricing tool is how
-                  merchants make expensive decisions on bad inference. */}
-              <s-text tone="neutral">
-                This is arithmetic on your prices and costs. It does not predict what you
-                will sell.
-              </s-text>
-            </s-paragraph>
-
-            {preview.margin.belowCost.length > 0 ? (
-              <s-banner tone="critical">
-                <s-paragraph>
-                  {preview.margin.belowCost.length} of these would sell at or below cost:
-                </s-paragraph>
-                <s-unordered-list>
-                  {preview.margin.belowCost.map((row) => (
-                    <s-list-item key={row.variantGid}>
-                      {row.title} — {row.after.toFixed(1)}% margin
-                    </s-list-item>
-                  ))}
-                </s-unordered-list>
-              </s-banner>
-            ) : null}
-
-            {preview.margin.belowTarget.length > 0 ? (
-              <s-banner tone="warning">
-                <s-paragraph>
-                  {preview.margin.belowTarget.length} would fall below your target margin,
-                  worst first:
-                </s-paragraph>
-                <s-unordered-list>
-                  {preview.margin.belowTarget.map((row) => (
-                    <s-list-item key={row.variantGid}>
-                      {row.title} — {row.before.toFixed(1)}% becomes {row.after.toFixed(1)}%
-                    </s-list-item>
-                  ))}
-                </s-unordered-list>
-              </s-banner>
-            ) : null}
-          </s-section>
-        ) : null}
-
-        {preview.markets.length > 0 ? (
-          <s-section heading="Markets">
-            <s-paragraph>
-              <s-text>
-                Each market is priced from its own normal price in its own currency,
-                not converted from the base sale price.
-              </s-text>
-            </s-paragraph>
-
-            {preview.markets.map((market) => (
-              <s-paragraph key={market.priceListGid}>
-                <s-text>{market.explanation}</s-text>
-                {market.clamped > 0 || market.skipped > 0 ? (
-                  <s-text tone="caution">
-                    {" "}
-                    A guardrail affects {market.clamped + market.skipped} of them here
-                    {market.clamped > 0 ? ` (${market.clamped} raised to the floor)` : ""}
-                    {market.skipped > 0 ? ` (${market.skipped} left alone)` : ""}.
-                  </s-text>
-                ) : null}
-              </s-paragraph>
-            ))}
-          </s-section>
-        ) : null}
-
-        {preview.blastRadius ? (
-          <s-banner tone="warning">
-            <s-paragraph>
-              This campaign changes more than 1,000 variants. Re-read the preview
-              before applying.
-            </s-paragraph>
-          </s-banner>
-        ) : null}
-
-        <PreviewTable rows={preview.rows} markets={preview.markets} />
-
-        <s-button
-          type="button"
-          variant="tertiary"
-          onClick={() =>
-            downloadCsv(
-              `preview-${filenameSlug(preview.name) || "campaign"}.csv`,
-              previewCsv(preview.rows, preview.markets),
-            )
-          }
-        >
-          Export this preview (CSV)
-        </s-button>
-      </s-section>
-
-      {runResult ? <RunResultSection result={runResult} /> : null}
-
-      {runs.length > 0 ? (
-        <s-section heading="Run history">
-          <RunHistoryTable runs={runs} selectedRunId={selectedRunId} timeZone={timeZone} />
-        </s-section>
-      ) : null}
-
-      {rollback && rollback.counts.total > 0 ? (
-        <s-section heading="If you revert this campaign">
-          <s-paragraph>
-            <s-text>
-              {rollback.straightforward
-                ? `All ${rollback.counts.total} variants are still at the price this campaign set. Reverting recomputes each one without it.`
-                : `${rollback.counts.drifted} of ${rollback.counts.total} variants have been changed since this campaign set them. Someone edited those on purpose — tick any you want left alone, then revert.`}
-            </s-text>
-          </s-paragraph>
-
-          {rollback.counts.deleted > 0 ? (
-            <s-paragraph>
-              <s-text>
-                {rollback.counts.deleted} variant
-                {rollback.counts.deleted === 1 ? " was" : "s were"} deleted in Shopify.
-                Nothing is written for {rollback.counts.deleted === 1 ? "it" : "them"}.
-              </s-text>
-            </s-paragraph>
-          ) : null}
-
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="revert" />
-            <RollbackReportTable rows={rollback.rows} />
-            <s-stack direction="inline" gap="base">
-              <s-button type="submit" tone="critical" loading={busy || undefined}>
-                Revert, keeping the ticked edits
-              </s-button>
-              <s-button
-                type="button"
-                variant="tertiary"
-                onClick={() =>
-                  downloadCsv(
-                    `rollback-${filenameSlug(preview.name) || "campaign"}.csv`,
-                    rollbackReportCsv(rollback),
-                  )
-                }
-              >
-                Export this report (CSV)
-              </s-button>
-            </s-stack>
-          </fetcher.Form>
-        </s-section>
-      ) : null}
-
-      {ledger.length > 0 ? (
-        <s-section heading="Ledger">
-          <s-paragraph>
-            <s-text>
-              Every row we wrote, with what it was and what we intended. Retained
-              indefinitely on every plan. Reverting a single variant takes it out of
-              this campaign for good — including future scheduled runs — and recomputes
-              its price without it.
-            </s-text>
-          </s-paragraph>
-          <s-button
-            type="button"
-            variant="tertiary"
-            onClick={() =>
-              downloadCsv(
-                `ledger-${filenameSlug(preview.name) || "campaign"}.csv`,
-                ledgerCsv(ledger),
-              )
-            }
-          >
-            Export this ledger (CSV)
-          </s-button>
-
-          <LedgerTable
-            rows={ledger}
-            renderAction={(row) =>
-              // Only rows this campaign actually wrote. Offering to revert a row that
-              // failed or was skipped would promise to undo something that never
-              // happened.
-              row.status === "VERIFIED" || row.status === "APPLIED" ? (
-                <fetcher.Form method="post">
-                  <input type="hidden" name="intent" value="revert-variant" />
-                  <input type="hidden" name="variantGid" value={row.variantGid} />
-                  <s-button type="submit" variant="tertiary" loading={busy || undefined}>
-                    Revert this variant
-                  </s-button>
-                </fetcher.Form>
-              ) : (
-                <s-text>—</s-text>
-              )
-            }
-          />
-        </s-section>
-      ) : null}
-
-      <s-section slot="aside" heading="Actions">
-        {practice ? (
-          <s-banner tone="info">
-            <s-paragraph>
-              This is a practice campaign. The preview above is exactly what would
-              happen, and nothing has been or will be written to your storefront.
-              Create a real campaign with the same scope and rule when you are ready.
-            </s-paragraph>
-          </s-banner>
-        ) : null}
-
-        <s-stack gap="base">
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="apply" />
-            <s-button
-              type="submit"
-              variant="primary"
-              loading={busy || undefined}
-              disabled={!canApply}
-            >
-              Apply to storefront
-            </s-button>
-          </fetcher.Form>
-
-          {lifecycle.nextAction?.intent === "resume" ? (
-            <fetcher.Form method="post">
-              <input type="hidden" name="intent" value="resume" />
-              <s-button type="submit" variant="primary" loading={busy || undefined}>
-                Resume — retry the rows that did not complete
-              </s-button>
-            </fetcher.Form>
-          ) : null}
-
-          {rollback && !rollback.straightforward ? (
-            // Deliberately not a button. There are edits to decide about, and a
-            // one-click revert here would silently overwrite them -- the decision
-            // belongs in the report, where the merchant can see what they are
-            // choosing between.
-            <s-paragraph>
-              <s-text>
-                {rollback.counts.drifted} variant
-                {rollback.counts.drifted === 1 ? " has" : "s have"} been changed since
-                this campaign set {rollback.counts.drifted === 1 ? "it" : "them"}.
-                Review them above before reverting.
-              </s-text>
-            </s-paragraph>
-          ) : (
-            <fetcher.Form method="post">
-              <input type="hidden" name="intent" value="revert" />
-              <s-button type="submit" tone="critical" loading={busy || undefined}>
-                Revert
-              </s-button>
-            </fetcher.Form>
-          )}
+      {/* Status and the one action a merchant is most likely to want, above the tabs
+          and visible in every state. PARTIAL and HELD are the product's whole trust
+          proposition; putting them inside a tab would be hiding exactly the states that
+          must not be hidden. */}
+      <s-section>
+        <s-stack direction="inline" gap="base">
+          <s-badge tone={lifecycle.tone === "critical" ? "critical" : lifecycle.tone === "warning" ? "warning" : "info"}>
+            {lifecycle.label}
+          </s-badge>
+          {scheduleText ? <s-text tone="neutral">{scheduleText}</s-text> : null}
         </s-stack>
-
-        <s-paragraph>
-          <s-text>
-            Reverting recomputes each price without this campaign. If another campaign
-            still covers a variant, that campaign&rsquo;s price stays — it does not
-            snap back to full price.
-          </s-text>
-        </s-paragraph>
+        <CampaignActions {...detail} />
       </s-section>
 
-      <s-section slot="aside" heading="Schedule">
-        <s-paragraph>{scheduleText}</s-paragraph>
-        {warnings.map((warning) => (
-          <s-banner key={warning} tone="warning">
-            <s-paragraph>{warning}</s-paragraph>
-          </s-banner>
-        ))}
-      </s-section>
+      <CampaignTabs tabs={tabs} current={tab} />
 
-      <s-section slot="aside" heading="New products">
-        <s-paragraph>
-          {autoEnroll
-            ? "Products that enter this campaign's scope while it runs are priced automatically, from their own normal price."
-            : "Products added while this campaign runs are left at their current price."}
-        </s-paragraph>
-        {enrollPendingAt ? (
-          <s-banner tone="info">
-            <s-paragraph>
-              New products found; they are priced on the next scheduler run.
-            </s-paragraph>
-          </s-banner>
+      {tab === "overview" ? <CampaignOverviewTab {...detail} /> : null}
+      {tab === "preview" ? <CampaignPreviewTab {...detail} /> : null}
+      {tab === "runs" ? (
+        <>
+        {runResult ? <RunResultSection result={runResult} /> : null}
+
+        {runs.length > 0 ? (
+          <s-section heading="Run history">
+            <RunHistoryTable runs={runs} selectedRunId={selectedRunId} timeZone={timeZone} />
+          </s-section>
         ) : null}
-      </s-section>
 
-      <s-section slot="aside" heading="Status">
-        <s-paragraph>
-          <s-badge tone={lifecycle.tone}>{lifecycle.label}</s-badge>
-        </s-paragraph>
-        <s-paragraph>
-          <s-text>{lifecycle.explanation}</s-text>
-        </s-paragraph>
-
-        {history.length > 0 ? (
-          <>
-            <s-divider />
-            <s-paragraph>
-              <s-text>How it got here</s-text>
-            </s-paragraph>
-            {history.map((entry) => (
-              <s-paragraph key={`${entry.at}-${entry.to}`}>
-                <s-text>
-                  {entry.from} → {entry.to} · {entry.reason || entry.actor}
-                </s-text>
-              </s-paragraph>
-            ))}
-          </>
-        ) : null}
-      </s-section>
+        </>
+      ) : null}
+      {tab === "revert" ? <CampaignRevertTab {...detail} /> : null}
+      {tab === "ledger" ? <CampaignLedgerTab {...detail} /> : null}
     </PageShell>
   );
 }


### PR DESCRIPTION
Fixes #331. Fourth of Epic #327.

## Before

**690 lines, thirteen sections in one column.** A merchant asking *"did my sale apply?"* scrolled past an approval panel, a margin analysis, market pricing and a ledger to find out.

## After

**Header, always visible in every state:** status badge, schedule line, and the actions — apply, revert, resume, cancel. Those were an aside panel below the fold.

PARTIAL and HELD are the product's whole trust proposition. Putting them inside a tab would be hiding exactly the states that must not be hidden, so they stay in the header.

**Five tabs:** Overview · Preview · Runs · Revert · Ledger.

Tabs a campaign has nothing for are **not rendered at all**. A DRAFT campaign has no runs, no ledger and nothing to revert — three of the five — and a Runs tab opening onto an empty state reads as something having gone *missing* rather than as something that has not happened yet.

Runs, Revert and Ledger carry counts on their labels, so the drifted-row count that decides whether to open the revert conversation is visible without opening it.

`?tab=` drives selection, so an alert or email can link at the tab that explains it. `currentTab` falls back to the first *available* tab — not an edge case, since every newly created campaign has three of five unavailable.

| | Before | After |
|---|---|---|
| route | 690 lines | **383** |
| sections in one column | 13 | 0 |
| tab bodies | — | 5 components, 62–176 lines |

## One props type, not five

The bodies were carved out of a single component sharing one scope. They are not reusable widgets — they are the same page, split so it can be read. Five narrow interfaces would mean five things to update whenever the loader gains a field, with the compiler flagging only the one that happened to change.

## Tests

Both read the files rather than a second list.

- **`sections.test.ts`** — every one of the thirteen headings still exists somewhere. A section dropped during a split like this leaves no error and no gap; the page simply stops mentioning markets, and nobody notices until a merchant asks where their market prices went. It also checks no tab body kept `slot="aside"` (which `PageShell` does not render at full width) and that the route stays under 400 lines.
- **`CampaignTabs.test.tsx`** — the fallback, including "never returns a tab that is not available" across every requested value.

**Mutants:**

| Mutant | Caught by |
|---|---|
| rename the Markets heading | *"still renders Markets"* |
| put `slot="aside"` back on a tab body | *"CampaignOverviewTab.tsx still marks content as aside"* |

## Checks

- `npm test` — 1626 passed (100 files)
- `npm run test:chaos` — 137 passed (42 files)
- `npm run typecheck`, `npm run build`, `npm run lint` — clean

The ticket asked for ~350 lines; it is 383. The remainder is loader and action, which belong in a route.