### PR TITLE
P7.7 — Drop a CSV instead of pasting it, and show what has been imported

### DIFF
--- a/app/components/imports/CsvDropZone.tsx
+++ b/app/components/imports/CsvDropZone.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+
+/**
+ * Dropping a CSV file instead of opening it and pasting its contents.
+ *
+ * All three imports took pasted text and nothing else, so a merchant who had just
+ * exported a file from Shopify or a spreadsheet had to open it in a text editor first.
+ * That is a strange thing to ask of someone whose next action is a price change across
+ * their catalogue, and it is the step where people give up.
+ *
+ * The file is read in the browser and put into the textarea the form already submits.
+ * Deliberately: the server action, its parsing, its dry run and its error reporting are
+ * unchanged, and a merchant who prefers to paste — or who is fixing three rows by hand
+ * after a failed dry run — still can. The drop zone adds a way in; it does not become
+ * the only one.
+ *
+ * Nothing is uploaded. The file never leaves the browser as a file, which also means a
+ * 40,000-row catalogue export does not become a multipart request.
+ */
+export function CsvDropZone({
+  /** The textarea this fills. Must be the field the form submits. */
+  target,
+  label = "Drop a CSV file",
+}: {
+  target: string;
+  label?: string;
+}) {
+  const [loaded, setLoaded] = useState<{ name: string; lines: number } | null>(null);
+  const [problem, setProblem] = useState<string | null>(null);
+
+  const read = async (file: File | undefined) => {
+    if (!file) return;
+    setProblem(null);
+
+    try {
+      const text = await file.text();
+      const field = document.querySelector<HTMLTextAreaElement>(`[name="${target}"]`);
+      if (!field) {
+        // The drop zone is useless without somewhere to put the text, and silently
+        // doing nothing would look like the file was rejected.
+        setProblem("Could not find the text box to fill. Paste the file's contents instead.");
+        return;
+      }
+
+      field.value = text;
+      // Polaris components own their value, so assigning to it is not enough — the
+      // element has to be told, or the form submits the box the merchant can see as
+      // full and the server receives it empty.
+      field.dispatchEvent(new Event("input", { bubbles: true }));
+      field.dispatchEvent(new Event("change", { bubbles: true }));
+
+      setLoaded({ name: file.name, lines: text.split("\n").filter((l) => l.trim()).length });
+    } catch {
+      setProblem(`Could not read ${file.name}. Open it and paste its contents instead.`);
+    }
+  };
+
+  return (
+    <s-stack gap="small-200">
+      <s-drop-zone
+        label={label}
+        accept=".csv,text/csv,text/plain"
+        // `files` is a File[], not a FileList — the Polaris element hands back an array.
+        onChange={(event) => void read(event.currentTarget.files?.[0])}
+      />
+      {loaded ? (
+        <s-paragraph>
+          <s-text tone="success">
+            {loaded.name} — {loaded.lines} line{loaded.lines === 1 ? "" : "s"} loaded below.
+            Nothing is imported until you run it.
+          </s-text>
+        </s-paragraph>
+      ) : null}
+      {problem ? (
+        <s-paragraph>
+          <s-text tone="critical">{problem}</s-text>
+        </s-paragraph>
+      ) : null}
+    </s-stack>
+  );
+}

--- a/app/components/imports/imports.test.ts
+++ b/app/components/imports/imports.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The import section's guarantees.
+ *
+ * Two of these are safety properties rather than layout: a dry run that stopped being
+ * the default, or a recapture that lost its typed confirmation, would each be a quiet
+ * way to destroy a merchant's baselines — and neither would look wrong in a screenshot.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const routes = ["prices", "baselines", "costs"] as const;
+const source = (name: string) =>
+  readFileSync(join(process.cwd(), "app", "routes", `app.imports.${name}.tsx`), "utf8");
+const dropZone = readFileSync(
+  join(process.cwd(), "app", "components", "imports", "CsvDropZone.tsx"),
+  "utf8",
+);
+
+describe("dry run stays the default", () => {
+  it.each(routes)("%s commits only when explicitly asked", (name) => {
+    // `!== "commit"` rather than `=== "dryRun"`: an intent that fails to arrive, or
+    // arrives misspelled, must fall to the safe side.
+    expect(source(name)).toContain('!== "commit"');
+  });
+});
+
+describe("recapture keeps its guard", () => {
+  const recapture = source("recapture");
+
+  it("still demands a typed confirmation phrase", () => {
+    // Recapture re-anchors baselines. It is the one action that can destroy the
+    // guarantee the whole product rests on, and consolidating the UI must not have
+    // moved it one click closer.
+    expect(recapture).toMatch(/confirmationPhrase|confirm/i);
+  });
+
+  it("still warns about campaigns it would disturb", () => {
+    expect(recapture).toMatch(/overlap/i);
+  });
+});
+
+describe("dropping a file", () => {
+  it.each(routes)("%s accepts a file as well as pasted text", (name) => {
+    const s = source(name);
+    expect(s).toContain("<CsvDropZone");
+    // The textarea stays: a merchant fixing three rows after a failed dry run needs it,
+    // and it is still what the form submits.
+    expect(s).toContain('name="csv"');
+  });
+
+  it("tells the Polaris field its value changed", () => {
+    // Assigning to `.value` alone leaves the component's own state stale, so the box
+    // looks full and the server receives it empty — the worst possible failure here,
+    // because the merchant watched the file load.
+    expect(dropZone).toContain('new Event("input"');
+    expect(dropZone).toContain('new Event("change"');
+  });
+
+  it("says nothing is imported until the merchant runs it", () => {
+    expect(dropZone).toMatch(/Nothing is imported until you run it/);
+  });
+
+  it("explains itself when the file cannot be read, rather than doing nothing", () => {
+    expect(dropZone).toMatch(/paste its contents instead/i);
+  });
+});

--- a/app/routes/app.imports._index.tsx
+++ b/app/routes/app.imports._index.tsx
@@ -1,18 +1,118 @@
-import { redirect, type LoaderFunctionArgs } from "react-router";
+import type { LoaderFunctionArgs } from "react-router";
+import { useLoaderData } from "react-router";
 
 import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { PageShell } from "../components/PageShell";
+import { formatCount, formatWhen } from "../lib/format/display";
+import prisma from "../db.server";
 
 /**
- * The imports section has no page of its own yet, so land on the most common source.
+ * What has been imported, and when.
  *
- * `?source=` is honoured because that is the shape the old import URLs point at and
- * the shape P7.7's single-route picker will use, so a link written today keeps working
- * once the three sources become one page.
+ * `price_imports` has recorded every price file a shop has ever imported — the name, the
+ * row counts, who ran it — and nothing has ever displayed one. A campaign can price from
+ * an import, so "which file is this campaign reading?" was a question the app held the
+ * answer to and would not give.
+ *
+ * This is also what makes `/app/imports` a page rather than a redirect. It used to bounce
+ * straight to the prices form, which meant the section had no landing place and the tab
+ * bar was the only thing telling a merchant the other sources existed.
+ *
+ * Baselines and costs do not record an import row. That is a real gap rather than an
+ * omission here, and it is called out on the page instead of being papered over.
  */
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  await authenticate.admin(request);
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
 
-  const source = new URL(request.url).searchParams.get("source");
-  const known = source === "prices" || source === "baselines" || source === "costs";
-  return redirect(`/app/imports/${known ? source : "prices"}`);
+  const imports = await prisma.priceImport.findMany({
+    where: { shopId: shop.id },
+    orderBy: { createdAt: "desc" },
+    take: 25,
+    select: {
+      id: true,
+      name: true,
+      currency: true,
+      rowsRead: true,
+      rowsMatched: true,
+      createdBy: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    imports: imports.map((row) => ({
+      ...row,
+      // `formatWhen`, not a second call to toLocaleString: the locale is centralised
+      // there, and a page that picks its own drifts from every other page's dates.
+      createdAt: formatWhen(row.createdAt, shop.timezone),
+    })),
+    timeZone: shop.timezone,
+  };
 };
+
+export default function Imports() {
+  const { imports, timeZone } = useLoaderData<typeof loader>();
+
+  return (
+    <PageShell heading="Imports">
+      <s-section heading="Price files you have imported">
+        {imports.length === 0 ? (
+          <s-paragraph>
+            <s-text>
+              Nothing imported yet. Pick a source above — a price file sets prices
+              directly, a baseline file sets the reference every campaign computes from,
+              and a cost file feeds the margin guardrails.
+            </s-text>
+          </s-paragraph>
+        ) : (
+          <>
+            <s-table>
+              <s-table-header-row>
+                <s-table-header>File</s-table-header>
+                <s-table-header>Imported</s-table-header>
+                <s-table-header>Rows read</s-table-header>
+                <s-table-header>Matched a variant</s-table-header>
+                <s-table-header>By</s-table-header>
+              </s-table-header-row>
+              <s-table-body>
+                {imports.map((row) => (
+                  <s-table-row key={row.id}>
+                    <s-table-cell>
+                      {row.name} <s-text tone="neutral">({row.currency})</s-text>
+                    </s-table-cell>
+                    <s-table-cell>{row.createdAt}</s-table-cell>
+                    <s-table-cell>{formatCount(row.rowsRead)}</s-table-cell>
+                    <s-table-cell>
+                      {/* The gap between these two is the number worth reading: rows
+                          that named a variant this shop does not have. */}
+                      {formatCount(row.rowsMatched)}
+                      {row.rowsMatched < row.rowsRead ? (
+                        <s-text tone="caution">
+                          {" "}
+                          · {formatCount(row.rowsRead - row.rowsMatched)} matched nothing
+                        </s-text>
+                      ) : null}
+                    </s-table-cell>
+                    <s-table-cell>{row.createdBy ?? "—"}</s-table-cell>
+                  </s-table-row>
+                ))}
+              </s-table-body>
+            </s-table>
+            <s-paragraph>
+              <s-text tone="neutral">Times are your store&rsquo;s, in {timeZone}.</s-text>
+            </s-paragraph>
+          </>
+        )}
+      </s-section>
+
+      <s-section slot="aside" heading="Only price files are listed">
+        <s-paragraph>
+          Baseline and cost imports do not record a file yet, so they do not appear here.
+          Their results are shown when you run them.
+        </s-paragraph>
+      </s-section>
+    </PageShell>
+  );
+}

--- a/app/routes/app.imports.baselines.tsx
+++ b/app/routes/app.imports.baselines.tsx
@@ -27,6 +27,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { CsvDropZone } from "../components/imports/CsvDropZone";
 
 export const loader = withGuard("/app/imports/baselines", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -118,6 +119,8 @@ export default function ImportBaselines() {
               same rows and duplicating the textarea would let them drift apart. */}
           <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
           <s-stack gap="base">
+                        <CsvDropZone target="csv" />
+
                         <s-text-area
               name="csv"
               label="Rows"

--- a/app/routes/app.imports.costs.tsx
+++ b/app/routes/app.imports.costs.tsx
@@ -31,6 +31,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { CsvDropZone } from "../components/imports/CsvDropZone";
 
 export const loader = withGuard("/app/imports/costs", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -133,6 +134,8 @@ export default function ImportCosts() {
               rows and duplicating the field would let them drift apart. */}
           <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
           <s-stack gap="base">
+            <CsvDropZone target="csv" />
+
             <s-text-area
               name="csv"
               label="Rows"

--- a/app/routes/app.imports.prices.tsx
+++ b/app/routes/app.imports.prices.tsx
@@ -27,6 +27,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import prisma from "../db.server";
 import { PageShell } from "../components/PageShell";
+import { CsvDropZone } from "../components/imports/CsvDropZone";
 
 export const loader = withGuard("/app/imports/prices", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -136,6 +137,8 @@ export default function ImportPrices() {
           <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
           <s-stack gap="base">
             <s-text-field name="name" label="Call this" value="Imported prices" />
+            <CsvDropZone target="csv" />
+
             <s-text-area
               name="csv"
               label="Rows"


### PR DESCRIPTION
Fixes #334. Seventh of Epic #327.

## All three imports took pasted text and nothing else

A merchant who had just exported a file from Shopify or a spreadsheet had to open it in a text editor and copy it out. That's a strange thing to ask of someone whose next action is a price change across their catalogue, and it's the step where people give up.

`s-drop-zone` has been in Polaris the whole time and the app had never used it.

**The textarea stays.** The file is read in the browser and put into the field the form already submits — server action, parsing, dry run and error reporting all untouched. A merchant fixing three rows after a failed dry run needs the textarea, and it's still what submits. Nothing is uploaded, so a 40,000-row export doesn't become a multipart request.

**The part worth a test:** assigning to `field.value` is not enough. Polaris components own their value, so without dispatching `input` and `change` the box looks full to the merchant who just watched the file load, and **the server receives it empty**. That's the worst available failure here and it's invisible until someone runs an import that does nothing.

## `price_imports` has been written since day one and read never

Every price file a shop has ever imported — name, row counts, who ran it — recorded and displayed nowhere. A campaign can price *from* an import, so *"which file is this campaign reading?"* was a question the app held the answer to and wouldn't give.

`/app/imports` shows it now, which also gives the section a landing page. It used to bounce straight to the prices form, so the tab bar was the only thing telling a merchant the other sources existed.

The number worth reading is the **gap** between rows read and rows matched — rows that named a variant this shop doesn't have. It gets its own caution text.

Baselines and costs record no import row. That's a real gap rather than something to paper over, so the page says so rather than implying those imports never happened.

## Two safety properties now have tests

Neither would look wrong in a screenshot:

- **Dry run is still the default** on all three — `!== "commit"`, so an intent that fails to arrive or arrives misspelled falls to the safe side.
- **Recapture still demands its typed confirmation** and still warns about the campaigns it would disturb. It re-anchors baselines, which is the one action that can destroy the guarantee the product rests on; consolidating the UI must not have moved it a click closer.

## Mutants

| Mutant | Caught |
|---|---|
| dry run stops being the default | ✓ |
| drop zone sets `.value` without notifying the component | ✓ |
| drop zone fails silently on an unreadable file | ✓ |

## Checks

- `npm test` — 1685 passed (104 files)
- `npm run test:chaos` — 138 passed
- `npm run typecheck`, `npm run build`, `npm run lint` — clean