### PR TITLE
Clear errors that belong to no shop, and state what they mean

### DIFF
--- a/chaos/harness/seed.ts
+++ b/chaos/harness/seed.ts
@@ -164,4 +164,14 @@ export async function seedFixture(options: SeedOptions): Promise<Fixture> {
  */
 export async function destroyFixture(domain: string): Promise<void> {
   await prisma.shop.deleteMany({ where: { domain } });
+
+  // Errors the app could not attribute to a shop. They have no shop to cascade from,
+  // so nothing else removes them -- and they are counted by the global error rate while
+  // no per-shop rate counts them. `shop-error-spike` asserts on exactly that asymmetry,
+  // so three of these left behind invert its premise and it fails claiming the platform
+  // is unhealthy.
+  //
+  // Three. Not fifty: it took exactly three, recorded while #346 was throwing, to break
+  // it. Any failure that happens before `ensureShop` leaves one.
+  await prisma.errorEvent.deleteMany({ where: { shopId: null } });
 }

--- a/chaos/scenarios/unattributed-errors.chaos.ts
+++ b/chaos/scenarios/unattributed-errors.chaos.ts
@@ -1,0 +1,96 @@
+/**
+ * Errors the app could not attribute to a shop.
+ *
+ * A failure before `ensureShop` — a bad session, a route that threw while resolving the
+ * shop, a bug in the unauthenticated path — records an error with no `shopId`. The
+ * queries feeding the alerts treat those two ways on purpose: the global count includes
+ * them, and the per-shop grouping filters them out with `shopId: { not: null }`.
+ *
+ * That is almost certainly right. Nobody's shop is failing, so no shop should be paged
+ * about it; but something *is* failing, so the platform rate should say so.
+ *
+ * Nothing stated it and nothing tested it, and the cost of that was real: three
+ * unattributed errors, recorded while the campaign page was throwing #346, inverted
+ * `shop-error-spike`'s premise and it failed claiming the platform was unhealthy. The
+ * behaviour was fine. The absence of an assertion about it was not.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { gather } from "../../app/services/alerting.server";
+import { withChaos } from "../harness/scenario";
+
+const PREFIX = "ANC-ORPHAN-";
+
+async function unattributedFailures(count: number) {
+  for (let i = 0; i < count; i++) {
+    await prisma.errorEvent.create({
+      data: {
+        errorId: `${PREFIX}${i}-${Date.now()}`,
+        // No shop. This is the whole point.
+        shopId: null,
+        code: "UNKNOWN",
+        message: "Threw before the shop was known",
+        userMessage: "Something went wrong.",
+      },
+    });
+  }
+}
+
+describe("chaos: an error with no shop", () => {
+  it("counts against the platform and against nobody's shop", async () => {
+    await withChaos(
+      "unattributed-errors",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async (chaos) => {
+        await prisma.errorEvent.deleteMany({ where: { errorId: { startsWith: PREFIX } } });
+
+        const now = new Date();
+        const before = await gather(now);
+        const beforeMine = before.shopRates?.find(
+          (rate) => rate.shopId === chaos.fixture.shopId,
+        );
+
+        await unattributedFailures(6);
+
+        const after = await gather(now);
+
+        expect(
+          after.errors - before.errors,
+          "the platform rate must see a failure nobody can be paged for",
+        ).toBe(6);
+
+        const afterMine = after.shopRates?.find((rate) => rate.shopId === chaos.fixture.shopId);
+        expect(
+          (afterMine?.errors ?? 0) - (beforeMine?.errors ?? 0),
+          "no shop's own rate may move for an error that was not theirs",
+        ).toBe(0);
+
+        // And they belong to no shop at all, rather than being quietly assigned to one.
+        expect(
+          after.shopRates?.some((rate) => rate.shopId === null),
+          "an unattributed error must not appear as a shop with a null id",
+        ).toBeFalsy();
+      },
+    );
+  });
+
+  it("does not survive its own scenario, so the next one starts clean", async () => {
+    // The teardown clears these precisely because nothing else can: they have no shop to
+    // cascade from. Three left behind is enough to break `shop-error-spike`.
+    await withChaos(
+      "unattributed-cleanup",
+      { catalog: { products: 1, variantsPerProduct: 1 }, percent: -10 },
+      async () => {
+        await unattributedFailures(3);
+        expect(await prisma.errorEvent.count({ where: { shopId: null } })).toBeGreaterThan(0);
+      },
+    );
+
+    expect(
+      await prisma.errorEvent.count({ where: { shopId: null } }),
+      "unattributed errors outlived the fixture, and the next scenario inherits them",
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #347.

## My first diagnosis was wrong

I filed this as chaos runs accumulating stale rows. Deleting **thirty** chaos-shop rows changed nothing. Deleting **three** fixed it — three errors with no `shopId`, recorded while the campaign page was throwing #346.

Chaos shops clean up correctly: `destroyFixture` deletes the shop and `ErrorEvent` cascades. An unattributed error has no shop to cascade from, so nothing removed it. The teardown does now.

## Why three is enough

The alert queries treat unattributed errors two ways **on purpose**:

```ts
prisma.errorEvent.count({ where: { createdAt: { gte: since } } })          // global: includes them
prisma.errorEvent.groupBy({ where: { …, shopId: { not: null } }, … })      // per-shop: excludes them
```

That asymmetry is exactly what `shop-error-spike` asserts on — *"fires per-shop without firing the global rate"*. So a handful of shop-less errors invert its premise and it fails claiming the platform is unhealthy.

Any failure before `ensureShop` leaves one: a bad session, a route that throws while resolving the shop, a bug in the unauthenticated path.

## The behaviour is right; nothing said so

Nobody's shop is failing, so no shop should be paged. But something *is* failing, so the platform rate should say so.

`unattributed-errors.chaos.ts` states it: six shop-less failures move the platform count by exactly six and no shop's own rate by anything, and they don't appear as a shop with a null id.

## Mutants

| Mutant | What it would mean |
|---|---|
| teardown stops clearing orphans | the next scenario inherits them |
| per-shop grouping counts them | a shop paged for an error that wasn't theirs |
| global count excludes them too | a failure nobody would ever be paged for |

All three caught.

## Checks

- **Two consecutive full chaos runs, 140 passing each, zero orphans left after** — which is the actual thing this fixes
- `npm test` — 1709 passed
- `npm run typecheck`, `npm run lint` — clean