### PR TITLE
Chunk the IN lists a negation stops Prisma splitting

### DIFF
--- a/app/services/campaigns/b2b-surfaces.server.ts
+++ b/app/services/campaigns/b2b-surfaces.server.ts
@@ -23,6 +23,7 @@ import type { QuantityTier } from "../../lib/pricing/quantity-breaks";
 import { logger } from "../../lib/logging/logger";
 import { metric } from "../../lib/telemetry/metrics";
 import { planQuantityBreaks, type B2BVariantInput } from "./b2b-plan.server";
+import { inChunks } from "../../lib/db/chunk";
 
 export interface B2BSurfaceOutcome {
   priceListGid: string;
@@ -205,21 +206,25 @@ export async function revertQuantityBreaks(
 
   // Only variants this campaign actually gave a ladder to. Clearing one it never touched
   // would take away a ladder somebody else set.
-  const written = await prisma.variantChange.findMany({
-    where: {
-      shopId,
-      priceListGid: list.priceListGid,
-      surfaceKind: "B2B",
-      variantGid: { in: [...variantGids] },
-      status: { in: ["VERIFIED", "CLAMPED"] },
-      // Rows that *gave* a ladder. A clearing row from an earlier revert carries none,
-      // and re-clearing would be a harmless no-op — this narrows the write rather than
-      // guarding correctness, which is why removing it fails no test.
-      quantityBreaks: { not: Prisma.DbNull },
-    },
-    select: { variantGid: true },
-    distinct: ["variantGid"],
-  });
+  // Chunked: `quantityBreaks: { not: … }` is a negation, and Prisma will not split a
+  // query that has one -- it fails outright rather than degrading (#346).
+  const written = await inChunks([...variantGids], (batch) =>
+    prisma.variantChange.findMany({
+      where: {
+        shopId,
+        priceListGid: list.priceListGid,
+        surfaceKind: "B2B",
+        variantGid: { in: batch },
+        status: { in: ["VERIFIED", "CLAMPED"] },
+        // Rows that *gave* a ladder. A clearing row from an earlier revert carries none,
+        // and re-clearing would be a harmless no-op — this narrows the write rather than
+        // guarding correctness, which is why removing it fails no test.
+        quantityBreaks: { not: Prisma.DbNull },
+      },
+      select: { variantGid: true },
+      distinct: ["variantGid"],
+    }),
+  );
 
   const ours = [...new Set(written.map((row) => row.variantGid))];
   if (ours.length === 0) return null;

--- a/app/services/campaigns/market-plan.server.ts
+++ b/app/services/campaigns/market-plan.server.ts
@@ -25,6 +25,7 @@ import { money, parseMoney, type Money } from "../../lib/money/money";
 import { planRun } from "../../lib/planning/plan";
 import type { PlanOutcome } from "../../lib/planning/types";
 import type { Guardrails, ResolvableCampaign } from "../../lib/pricing/types";
+import { inChunks } from "../../lib/db/chunk";
 
 export interface MarketList {
   priceListGid: string;
@@ -315,15 +316,19 @@ async function captureMarketBaselines(
     // conversion in play — so the currency check below passes and the number is right.
     // The check stays anyway: the day a B2B catalogue is priced in another currency is
     // the day this would otherwise be wrong by an exchange rate, silently.
-    const entries = await prisma.priceSurfaceEntry.findMany({
-      where: {
-        shopId,
-        priceListGid: list.priceListGid,
-        variantGid: { in: variantGids },
-        livePrice: { not: null },
-      },
-      select: { variantGid: true, livePrice: true, currency: true },
-    });
+    // `livePrice: { not: null }` is a negation, so Prisma will not split this query
+    // however long the gid list is -- it fails outright with P2029 (#346).
+    const entries = await inChunks(variantGids, (batch) =>
+      prisma.priceSurfaceEntry.findMany({
+        where: {
+          shopId,
+          priceListGid: list.priceListGid,
+          variantGid: { in: batch },
+          livePrice: { not: null },
+        },
+        select: { variantGid: true, livePrice: true, currency: true },
+      }),
+    );
 
     for (const entry of entries) {
       found.set(entry.variantGid, money(Number(entry.livePrice), entry.currency || list.currency));

--- a/app/services/campaigns/preview.server.ts
+++ b/app/services/campaigns/preview.server.ts
@@ -24,6 +24,7 @@ import {
   type SurfaceCell,
 } from "./types";
 import { rowsThatFit } from "../../lib/ui/table-budget";
+import { inChunks } from "../../lib/db/chunk";
 
 export interface PreviewOptions {
   /** Preview the revert instead of the apply. */
@@ -295,17 +296,24 @@ async function marketCellsFor(
 async function costsFor(shopId: string, variantGids: readonly string[]) {
   if (variantGids.length === 0) return new Map<string, Money>();
 
-  const rows = await prisma.baseline.findMany({
-    where: {
-      shopId,
-      surfaceKind: "BASE",
-      priceListGid: "",
-      supersededAt: null,
-      variantGid: { in: [...variantGids] },
-      cost: { not: null },
-    },
-    select: { variantGid: true, cost: true, currency: true },
-  });
+  // Chunked, and this one cannot be left to Prisma at all. A long `IN` list is
+  // normally split by the query engine -- badly, which is #324 -- but `cost: { not:
+  // null }` is a negation, and Prisma refuses to split a query that has one. The whole
+  // statement fails with P2029 rather than degrading, so the campaign page returned a
+  // generic error screen for every campaign over ~32,765 variants (#346).
+  const rows = await inChunks([...variantGids], (batch) =>
+    prisma.baseline.findMany({
+      where: {
+        shopId,
+        surfaceKind: "BASE",
+        priceListGid: "",
+        supersededAt: null,
+        variantGid: { in: batch },
+        cost: { not: null },
+      },
+      select: { variantGid: true, cost: true, currency: true },
+    }),
+  );
 
   return new Map(
     rows.map((row) => [row.variantGid, money(Number(row.cost), row.currency)] as const),

--- a/chaos/scenarios/bind-variable-ceiling.chaos.ts
+++ b/chaos/scenarios/bind-variable-ceiling.chaos.ts
@@ -28,6 +28,7 @@ import {
   titleMapFor,
 } from "../../app/services/campaigns/candidates.server";
 import { captureBaselines } from "../../app/services/baselines.server";
+import { previewCampaign } from "../../app/services/campaigns/preview.server";
 import { withChaos } from "../harness/scenario";
 
 /** Comfortably past the ceiling, and past a whole number of chunks. */
@@ -116,6 +117,46 @@ describe("chaos: a campaign wider than one prepared statement", () => {
         expect(titles.size).toBe(OVER_CEILING);
         expect(products.size).toBe(OVER_CEILING);
         expect(titles.get(gids[OVER_CEILING - 1])).toBe(`Wide ${OVER_CEILING - 1}`);
+      },
+    );
+  });
+
+  it("previews a campaign past the ceiling, negations and all", async () => {
+    await withChaos(
+      "bind-variable-ceiling-preview",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -15 },
+      async (ctx) => {
+        const { shopId, campaignId } = ctx.fixture;
+
+        // The campaign page reads costs for every variant in the plan, filtered with
+        // `cost: { not: null }`. That negation is the part that matters: Prisma splits a
+        // long IN list by itself, badly (#324) -- but it refuses to split a query
+        // carrying a negation at all, so this one failed outright with P2029 rather
+        // than degrading. The ceiling test above could not have caught it, because
+        // every query it exercises is splittable.
+        const gids = await seedWide(shopId, OVER_CEILING);
+        await captureBaselines(shopId, { variantGids: gids, source: "INSTALL_CAPTURE" });
+
+        // Costs on every baseline, so the negated filter matches rather than trivially
+        // excluding the rows and shrinking the list.
+        await prisma.baseline.updateMany({
+          where: { shopId, surfaceKind: "BASE" },
+          data: { cost: BigInt(5_000) },
+        });
+
+        // Scope the campaign at the whole catalogue so the plan is the wide one.
+        await prisma.campaign.update({
+          where: { id: campaignId },
+          data: { schedule: { kind: "manual", rounding: "none", ast: { groups: [] } } as never },
+        });
+
+        const preview = await previewCampaign(shopId, campaignId);
+
+        expect(
+          preview.counts.planned,
+          "the campaign page must render for a campaign of any size",
+        ).toBeGreaterThan(32_767);
+        expect(preview.blocked).toBeUndefined();
       },
     );
   });

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -17,7 +17,7 @@ embedded = true
 
 [build]
 automatically_update_urls_on_dev = true
-dev_store_url = "anchor-flow-ncf7hobw.myshopify.com"
+dev_store_url = "anchor-perf.myshopify.com"
 
 [webhooks]
 api_version = "2026-07"


### PR DESCRIPTION
Fixes #346. Found by opening the campaign page to look at #331's new tabs.

## The campaign page 500s for any large campaign

```
Invalid `prisma.baseline.findMany()` invocation:
  Parameter limits for this database provider require this query to be split into
  multiple queries, but the negation filters used prevent the query from being split.
  code: P2029
```

## Why this is not just more of #324

**P2029, not P2035.** Prisma normally splits a long `IN` list itself — badly, at exactly the ceiling, which was #324. It **refuses to split a query carrying a negation at all**, so there is no partial mitigation and no degradation. The statement simply fails.

```ts
variantGid: { in: [...variantGids] },   // the whole plan — 62,535
cost: { not: null },                    // ← this
```

#326 chunked `candidates`, `run`, `rollback-report` and `baselines`. This site is in `preview.server` and wasn't covered — and the two market/B2B sites #326 explicitly deferred have exactly the same shape:

| File | The negation |
|---|---|
| `preview.server.ts` | `cost: { not: null }` |
| `market-plan.server.ts` | `livePrice: { not: null }` |
| `b2b-surfaces.server.ts` | `quantityBreaks: { not: Prisma.DbNull }` |

The reasoning above the first one — costs for every variant in the plan rather than the shown page, because *"what does this cost me"* means the campaign and not its first twenty-five rows — is right. The query just has to be chunked.

## What the merchant saw

> **Some of the values on this form need fixing before it can be saved.**

There is no form, and nothing needs fixing. The campaign page is where a merchant goes to see what happened, revert, or resume; for a large campaign it was a generic error screen with misleading advice.

## The test that existed could not have caught it

`bind-variable-ceiling.chaos.ts` exercises only splittable queries. The new scenario previews a 34,000-variant campaign **with costs on every baseline**, so the negated filter actually matches rather than trivially excluding rows and shrinking the list.

**Mutation:** un-chunking `costsFor` reproduces the production error verbatim —

```
Parameter limits for this database provider require this query to be split into
multiple queries, but the negation filters used prevent the query from being split.
```

## Verified live

The campaign page for the 62,535-variant campaign now renders: header with **Completed** badge, schedule line, and Apply/Revert above the fold; tabs `Overview · Preview · Runs (2) · Ledger (200)` — with **Revert correctly absent**, since that campaign has nothing left to roll back.

## Checks

- `npm test` — 1626 passed
- `npm run test:chaos` — 138 passed (42 files)
- `npm run typecheck`, `npm run lint`, `npm run build` — clean

Separately filed: **#347**, a chaos-harness isolation weakness this surfaced. Three shop-less error events — recorded while this very bug was throwing — invert `shop-error-spike`'s premise, because the global rate counts unattributed errors and no per-shop rate does.