### PR TITLE
Keep each step's "Why?" with its own step

### DIFF
--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -52,6 +52,17 @@ describe("a brand new shop", () => {
   it("leads with the next action", () => {
     expect(html).toContain("Sync catalogue");
   });
+
+  it("keeps each step's Why with its own step, not the one below", () => {
+    // The row wraps on a narrow column. With the toggle last it wrapped onto its own
+    // line and read as belonging to the next step — an explanation attached to the
+    // wrong step is worse than no explanation.
+    const step = html.slice(html.indexOf("Capture your baselines"));
+    expect(
+      step.indexOf("Why?") < step.indexOf("Sync catalogue"),
+      "Why? must come before the action so the action is what wraps",
+    ).toBe(true);
+  });
 });
 
 describe("a shop part-way through", () => {

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -52,13 +52,18 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
           {step.done ? "Done" : isNext ? "Next" : "Later"}
         </s-badge>
         <s-text type="strong">{step.title}</s-text>
-        {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
         {/* Progressive disclosure, not a link away. The reasoning belongs next to the
             step it explains — sending a merchant to a docs page to find out why they
-            are being asked to sync is how they end up not syncing. */}
+            are being asked to sync is how they end up not syncing.
+            
+            Before the action, deliberately. The row wraps on a narrow column, and when
+            the toggle was last it wrapped onto its own line and read as belonging to
+            the step below it. The action wrapping is harmless; an explanation attached
+            to the wrong step is not. */}
         <s-clickable onClick={() => setWhy((open) => !open)}>
           <s-text tone="neutral">{why ? "Hide why" : "Why?"}</s-text>
         </s-clickable>
+        {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
       </s-stack>
 
       {why ? (


### PR DESCRIPTION
Follow-up to #356 (#337). Found by looking at the deployed page, not by a test.

## What it looked like

The step row wraps on a narrow column, and with the toggle rendered last it wrapped onto its own line — so **"Why?" sat directly above the next step and read as belonging to it**.

An explanation attached to the wrong step is worse than no explanation, and on this card the explanations are the part that teaches what a baseline is.

## The fix

The toggle goes *before* the action. The action wrapping is harmless; the toggle detaching is not.

Pinned by an assertion on their order — the wrap itself is a layout outcome no markup snapshot would reveal, but the order that causes it is checkable. Putting the toggle back after the action fails with *"Why? must come before the action so the action is what wraps"*.

## Checks

- `npm test` — 1709 passed
- `npm run typecheck` — clean