### PR TITLE
P7.10 — The first screen after installing stops being an essay

### DIFF
--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * The first screen after installing, and how much it says before it asks anything.
+ *
+ * The checklist used to render every step's explanation at once — roughly 120 words
+ * before the merchant reached a link. The explanations are good, and the baseline
+ * concept genuinely needs teaching; the mistake was teaching all of it before being
+ * asked.
+ *
+ * Two things must not be lost in making it compact: the reassurance that nothing is
+ * written yet, and the fact that a completed step offers no button. Redoing the first
+ * step recaptures baselines, which mid-sale makes the sale prices somebody's new
+ * normal — permanently.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { OnboardingCard } from "./OnboardingCard";
+import { onboarding } from "../lib/onboarding/steps";
+
+const render = (facts: Parameters<typeof onboarding>[0]) =>
+  renderToStaticMarkup(<OnboardingCard state={onboarding(facts)} />);
+
+const fresh = {
+  hasBaselines: false,
+  hasCampaign: false,
+  hasPracticed: false,
+  hasCleanRun: false,
+};
+
+describe("a brand new shop", () => {
+  const html = render(fresh);
+
+  it("does not open with a wall of explanation", () => {
+    // Every step's `detail` is a paragraph. Rendering them all is what made this a wall.
+    const words = html.replace(/<[^>]+>/g, " ").split(/\s+/).filter(Boolean).length;
+    expect(words, "the first screen after install should not be an essay").toBeLessThan(60);
+  });
+
+  it("still says nothing is written yet, which is the reassurance that earns trust", () => {
+    expect(html).toMatch(/changes a price until you apply/i);
+  });
+
+  it("shows progress, so the checklist reads as finishable", () => {
+    expect(html).toMatch(/0 of \d+ done/);
+  });
+
+  it("keeps the teaching available rather than deleting it", () => {
+    expect(html).toContain("Why?");
+  });
+
+  it("leads with the next action", () => {
+    expect(html).toContain("Sync catalogue");
+  });
+});
+
+describe("a shop part-way through", () => {
+  const html = render({ ...fresh, hasBaselines: true });
+
+  it("counts what is actually done, not what was clicked past", () => {
+    expect(html).toMatch(/1 of \d+ done/);
+  });
+
+  it("offers no button on a completed step", () => {
+    // Redoing the first step recaptures baselines. Mid-sale that makes the sale prices
+    // the new normal, permanently — so a finished step must not invite a repeat.
+    expect(html).not.toContain("Sync catalogue");
+  });
+});
+
+describe("a shop that has finished", () => {
+  it("retires the card entirely", () => {
+    expect(
+      render({
+        hasBaselines: true,
+        hasCampaign: true,
+        hasPracticed: true,
+        hasCleanRun: true,
+      }),
+    ).toBe("");
+  });
+});

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -1,42 +1,71 @@
-import type { OnboardingState } from "../lib/onboarding/steps";
+import { useState } from "react";
+
+import type { OnboardingState, OnboardingStep } from "../lib/onboarding/steps";
 
 /**
  * The checklist, until the first campaign has run cleanly.
  *
- * It leads with *why* rather than what to click. The baseline concept is unfamiliar and
- * the app's whole value rests on the merchant understanding it, and nobody reads the
- * docs first — so the teaching happens here or it does not happen.
+ * It used to render every step's explanation at once — roughly 120 words before the
+ * merchant reached a link, on the first screen they see after installing. The
+ * explanations are good and the baseline concept genuinely does need teaching; the
+ * mistake was teaching all of it before being asked.
+ *
+ * So the checklist is a checklist: one line per step, the next step's action in reach,
+ * and the *why* behind a toggle. A merchant who wants the reasoning can have it in one
+ * click; a merchant who wants to get on with it is not made to scroll past it.
  *
  * Completed steps lose their button. A finished step with a call to action invites
- * redoing it, and redoing the first one recaptures baselines — which mid-sale would
- * make the sale prices somebody's new normal, permanently.
+ * redoing it, and redoing the first one recaptures baselines — which mid-sale would make
+ * the sale prices somebody's new normal, permanently.
+ *
+ * The state comes from what the shop has actually done, never from "steps dismissed", so
+ * there is nothing here to dismiss: the card retires itself when the work is real.
  */
 export function OnboardingCard({ state }: { state: OnboardingState }) {
   if (state.complete) return null;
 
+  const done = state.steps.filter((step) => step.done).length;
+
   return (
     <s-section heading="Getting started">
-      <s-paragraph>
-        <s-text>
-          Three steps to your first campaign. Nothing here changes a price until you
-          explicitly apply one.
-        </s-text>
-      </s-paragraph>
+      <s-stack direction="inline" gap="base">
+        <s-badge tone={done === state.steps.length ? "success" : "info"}>
+          {done} of {state.steps.length} done
+        </s-badge>
+        <s-text tone="neutral">Nothing here changes a price until you apply one.</s-text>
+      </s-stack>
 
       {state.steps.map((step) => (
-        <s-box key={step.id}>
-          <s-paragraph>
-            <s-badge tone={step.done ? "success" : step.id === state.next?.id ? "info" : "neutral"}>
-              {step.done ? "Done" : step.id === state.next?.id ? "Next" : "Later"}
-            </s-badge>{" "}
-            <s-text>{step.title}</s-text>
-          </s-paragraph>
-          <s-paragraph>
-            <s-text>{step.detail}</s-text>
-          </s-paragraph>
-          {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
-        </s-box>
+        <Step key={step.id} step={step} isNext={step.id === state.next?.id} />
       ))}
     </s-section>
+  );
+}
+
+function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
+  const [why, setWhy] = useState(false);
+
+  return (
+    <s-box>
+      <s-stack direction="inline" gap="base">
+        <s-badge tone={step.done ? "success" : isNext ? "info" : "neutral"}>
+          {step.done ? "Done" : isNext ? "Next" : "Later"}
+        </s-badge>
+        <s-text type="strong">{step.title}</s-text>
+        {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
+        {/* Progressive disclosure, not a link away. The reasoning belongs next to the
+            step it explains — sending a merchant to a docs page to find out why they
+            are being asked to sync is how they end up not syncing. */}
+        <s-clickable onClick={() => setWhy((open) => !open)}>
+          <s-text tone="neutral">{why ? "Hide why" : "Why?"}</s-text>
+        </s-clickable>
+      </s-stack>
+
+      {why ? (
+        <s-paragraph>
+          <s-text>{step.detail}</s-text>
+        </s-paragraph>
+      ) : null}
+    </s-box>
   );
 }


### PR DESCRIPTION
Fixes #337. Tenth and last of Epic #327.

## 187 words before the first link

The getting-started checklist rendered every step's explanation at once — on the first screen a merchant sees after installing.

The explanations are *good*, and the baseline concept genuinely needs teaching: the app's whole value rests on the merchant understanding that a campaign computes from a baseline rather than from whatever price is live. The mistake was teaching all of it before being asked.

It's a checklist now — one line per step, the next action in reach, **"0 of 3 done"** so it reads as finishable, and the *why* behind a toggle. **Under 60 words to first action**, asserted by counting them.

## Two things had to survive the trim

Both are trust rather than layout, and both now have tests:

- **"Nothing here changes a price until you apply one."** That sentence is what earns the first sync.
- **A completed step still offers no button.** Redoing the first one recaptures baselines, which mid-sale makes the sale prices somebody's new normal — permanently.

State still comes from what the shop has actually *done*, never from steps dismissed, so there's nothing to dismiss: the card retires itself when the work is real.

## Mutants

| Mutant | Caught by |
|---|---|
| render every explanation again | *"the first screen after install should not be an essay: expected 187 to be less than 60"* |
| completed step keeps its button | *"offers no button on a completed step"* |
| drop the "nothing is written" reassurance | ✓ |

## The save bar is filed as #355, not shipped

`app.settings._index.tsx` has **three separate forms** and the admin shows one save bar at a time. Wiring it to one of them is worse than none — it would appear for a change in one section and not the others, and a merchant would learn it's unreliable rather than partial.

Merging the three is the right fix and isn't small: `writeSettings` replaces the settings JSON wholesale, and there's already history of a bug where saving a guardrail switched notification preferences off. #355 states that.

Also recorded there: the save bar is **deliberately not** for the campaign editor. It says *"you changed something that exists"*; the editor creates. NA shows one there and it's the one thing on their editor worth not copying.

## Checks

- `npm test` — 1708 passed (107 files)
- `npm run test:chaos` — 138 passed
- `npm run typecheck`, `npm run build`, `npm run lint` — clean