### PR TITLE
Settings is one form with one save bar

### DIFF
--- a/app/components/SettingsSaveBar.tsx
+++ b/app/components/SettingsSaveBar.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Shopify's own save bar, for the settings form.
+ *
+ * The admin puts "Unsaved changes · Discard · Save" in the top bar the moment a field
+ * changes, and merchants expect it because every other page in the admin has it. Ours
+ * had a submit button at the bottom of each section, so changing a value in the third
+ * section meant scrolling past two others to save it.
+ *
+ * It needed the three forms merged into one first. One save bar wired to one of three
+ * forms is worse than none: it would appear for a change in one section and not the
+ * others, and a merchant learns it is unreliable rather than that it is partial.
+ *
+ * Deliberately not on the campaign editor. A save bar says "you have changed something
+ * that exists"; the editor *creates* a campaign, and offering Discard on a thing that
+ * has never existed invites the question of what it would discard.
+ *
+ * Dirty state is read from the form rather than mirrored into React state. Mirroring
+ * means two sources of truth for "has this changed", and the one that goes stale is the
+ * one deciding whether the merchant is warned before leaving.
+ */
+export function SettingsSaveBar({
+  form,
+  saving,
+  id = "settings-save-bar",
+}: {
+  form: React.RefObject<HTMLFormElement | null>;
+  saving: boolean;
+  id?: string;
+}) {
+  const pristine = useRef<string | null>(null);
+
+  useEffect(() => {
+    const element = form.current;
+    if (!element) return;
+
+    const snapshot = () =>
+      new URLSearchParams(new FormData(element) as unknown as string[][]).toString();
+    pristine.current = snapshot();
+
+    const bar = () =>
+      (
+        globalThis as {
+          shopify?: { saveBar?: { show(id: string): void; hide(id: string): void } };
+        }
+      ).shopify?.saveBar;
+
+    const onChange = () => {
+      const control = bar();
+      if (!control) return; // Outside the admin frame — a test, or a direct page load.
+      if (snapshot() !== pristine.current) control.show(id);
+      else control.hide(id);
+    };
+
+    element.addEventListener("input", onChange);
+    element.addEventListener("change", onChange);
+    return () => {
+      element.removeEventListener("input", onChange);
+      element.removeEventListener("change", onChange);
+    };
+  }, [form, id]);
+
+  // After a save the form's current values become the new pristine state, or the bar
+  // stays up over a form that already matches what is stored.
+  useEffect(() => {
+    if (saving || !form.current) return;
+    pristine.current = new URLSearchParams(
+      new FormData(form.current) as unknown as string[][],
+    ).toString();
+    (globalThis as { shopify?: { saveBar?: { hide(id: string): void } } }).shopify?.saveBar?.hide(
+      id,
+    );
+  }, [saving, form, id]);
+
+  return (
+    <ui-save-bar id={id}>
+      <button variant="primary" onClick={() => form.current?.requestSubmit()}>
+        {saving ? "Saving…" : "Save"}
+      </button>
+      <button
+        onClick={() => {
+          // Reset restores every section, not only the one that was touched — which is
+          // the point of them being one form.
+          form.current?.reset();
+          (
+            globalThis as { shopify?: { saveBar?: { hide(id: string): void } } }
+          ).shopify?.saveBar?.hide(id);
+        }}
+      >
+        Discard
+      </button>
+    </ui-save-bar>
+  );
+}

--- a/app/lib/ui/settings-form.test.ts
+++ b/app/lib/ui/settings-form.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Settings is one form, and saving one section cannot switch off another.
+ *
+ * It was three forms with three intents, each writing `{ ...existing, its own fields }`
+ * so the other two survived. That worked, and it is also how a bug once switched
+ * notification preferences off while saving a guardrail: every write had to remember
+ * what it was not touching, and one of them forgot.
+ *
+ * With one form every field is present on every save, so nothing depends on being
+ * remembered. The failure this guards is the regression back to per-section intents,
+ * which would look tidy and reintroduce the same class of bug.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const route = readFileSync(
+  join(process.cwd(), "app", "routes", "app.settings._index.tsx"),
+  "utf8",
+);
+const saveBar = readFileSync(
+  join(process.cwd(), "app", "components", "SettingsSaveBar.tsx"),
+  "utf8",
+);
+
+describe("one form", () => {
+  it("has exactly one form element, opened and closed", () => {
+    expect(route.match(/<fetcher\.Form/g) ?? []).toHaveLength(1);
+    expect(route.match(/<\/fetcher\.Form>/g) ?? []).toHaveLength(1);
+  });
+
+  it("has no per-section intents left to branch on", () => {
+    expect(route).not.toContain('name="intent"');
+    expect(route).not.toContain('=== "rounding"');
+    expect(route).not.toContain('=== "notifications"');
+  });
+
+  it("writes guardrails, rounding and preferences on the same submit", () => {
+    // Scoped to the action body. Slicing to the end of the file also swept in the form
+    // fields, so deleting the whole `writePreferences` call still passed — the field
+    // names were matching the inputs that render them.
+    const start = route.indexOf("export const action");
+    const action = route.slice(start, route.indexOf("\n});", start));
+
+    for (const field of ["minPrice", "violationPolicy", "rounding:", "writePreferences"]) {
+      expect(action, `${field} is not written by the single save`).toContain(field);
+    }
+  });
+
+  it("still reads existing settings, for fields no control here owns", () => {
+    expect(route).toContain("...existing");
+  });
+});
+
+describe("the save bar", () => {
+  it("re-reads the form after a save, so it does not linger", () => {
+    // A bar left showing over a form that already matches what is stored trains people
+    // to ignore it.
+    expect(saveBar).toContain("[saving, form, id]");
+  });
+
+  it("discards by resetting the whole form, not one section", () => {
+    expect(saveBar).toContain("form.current?.reset()");
+  });
+
+  it("does nothing outside the admin frame rather than throwing", () => {
+    // `shopify` is App Bridge's global. A direct page load or a test has no admin.
+    expect(saveBar).toContain("if (!control) return");
+  });
+});

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -1,4 +1,5 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useRef } from "react";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -16,6 +17,7 @@ import {
   ROUNDING_LABELS,
 } from "../lib/money/rounding-policy";
 import { PageShell } from "../components/PageShell";
+import { SettingsSaveBar } from "../components/SettingsSaveBar";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -61,30 +63,13 @@ export const action = withGuard("/app/settings", async ({ request }: ActionFunct
   const actor = actorFor(sessionToken, session.shop);
   const form = await request.formData();
 
-  if (String(form.get("intent")) === "notifications") {
-    await writePreferences(shop.id, {
-      email: String(form.get("email") ?? ""),
-      onCompletion: form.get("onCompletion") === "on",
-      onPartialOrFailure: form.get("onPartialOrFailure") === "on",
-      onDrift: form.get("onDrift") === "on",
-      onRevert: form.get("onRevert") === "on",
-      weeklyDigest: form.get("weeklyDigest") === "on",
-    });
-    return { ok: true, message: "Notification preferences saved." };
-  }
-
-  if (String(form.get("intent")) === "rounding") {
-    const existing = await readSettings(shop.id);
-
-    await writeSettings(
-      shop.id,
-      { ...existing, rounding: readRoundingPolicy(form.entries()) },
-      actor,
-    );
-
-    return { ok: true, message: "Rounding saved. New campaigns start with these." };
-  }
-
+  // One form, one save. It used to be three forms with three intents, each doing
+  // `{ ...existing, its own fields }` so the other two survived. That worked and it is
+  // also how a bug once switched notification preferences off while saving a guardrail:
+  // every write had to remember what it was not touching.
+  //
+  // With one form every field is present on every save, so nothing depends on being
+  // remembered. `{ ...existing }` stays only for fields no control on this page owns.
   const existing = await readSettings(shop.id);
 
   const saved = await writeSettings(
@@ -97,11 +82,21 @@ export const action = withGuard("/app/settings", async ({ request }: ActionFunct
       minPrice: emptyToNull(form.get("minPrice")),
       violationPolicy: asPolicy(form.get("violationPolicy")),
       missingCostPolicy: form.get("missingCostPolicy") === "error" ? "error" : "skip",
+      rounding: readRoundingPolicy(form.entries()),
     },
     actor,
   );
 
-  return { ok: true, message: "Guardrails saved. They apply to every campaign.", saved };
+  await writePreferences(shop.id, {
+    email: String(form.get("email") ?? ""),
+    onCompletion: form.get("onCompletion") === "on",
+    onPartialOrFailure: form.get("onPartialOrFailure") === "on",
+    onDrift: form.get("onDrift") === "on",
+    onRevert: form.get("onRevert") === "on",
+    weeklyDigest: form.get("weeklyDigest") === "on",
+  });
+
+  return { ok: true, message: "Settings saved.", saved };
 });
 
 function emptyToNull(value: FormDataEntryValue | null): number | null {
@@ -128,6 +123,7 @@ export default function Settings() {
     mailConfigured,
   } = useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
+  const formRef = useRef<HTMLFormElement>(null);
   const busy = fetcher.state !== "idle";
 
   const costCoverage = variants === 0 ? 0 : Math.round((withCost / variants) * 100);
@@ -140,6 +136,7 @@ export default function Settings() {
         </s-banner>
       ) : null}
 
+      <fetcher.Form method="post" ref={formRef}>
       {/* Three long sections in one page, so a merchant who came here to change one
           number does not scroll past the other two hunting for it. In-page anchors
           rather than more routes: these settings are read together — a rounding rule
@@ -173,7 +170,6 @@ export default function Settings() {
           </s-banner>
         ) : null}
 
-        <fetcher.Form method="post">
           <s-stack gap="base">
             <s-checkbox
               name="neverBelowCost"
@@ -222,12 +218,7 @@ export default function Settings() {
                 Fail the campaign
               </s-option>
             </s-select>
-
-            <s-button type="submit" variant="primary" loading={busy || undefined}>
-              Save guardrails
-            </s-button>
           </s-stack>
-        </fetcher.Form>
       </s-section>
 
       <s-section id="rounding" heading="Rounding">
@@ -237,9 +228,6 @@ export default function Settings() {
             once here; each campaign can override it.
           </s-text>
         </s-paragraph>
-
-        <fetcher.Form method="post">
-          <input type="hidden" name="intent" value="rounding" />
 
           <s-stack gap="base">
             <s-select name="rounding.default" label="Everywhere, unless overridden">
@@ -295,12 +283,7 @@ export default function Settings() {
                 })}
               </>
             ) : null}
-
-            <s-button type="submit" variant="primary" loading={busy || undefined}>
-              Save rounding
-            </s-button>
           </s-stack>
-        </fetcher.Form>
       </s-section>
 
       <s-section id="notifications" heading="Notifications">
@@ -320,8 +303,6 @@ export default function Settings() {
           </s-banner>
         ) : null}
 
-        <fetcher.Form method="post">
-          <input type="hidden" name="intent" value="notifications" />
           <s-stack gap="base">
             <s-text-field
               name="email"
@@ -359,12 +340,7 @@ export default function Settings() {
               label="Weekly summary"
               checked={notifications.weeklyDigest || undefined}
             />
-
-            <s-button type="submit" variant="primary" loading={busy || undefined}>
-              Save notification preferences
-            </s-button>
           </s-stack>
-        </fetcher.Form>
 
         <s-paragraph>
           <s-text>
@@ -374,6 +350,10 @@ export default function Settings() {
           </s-text>
         </s-paragraph>
       </s-section>
+
+      </fetcher.Form>
+
+      <SettingsSaveBar form={formRef} saving={busy} />
 
       <s-section slot="aside" heading="Why floors are checked last">
         <s-paragraph>


### PR DESCRIPTION
Fixes #355.

## Three forms became one

Each of the three sections had its own form and its own intent, writing `{ ...existing, its own fields }` so the other two survived.

That worked — and it's also how a bug once switched **notification preferences off while saving a guardrail**. Every write had to remember what it wasn't touching, and one of them forgot.

One form now. Every field is present on every save, so nothing depends on being remembered; `{ ...existing }` remains only for settings no control on this page owns. The action has no intents left to branch on.

## That merge is what the save bar needed

Wiring it to one of three forms is worse than none: it would appear for a change in one section and not the others, and a merchant learns a bar is *unreliable* rather than that it's *partial*.

It shows on any change, saves the lot, and **Discard restores every section** rather than only the one that was touched — which is the point of them being one form.

**Deliberately not on the campaign editor.** A save bar says *"you have changed something that exists"*; the editor **creates** a campaign, and offering Discard on a thing that has never existed invites the question of what it would discard.

Two details:

- Dirty state is read from the form, not mirrored into React state. Mirroring means two sources of truth for "has this changed", and the stale one decides whether the merchant is warned before leaving.
- The pristine snapshot is retaken after a save, or the bar lingers over a form that already matches what's stored — which trains people to ignore it.

## One of my assertions passed for the wrong reason

Checking that the action "writes preferences" by looking for `weeklyDigest` in a slice running to the end of the file matched **the form input**, so deleting the entire `writePreferences` call still passed. Mutation testing caught it; scoped to the action body it now fails with *"writePreferences is not written by the single save"*.

| Mutant | Caught |
|---|---|
| per-section intent comes back | ✓ |
| single save stops writing preferences | ✓ (after the fix above) |

## Checks

- `npm test` — 1719 passed
- `npm run test:chaos` — 140 passed
- `npm run typecheck`, `npm run build`, `npm run lint` — clean