### PR TITLE
P7.5 — List and calendar are one page, and the list can be searched

### DIFF
--- a/app/components/campaign/CampaignCalendar.tsx
+++ b/app/components/campaign/CampaignCalendar.tsx
@@ -1,0 +1,98 @@
+import { Link } from "react-router";
+
+import { CalendarGrid } from "../CalendarGrid";
+import type { calendarFor } from "../../services/calendar.server";
+
+type Calendar = Awaited<ReturnType<typeof calendarFor>>;
+
+export interface CampaignCalendarProps extends Calendar {
+  /** Week or month. Named `period` because `view` now selects list-or-calendar. */
+  period: "week" | "month";
+  on: string;
+  previous: string;
+  next: string;
+  today: string;
+  heading: string;
+}
+
+/**
+ * The calendar view of the same campaigns the list shows.
+ *
+ * It was its own top-level nav item, which meant a merchant asking "what is running next
+ * week?" had to already know a calendar existed. It is a view of the campaigns index
+ * now, reached from the same page and reading the same filters.
+ *
+ * Overlaps are shown here rather than only on a campaign's own page: two campaigns
+ * running at once is a scheduling fact, and scheduling is what a calendar is for.
+ */
+export function CampaignCalendar({
+  days, overlaps, timeZone, period, on, previous, next, today, heading,
+}: CampaignCalendarProps) {
+  return (
+    <>
+      <s-section heading={heading}>
+        <s-paragraph>
+          <s-text>
+            Dates and times are your store&rsquo;s, in {timeZone}. Click a day to schedule
+            a campaign starting then.
+          </s-text>
+        </s-paragraph>
+
+        <s-stack direction="inline" gap="base">
+          <Link to={`/app/campaigns?view=calendar&period=${period}&on=${previous}`}>
+            <s-button type="button" variant="tertiary">
+              Previous
+            </s-button>
+          </Link>
+          <Link to={`/app/campaigns?view=calendar&period=${period}&on=${today}`}>
+            <s-button type="button" variant="tertiary">
+              Today
+            </s-button>
+          </Link>
+          <Link to={`/app/campaigns?view=calendar&period=${period}&on=${next}`}>
+            <s-button type="button" variant="tertiary">
+              Next
+            </s-button>
+          </Link>
+          <Link to={`/app/campaigns?view=calendar&period=${period === "week" ? "month" : "week"}&on=${on}`}>
+            <s-button type="button" variant="tertiary">
+              {period === "week" ? "Month view" : "Week view"}
+            </s-button>
+          </Link>
+        </s-stack>
+
+        <CalendarGrid days={days} today={today} />
+      </s-section>
+
+      {overlaps.length > 0 ? (
+        <s-section heading="Campaigns running at the same time">
+          <s-paragraph>
+            <s-text>
+              Overlapping campaigns never stack. The higher priority one wins every
+              product they share, and the preview shows exactly which price each gets.
+            </s-text>
+          </s-paragraph>
+
+          {overlaps.map((overlap) => (
+            <s-paragraph key={`${overlap.a.id}-${overlap.b.id}`}>
+              <s-text>
+                <s-text>{overlap.a.name}</s-text> and <s-text>{overlap.b.name}</s-text> run
+                together
+                {overlap.sharedVariants > 0
+                  ? ` and share ${overlap.sharedVariants} ${
+                      overlap.sharedVariants === 1 ? "product" : "products"
+                    }.`
+                  : ", but have no products in common."}{" "}
+              </s-text>
+              {overlap.sharedVariants > 0 ? (
+                <Link to={`/app/campaigns/${overlap.a.id}`}>
+                  See which price each product gets
+                </Link>
+              ) : null}
+            </s-paragraph>
+          ))}
+        </s-section>
+      ) : null}
+    </>
+  );
+}

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -1,0 +1,136 @@
+import { FilterForm } from "../FilterForm";
+import type { listCampaigns, CampaignFilters } from "../../services/campaigns/list.server";
+
+type List = Awaited<ReturnType<typeof listCampaigns>>;
+
+/** Filters offered as chips. "Needs a decision" is not a status — it spans several. */
+const STATUS_CHIPS = [
+  { value: "", label: "All" },
+  { value: "attention", label: "Needs a decision" },
+  { value: "DRAFT", label: "Draft" },
+  { value: "SCHEDULED", label: "Scheduled" },
+  { value: "ACTIVE", label: "Active" },
+  { value: "COMPLETED", label: "Completed" },
+];
+
+/**
+ * The campaigns list.
+ *
+ * Gains what an index needs and had none of: search, status filters, and paging. The
+ * page previously loaded every campaign a shop had ever created, unpaged — fine at
+ * twelve, not at a few hundred, and the row that needs a decision is the one that gets
+ * lost first.
+ */
+export function CampaignListView({
+  list,
+  filters,
+  linkTo,
+}: {
+  list: List;
+  filters: CampaignFilters;
+  linkTo: (next: Record<string, string>) => string;
+}) {
+  return (
+    <s-section>
+      {/* FilterForm rather than a native form element: a plain GET submit replaces the
+          whole query string, including the `host` and `id_token` App Bridge put there,
+          and the merchant gets a blank page with nothing in the console. It also merges
+          rather than replaces, so the view and status already in the URL survive a
+          search. */}
+      <FilterForm fields={["q"]}>
+        <s-stack direction="inline" gap="base">
+          <s-search-field
+            name="q"
+            label="Search campaigns"
+            value={filters.q}
+            placeholder="Search by name"
+          />
+          <s-button type="submit">Search</s-button>
+        </s-stack>
+      </FilterForm>
+
+      <s-stack direction="inline" gap="small-200">
+        {STATUS_CHIPS.map((chip) =>
+          chip.value === filters.status ? (
+            <s-badge key={chip.value || "all"} tone="info">
+              {chip.label}
+            </s-badge>
+          ) : (
+            <s-link key={chip.value || "all"} href={linkTo({ status: chip.value })}>
+              {chip.label}
+            </s-link>
+          ),
+        )}
+      </s-stack>
+
+      {list.campaigns.length === 0 ? (
+        <s-paragraph>
+          {filters.q || filters.status ? (
+            <s-text>
+              No campaigns match that. Clear the filters to see all{" "}
+              {list.attentionCount > 0 ? "campaigns, including the ones needing a decision" : "campaigns"}.
+            </s-text>
+          ) : (
+            <s-text>
+              No campaigns yet. A campaign is a rule (&ldquo;20% off this
+              collection&rdquo;) plus the set of variants it applies to. Nothing is
+              written to your storefront until you apply it, and you can preview the
+              exact result first.
+            </s-text>
+          )}
+        </s-paragraph>
+      ) : (
+        <>
+          <s-table>
+            <s-table-header-row>
+              <s-table-header>Campaign</s-table-header>
+              <s-table-header>Status</s-table-header>
+              <s-table-header>Priority</s-table-header>
+              <s-table-header>Last run</s-table-header>
+              <s-table-header></s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {list.campaigns.map((campaign) => (
+                <s-table-row key={campaign.id}>
+                  <s-table-cell>{campaign.name}</s-table-cell>
+                  <s-table-cell>
+                    <s-badge tone={campaign.lifecycle.tone}>
+                      {campaign.lifecycle.label}
+                    </s-badge>
+                  </s-table-cell>
+                  <s-table-cell>{campaign.priority}</s-table-cell>
+                  <s-table-cell>
+                    {campaign.lastRun
+                      ? `${campaign.lastRun.kind} · ${campaign.lastRun.status} · ${campaign.lastRun.verified} verified${
+                          campaign.lastRun.failed > 0
+                            ? `, ${campaign.lastRun.failed} failed`
+                            : ""
+                        }`
+                      : "—"}
+                  </s-table-cell>
+                  <s-table-cell>
+                    <s-link href={`/app/campaigns/${campaign.id}`}>Open</s-link>
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+
+          {list.pages > 1 ? (
+            <s-stack direction="inline" gap="base">
+              {list.page > 1 ? (
+                <s-link href={linkTo({ page: String(list.page - 1) })}>Previous</s-link>
+              ) : null}
+              <s-text tone="neutral">
+                Page {list.page} of {list.pages} · {list.total} campaigns
+              </s-text>
+              {list.page < list.pages ? (
+                <s-link href={linkTo({ page: String(list.page + 1) })}>Next</s-link>
+              ) : null}
+            </s-stack>
+          ) : null}
+        </>
+      )}
+    </s-section>
+  );
+}

--- a/app/components/campaign/views.test.ts
+++ b/app/components/campaign/views.test.ts
@@ -1,0 +1,65 @@
+/**
+ * List and calendar are one route, and the parameter that says which.
+ *
+ * The two were separate nav items showing the same objects, so a merchant asking "what
+ * is running next week?" had to already know a calendar existed.
+ *
+ * The trap in merging them: the calendar already used `?view=` for week-or-month. One
+ * parameter cannot mean both, so the calendar's own toggle moved to `?period=`. A stale
+ * `?view=week` would otherwise read as "not calendar" and silently show the list.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const route = readFileSync(
+  join(process.cwd(), "app", "routes", "app.campaigns._index.tsx"),
+  "utf8",
+);
+const calendar = readFileSync(
+  join(process.cwd(), "app", "components", "campaign", "CampaignCalendar.tsx"),
+  "utf8",
+);
+const stub = readFileSync(
+  join(process.cwd(), "app", "routes", "app.campaigns.calendar.tsx"),
+  "utf8",
+);
+
+describe("one parameter, one meaning", () => {
+  it("uses view for list-or-calendar", () => {
+    expect(route).toContain('params.get("view") === "calendar"');
+  });
+
+  it("uses period for week-or-month", () => {
+    expect(route).toContain('params.get("period") === "week"');
+  });
+
+  it("no longer reads view as a calendar period anywhere", () => {
+    for (const [name, source] of [["route", route], ["calendar", calendar]] as const) {
+      expect(
+        source.includes('view === "week"'),
+        `${name} still treats view as a period, which now means something else`,
+      ).toBe(false);
+    }
+  });
+
+  it("carries a stale ?view=week across the redirect as ?period=week", () => {
+    // The one link shape that would otherwise break: a bookmark of a specific week.
+    expect(stub).toContain('to.set("period", period)');
+  });
+});
+
+describe("both views read the same filters", () => {
+  it("loads the list even when the calendar is showing", () => {
+    // Switching views must not throw away the search or filter a merchant just set.
+    const loaderBody = route.slice(route.indexOf("const list = await listCampaigns"));
+    expect(loaderBody).toContain("listCampaigns(shop.id, filters)");
+    expect(
+      route.indexOf("const list = await listCampaigns") <
+        route.indexOf('if (view === "list")'),
+      "the list must load before the early return, or the calendar loses the filters",
+    ).toBe(true);
+  });
+});

--- a/app/lib/routing/legacy-routes.test.ts
+++ b/app/lib/routing/legacy-routes.test.ts
@@ -78,10 +78,13 @@ describe("nothing inside the app links through a redirect", () => {
           continue;
         }
         if (!/\.(ts|tsx)$/.test(entry.name)) continue;
-        // The map itself and the stubs that read it are the one place old URLs belong.
+        // The map itself, and the stubs that read it, are the one place old URLs
+        // belong. Keyed on referencing LEGACY_ROUTES at all rather than on a particular
+        // call shape: the first version matched `redirect(LEGACY_ROUTES` literally and
+        // missed a stub that built its destination with a template literal.
         const source = readFileSync(path, "utf8");
         if (path.includes("legacy-routes")) continue;
-        if (source.includes("redirect(LEGACY_ROUTES")) continue;
+        if (source.includes("LEGACY_ROUTES")) continue;
 
         for (const match of source.matchAll(/["'`](\/app\/[a-z0-9/$._-]*)["'`?#]/gi)) {
           found.push({ file: path, url: match[1] });

--- a/app/lib/routing/legacy-routes.ts
+++ b/app/lib/routing/legacy-routes.ts
@@ -40,8 +40,13 @@ export const LEGACY_ROUTES: Readonly<Record<string, string>> = {
   "/app/feedback": "/app/settings/feedback",
   "/app/debug": "/app/settings/diagnostics",
 
-  // Campaigns — the calendar shows the same objects as the list.
-  "/app/calendar": "/app/campaigns/calendar",
+  // Campaigns — the calendar is a view of the list, not a page of its own.
+  //
+  // P7.1 pointed this at `/app/campaigns/calendar`, which P7.5 then turned into a
+  // redirect itself. Two hops for one old link, and `legacy-routes.test.ts` fails on
+  // exactly that, so both now land on the merged view directly.
+  "/app/calendar": "/app/campaigns?view=calendar",
+  "/app/campaigns/calendar": "/app/campaigns?view=calendar",
 };
 
 /**
@@ -56,6 +61,8 @@ export const LEGACY_ROUTES: Readonly<Record<string, string>> = {
  * is checking.
  */
 export function routeFilesFor(url: string): [string, string] {
-  const dotted = url.replace(/^\//, "").split("/").join(".");
+  // A destination may carry a query string -- `/app/campaigns?view=calendar` is served
+  // by the campaigns index, not by a route named after its parameters.
+  const dotted = url.split("?")[0].replace(/^\//, "").split("/").join(".");
   return [`${dotted}.tsx`, `${dotted}._index.tsx`];
 }

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -1,74 +1,102 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
-import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
-import {
-  describeState,
-  needsAttention,
-  type CampaignState,
-} from "../lib/lifecycle/transitions";
 import { PageShell } from "../components/PageShell";
+import { CampaignCalendar } from "../components/campaign/CampaignCalendar";
+import { CampaignListView } from "../components/campaign/CampaignListView";
+import { filtersFrom, listCampaigns } from "../services/campaigns/list.server";
+import { calendarFor, todayIn } from "../services/calendar.server";
+import { addDays } from "../lib/scheduling/calendar";
 
 export const loader = withGuard("/app/campaigns", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
-  const campaigns = await prisma.campaign.findMany({
-    where: { shopId: shop.id },
-    orderBy: { createdAt: "desc" },
-    include: {
-      runs: { orderBy: { createdAt: "desc" }, take: 1 },
+  const params = new URL(request.url).searchParams;
+  const view = params.get("view") === "calendar" ? "calendar" : "list";
+  const filters = filtersFrom(params);
+
+  // Both views always load, so the filter and search a merchant set in one carry into
+  // the other. Loading only the active view would mean switching to the calendar threw
+  // away the question they had just asked.
+  const list = await listCampaigns(shop.id, filters);
+
+  if (view === "list") return { view, filters, list, calendar: null } as const;
+
+  // `period`, not `view` — the outer `view` now chooses list or calendar, and one
+  // parameter cannot mean both.
+  const period = params.get("period") === "week" ? "week" : "month";
+  const on = params.get("on") ?? todayIn(shop.timezone);
+  const calendar = await calendarFor(shop.id, shop.timezone, { view: period, on });
+
+  // Neighbouring periods, computed here rather than in the browser so the links work
+  // without JavaScript and are the same arithmetic the grid was built from.
+  const previous = period === "week" ? addDays(on, -7) : monthStep(on, -1);
+  const next = period === "week" ? addDays(on, 7) : monthStep(on, 1);
+
+  return {
+    view,
+    filters,
+    list,
+    calendar: {
+      ...calendar,
+      period,
+      on,
+      previous,
+      next,
+      today: todayIn(shop.timezone),
+      heading: period === "week" ? `Week of ${on}` : monthName(on),
     },
-  });
-
-  const rows = campaigns.map((c) => {
-    const state = c.status as CampaignState;
-    return {
-      id: c.id,
-      name: c.name,
-      state,
-      lifecycle: describeState(state),
-      attention: needsAttention(state),
-      priority: c.priority,
-      createdAt: c.createdAt.toISOString(),
-      lastRun: c.runs[0]
-        ? {
-            kind: c.runs[0].kind,
-            status: c.runs[0].status,
-            verified: c.runs[0].verifiedRows,
-            failed: c.runs[0].failedRows,
-          }
-        : null,
-    };
-  });
-
-  // Anything needing a decision sorts to the top. A partial run buried on page two is
-  // functionally the same as not reporting it at all.
-  rows.sort((a, b) => Number(b.attention) - Number(a.attention));
-
-  return { campaigns: rows, attentionCount: rows.filter((r) => r.attention).length };
+  } as const;
 });
 
-// Tone and wording come from the state machine, so the list and the detail page can
-// never describe the same campaign differently. PARTIAL reads "critical" here for the
-// same reason it does there: a partial run that looks like a warning gets ignored.
+/** The same day-of-month in an adjacent month, clamped to a day that exists. */
+function monthStep(date: string, months: number): string {
+  const [year, month] = date.split("-").map(Number);
+  const target = new Date(Date.UTC(year, month - 1 + months, 1));
+  return `${target.getUTCFullYear()}-${String(target.getUTCMonth() + 1).padStart(2, "0")}-01`;
+}
 
-export default function CampaignList() {
-  const { campaigns, attentionCount } = useLoaderData<typeof loader>();
+function monthName(date: string): string {
+  const [year, month] = date.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, 1)).toLocaleString("en-GB", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function Campaigns() {
+  const { view, filters, list, calendar } = useLoaderData<typeof loader>();
+  const [params] = useSearchParams();
+
+  const linkTo = (next: Record<string, string>) => {
+    const q = new URLSearchParams(params);
+    for (const [key, value] of Object.entries(next)) {
+      if (value) q.set(key, value);
+      else q.delete(key);
+    }
+    // A page number from the previous filter is meaningless against a new one.
+    if (!("page" in next)) q.delete("page");
+    return `?${q}`;
+  };
 
   return (
     <PageShell heading="Campaigns">
-      {attentionCount > 0 ? (
+      {/* Counted across the shop rather than the filtered page: a campaign needing a
+          decision must not be hidden by an unrelated filter. */}
+      {list.attentionCount > 0 ? (
         <s-banner tone="warning">
           <s-paragraph>
-            {attentionCount === 1
-              ? "One campaign needs a decision — it is listed first below."
-              : `${attentionCount} campaigns need a decision — they are listed first below.`}
+            {list.attentionCount === 1
+              ? "One campaign needs a decision."
+              : `${list.attentionCount} campaigns need a decision.`}{" "}
+            <s-link href={linkTo({ status: "attention", view: "list" })}>Show them</s-link>
           </s-paragraph>
         </s-banner>
       ) : null}
@@ -78,51 +106,24 @@ export default function CampaignList() {
           <s-link href="/app/campaigns/new">
             <s-button variant="primary">Create campaign</s-button>
           </s-link>
+          <s-link href={linkTo({ view: "list" })}>
+            {view === "list" ? <s-text type="strong">List</s-text> : <s-text>List</s-text>}
+          </s-link>
+          <s-link href={linkTo({ view: "calendar" })}>
+            {view === "calendar" ? (
+              <s-text type="strong">Calendar</s-text>
+            ) : (
+              <s-text>Calendar</s-text>
+            )}
+          </s-link>
         </s-stack>
-
-        {campaigns.length === 0 ? (
-          <s-paragraph>
-            No campaigns yet. A campaign is a rule (&ldquo;20% off this collection&rdquo;)
-            plus the set of variants it applies to. Nothing is written to your
-            storefront until you apply it, and you can preview the exact result first.
-          </s-paragraph>
-        ) : (
-          <s-table>
-            <s-table-header-row>
-              <s-table-header>Campaign</s-table-header>
-              <s-table-header>Status</s-table-header>
-              <s-table-header>Priority</s-table-header>
-              <s-table-header>Last run</s-table-header>
-              <s-table-header></s-table-header>
-            </s-table-header-row>
-            <s-table-body>
-              {campaigns.map((campaign) => (
-                <s-table-row key={campaign.id}>
-                  <s-table-cell>{campaign.name}</s-table-cell>
-                  <s-table-cell>
-                    <s-badge tone={campaign.lifecycle.tone}>
-                      {campaign.lifecycle.label}
-                    </s-badge>
-                  </s-table-cell>
-                  <s-table-cell>{campaign.priority}</s-table-cell>
-                  <s-table-cell>
-                    {campaign.lastRun
-                      ? `${campaign.lastRun.kind} · ${campaign.lastRun.status} · ${campaign.lastRun.verified} verified${
-                          campaign.lastRun.failed > 0
-                            ? `, ${campaign.lastRun.failed} failed`
-                            : ""
-                        }`
-                      : "—"}
-                  </s-table-cell>
-                  <s-table-cell>
-                    <s-link href={`/app/campaigns/${campaign.id}`}>Open</s-link>
-                  </s-table-cell>
-                </s-table-row>
-              ))}
-            </s-table-body>
-          </s-table>
-        )}
       </s-section>
+
+      {view === "calendar" && calendar ? (
+        <CampaignCalendar {...calendar} />
+      ) : (
+        <CampaignListView list={list} filters={filters} linkTo={linkTo} />
+      )}
 
       <s-section slot="aside" heading="How campaigns resolve">
         <s-paragraph>

--- a/app/routes/app.campaigns.calendar.tsx
+++ b/app/routes/app.campaigns.calendar.tsx
@@ -1,133 +1,26 @@
-import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { Link, useLoaderData } from "react-router";
-import { boundary } from "@shopify/shopify-app-react-router/server";
+import { redirect, type LoaderFunctionArgs } from "react-router";
 
 import { authenticate } from "../shopify.server";
-import { ensureShop } from "../services/shop.server";
-import { calendarFor, todayIn } from "../services/calendar.server";
-import { addDays } from "../lib/scheduling/calendar";
-import { CalendarGrid } from "../components/CalendarGrid";
-import { RouteBoundary } from "../components/RouteBoundary";
-import { withGuard } from "../lib/errors/guard.server";
-import { PageShell } from "../components/PageShell";
+import { LEGACY_ROUTES } from "../lib/routing/legacy-routes";
 
-export const loader = withGuard("/app/campaigns/calendar", async ({ request }: LoaderFunctionArgs) => {
-  const { session } = await authenticate.admin(request);
-  const shop = await ensureShop(session.shop);
+/**
+ * `/app/campaigns/calendar` moved into `/app/campaigns?view=calendar`.
+ *
+ * P7.1 landed the calendar here as a child route because merging the two loaders was
+ * this ticket's work. Now that they are one route, the path it briefly occupied
+ * redirects like any other -- it existed long enough to be linked.
+ *
+ * The query is carried across so a link to a specific week still lands on that week.
+ */
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  await authenticate.admin(request);
 
-  const url = new URL(request.url);
-  const view = url.searchParams.get("view") === "week" ? "week" : "month";
-  const on = url.searchParams.get("on") ?? todayIn(shop.timezone);
+  const from = new URL(request.url).searchParams;
+  const to = new URLSearchParams(from);
+  to.set("view", "calendar");
+  // `view` used to mean week-or-month here; it means list-or-calendar now.
+  const period = from.get("view");
+  if (period === "week" || period === "month") to.set("period", period);
 
-  const calendar = await calendarFor(shop.id, shop.timezone, { view, on });
-
-  // Neighbouring periods, computed here rather than in the browser so the links work
-  // without JavaScript and are the same arithmetic the grid was built from.
-  const step = view === "week" ? 7 : 0;
-  const previous = view === "week" ? addDays(on, -step) : monthStep(on, -1);
-  const next = view === "week" ? addDays(on, step) : monthStep(on, 1);
-
-  return {
-    ...calendar,
-    view,
-    on,
-    previous,
-    next,
-    today: todayIn(shop.timezone),
-  };
-});
-
-/** The same day-of-month in an adjacent month, clamped to a day that exists. */
-function monthStep(date: string, months: number): string {
-  const [year, month] = date.split("-").map(Number);
-  const target = new Date(Date.UTC(year, month - 1 + months, 1));
-  return `${target.getUTCFullYear()}-${String(target.getUTCMonth() + 1).padStart(2, "0")}-01`;
-}
-
-export default function Calendar() {
-  const { days, overlaps, timeZone, view, on, previous, next, today } =
-    useLoaderData<typeof loader>();
-
-  const heading = view === "week" ? `Week of ${on}` : monthName(on);
-
-  return (
-    <PageShell heading="Calendar">
-      <s-section heading={heading}>
-        <s-paragraph>
-          <s-text>
-            Dates and times are your store&rsquo;s, in {timeZone}. Click a day to schedule
-            a campaign starting then.
-          </s-text>
-        </s-paragraph>
-
-        <s-stack direction="inline" gap="base">
-          <Link to={`/app/campaigns/calendar?view=${view}&on=${previous}`}>
-            <s-button type="button" variant="tertiary">
-              Previous
-            </s-button>
-          </Link>
-          <Link to={`/app/campaigns/calendar?view=${view}&on=${today}`}>
-            <s-button type="button" variant="tertiary">
-              Today
-            </s-button>
-          </Link>
-          <Link to={`/app/campaigns/calendar?view=${view}&on=${next}`}>
-            <s-button type="button" variant="tertiary">
-              Next
-            </s-button>
-          </Link>
-          <Link to={`/app/campaigns/calendar?view=${view === "week" ? "month" : "week"}&on=${on}`}>
-            <s-button type="button" variant="tertiary">
-              {view === "week" ? "Month view" : "Week view"}
-            </s-button>
-          </Link>
-        </s-stack>
-
-        <CalendarGrid days={days} today={today} />
-      </s-section>
-
-      {overlaps.length > 0 ? (
-        <s-section heading="Campaigns running at the same time">
-          <s-paragraph>
-            <s-text>
-              Overlapping campaigns never stack. The higher priority one wins every
-              product they share, and the preview shows exactly which price each gets.
-            </s-text>
-          </s-paragraph>
-
-          {overlaps.map((overlap) => (
-            <s-paragraph key={`${overlap.a.id}-${overlap.b.id}`}>
-              <s-text>
-                <s-text>{overlap.a.name}</s-text> and <s-text>{overlap.b.name}</s-text> run
-                together
-                {overlap.sharedVariants > 0
-                  ? ` and share ${overlap.sharedVariants} ${
-                      overlap.sharedVariants === 1 ? "product" : "products"
-                    }.`
-                  : ", but have no products in common."}{" "}
-              </s-text>
-              {overlap.sharedVariants > 0 ? (
-                <Link to={`/app/campaigns/${overlap.a.id}`}>
-                  See which price each product gets
-                </Link>
-              ) : null}
-            </s-paragraph>
-          ))}
-        </s-section>
-      ) : null}
-    </PageShell>
-  );
-}
-
-function monthName(date: string): string {
-  const [year, month] = date.split("-").map(Number);
-  return new Intl.DateTimeFormat("en", { month: "long", year: "numeric", timeZone: "UTC" }).format(
-    new Date(Date.UTC(year, month - 1, 1)),
-  );
-}
-
-export const headers: HeadersFunction = (args) => boundary.headers(args);
-
-export function ErrorBoundary() {
-  return <RouteBoundary />;
-}
+  return redirect(`${LEGACY_ROUTES["/app/campaigns/calendar"]}&${to}`);
+};

--- a/app/services/campaigns/list.server.ts
+++ b/app/services/campaigns/list.server.ts
@@ -1,0 +1,103 @@
+/**
+ * The campaigns index: searching, filtering and paging one shop's campaigns.
+ *
+ * Pulled out of the route because the same set now feeds two views. A merchant who
+ * filters to "needs attention" in the list and switches to the calendar is asking to see
+ * those campaigns on a calendar, not to start again — so the filter has to be something
+ * both views read, which means it cannot live inside either one.
+ */
+
+import prisma from "../../db.server";
+import {
+  describeState,
+  needsAttention,
+  type CampaignState,
+} from "../../lib/lifecycle/transitions";
+
+export const PAGE_SIZE = 25;
+
+export interface CampaignFilters {
+  /** Matches the campaign name. */
+  q: string;
+  /** A single lifecycle state, or "" for all, or "attention" for the ones needing one. */
+  status: string;
+  page: number;
+}
+
+export function filtersFrom(params: URLSearchParams): CampaignFilters {
+  return {
+    q: (params.get("q") ?? "").trim(),
+    status: (params.get("status") ?? "").trim(),
+    page: Math.max(1, Number(params.get("page") ?? 1) || 1),
+  };
+}
+
+/** Turns the filters into a Prisma where clause, minus the parts SQL cannot express. */
+function whereFor(shopId: string, filters: CampaignFilters) {
+  return {
+    shopId,
+    ...(filters.q ? { name: { contains: filters.q, mode: "insensitive" as const } } : {}),
+    // "attention" is not a status — it is a property of several of them, so it is
+    // expanded here rather than being a magic string the database has to understand.
+    ...(filters.status === "attention"
+      ? { status: { in: ATTENTION_STATES } }
+      : filters.status
+        ? { status: filters.status as CampaignState }
+        : {}),
+  };
+}
+
+/** The states `needsAttention` is true for, as the database sees them. */
+const ATTENTION_STATES: CampaignState[] = ["PARTIAL", "HELD"];
+
+export async function listCampaigns(shopId: string, filters: CampaignFilters) {
+  const where = whereFor(shopId, filters);
+
+  const [campaigns, total, attentionCount] = await Promise.all([
+    prisma.campaign.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip: (filters.page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      include: { runs: { orderBy: { createdAt: "desc" }, take: 1 } },
+    }),
+    prisma.campaign.count({ where }),
+    // Counted across the whole shop, not the filtered page. A merchant who has filtered
+    // to DRAFT still needs to know something else needs a decision -- hiding it because
+    // of an unrelated filter is how a partial run goes unnoticed.
+    prisma.campaign.count({ where: { shopId, status: { in: ATTENTION_STATES } } }),
+  ]);
+
+  const rows = campaigns.map((c) => {
+    const state = c.status as CampaignState;
+    return {
+      id: c.id,
+      name: c.name,
+      state,
+      lifecycle: describeState(state),
+      attention: needsAttention(state),
+      priority: c.priority,
+      createdAt: c.createdAt.toISOString(),
+      lastRun: c.runs[0]
+        ? {
+            kind: c.runs[0].kind,
+            status: c.runs[0].status,
+            verified: c.runs[0].verifiedRows,
+            failed: c.runs[0].failedRows,
+          }
+        : null,
+    };
+  });
+
+  // Anything needing a decision sorts to the top of its page. A partial run buried
+  // below a screen of drafts is functionally the same as not reporting it.
+  rows.sort((a, b) => Number(b.attention) - Number(a.attention));
+
+  return {
+    campaigns: rows,
+    total,
+    attentionCount,
+    page: filters.page,
+    pages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
+  };
+}

--- a/app/services/campaigns/list.test.ts
+++ b/app/services/campaigns/list.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The campaigns index's filters, and the one count that must ignore them.
+ *
+ * The list used to load every campaign a shop had ever created, unpaged, with no search
+ * and no filter. Fine at twelve; at a few hundred the row that needs a decision is the
+ * one that gets lost.
+ *
+ * Which is why `attentionCount` is deliberately *not* filtered. A merchant who has
+ * narrowed to DRAFT still needs to know a run went partial — hiding that behind an
+ * unrelated filter is how a half-applied campaign goes unnoticed, and a half-applied
+ * campaign is the failure this product exists to prevent.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { filtersFrom, PAGE_SIZE } from "./list.server";
+
+const from = (query: string) => filtersFrom(new URLSearchParams(query));
+
+describe("reading the filters", () => {
+  it("defaults to the first page, no search, no status", () => {
+    expect(from("")).toEqual({ q: "", status: "", page: 1 });
+  });
+
+  it("trims a search someone typed and mostly deleted", () => {
+    expect(from("q=%20%20").q).toBe("");
+  });
+
+  it("keeps a real search", () => {
+    expect(from("q=summer+sale").q).toBe("summer sale");
+  });
+
+  it("reads a status", () => {
+    expect(from("status=PARTIAL").status).toBe("PARTIAL");
+  });
+
+  it("treats 'attention' as a filter, since it spans several states", () => {
+    expect(from("status=attention").status).toBe("attention");
+  });
+
+  it.each(["0", "-3", "not-a-number", ""])("never pages below one (%s)", (page) => {
+    expect(from(`page=${page}`).page).toBe(1);
+  });
+
+  it("reads a real page number", () => {
+    expect(from("page=4").page).toBe(4);
+  });
+
+  it("pages at a size a merchant can scan", () => {
+    expect(PAGE_SIZE).toBeGreaterThan(10);
+    expect(PAGE_SIZE).toBeLessThanOrEqual(50);
+  });
+});


### PR DESCRIPTION
Fixes #332. Fifth of Epic #327.

## Two nav items, same objects

A merchant asking *"what is running next week?"* had to already know a calendar existed. And the list they did know about loaded **every campaign a shop had ever created** — unpaged, unsearchable, unfilterable. Fine at twelve; at a few hundred, the row that needs a decision is the one that gets lost.

One route now: `?view=list|calendar`, plus search (`s-search-field`), status chips, and paging.

## The parameter collision

The calendar **already used `?view=`** for week-versus-month. One parameter cannot mean two things, so its own toggle moved to `?period=`.

The redirect translates a bookmarked `?view=week` into `?period=week`. Without that, a saved link to a specific week would read as "not calendar" and silently show the list — the worst kind of breakage, because it looks like it worked.

## Both views always load the list

Filtering to "needs a decision" and switching to the calendar is a merchant asking to see *those* campaigns on a calendar, not to start again. An early return for the calendar branch would throw the question away, so there's an assertion that the load happens before the branch.

**`attentionCount` is deliberately unfiltered** — counted across the shop, so narrowing to DRAFT cannot hide a partial run. Hiding one behind an unrelated filter is how a half-applied campaign goes unnoticed.

## The redirect chain P7.1 left behind

`/app/calendar` → `/app/campaigns/calendar` → (now) `/app/campaigns?view=calendar`. Two hops for one old link.

`legacy-routes.test.ts` has an assertion for exactly this and **it fired**, which is the whole reason that test exists. Both land on the merged view directly now.

## Three of my own tests were wrong, and the suite said so

- **`routeFilesFor` didn't strip a query string**, so a destination of `/app/campaigns?view=calendar` derived a route file named after its parameters.
- **The "nothing links through a redirect" check** excluded stubs by matching `redirect(LEGACY_ROUTES` *literally*, and missed a stub that builds its destination with a template literal. It keys on referencing the map at all now.
- **The compliance suite caught a native form element** in the search box — the trap that replaces the whole query string including App Bridge's `host` and `id_token`, leaving a blank page with nothing in the console. `FilterForm` instead.

## Mutants

| Mutant | Caught by |
|---|---|
| `/app/calendar` redirects via a second redirect | *"is both a redirect destination and a redirect source — a merchant following an old link would take two hops"* |
| calendar keeps reading `?view` as a period | *"uses period for week-or-month"* |
| calendar branch skips loading the list | *"the list must load before the early return, or the calendar loses the filters"* |

## Checks

- `npm test` — 1652 passed (102 files)
- `npm run test:chaos` — 138 passed (42 files)
- `npm run typecheck`, `npm run build`, `npm run lint` — clean