### PR TITLE
A spatial and typographic scale, applied to the shared primitives

### DIFF
--- a/app/components/AsyncState.tsx
+++ b/app/components/AsyncState.tsx
@@ -1,3 +1,5 @@
+import { PAD, SPACE } from "../lib/ui/spacing";
+
 /**
  * The three states a data-bearing section can be in, in one place.
  *
@@ -15,17 +17,30 @@ export interface EmptyStateProps {
   action?: { label: string; href: string };
 }
 
+/**
+ * Nothing here, said deliberately.
+ *
+ * Centred and given block padding, because the failure mode of an empty state is looking
+ * like a rendering accident. Left-aligned at the top of a full-width card, a title and
+ * one sentence read as the beginning of content that did not arrive; the same words in
+ * the middle of an obviously intentional space read as an answer.
+ *
+ * The three parts sit at item rhythm: the title, the reason and the way out are one
+ * thought, and spacing them apart makes the merchant read three unrelated things.
+ */
 export function EmptyState({ title, description, action }: EmptyStateProps) {
   return (
-    <s-stack gap="base">
-      <s-heading>{title}</s-heading>
-      {description ? (
-        <s-paragraph>
-          <s-text>{description}</s-text>
-        </s-paragraph>
-      ) : null}
-      {action ? <s-button href={action.href}>{action.label}</s-button> : null}
-    </s-stack>
+    <s-box paddingBlock={PAD.block}>
+      <s-stack gap={SPACE.item} alignItems="center">
+        <s-heading>{title}</s-heading>
+        {description ? (
+          <s-paragraph>
+            <s-text color="subdued">{description}</s-text>
+          </s-paragraph>
+        ) : null}
+        {action ? <s-button href={action.href}>{action.label}</s-button> : null}
+      </s-stack>
+    </s-box>
   );
 }
 
@@ -48,19 +63,28 @@ export function InlineError({
       <s-paragraph>{message}</s-paragraph>
       {errorId ? (
         <s-paragraph>
-          <s-text>Reference {errorId}</s-text>
+          {/* Subdued, not because it matters less -- it is the whole point of the id --
+              but because it is a string to copy rather than a sentence to read, and it
+              should not compete with the message that tells the merchant what broke. */}
+          <s-text color="subdued">Reference {errorId}</s-text>
         </s-paragraph>
       ) : null}
     </s-banner>
   );
 }
 
-/** A section waiting on a fetcher, as opposed to a whole-page navigation. */
+/**
+ * A section waiting on a fetcher, as opposed to a whole-page navigation.
+ *
+ * Item rhythm and a shared centre line: a spinner and its label are one object, and at
+ * `base` with no alignment the label sat off the spinner's centre far enough to look
+ * like two things that happened to be next to each other.
+ */
 export function InlineBusy({ label = "Working…" }: { label?: string }) {
   return (
-    <s-stack direction="inline" gap="base">
+    <s-stack direction="inline" gap={SPACE.item} alignItems="center">
       <s-spinner accessibilityLabel={label} size="base" />
-      <s-text>{label}</s-text>
+      <s-text color="subdued">{label}</s-text>
     </s-stack>
   );
 }

--- a/app/components/CountsRow.tsx
+++ b/app/components/CountsRow.tsx
@@ -1,15 +1,65 @@
 import { formatCount } from "../lib/format/display";
+import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
 
-/** A row of labelled figures, used for preview and catalogue summaries. */
+/**
+ * A row of labelled figures, used for preview and catalogue summaries.
+ *
+ * ## Why these are tiles and not a row of text
+ *
+ * It used to be four unpadded boxes in an inline stack: a label, a number, a gap, repeat.
+ * With no interior and no edge, "Will change 412 Already correct 9,081 Skipped 3" is one
+ * run of text that the reader has to parse into pairs themselves — and these four numbers
+ * are the summary of what a campaign is about to do to a live storefront. They are the
+ * most important thing on the preview page and they were the least legible.
+ *
+ * Each figure now sits in its own bounded tile: padding so the pair has room, a hairline
+ * so the boundary between one figure and the next is a line rather than an inference, and
+ * tight rhythm inside so the label and the number read as one phrase.
+ *
+ * ## Equal columns, not an inline stack
+ *
+ * A grid rather than `direction="inline"`, because an inline stack sizes each tile to its
+ * own content. "Clamped 0" then gets a third of the width of "Already correct 9,081", and
+ * a row of unequal boxes reads as a ranking — the widest looks the most important, which
+ * has nothing to do with what the numbers mean. Equal columns say these are four
+ * measurements of one thing.
+ *
+ * The template is built from the item count rather than hardcoded, so a caller passing
+ * three or five gets a full row rather than a gap on the end.
+ *
+ * **One comma.** Polaris splits a responsive value on the comma to separate "when the
+ * query matches" from "otherwise", so a `repeat(4, 1fr)` on either side of it takes its
+ * own comma as that separator and the whole value stops parsing — falling back to `none`,
+ * which stacks the tiles into a single column that looks like a deliberate layout rather
+ * than a broken string. Spelling out `1fr 1fr 1fr 1fr` is the price of that.
+ */
 export function CountsRow({ items }: { items: Array<{ label: string; value: number }> }) {
+  // `|| "1fr"` for the empty list: an empty template string leaves the responsive value
+  // ending in a bare comma, which is the unparseable shape described above.
+  const columns = items.map(() => "1fr").join(" ") || "1fr";
+
   return (
-    <s-stack direction="inline" gap="large">
+    <s-grid
+      // Two up when the card gets narrow. Four tiles in a 400px column would be four
+      // slivers, and a figure that wraps mid-number is worse than a second row.
+      gridTemplateColumns={`@container (inline-size <= 600px) 1fr 1fr, ${columns}`}
+      gap={SPACE.item}
+    >
       {items.map((item) => (
-        <s-box key={item.label}>
-          <s-text>{item.label}</s-text>
-          <s-heading>{formatCount(item.value)}</s-heading>
+        <s-box
+          key={item.label}
+          padding={PAD.card}
+          borderWidth={HAIRLINE.borderWidth}
+          borderStyle={HAIRLINE.borderStyle}
+          borderColor={HAIRLINE.borderColor}
+          borderRadius="base"
+        >
+          <s-stack gap={SPACE.tight}>
+            <s-text color="subdued">{item.label}</s-text>
+            <s-heading>{formatCount(item.value)}</s-heading>
+          </s-stack>
         </s-box>
       ))}
-    </s-stack>
+    </s-grid>
   );
 }

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import type { OnboardingState, OnboardingStep } from "../lib/onboarding/steps";
+import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
 
 /**
  * The checklist, until the first campaign has run cleanly.
@@ -20,6 +21,13 @@ import type { OnboardingState, OnboardingStep } from "../lib/onboarding/steps";
  *
  * The state comes from what the shop has actually done, never from "steps dismissed", so
  * there is nothing here to dismiss: the card retires itself when the work is real.
+ *
+ * Three rhythms, nested, and they are what make it scan as a checklist rather than a
+ * paragraph with badges in it: section rhythm between the progress line and the list,
+ * item rhythm between the steps, item rhythm again inside a step. The steps are bounded
+ * boxes for the same reason the stat tiles are — a checklist whose items have no edges
+ * is just four lines of text, and the merchant has to count the badges to work out where
+ * one step stops.
  */
 export function OnboardingCard({ state }: { state: OnboardingState }) {
   if (state.complete) return null;
@@ -28,16 +36,23 @@ export function OnboardingCard({ state }: { state: OnboardingState }) {
 
   return (
     <s-section heading="Getting started">
-      <s-stack direction="inline" gap="base">
-        <s-badge tone={done === state.steps.length ? "success" : "info"}>
-          {done} of {state.steps.length} done
-        </s-badge>
-        <s-text tone="neutral">Nothing here changes a price until you apply one.</s-text>
-      </s-stack>
+      <s-stack gap={SPACE.section}>
+        <s-stack direction="inline" gap={SPACE.item} alignItems="center">
+          <s-badge tone={done === state.steps.length ? "success" : "info"}>
+            {done} of {state.steps.length} done
+          </s-badge>
+          {/* `color="subdued"`, not `tone="neutral"`. Tone carries status, and "neutral"
+              says this sentence has none -- which is not the same as saying it is
+              supporting text, and is not what the muted rendering here was for. */}
+          <s-text color="subdued">Nothing here changes a price until you apply one.</s-text>
+        </s-stack>
 
-      {state.steps.map((step) => (
-        <Step key={step.id} step={step} isNext={step.id === state.next?.id} />
-      ))}
+        <s-stack gap={SPACE.item}>
+          {state.steps.map((step) => (
+            <Step key={step.id} step={step} isNext={step.id === state.next?.id} />
+          ))}
+        </s-stack>
+      </s-stack>
     </s-section>
   );
 }
@@ -46,31 +61,39 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
   const [why, setWhy] = useState(false);
 
   return (
-    <s-box>
-      <s-stack direction="inline" gap="base">
-        <s-badge tone={step.done ? "success" : isNext ? "info" : "neutral"}>
-          {step.done ? "Done" : isNext ? "Next" : "Later"}
-        </s-badge>
-        <s-text type="strong">{step.title}</s-text>
-        {/* Progressive disclosure, not a link away. The reasoning belongs next to the
-            step it explains — sending a merchant to a docs page to find out why they
-            are being asked to sync is how they end up not syncing.
-            
-            Before the action, deliberately. The row wraps on a narrow column, and when
-            the toggle was last it wrapped onto its own line and read as belonging to
-            the step below it. The action wrapping is harmless; an explanation attached
-            to the wrong step is not. */}
-        <s-clickable onClick={() => setWhy((open) => !open)}>
-          <s-text tone="neutral">{why ? "Hide why" : "Why?"}</s-text>
-        </s-clickable>
-        {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
-      </s-stack>
+    <s-box
+      padding={PAD.card}
+      borderWidth={HAIRLINE.borderWidth}
+      borderStyle={HAIRLINE.borderStyle}
+      borderColor={HAIRLINE.borderColor}
+      borderRadius="base"
+    >
+      <s-stack gap={SPACE.item}>
+        <s-stack direction="inline" gap={SPACE.item} alignItems="center">
+          <s-badge tone={step.done ? "success" : isNext ? "info" : "neutral"}>
+            {step.done ? "Done" : isNext ? "Next" : "Later"}
+          </s-badge>
+          <s-text type="strong">{step.title}</s-text>
+          {/* Progressive disclosure, not a link away. The reasoning belongs next to the
+              step it explains — sending a merchant to a docs page to find out why they
+              are being asked to sync is how they end up not syncing.
 
-      {why ? (
-        <s-paragraph>
-          <s-text>{step.detail}</s-text>
-        </s-paragraph>
-      ) : null}
+              Before the action, deliberately. The row wraps on a narrow column, and when
+              the toggle was last it wrapped onto its own line and read as belonging to
+              the step below it. The action wrapping is harmless; an explanation attached
+              to the wrong step is not. */}
+          <s-clickable onClick={() => setWhy((open) => !open)}>
+            <s-text color="subdued">{why ? "Hide why" : "Why?"}</s-text>
+          </s-clickable>
+          {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
+        </s-stack>
+
+        {why ? (
+          <s-paragraph>
+            <s-text color="subdued">{step.detail}</s-text>
+          </s-paragraph>
+        ) : null}
+      </s-stack>
     </s-box>
   );
 }

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -1,5 +1,7 @@
 import { Children, cloneElement, isValidElement, type ReactNode } from "react";
 
+import { SPACE } from "../lib/ui/spacing";
+
 /**
  * Every page in the app, at the full width of the screen.
  *
@@ -23,6 +25,20 @@ import { Children, cloneElement, isValidElement, type ReactNode } from "react";
  * The column collapses under 900px so the aside falls below the content rather than
  * being squeezed into something unreadable. It is a container query, not a media
  * query: the app renders in an admin iframe whose width is not the window's.
+ *
+ * ## The page rhythm lives here
+ *
+ * Both branches wrap their content in a stack at `SPACE.page`, and that is the only
+ * place in the app the distance between top-level sections is decided. Two reasons it
+ * is not left to the routes:
+ *
+ * - The two branches used to disagree. A page with an aside got `gap="base"` between its
+ *   sections; a page without one fell through to whatever `s-page` does with loose
+ *   children. Same app, two rhythms, decided by whether the page happened to have a
+ *   sidebar — which is exactly the kind of accident that reads as "unstyled".
+ * - Page rhythm has to be the largest gap on the screen to do its job. If a route can set
+ *   it, some route eventually sets it smaller than the gaps inside its own sections, and
+ *   the page stops having visible structure at all.
  */
 export function PageShell({
   heading,
@@ -41,7 +57,7 @@ export function PageShell({
   if (aside.length === 0) {
     return (
       <s-page heading={heading} inlineSize="large">
-        {main}
+        <s-stack gap={SPACE.page}>{main}</s-stack>
       </s-page>
     );
   }
@@ -49,16 +65,24 @@ export function PageShell({
   return (
     <s-page heading={heading} inlineSize="large">
       <s-grid
-        gap="base"
+        gap={SPACE.page}
+        // The column gap is the page rhythm too, not a smaller one. Two columns set
+        // closer together than the sections stacked within them read as one column of
+        // torn paper, because the strongest gap on the screen would then be running the
+        // wrong way.
+        //
         // One comma only. Polaris splits a responsive value on the comma to separate
         // "when the query matches" from "otherwise", so a `minmax(0, 1fr)` in here
         // takes its own comma as that separator and the whole value stops parsing --
         // which silently falls back to `none` and stacks the aside underneath, looking
         // exactly like a layout choice rather than a broken string.
         gridTemplateColumns="@container (inline-size <= 900px) 1fr, 1fr 22rem"
+        // Without this the aside column stretches to the height of the main content, so
+        // a one-line sidebar next to a long table becomes a very tall empty card.
+        alignItems="start"
       >
-        <s-stack gap="base">{main}</s-stack>
-        <s-stack gap="base">
+        <s-stack gap={SPACE.page}>{main}</s-stack>
+        <s-stack gap={SPACE.page}>
           {aside.map((child) =>
             // The slot is meaningless now that these are ordinary grid children, and
             // leaving it on would have them looking for a slot no ancestor provides.

--- a/app/components/SectionTabs.tsx
+++ b/app/components/SectionTabs.tsx
@@ -1,5 +1,7 @@
 import { Link, useLocation, useSearchParams } from "react-router";
 
+import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
+
 export interface SectionTab {
   href: string;
   label: string;
@@ -23,6 +25,20 @@ export interface SectionTab {
  * The current tab is matched exactly, never by prefix. A section root like `/app/prices`
  * prefixes every other tab in its section, so `startsWith` would light up the first tab
  * on every page.
+ *
+ * ## Why it now looks like navigation
+ *
+ * It used to be five links in a row with the current one in bold — no shape, no rule, no
+ * indication that the row was a control rather than a sentence. Three things fix that,
+ * and all three are structural rather than decorative:
+ *
+ * - **A rule underneath.** It closes the row, which is what makes it read as a bar
+ *   sitting above the content instead of the first line of it.
+ * - **The current tab is a filled pill**, not just bold text. Weight alone is a weak
+ *   signal in a row where every other item is a coloured link, and "which of these five
+ *   views am I looking at" is the one question this component exists to answer.
+ * - **Every tab is padded to the same box**, current or not, so nothing shifts when the
+ *   selection moves. Padding only the selected one makes the row twitch on every click.
  */
 export function SectionTabs({ tabs }: { tabs: SectionTab[] }) {
   const { pathname } = useLocation();
@@ -33,21 +49,37 @@ export function SectionTabs({ tabs }: { tabs: SectionTab[] }) {
   const query = carried.toString();
 
   return (
-    <s-stack direction="inline" gap="base">
-      {tabs.map((tab) => {
-        const current = pathname === tab.href;
-        const label = tab.badge ? `${tab.label} (${tab.badge})` : tab.label;
+    <s-box
+      // Only the block-end edge carries a width, so this is a rule under the row rather
+      // than a box around it. Polaris orders the four values block-start, block-end,
+      // inline-start, inline-end -- not the CSS order, which is the easy thing to get
+      // wrong here and produces a line down the left of the page instead.
+      borderWidth="none base none none"
+      borderStyle={HAIRLINE.borderStyle}
+      borderColor={HAIRLINE.borderColor}
+      paddingBlockEnd={SPACE.item}
+    >
+      <s-stack direction="inline" gap={SPACE.item} alignItems="center">
+        {tabs.map((tab) => {
+          const current = pathname === tab.href;
+          const label = tab.badge ? `${tab.label} (${tab.badge})` : tab.label;
 
-        return current ? (
-          <s-text key={tab.href} type="strong">
-            {label}
-          </s-text>
-        ) : (
-          <Link key={tab.href} to={query ? `${tab.href}?${query}` : tab.href}>
-            {label}
-          </Link>
-        );
-      })}
-    </s-stack>
+          return current ? (
+            <s-box
+              key={tab.href}
+              padding={PAD.control}
+              borderRadius="base"
+              background="subdued"
+            >
+              <s-text type="strong">{label}</s-text>
+            </s-box>
+          ) : (
+            <s-box key={tab.href} padding={PAD.control}>
+              <Link to={query ? `${tab.href}?${query}` : tab.href}>{label}</Link>
+            </s-box>
+          );
+        })}
+      </s-stack>
+    </s-box>
   );
 }

--- a/app/components/prices/Pagination.tsx
+++ b/app/components/prices/Pagination.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from "react-router";
 
 import { formatCount } from "../../lib/format/display";
+import { SPACE } from "../../lib/ui/spacing";
 
 /**
  * Paging, and saying where you are in the set.
@@ -12,6 +13,14 @@ import { formatCount } from "../../lib/format/display";
  *
  * `from`/`to` rather than only a page number, because "showing 51-100 of 3,412" answers
  * the question a merchant scanning for one variant is actually asking.
+ *
+ * The three parts sit at item rhythm and share a centre line: Previous, the count, Next
+ * are one control, and spacing them like separate blocks -- which `gap="base"` did -- was
+ * asking the merchant to notice three things instead of one.
+ *
+ * The count is `subdued` and tabular. Subdued because it is orientation, not the action;
+ * tabular because the digits change on every click, and proportional figures make the
+ * two buttons either side of them shuffle sideways each time.
  */
 export function Pagination({
   page,
@@ -40,11 +49,11 @@ export function Pagination({
   if (total === 0) return null;
 
   return (
-    <s-stack direction="inline" gap="base">
+    <s-stack direction="inline" gap={SPACE.item} alignItems="center">
       <s-button disabled={page <= 1 || undefined} onClick={() => goTo(page - 1)}>
         Previous
       </s-button>
-      <s-text tone="neutral">
+      <s-text color="subdued" fontVariantNumeric="tabular-nums">
         {from}–{to} of {formatCount(total)} {noun}
       </s-text>
       <s-button disabled={page >= lastPage || undefined} onClick={() => goTo(page + 1)}>

--- a/app/components/prices/VariantSearch.tsx
+++ b/app/components/prices/VariantSearch.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { FilterForm } from "../FilterForm";
+import { SPACE } from "../../lib/ui/spacing";
 
 /**
  * The search every prices tab shares, plus whatever else that tab filters on.
@@ -12,6 +13,14 @@ import { FilterForm } from "../FilterForm";
  * It merges rather than replaces, which is what lets a search survive a tab switch —
  * the tab links carry the query string, and this puts `q` back into it rather than
  * rebuilding it from scratch.
+ *
+ * The two directions take different rhythms, and that is the rule rather than an
+ * exception to it. Inline, the field and the button share one baseline and read as a
+ * single control, so they sit at item rhythm and align on their bottom edge — the label
+ * is hidden in that mode, so the two are the same height and `end` is what puts the
+ * button on the field's line rather than floating above it. Stacked, every field carries
+ * its own visible label, and item rhythm leaves that label crowding the field above it;
+ * stacked fields get section rhythm so each one owns its label.
  */
 export function VariantSearch({
   fields,
@@ -37,7 +46,11 @@ export function VariantSearch({
 }) {
   return (
     <FilterForm fields={fields}>
-      <s-stack direction={direction} gap="base">
+      <s-stack
+        direction={direction}
+        gap={direction === "inline" ? SPACE.item : SPACE.section}
+        alignItems={direction === "inline" ? "end" : undefined}
+      >
         <s-search-field
           name="q"
           label={label}
@@ -46,7 +59,17 @@ export function VariantSearch({
           value={query}
         />
         {children}
-        <s-button type="submit">Search</s-button>
+        {direction === "inline" ? (
+          <s-button type="submit">Search</s-button>
+        ) : (
+          // A block stack stretches its children, so the submit button was rendering the
+          // full width of the card -- a Search button the size of the table it filters.
+          // The row wrapper gives it back its own width without narrowing the fields
+          // above it, which is what `alignItems` on the outer stack would have done.
+          <s-stack direction="inline">
+            <s-button type="submit">Search</s-button>
+          </s-stack>
+        )}
       </s-stack>
     </FilterForm>
   );

--- a/app/lib/ui/spacing.test.ts
+++ b/app/lib/ui/spacing.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The scale, and the primitives that are supposed to be using it.
+ *
+ * The bug this guards is not a crash. It is the state the app was in before: `gap="base"`
+ * fifty-four times, `gap` with any other value thirteen times, `padding` twice in the
+ * whole codebase. Nothing was broken, everything compiled, and the app looked unstyled —
+ * because every relationship on the screen was drawn at the same distance, and spacing is
+ * the only thing telling a reader what belongs to what.
+ *
+ * That regresses one component at a time, silently, and no reviewer catches it by reading
+ * a diff that says `gap="base"`. So it is checked here instead:
+ *
+ * - the rhythms stay far enough apart on the scale to be *seen* as different, and
+ * - the shared primitives keep asking the scale rather than writing a literal.
+ *
+ * Routes are deliberately out of scope. They are a separate pass, and a test that failed
+ * on every unrevisited route would be turned off within the week.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { PAD, SPACE, type Space } from "./spacing";
+
+const ROOT = process.cwd();
+
+/**
+ * Polaris' scale in ascending order, so "is this gap bigger than that one" is an index
+ * comparison. The ordering is the part worth writing down: `small` is larger than
+ * `small-100`, and `large-100` is larger than `large`, because the numbered steps move
+ * away from the middle rather than towards it.
+ */
+const SCALE: Space[] = [
+  "small-500",
+  "small-400",
+  "small-300",
+  "small-200",
+  "small-100",
+  "small",
+  "base",
+  "large",
+  "large-100",
+  "large-200",
+  "large-300",
+  "large-400",
+  "large-500",
+];
+
+const step = (value: Space) => SCALE.indexOf(value);
+
+describe("the rhythms are ordered", () => {
+  it("gets bigger as the things it separates get further apart in meaning", () => {
+    expect(step(SPACE.tight)).toBeLessThan(step(SPACE.item));
+    expect(step(SPACE.item)).toBeLessThan(step(SPACE.section));
+    expect(step(SPACE.section)).toBeLessThan(step(SPACE.page));
+  });
+
+  it("keeps every rhythm on the scale Polaris actually accepts", () => {
+    for (const value of Object.values(SPACE)) {
+      expect(SCALE, `"${value}" is not a Polaris size keyword`).toContain(value);
+    }
+  });
+});
+
+describe("the rhythms are far enough apart to be visible", () => {
+  /**
+   * Two adjacent steps on this scale are not reliably distinguishable side by side, and a
+   * distinction a merchant cannot see is not a distinction. Two steps apart is the floor;
+   * the values chosen are further than that, which leaves room to tune one without the
+   * hierarchy collapsing.
+   */
+  it.each([
+    ["item over tight", SPACE.tight, SPACE.item],
+    ["section over item", SPACE.item, SPACE.section],
+    ["page over section", SPACE.section, SPACE.page],
+  ])("%s", (_name, smaller, larger) => {
+    expect(
+      step(larger) - step(smaller),
+      "these two rhythms are neighbours on the scale, so they will read as the same gap",
+    ).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("section padding stays inside what s-section allows", () => {
+  it("is base or none, because Polaris offers nothing else there", () => {
+    // `s-section`'s padding is typed `'base' | 'none'` only. A finer value compiles
+    // nowhere, and reaching for one is the signal that the thing wants to be an s-box.
+    expect(["base", "none"]).toContain(PAD.card);
+    expect(PAD.flush).toBe("none");
+  });
+});
+
+/**
+ * The shared primitives. Every page in the app is assembled from these, so a literal that
+ * creeps back in here is not one component drifting — it is the flat rhythm returning
+ * everywhere at once.
+ */
+const PRIMITIVES = [
+  "app/components/PageShell.tsx",
+  "app/components/SectionTabs.tsx",
+  "app/components/AsyncState.tsx",
+  "app/components/CountsRow.tsx",
+  "app/components/OnboardingCard.tsx",
+  "app/components/prices/Pagination.tsx",
+  "app/components/prices/VariantSearch.tsx",
+];
+
+describe("the shared primitives take their spacing from the scale", () => {
+  it("is looking at files that exist, so it cannot pass by checking nothing", () => {
+    for (const file of PRIMITIVES) {
+      expect(readFileSync(join(ROOT, file), "utf8").length).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(PRIMITIVES)("%s", (file) => {
+    const source = readFileSync(join(ROOT, file), "utf8");
+
+    // A literal is how the flat rhythm got in: `gap="base"` is invisible in review and
+    // means "whatever base happens to be" rather than "this is the section rhythm".
+    // `gap={SPACE.section}` says which relationship is being drawn, and moves when the
+    // scale moves.
+    const literals = [
+      ...source.matchAll(/\s(gap|padding|paddingBlock|paddingBlockEnd)="([^"]*)"/g),
+    ].map((match) => `${match[1]}="${match[2]}"`);
+
+    expect(
+      literals,
+      `${file} hardcodes spacing — use SPACE or PAD from app/lib/ui/spacing, so the ` +
+        `rhythm is named rather than guessed`,
+    ).toEqual([]);
+  });
+});

--- a/app/lib/ui/spacing.ts
+++ b/app/lib/ui/spacing.ts
@@ -1,0 +1,175 @@
+/**
+ * The app's spatial and typographic scale, in one place.
+ *
+ * ## Why this file exists
+ *
+ * Before it, the app used `gap="base"` fifty-four times, any other gap thirteen times,
+ * and `padding` twice in the entire codebase. Every relationship on the screen — a page
+ * and its sections, a section and its blocks, a button and the text beside it — was
+ * rendered at the same distance. That is not a subtle flaw. Spacing is the only signal a
+ * reader has for *what belongs to what*, so a single flat rhythm tells them nothing, and
+ * a UI that tells you nothing about its own structure is what "unstyled" actually means.
+ *
+ * The fix is not more space. It is **fewer, more different** spaces. Three rhythms that
+ * are visibly distinct beat nine that are nearly identical, because the eye reads the
+ * ratio, not the pixel count.
+ *
+ * ## The scale
+ *
+ * Polaris exposes one size scale for both `gap` and `padding`, ascending:
+ *
+ * ```
+ * small-500 … small-100  small  base  large  large-100 … large-500
+ * ```
+ *
+ * Note the ordering trap: `small` is *larger* than `small-100`, and `large-100` is
+ * *larger* than `large`. The numbered steps move away from the middle, so `small-500` is
+ * the smallest value on the scale and `large-500` the biggest.
+ *
+ * This app uses four of them, each roughly double the one below it. The doubling is the
+ * point: two adjacent steps on the Polaris scale are not reliably distinguishable, and a
+ * distinction a merchant cannot see is a distinction that is not there.
+ *
+ * | Rhythm    | Token         | Separates                                    |
+ * |-----------|---------------|----------------------------------------------|
+ * | Page      | `large-200`   | top-level sections on a page                  |
+ * | Section   | `base`        | blocks inside one section                     |
+ * | Item      | `small-100`   | related controls, list rows, badge and label  |
+ * | Tight     | `small-300`   | parts of one thing — a label over its figure  |
+ *
+ * `base` stays the section rhythm on purpose. It is what most of those fifty-four
+ * existing `gap="base"` uses already meant, so the routes that have not been revisited
+ * yet stay correct rather than becoming subtly wrong while this lands.
+ *
+ * ## Applying it
+ *
+ * - **Page rhythm** belongs to `PageShell` and nothing else. A route should never set the
+ *   distance between its own sections; the shell owns that, which is why every page in
+ *   the app has the same one.
+ * - **Section rhythm** goes between blocks that are separately readable inside a card: a
+ *   filter form and the table it filters, a paragraph and the button under it. Stacked
+ *   form fields also take section rhythm, not item rhythm — each field carries its own
+ *   label above it, and item rhythm leaves the label of one field crowding the field
+ *   above it.
+ * - **Item rhythm** goes between controls that share a baseline and read as one row:
+ *   Previous / count / Next, a badge and the sentence next to it, tabs.
+ * - **Tight rhythm** is for parts of a single object. If the two things would be read
+ *   aloud as one phrase — "Will change: 412" — they get tight rhythm.
+ *
+ * ## Padding
+ *
+ * `s-section` accepts only `base` or `none`; there is no finer control and none is
+ * needed, because a section is a card and a card has one interior. `none` is for content
+ * that must reach the card's edge — a full-bleed table — and nothing else.
+ *
+ * `s-box` takes the whole scale. It is used two ways here, and they should not be
+ * confused: a box with `PAD.card` plus a border and radius is *a card inside a card* (a
+ * stat tile, a checklist step) and should be used sparingly; a box with `PAD.control` is
+ * just a padded run of content (a tab, a chip) and carries no chrome of its own.
+ *
+ * ## Typography
+ *
+ * Polaris gives `s-heading` no size prop. Hierarchy comes from *which element you reach
+ * for*, not from a size attribute, so the rule has to be about placement:
+ *
+ * - **Page title** — the `heading` prop on `PageShell`. Exactly one per page. Never an
+ *   `s-heading` at the top of a route; that renders a second, competing title.
+ * - **Section title** — the `heading` prop on `s-section`. Not a child `s-heading`:
+ *   the prop is what lets Polaris level the document outline correctly.
+ * - **Sub-block title** — a bare `s-heading` inside a section, for a block that needs a
+ *   name but does not deserve a card of its own. This is the only place `s-heading`
+ *   should appear, plus the figure in a stat tile, where the number *is* the heading.
+ * - **Body copy** — `s-paragraph`. It is a block element and brings its own leading.
+ *   Wrapping a bare `s-text` in an `s-paragraph` adds nothing unless the text needs its
+ *   own tone or colour.
+ * - **`s-text type="strong"`** — emphasis *within* a line: the value in a label/value
+ *   pair, the name of a row, the tab you are on. It is not a small heading, and a strong
+ *   run of text on its own line is a heading written the wrong way.
+ * - **`s-text color="subdued"`** — supporting text that is true but not what the eye
+ *   should land on: the label above a figure, a reference id, a hint under a control,
+ *   "51–100 of 3,412". Never on anything actionable.
+ * - **`s-text tone="…"`** — reserved for *meaning*, not for emphasis: `success`,
+ *   `warning`, `critical`, `caution`, `info`. In particular `tone="neutral"` is not a
+ *   way to spell "quieter" — it says "this has no status", which is different, and the
+ *   app had been using it where `color="subdued"` was meant. (There is no
+ *   `tone="subdued"`; `subdued` is a colour, and passing it as a tone silently does
+ *   nothing.)
+ * - **Figures** get `fontVariantNumeric="tabular-nums"` wherever the number changes in
+ *   place — a paging count, a live total. Proportional digits make the surrounding text
+ *   jump every time the value updates.
+ */
+
+/**
+ * Polaris' size scale, ascending.
+ *
+ * Restated here rather than imported: `@shopify/polaris-types` declares `SizeKeyword`
+ * internally and does not export it, and a `satisfies` check against the real union is
+ * worth more than the DRY. If Polaris ever adds a step, the constants below still
+ * typecheck against the JSX props, which is where it would actually matter.
+ */
+export type Space =
+  | "small-500"
+  | "small-400"
+  | "small-300"
+  | "small-200"
+  | "small-100"
+  | "small"
+  | "base"
+  | "large"
+  | "large-100"
+  | "large-200"
+  | "large-300"
+  | "large-400"
+  | "large-500";
+
+/** The same scale, plus the "no padding at all" case that only padding has. */
+export type Padding = Space | "none";
+
+/**
+ * The four rhythms, largest to smallest.
+ *
+ * Ordered here the way they are ordered on screen, so the gaps between them are visible
+ * in the source too. Each step is about double the last.
+ */
+export const SPACE = {
+  /** Between top-level sections. Owned by `PageShell`; routes do not set this. */
+  page: "large-200",
+  /** Between separately readable blocks inside one section, and between stacked fields. */
+  section: "base",
+  /** Between controls that read as one row, and between rows of a short list. */
+  item: "small-100",
+  /** Between parts of a single object — a label and the figure it names. */
+  tight: "small-300",
+} as const satisfies Record<string, Space>;
+
+/**
+ * Interiors.
+ *
+ * Deliberately short. Padding is where a design gets away from itself fastest, and four
+ * named interiors cover everything this app renders.
+ */
+export const PAD = {
+  /** An `s-section`'s interior, and an `s-box` standing in for a card. */
+  card: "base",
+  /** A padded run of content with no chrome: a tab, a chip, a table cell stand-in. */
+  control: "small-100 base",
+  /** Vertical breathing room around a block that is mostly empty — an empty state. */
+  block: "large-200",
+  /** Content that must reach the card's edge. A full-bleed table, and little else. */
+  flush: "none",
+} as const;
+
+/**
+ * The hairline used for tiles and sub-navigation rules.
+ *
+ * Grouped as one object because a border is three props that must agree, and only two of
+ * them have useful defaults. A width set on its own inherits the default colour `base`,
+ * which is heavier than a divider wants — a row of stat tiles outlined in it reads as a
+ * spreadsheet rather than as grouping. Spreading one constant is how the three stay
+ * together.
+ */
+export const HAIRLINE = {
+  borderWidth: "base",
+  borderStyle: "solid",
+  borderColor: "subdued",
+} as const;


### PR DESCRIPTION
The UI reads as unstyled. This is why, measured:

- `gap="base"` × **54**; any other gap × 13; `padding` used **twice in the entire codebase**.
- So a page and its sections, a section and its blocks, and a button and the text beside it all render at the same distance.

Spacing is the only signal a reader has for *what belongs to what*. One flat rhythm tells them nothing — and a UI that tells you nothing about its own structure is what "unstyled" means.

## The fix is fewer, more different spaces

Four rhythms, each roughly **double** the one below. Two adjacent Polaris steps aren't reliably distinguishable, and a distinction a merchant can't see isn't there.

| Rhythm | Token | Separates |
|---|---|---|
| Page | `large-200` | top-level sections — owned by `PageShell` alone |
| Section | `base` | separately readable blocks inside a card |
| Item | `small-100` | controls sharing a baseline — Previous/count/Next |
| Tight | `small-300` | parts of one object — a label over its figure |

`base` stays the section rhythm **on purpose**, so the 46 untouched `gap="base"` uses in routes stay correct rather than becoming subtly wrong while this lands.

`app/lib/ui/spacing.ts` carries the reasoning, including the ordering trap: `small` is *larger* than `small-100`, `large-100` *larger* than `large`.

## Typography, given Polaris gives `s-heading` no size prop

Hierarchy comes from which element you reach for: the `heading` **prop** on `s-section` levels the outline; a bare `s-heading` is a sub-block; `type="strong"` is emphasis *within a line*, never a small heading.

**There is no `tone="subdued"`.** `subdued` is a *colour*; passing it as a tone silently does nothing. The app used `tone="neutral"` for de-emphasis, which actually asserts *"this has no status"* — a different statement. Converted here; 16 remain in routes.

## Two real defects found on the way

- **`PageShell` used different rhythms depending on whether a page had an aside** — same app, two spacings, decided by whether there was a sidebar.
- **`VariantSearch`'s block mode stretched its submit button to the full card width**, because a block stack stretches its children.

## The biggest visual change

`CountsRow` — four unpadded boxes in an *inline* stack, which sized each tile to its content. So "Clamped 0" got a third the width of "Already correct 9,081", and the row summarising what a campaign is about to do to a live storefront read as a ranking. Equal-column grid now, bordered and padded.

## Guarded

`spacing.test.ts` asserts the rhythms are ordered **and at least two scale steps apart**, and that the shared primitives never hardcode a gap. Reverting the page rhythm to `base` fails with *"these two rhythms are neighbours on the scale, so they will read as the same gap"*.

## Checks

- `npm test` — **1733 passed** (was 1719; +14 new, none lost or modified)
- `npm run test:chaos` — 140 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors

No route touched, no loader or action altered, no test edited or deleted, no CSS file or `style=` hack added. Pages follow next, one at a time.