### PR TITLE
P7.9 — Money is entered with a money field

### DIFF
--- a/app/components/RuleValueField.tsx
+++ b/app/components/RuleValueField.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+/**
+ * The rule's amount, which is a percentage or a price depending on the rule.
+ *
+ * One input served both, as a generic number field, so "−20" meant 20% off under one
+ * rule and £20 off under another with nothing on screen to say which. The label read
+ * "Value" either way.
+ *
+ * A money field is not cosmetic here. It knows it is entering currency: how many decimal
+ * places the amount has, and what a merchant's locale uses as a separator. A generic
+ * number field is where a ¥1,000 price acquires decimals it cannot have — the
+ * presentational half of the bug that made every fixed-amount rule USD with a hardcoded
+ * ×100 (#343).
+ *
+ * The label changes with the rule too, because "Value" is the word that let the two
+ * meanings share a field in the first place.
+ */
+export function RuleValueField({
+  currency,
+  name = "ruleValue",
+  selectName = "ruleKind",
+}: {
+  currency: string;
+  name?: string;
+  selectName?: string;
+}) {
+  const [kind, setKind] = useState("percent-change");
+  const money = kind === "fixed-change" || kind === "set-exact";
+
+  return (
+    <>
+      <s-select
+        name={selectName}
+        label="Adjustment"
+        onChange={(event) => setKind(String(event.currentTarget.value))}
+      >
+        <s-option value="percent-change" defaultSelected>
+          Percent change from baseline
+        </s-option>
+        <s-option value="fixed-change">Fixed change from baseline</s-option>
+        <s-option value="set-exact">Set an exact price</s-option>
+      </s-select>
+
+      {money ? (
+        <s-money-field
+          name={name}
+          label={kind === "set-exact" ? `Price (${currency})` : `Amount (${currency})`}
+          value={kind === "set-exact" ? "" : "-10"}
+          details={
+            kind === "set-exact"
+              ? "Every variant in scope gets this exact price."
+              : `Negative reduces. -10 takes ${currency} 10 off the baseline.`
+          }
+        />
+      ) : (
+        <s-number-field
+          name={name}
+          label="Percentage"
+          value="-20"
+          details="Negative discounts. -20 means 20% off the baseline."
+        />
+      )}
+    </>
+  );
+}

--- a/app/lib/ui/money-input.test.ts
+++ b/app/lib/ui/money-input.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Money is entered with a money field, never a generic number field.
+ *
+ * Rule 7 says money is integer minor units with no floats near a price. The server side
+ * of that was fixed in #343 — the rule parser takes the currency and uses
+ * `10 ** decimalsFor(currency)` rather than a literal 100. This is the other half: a
+ * generic number input does not know how many decimal places a currency has, or what a
+ * merchant's locale uses as a separator, so it is where a ¥1,000 floor acquires decimals
+ * yen does not have.
+ *
+ * The check reads the routes rather than a list, so a price input added next month is
+ * covered without anyone remembering this file exists.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROUTES = join(process.cwd(), "app", "routes");
+const COMPONENTS = join(process.cwd(), "app", "components");
+
+function sources(): Array<{ name: string; text: string }> {
+  const read = (dir: string) =>
+    readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isFile() && e.name.endsWith(".tsx"))
+      .map((e) => ({ name: e.name, text: readFileSync(join(dir, e.name), "utf8") }));
+
+  return [...read(ROUTES), ...read(COMPONENTS)];
+}
+
+/** A field whose label names a currency, or whose name says it is a price. */
+const MONEY_FIELD = /<s-(number|text)-field[^>]*?(?:name="(?:minPrice|price|amount)"|label=\{?`?[^>]*\((?:USD|\$\{currency\})\))/s;
+
+describe("price inputs", () => {
+  it("finds files to check, so this cannot pass by checking nothing", () => {
+    expect(sources().length).toBeGreaterThan(20);
+  });
+
+  it("never enter money through a plain number or text field", () => {
+    const offenders = sources()
+      .filter(({ text }) => MONEY_FIELD.test(text))
+      .map(({ name }) => name);
+
+    expect(
+      offenders,
+      "these take a currency amount through a generic field — use s-money-field, which " +
+        "knows the currency's decimal places and the merchant's separator",
+    ).toEqual([]);
+  });
+
+  it("uses a money field where a price is entered", () => {
+    const withMoney = sources().filter(({ text }) => text.includes("<s-money-field"));
+
+    expect(
+      withMoney.map((f) => f.name).sort(),
+      "the absolute price floor and the campaign rule amount are both money",
+    ).toEqual(["RuleValueField.tsx", "app.settings._index.tsx"]);
+  });
+});
+
+describe("the rule amount changes with the rule", () => {
+  const field = readFileSync(join(COMPONENTS, "RuleValueField.tsx"), "utf8");
+
+  it("is a percentage for a percent rule and money for a fixed one", () => {
+    // One input served both as a generic number field, so "-20" meant 20% off under one
+    // rule and £20 off under another, with nothing on screen to say which.
+    expect(field).toContain('kind === "fixed-change" || kind === "set-exact"');
+    expect(field).toContain("<s-money-field");
+    expect(field).toContain("<s-number-field");
+  });
+
+  it("stops calling it Value, which is what let the two meanings share a field", () => {
+    expect(field).not.toMatch(/label="Value"/);
+    expect(field).toContain('label="Percentage"');
+  });
+
+  it("names the currency when it is asking for money", () => {
+    expect(field).toMatch(/\$\{currency\}/);
+  });
+});

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -26,6 +26,7 @@ import { segmentToAst } from "../services/segments.server";
 import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/draft-form";
 import { PageShell } from "../components/PageShell";
 import { DraftPreview } from "../components/DraftPreview";
+import { RuleValueField } from "../components/RuleValueField";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
 export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
@@ -378,20 +379,7 @@ export default function NewCampaign() {
           <s-stack gap="base">
             <s-text-field name="name" label="Campaign name" value="Sale" required />
 
-            <s-select name="ruleKind" label="Adjustment">
-              <s-option value="percent-change" defaultSelected>
-                Percent change from baseline
-              </s-option>
-              <s-option value="fixed-change">Fixed change from baseline</s-option>
-              <s-option value="set-exact">Set an exact price</s-option>
-            </s-select>
-
-            <s-number-field
-              name="ruleValue"
-              label="Value"
-              value="-20"
-              details="Negative discounts. -20 means 20% off the baseline."
-            />
+            <RuleValueField currency={currencies[0] ?? "USD"} />
 
             <s-select name="compareAt" label="Compare-at price">
               <s-option value="set-to-baseline" defaultSelected>

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -188,7 +188,11 @@ export default function Settings() {
               details="Share of the selling price. 25 means a price of at least cost ÷ 0.75. Leave blank for none."
             />
 
-            <s-number-field
+            {/* A money field, not a number field. This is a price, and the two differ
+                in how they handle the decimal separator a merchant's locale uses and
+                how many places the currency actually has — a generic number input is
+                where a ¥1,000 floor becomes ¥1,000.00 and then something else. */}
+            <s-money-field
               name="minPrice"
               label={`Minimum price (${currency})`}
               value={settings.minPrice?.toString() ?? ""}


### PR DESCRIPTION
Fixes #336. Ninth of Epic #327.

## The other half of #343

Rule 7: money is integer minor units, no floats near a price. #343 fixed the **server** half — the rule parser takes the currency and uses `10 ** decimalsFor(currency)` rather than a literal 100.

This is the input half. A generic number field doesn't know how many decimal places a currency has, or what a merchant's locale uses as a separator. It's where a ¥1,000 floor acquires decimals yen doesn't have.

`s-money-field` has been in Polaris the whole time. The app had 15 text fields and 7 number fields, and some of them were prices.

## The campaign rule's amount was the worst of them

**One generic input served both meanings.** `-20` meant *20% off the baseline* under one rule and *£20 off* under another — with nothing on screen to say which. The label read **"Value"** either way, which is exactly what let the two meanings share a field.

It's now a percentage field for a percent rule, and a money field naming the currency for a fixed one. And it no longer says "Value".

## The test reads the routes, not a list

`money-input.test.ts` fails on any `s-number-field` or `s-text-field` whose name or label says it takes currency — so a price input added next month is covered without anyone remembering the file exists.

| Mutant | Caught |
|---|---|
| price floor back to a number field | *"these take a currency amount through a generic field"* |
| rule amount back to one generic "Value" field | ✓ |

## `s-thumbnail` is filed separately, as #353

It's the one item on this ticket's list that **is not a component swap**. The app stores no image data — `VariantIndex` has no image column and the sync has never requested `featuredImage`. Adding thumbnails means a migration, changes to **both** sync paths, codegen, and a 102,132-variant re-sync.

Bundling a data-pipeline change into a component ticket is how the bulk path silently dropped a whole table once already (#252). #353 states the real cost.

## Checks

- `npm test` — 1700 passed (106 files)
- `npm run test:chaos` — 138 passed
- `npm run typecheck`, `npm run build`, `npm run lint` — clean