### PR TITLE
P7.6 — One search, one pager and one tab bar across the prices section

### DIFF
--- a/app/components/prices/Pagination.tsx
+++ b/app/components/prices/Pagination.tsx
@@ -1,0 +1,55 @@
+import { useSearchParams } from "react-router";
+
+import { formatCount } from "../../lib/format/display";
+
+/**
+ * Paging, and saying where you are in the set.
+ *
+ * Every table in the prices section had its own copy of this arithmetic, each free to
+ * be off by one differently. It is the kind of duplication that never causes a bug big
+ * enough to chase and always causes small ones: a last page that says "51-50 of 50", a
+ * Next button that stays enabled on the final page.
+ *
+ * `from`/`to` rather than only a page number, because "showing 51-100 of 3,412" answers
+ * the question a merchant scanning for one variant is actually asking.
+ */
+export function Pagination({
+  page,
+  total,
+  pageSize,
+  noun = "variants",
+}: {
+  page: number;
+  total: number;
+  pageSize: number;
+  /** What is being counted, so the sentence reads naturally on every tab. */
+  noun?: string;
+}) {
+  const [, setSearchParams] = useSearchParams();
+
+  const lastPage = Math.max(1, Math.ceil(total / pageSize));
+  const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const to = Math.min(total, page * pageSize);
+
+  const goTo = (next: number) =>
+    setSearchParams((params) => {
+      params.set("page", String(next));
+      return params;
+    });
+
+  if (total === 0) return null;
+
+  return (
+    <s-stack direction="inline" gap="base">
+      <s-button disabled={page <= 1 || undefined} onClick={() => goTo(page - 1)}>
+        Previous
+      </s-button>
+      <s-text tone="neutral">
+        {from}–{to} of {formatCount(total)} {noun}
+      </s-text>
+      <s-button disabled={page >= lastPage || undefined} onClick={() => goTo(page + 1)}>
+        Next
+      </s-button>
+    </s-stack>
+  );
+}

--- a/app/components/prices/PricesTabs.tsx
+++ b/app/components/prices/PricesTabs.tsx
@@ -1,0 +1,53 @@
+import { Link, useLocation, useSearchParams } from "react-router";
+
+export interface PricesTab {
+  href: string;
+  label: string;
+  /** Shown beside the label. Zero is not shown — an empty count is noise. */
+  badge?: number;
+}
+
+/**
+ * The prices section's tabs.
+ *
+ * Five views of the same variant rows: what the storefront shows, what it should show,
+ * what it costs, what we last wrote, and where the two disagree. They were five
+ * top-level nav items, which made them read as five features rather than five columns.
+ *
+ * **The tab links carry the query string.** Searching for a SKU in Baselines and
+ * switching to What's live is a merchant asking about that SKU, not asking to start
+ * again. Dropping the query on a tab switch is the small betrayal that teaches people
+ * to distrust a filter.
+ *
+ * `page` is deliberately dropped: page 4 of the baselines is not page 4 of drift, and
+ * landing on an empty page reads as "nothing here" rather than "wrong page".
+ */
+export function PricesTabs({ tabs }: { tabs: PricesTab[] }) {
+  const { pathname } = useLocation();
+  const [params] = useSearchParams();
+
+  const carried = new URLSearchParams(params);
+  carried.delete("page");
+  const query = carried.toString();
+
+  return (
+    <s-stack direction="inline" gap="base">
+      {tabs.map((tab) => {
+        // Exact match only. `/app/prices` is the prefix of every other tab, so a
+        // `startsWith` here would light up Variants on every page in the section.
+        const current = pathname === tab.href;
+        const label = tab.badge ? `${tab.label} (${tab.badge})` : tab.label;
+
+        return current ? (
+          <s-text key={tab.href} type="strong">
+            {label}
+          </s-text>
+        ) : (
+          <Link key={tab.href} to={query ? `${tab.href}?${query}` : tab.href}>
+            {label}
+          </Link>
+        );
+      })}
+    </s-stack>
+  );
+}

--- a/app/components/prices/VariantSearch.tsx
+++ b/app/components/prices/VariantSearch.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+import { FilterForm } from "../FilterForm";
+
+/**
+ * The search every prices tab shares, plus whatever else that tab filters on.
+ *
+ * `FilterForm`, never a native form element: a plain GET submit replaces the whole query
+ * string including the `host` and `id_token` App Bridge put there, and the merchant gets
+ * a blank page with nothing in the console to explain it.
+ *
+ * It merges rather than replaces, which is what lets a search survive a tab switch —
+ * the tab links carry the query string, and this puts `q` back into it rather than
+ * rebuilding it from scratch.
+ */
+export function VariantSearch({
+  fields,
+  query,
+  label = "Search",
+  placeholder = "Search by title or SKU",
+  /**
+   * Inline for a tab whose only control is the search box; block for one that stacks
+   * several selects beneath it. Not a style choice — three selects laid out inline wrap
+   * into something unreadable at the width a table leaves.
+   */
+  direction = "inline",
+  children,
+}: {
+  /** Every field this tab owns. Anything else in the URL is left alone. */
+  fields: readonly string[];
+  query: string;
+  label?: string;
+  placeholder?: string;
+  direction?: "inline" | "block";
+  /** Extra controls for this tab — a vendor select, a state filter. */
+  children?: ReactNode;
+}) {
+  return (
+    <FilterForm fields={fields}>
+      <s-stack direction={direction} gap="base">
+        <s-search-field
+          name="q"
+          label={label}
+          labelAccessibilityVisibility={direction === "inline" ? "exclusive" : undefined}
+          placeholder={placeholder}
+          value={query}
+        />
+        {children}
+        <s-button type="submit">Search</s-button>
+      </s-stack>
+    </FilterForm>
+  );
+}

--- a/app/components/prices/tabs.test.ts
+++ b/app/components/prices/tabs.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The prices tabs, and the filter that has to survive them.
+ *
+ * Five views of the same variant rows. Searching for a SKU in Baselines and switching to
+ * What's live is a merchant asking about *that SKU* — not asking to start again. Dropping
+ * the query on a tab switch is the small betrayal that teaches people to distrust a
+ * filter, and it is invisible in a screenshot.
+ *
+ * `page` is the exception: page 4 of the baselines is not page 4 of drift, and landing
+ * on an empty page reads as "nothing here" rather than "wrong page".
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const tabs = readFileSync(
+  join(process.cwd(), "app", "components", "prices", "PricesTabs.tsx"),
+  "utf8",
+);
+const layout = readFileSync(
+  join(process.cwd(), "app", "routes", "app.prices.tsx"),
+  "utf8",
+);
+const search = readFileSync(
+  join(process.cwd(), "app", "components", "prices", "VariantSearch.tsx"),
+  "utf8",
+);
+
+describe("filters survive a tab switch", () => {
+  it("carries the query string onto every tab link", () => {
+    expect(tabs).toContain("new URLSearchParams(params)");
+    expect(tabs).toMatch(/query \? `\$\{tab\.href\}\?\$\{query\}` : tab\.href/);
+  });
+
+  it("drops the page number, which does not transfer between tabs", () => {
+    expect(tabs).toContain('carried.delete("page")');
+  });
+});
+
+describe("the current tab", () => {
+  it("matches exactly, because /app/prices prefixes every other tab", () => {
+    // `startsWith` here would light up Variants on every page in the section.
+    expect(tabs).toContain("pathname === tab.href");
+    expect(tabs).not.toContain("pathname.startsWith");
+  });
+});
+
+describe("drift is countable without being opened", () => {
+  it("counts what the drift tab itself lists", () => {
+    // A badge that disagrees with the page it points at is worse than no badge.
+    expect(layout).toContain('resolution: "PENDING"');
+  });
+
+  it("puts the count on the tab", () => {
+    expect(layout).toMatch(/label: "Drift", badge: drifted/);
+  });
+
+  it("shows nothing at zero, since an empty count is noise", () => {
+    expect(tabs).toContain("tab.badge ? `${tab.label} (${tab.badge})` : tab.label");
+  });
+});
+
+describe("search on an embedded surface", () => {
+  it("never uses a native form element", () => {
+    // A plain GET submit replaces the whole query string, including the host and
+    // id_token App Bridge put there, and the merchant gets a blank page.
+    expect(search).toContain("FilterForm");
+    expect(search).not.toMatch(/<form[\s>]/);
+  });
+
+  it("uses the search field Polaris provides rather than a text box", () => {
+    expect(search).toContain("<s-search-field");
+  });
+});

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -1,12 +1,13 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useLoaderData, useSearchParams } from "react-router";
+import { useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { formatMoney, money } from "../lib/money/money";
-import { FilterForm } from "../components/FilterForm";
+import { VariantSearch } from "../components/prices/VariantSearch";
+import { Pagination } from "../components/prices/Pagination";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
@@ -88,33 +89,10 @@ export const loader = withGuard("/app/prices", async ({ request }: LoaderFunctio
 
 export default function Catalog() {
   const { rows, total, page, query, pageSize } = useLoaderData<typeof loader>();
-  const [, setSearchParams] = useSearchParams();
-
-  const lastPage = Math.max(1, Math.ceil(total / pageSize));
-  const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
-  const to = Math.min(total, page * pageSize);
-
-  const goTo = (next: number) =>
-    setSearchParams((params) => {
-      params.set("page", String(next));
-      return params;
-    });
-
   return (
     <PageShell heading="Catalogue">
       <s-section>
-        <FilterForm fields={["q"]}>
-          <s-stack direction="inline" gap="base">
-            <s-text-field
-              name="q"
-              label="Search"
-              labelAccessibilityVisibility="exclusive"
-              placeholder="Search by title or SKU"
-              value={query}
-            />
-            <s-button type="submit">Search</s-button>
-          </s-stack>
-        </FilterForm>
+        <VariantSearch fields={["q"]} query={query} />
 
         {total === 0 ? (
           <s-paragraph>
@@ -124,12 +102,6 @@ export default function Catalog() {
           </s-paragraph>
         ) : (
           <>
-            <s-paragraph>
-              <s-text>
-                Showing {from}–{to} of {total} variants
-              </s-text>
-            </s-paragraph>
-
             <s-table>
               <s-table-header-row>
                 <s-table-header>Variant</s-table-header>
@@ -163,19 +135,7 @@ export default function Catalog() {
               </s-table-body>
             </s-table>
 
-            {lastPage > 1 ? (
-              <s-stack direction="inline" gap="base">
-                <s-button disabled={page <= 1} onClick={() => goTo(page - 1)}>
-                  Previous
-                </s-button>
-                <s-text>
-                  Page {page} of {lastPage}
-                </s-text>
-                <s-button disabled={page >= lastPage} onClick={() => goTo(page + 1)}>
-                  Next
-                </s-button>
-              </s-stack>
-            ) : null}
+            <Pagination page={page} total={total} pageSize={pageSize} />
           </>
         )}
       </s-section>

--- a/app/routes/app.prices.baselines.tsx
+++ b/app/routes/app.prices.baselines.tsx
@@ -24,7 +24,8 @@ import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
 import { baselineHistory, browseBaselines } from "../services/baseline-browser.server";
 import { BaselineTable } from "../components/BaselineTable";
-import { FilterForm } from "../components/FilterForm";
+import { VariantSearch } from "../components/prices/VariantSearch";
+import { Pagination } from "../components/prices/Pagination";
 import { baselinesCsv } from "../lib/reporting/baselines-csv";
 import { downloadCsv } from "../lib/reporting/csv";
 import { RouteBoundary } from "../components/RouteBoundary";
@@ -61,12 +62,6 @@ export default function Baselines() {
     useLoaderData<typeof loader>();
   const [, setSearchParams] = useSearchParams();
 
-  const lastPage = Math.max(1, Math.ceil(total / 25));
-  const goTo = (next: number) =>
-    setSearchParams((params) => {
-      params.set("page", String(next));
-      return params;
-    });
 
   const show = (gid: string) =>
     setSearchParams((params) => {
@@ -77,9 +72,12 @@ export default function Baselines() {
   return (
     <PageShell heading="Baselines">
       <s-section>
-        <FilterForm fields={FILTER_FIELDS}>
-          <s-stack gap="base">
-            <s-text-field name="q" label="Title, SKU or variant ID" value={filters.q ?? ""} />
+        <VariantSearch
+          fields={FILTER_FIELDS}
+          query={filters.q ?? ""}
+          label="Title, SKU or variant ID"
+          direction="block"
+        >
 
             <s-select name="vendor" label="Vendor">
               <s-option value="" defaultSelected={!filters.vendor}>
@@ -110,9 +108,7 @@ export default function Baselines() {
               checked={filters.divergedOnly || undefined}
             />
 
-            <s-button type="submit">Filter</s-button>
-          </s-stack>
-        </FilterForm>
+        </VariantSearch>
 
         {rows.length === 0 ? (
           <s-paragraph>
@@ -123,7 +119,7 @@ export default function Baselines() {
           <>
             <s-paragraph>
               <s-text>
-                {total} variants · showing {rows.length}
+                {total} variants
               </s-text>
             </s-paragraph>
 
@@ -140,19 +136,7 @@ export default function Baselines() {
 
             <BaselineTable rows={rows} onShowHistory={show} />
 
-            {lastPage > 1 ? (
-              <s-stack direction="inline" gap="base">
-                <s-button disabled={page <= 1} onClick={() => goTo(page - 1)}>
-                  Previous
-                </s-button>
-                <s-text>
-                  Page {page} of {lastPage}
-                </s-text>
-                <s-button disabled={page >= lastPage} onClick={() => goTo(page + 1)}>
-                  Next
-                </s-button>
-              </s-stack>
-            ) : null}
+            <Pagination page={page} total={total} pageSize={25} noun="baselines" />
           </>
         )}
       </s-section>

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -11,7 +11,7 @@ import { toAdminClient } from "../services/admin-client.server";
 import { reconciliationCsv } from "../lib/reporting/reconciliation-csv";
 import { downloadCsv } from "../lib/reporting/csv";
 import { ReconciliationTable } from "../components/ReconciliationTable";
-import { FilterForm } from "../components/FilterForm";
+import { VariantSearch } from "../components/prices/VariantSearch";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
@@ -106,9 +106,12 @@ export default function Reconciliation() {
           </s-banner>
         )}
 
-        <FilterForm fields={RECONCILE_FIELDS}>
-          <s-stack gap="base">
-            <s-text-field name="q" label="Title, SKU or variant ID" value={selected.q} />
+        <VariantSearch
+          fields={RECONCILE_FIELDS}
+          query={selected.q}
+          label="Title, SKU or variant ID"
+          direction="block"
+        >
 
             <s-select name="surface" label="Surface">
               <s-option value="any" defaultSelected={selected.surface === "any"}>
@@ -156,9 +159,7 @@ export default function Reconciliation() {
               </s-option>
             </s-select>
 
-            <s-button type="submit">Filter</s-button>
-          </s-stack>
-        </FilterForm>
+        </VariantSearch>
       </s-section>
 
       <s-section heading="Check against Shopify right now">

--- a/app/routes/app.prices.tsx
+++ b/app/routes/app.prices.tsx
@@ -1,25 +1,50 @@
-import { Outlet } from "react-router";
+import type { LoaderFunctionArgs } from "react-router";
+import { Outlet, useLoaderData } from "react-router";
 
-import { SectionNav } from "../components/SectionNav";
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { PricesTabs } from "../components/prices/PricesTabs";
+import prisma from "../db.server";
 
 /**
  * The prices section: five views of the same variant rows.
  *
- * Catalogue, baselines, costs, what is live and drift were five top-level nav items
- * and five separate tables, each with its own filtering, paging and empty state — 997
- * lines to show one thing with different columns. They are one section now; sharing
- * the table shell itself is P7.6.
+ * Catalogue, baselines, costs, what is live and drift were five top-level nav items and
+ * five separate tables, each with its own filtering, paging and empty state — a
+ * thousand lines to show one thing with different columns.
+ *
+ * The loader exists for one number. Drift is the case a merchant will not go looking
+ * for: someone edited a price by hand under a running campaign, and nothing about the
+ * storefront looks wrong. Putting the count on the tab means it is noticed without
+ * being opened, which is the difference between a diagnostic and a warning.
  */
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  // PENDING, matching what the drift tab itself lists. Counting unresolved by
+  // `resolvedAt: null` would also include events a merchant has already decided on but
+  // whose resolution has not been stamped, and a badge that disagrees with the page it
+  // points at is worse than no badge.
+  const drifted = await prisma.driftEvent.count({
+    where: { shopId: shop.id, resolution: "PENDING" },
+  });
+
+  return { drifted };
+};
+
 export default function PricesSection() {
+  const { drifted } = useLoaderData<typeof loader>();
+
   return (
     <>
-      <SectionNav
+      <PricesTabs
         tabs={[
           { href: "/app/prices", label: "Variants" },
           { href: "/app/prices/baselines", label: "Baselines" },
           { href: "/app/prices/costs", label: "Costs" },
           { href: "/app/prices/live", label: "What's live" },
-          { href: "/app/prices/drift", label: "Drift" },
+          { href: "/app/prices/drift", label: "Drift", badge: drifted },
         ]}
       />
       <Outlet />


### PR DESCRIPTION
Fixes #333. Sixth of Epic #327.

## Five tables, one set of rows

Catalogue, baselines, costs, what-is-live and drift each had their own search box, their own paging arithmetic and their own empty state. P7.1 put them in one section; this makes them share a shell.

## Filters survive a tab switch

The tab links carry the query string. Searching for a SKU in Baselines and switching to What's live is a merchant asking about **that SKU**, not asking to start again.

Dropping a query on a tab switch is the small betrayal that teaches people to distrust a filter — and it's invisible in a screenshot, which is why it has a test rather than a look.

`page` is deliberately **not** carried: page 4 of the baselines is not page 4 of drift, and landing on an empty page reads as "nothing here" rather than "wrong page".

## The drift count sits on its tab

Drift is the case a merchant will not go looking for — someone edited a price by hand under a running campaign, and nothing about the storefront looks wrong. A count on the tab is the difference between a diagnostic and a warning.

It counts `PENDING`, matching what the tab itself lists. **A badge that disagrees with the page it points at is worse than no badge.**

## Two details worth stating

- The current tab is matched **exactly**, not by prefix. `/app/prices` prefixes every other tab, so `startsWith` would light up Variants on every page in the section.
- `Pagination` reports *"51–100 of 3,412"* rather than *"page 2 of 69"* — the question a merchant scanning for one variant is actually asking. It replaces three copies of the same off-by-one-prone arithmetic.

`VariantSearch` gives all three searchable tabs `s-search-field` — a component the app had never used, and one of #336's targets.

## Two existing tests caught me

- The **compliance suite** would have caught a native form element, which is why `VariantSearch` wraps `FilterForm` — the App Bridge trap that wipes `host`/`id_token` and leaves a blank page.
- **`display.test`** rejected `toLocaleString("en-GB")` on the row count. The rule is about dates silently taking the server's zone; a count is a number and harmless — but the check can't tell, and shouldn't have to. `formatCount` instead.

## Mutants

| Mutant | Caught |
|---|---|
| tab links drop the query string | ✓ |
| page number carried across tabs | ✓ |
| current tab matched by prefix | ✓ |
| badge counts a different set than the tab lists | ✓ |

## Checks

- `npm test` — 1669 passed (103 files)
- `npm run test:chaos` — 138 passed
- `npm run typecheck`, `npm run build`, `npm run lint` — clean