### PR TITLE
Put sections straight into the page again: wrapping them renders blank

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -78,8 +78,14 @@ describe("pages without an aside", () => {
     </PageShell>,
   );
 
-  it("do not pay for a two-column grid", () => {
+  it("put their sections straight into the page, with no wrapper", () => {
+    // Not a style preference. Wrapping them — in an `s-stack`, and then in a
+    // single-column `s-grid` — rendered the page blank in the admin: heading present,
+    // every section gone, no error. Both were found by opening the page, so this
+    // assertion is the only thing standing between the next tidy-up and a blank page.
     expect(html).not.toContain("<s-grid");
+    expect(html).not.toContain("<s-stack");
+    expect(html).toContain("just rows");
   });
 
   it("still render their content", () => {

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -55,9 +55,22 @@ export function PageShell({
   const main = all.filter((child) => !isAside(child));
 
   if (aside.length === 0) {
+    // Children go straight into `s-page`, with no wrapper of any kind.
+    //
+    // This looks inconsistent with the two-column branch below, which wraps its columns
+    // in stacks, and it is deliberate. Wrapping here — in an `s-stack`, and then in a
+    // single-column `s-grid` — rendered the page *blank* in the admin: the heading
+    // appeared and every section vanished, with no error and nothing in the console.
+    // Both were caught by opening the page; neither was caught by a test, because the
+    // markup serialises fine and Polaris' layout only runs in the browser.
+    //
+    // So `s-page` owns the spacing between its own direct sections, and the page rhythm
+    // in `spacing.ts` applies to content this component nests deliberately. Do not
+    // "tidy" this into matching the branch below without loading a page that has no
+    // aside — `/app/prices/live` is one — and looking at it.
     return (
       <s-page heading={heading} inlineSize="large">
-        <s-stack gap={SPACE.page}>{main}</s-stack>
+        {main}
       </s-page>
     );
   }


### PR DESCRIPTION
Fixes a regression I shipped in #360.

## What broke

The foundation pass wrapped `PageShell`'s no-aside branch in an `s-stack`, so both branches would share the page rhythm. In the admin that renders the page **blank** — heading present, every section gone, **no error and nothing in the console**.

`/app/prices/live` is one such page, and it had rendered fine an hour earlier.

## The wrong second guess

I assumed the difference was the `s-grid` that the two-column branch nests its stacks inside, and tried a single-column grid. **Same blank page.** The assumption was wrong and the second attempt cost as much as the first.

## The fix

Children go straight into `s-page`, exactly as before. `s-page` owns the spacing between its own direct sections; the page rhythm in `spacing.ts` applies to content `PageShell` nests deliberately.

The two branches now look inconsistent. They are not — one of them is load-bearing, and the comment says so, naming a page to check.

## Why no test caught it

The markup serialises perfectly. Polaris' layout only runs in the browser, and the app renders in a cross-origin admin iframe that the accessibility tree cannot see into — so a screenshot is the only instrument available.

The assertion added here is the next best thing: it fails if anyone wraps that branch again, and explains why. Mutation-tested by putting the `s-stack` back.

## Worth recording

The agent that wrote the original change **flagged this exact line** as the one thing it could not verify without a browser. It was right to flag it, and I shipped it anyway rather than checking first. That ordering is the actual lesson.

## Checks

- `npm test` — 1733 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors