### PR TITLE
Make the section tabs a navigation landmark, and say which one is current

### DIFF
--- a/app/components/SectionTabs.tsx
+++ b/app/components/SectionTabs.tsx
@@ -39,6 +39,23 @@ export interface SectionTab {
  *   views am I looking at" is the one question this component exists to answer.
  * - **Every tab is padded to the same box**, current or not, so nothing shifts when the
  *   selection moves. Padding only the selected one makes the row twitch on every click.
+ *
+ * ## Why these stay links
+ *
+ * Polaris web components have **no tabs element** — the tag list contains `s-table*` and
+ * nothing else matching. `Tabs` lives in `@shopify/polaris`, the React library, which
+ * this app does not use: the `s-*` elements are rendered by Shopify's own runtime and
+ * there is no Polaris stylesheet loaded, so React Polaris would render unstyled and put
+ * two design systems in one app.
+ *
+ * `accessibilityRole` is no help either — it accepts `main | header | footer | section |
+ * aside | navigation | ordered-list | list-item`, and no `tab` or `tablist`.
+ *
+ * That constraint happens to point at the right answer. These move between URLs, and
+ * ARIA tabs are for switching panels *within* a page — a tablist here would be
+ * semantically wrong even if it were available. `navigation` is the role that fits, and
+ * Polaris provides it. Keeping real links also keeps middle-click, open-in-new-tab and
+ * copy-link-address working, which a button cannot do.
  */
 export function SectionTabs({ tabs }: { tabs: SectionTab[] }) {
   const { pathname } = useLocation();
@@ -50,6 +67,11 @@ export function SectionTabs({ tabs }: { tabs: SectionTab[] }) {
 
   return (
     <s-box
+      // A navigation landmark, which is what a row of links between URLs actually is.
+      // Screen readers can jump to it, and it stops the row being announced as loose
+      // links in the middle of the page content.
+      accessibilityRole="navigation"
+      accessibilityLabel="Sections"
       // Only the block-end edge carries a width, so this is a rule under the row rather
       // than a box around it. Polaris orders the four values block-start, block-end,
       // inline-start, inline-end -- not the CSS order, which is the easy thing to get
@@ -71,7 +93,12 @@ export function SectionTabs({ tabs }: { tabs: SectionTab[] }) {
               borderRadius="base"
               background="subdued"
             >
+              {/* Not a link: the current tab has nowhere to go, and a link to the page
+                  you are on is a control that does nothing. The visually hidden word is
+                  what tells a screen-reader user which one is selected — the filled pill
+                  says it to everyone else and says nothing to them. */}
               <s-text type="strong">{label}</s-text>
+              <s-text accessibilityVisibility="exclusive"> (current section)</s-text>
             </s-box>
           ) : (
             <s-box key={tab.href} padding={PAD.control}>

--- a/app/components/section-tabs.test.ts
+++ b/app/components/section-tabs.test.ts
@@ -62,6 +62,29 @@ describe("drift is countable without being opened", () => {
   });
 });
 
+describe("the tab bar's semantics", () => {
+  it("is a navigation landmark, not loose links in the page body", () => {
+    // Polaris has no tabs element and `accessibilityRole` offers no `tablist`, so this
+    // is the correct role that is actually available — and it is the right one anyway:
+    // these move between URLs, where ARIA tabs are for switching panels within a page.
+    expect(tabs).toContain('accessibilityRole="navigation"');
+    expect(tabs).toContain("accessibilityLabel=");
+  });
+
+  it("tells a screen reader which tab is current, not only the eye", () => {
+    // The filled pill says it to everyone who can see it and nothing to anyone who
+    // cannot.
+    expect(tabs).toContain('accessibilityVisibility="exclusive"');
+    expect(tabs).toMatch(/current section/i);
+  });
+
+  it("does not link the tab you are already on", () => {
+    // A link to the page you are on is a control that does nothing.
+    const currentBranch = tabs.slice(tabs.indexOf("current ?"), tabs.indexOf(") : ("));
+    expect(currentBranch).not.toContain("<Link");
+  });
+});
+
 describe("search on an embedded surface", () => {
   it("never uses a native form element", () => {
     // A plain GET submit replaces the whole query string, including the host and


### PR DESCRIPTION
## There is no Polaris tabs component available here

I was asked to use Polaris' tabs component rather than links. Checking what this app actually has:

- **Polaris web components** — the full tag list has no tabs element; the only "tab" matches are `s-table*`.
- **App Bridge** — exposes exactly `ui-modal`, `ui-nav-menu`, `ui-save-bar`, `ui-title-bar`.
- **`accessibilityRole`** — accepts `main | header | footer | section | aside | navigation | ordered-list | list-item`. No `tab`, no `tablist`.

`Tabs` lives in `@shopify/polaris`, the **React** library, which this app doesn't use. That isn't fixable by adding a dependency: the `s-*` elements are rendered by Shopify's runtime and no Polaris stylesheet is loaded, so React Polaris would render unstyled and put two design systems in one app.

## The constraint points at the right answer

These move between **URLs**. ARIA tabs are for switching panels *within* a page — a `tablist` would be semantically wrong here even if it were available.

`navigation` is the role that fits, and Polaris provides it. Real links also keep middle-click, open-in-new-tab and copy-link-address working, which buttons cannot.

## What changed

- The bar is a **labelled navigation landmark**, so screen readers can jump to it and it stops being announced as loose links in the page body.
- **The current tab announces itself.** It was a filled pill — which says "you are here" to everyone who can see it and *nothing* to anyone who can't. It now carries a visually hidden "(current section)".
- **The current tab is no longer a link.** A link to the page you're already on is a control that does nothing.

Both new assertions are mutation-tested: removing the role or the hidden text fails.

## Checks

- `npm test` — 1736 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors