### PR TITLE
Use the prop that means what we mean: colour for emphasis, tone for status

### DIFF
--- a/app/components/CalendarGrid.tsx
+++ b/app/components/CalendarGrid.tsx
@@ -28,7 +28,7 @@ export function CalendarGrid({ days, today }: { days: CalendarDay[]; today: stri
       <s-grid gridTemplateColumns="repeat(7, 1fr)" gap="small-200">
         {WEEKDAYS.map((weekday) => (
           <s-box key={weekday} padding="small-200">
-            <s-text tone="neutral">{weekday}</s-text>
+            <s-text color="subdued">{weekday}</s-text>
           </s-box>
         ))}
       </s-grid>

--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -19,7 +19,7 @@ export function DraftPreview({ preview }: { preview: Preview | null }) {
   if (!preview) {
     return (
       <s-paragraph>
-        <s-text tone="neutral">Set a rule to see what it would do.</s-text>
+        <s-text color="subdued">Set a rule to see what it would do.</s-text>
       </s-paragraph>
     );
   }
@@ -39,7 +39,7 @@ export function DraftPreview({ preview }: { preview: Preview | null }) {
   if (preview.matched === 0) {
     return (
       <s-paragraph>
-        <s-text tone="neutral">Nothing matches this scope yet.</s-text>
+        <s-text color="subdued">Nothing matches this scope yet.</s-text>
       </s-paragraph>
     );
   }
@@ -57,7 +57,7 @@ export function DraftPreview({ preview }: { preview: Preview | null }) {
           needs the other 20 explained here rather than after the run. */}
       {preview.alreadyCorrect > 0 ? (
         <s-paragraph>
-          <s-text tone="neutral">
+          <s-text color="subdued">
             {formatCount(preview.alreadyCorrect)} already at this price.
           </s-text>
         </s-paragraph>
@@ -97,7 +97,7 @@ export function DraftPreview({ preview }: { preview: Preview | null }) {
                   {row.skippedReason ? (
                     <s-text tone="caution">{row.skippedReason}</s-text>
                   ) : row.unchanged ? (
-                    <s-text tone="neutral">no change</s-text>
+                    <s-text color="subdued">no change</s-text>
                   ) : (
                     <s-text>
                       {row.after ?? "—"}
@@ -113,7 +113,7 @@ export function DraftPreview({ preview }: { preview: Preview | null }) {
 
       {preview.changing + preview.alreadyCorrect + preview.skipped > preview.rows.length ? (
         <s-paragraph>
-          <s-text tone="neutral">
+          <s-text color="subdued">
             Showing the first {formatCount(preview.rows.length)}. Every row is priced the
             same way.
           </s-text>

--- a/app/components/RunResultSection.tsx
+++ b/app/components/RunResultSection.tsx
@@ -94,7 +94,7 @@ export function RunResultSection({ result }: { result: CampaignResult }) {
       ) : null}
 
       <s-paragraph>
-        <s-text tone="neutral">{result.unavailable}</s-text>
+        <s-text color="subdued">{result.unavailable}</s-text>
       </s-paragraph>
     </s-section>
   );
@@ -104,7 +104,7 @@ function Count({ label, value }: { label: string; value: number }) {
   return (
     <s-stack gap="none">
       <s-text type="strong">{formatCount(value)}</s-text>
-      <s-text tone="neutral">{label}</s-text>
+      <s-text color="subdued">{label}</s-text>
     </s-stack>
   );
 }

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -121,7 +121,7 @@ export function CampaignListView({
               {list.page > 1 ? (
                 <s-link href={linkTo({ page: String(list.page - 1) })}>Previous</s-link>
               ) : null}
-              <s-text tone="neutral">
+              <s-text color="subdued">
                 Page {list.page} of {list.pages} · {list.total} campaigns
               </s-text>
               {list.page < list.pages ? (

--- a/app/components/campaign/CampaignPreviewTab.tsx
+++ b/app/components/campaign/CampaignPreviewTab.tsx
@@ -83,7 +83,7 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
             <s-paragraph>
               {/* Said plainly, because overstating causality in a pricing tool is how
                   merchants make expensive decisions on bad inference. */}
-              <s-text tone="neutral">
+              <s-text color="subdued">
                 This is arithmetic on your prices and costs. It does not predict what you
                 will sell.
               </s-text>

--- a/app/lib/ui/polaris-props.test.ts
+++ b/app/lib/ui/polaris-props.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Using the prop that means what we mean.
+ *
+ * Polaris separates two things the app had been conflating:
+ *
+ *   `tone`  — status. success, warning, critical, caution, info, and `neutral`, which
+ *             asserts *"this has no status"*.
+ *   `color` — emphasis. `base`, `strong`, and `subdued`.
+ *
+ * De-emphasised text was written as `tone="neutral"` in fifteen places. That renders
+ * close enough to pass a glance, and it is a different statement: it says a timestamp,
+ * a currency code and a "Jump to" label each have a *status*, and that the status is
+ * none. On a badge that is exactly right — a `neutral` badge is how "Frozen" says it is
+ * a state rather than a warning. On body text it is a category error.
+ *
+ * There is also no `tone="subdued"`: `subdued` is a colour, so the version of this
+ * mistake that reaches for the right word silently does nothing at all.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const APP = join(process.cwd(), "app");
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+/** Routes that deliberately render outside the embedded admin, with their own CSS. */
+const OUTSIDE_THE_ADMIN = ["routes/_index", "routes/help.$"];
+
+const files = tsxFiles(APP)
+  .filter((path) => !OUTSIDE_THE_ADMIN.some((skip) => path.includes(skip)))
+  .map((path) => ({ path: path.replace(`${APP}/`, ""), source: readFileSync(path, "utf8") }));
+
+describe("emphasis is a colour, status is a tone", () => {
+  it("finds files to check", () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it("never de-emphasises text with a status tone", () => {
+    const offenders = files
+      .filter(({ source }) => /<s-text\b[^>]*\stone="neutral"/.test(source))
+      .map(({ path }) => path);
+
+    expect(
+      offenders,
+      'these say body text has "no status" when they mean it is quieter — use color="subdued"',
+    ).toEqual([]);
+  });
+
+  it("never passes subdued as a tone, which silently does nothing", () => {
+    const offenders = files
+      .filter(({ source }) => source.includes('tone="subdued"'))
+      .map(({ path }) => path);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("still allows a neutral badge, which is a real status", () => {
+    // "Frozen" is a state, not a warning. Removing this would be the overcorrection.
+    const badges = files.filter(({ source }) => /<s-badge\b[^>]*\stone="neutral"/.test(source));
+    expect(badges.length, "the neutral badge should not have been swept up").toBeGreaterThan(0);
+  });
+});
+
+describe("native HTML inside the embedded app", () => {
+  /**
+   * Three places use it and each is unavoidable, so they are listed rather than
+   * forbidden — the list is what makes a *fourth* one visible in review.
+   */
+  const ALLOWED = new Map([
+    // `ui-save-bar` is an App Bridge element whose own types augment
+    // `ButtonHTMLAttributes`: native buttons are the documented children.
+    ["components/SettingsSaveBar.tsx", "ui-save-bar requires native buttons"],
+    // Polaris has no monospace or code text — `s-text`'s types are the only option and
+    // offer address/redundant/strong/generic. A stack trace needs preserved whitespace.
+    ["components/ErrorScreen.tsx", "no Polaris equivalent for a stack trace"],
+    ["routes/app.settings.diagnostics.tsx", "no Polaris equivalent for a stack trace"],
+    // No progress component exists; `s-spinner` is indeterminate and has no bar form.
+    ["components/RouteProgress.tsx", "no Polaris progress bar"],
+  ]);
+
+  it("is confined to the cases that have no Polaris equivalent", () => {
+    const offenders = files
+      .filter(({ source }) => /<(pre|button|div|span|table|h[1-6])[\s>]/.test(source))
+      .map(({ path }) => path)
+      .filter((path) => !ALLOWED.has(path));
+
+    expect(
+      offenders,
+      "these use native HTML where a Polaris component exists — and native elements " +
+        "carry none of the admin's styling, so they render as unstyled browser defaults",
+    ).toEqual([]);
+  });
+
+  it("keeps the allow-list honest by requiring each entry to still exist", () => {
+    for (const [path] of ALLOWED) {
+      expect(() => statSync(join(APP, path)), `${path} is allow-listed but gone`).not.toThrow();
+    }
+  });
+});

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -347,7 +347,7 @@ export default function CampaignDetail() {
           <s-badge tone={lifecycle.tone === "critical" ? "critical" : lifecycle.tone === "warning" ? "warning" : "info"}>
             {lifecycle.label}
           </s-badge>
-          {scheduleText ? <s-text tone="neutral">{scheduleText}</s-text> : null}
+          {scheduleText ? <s-text color="subdued">{scheduleText}</s-text> : null}
         </s-stack>
         <CampaignActions {...detail} />
       </s-section>

--- a/app/routes/app.imports._index.tsx
+++ b/app/routes/app.imports._index.tsx
@@ -80,7 +80,7 @@ export default function Imports() {
                 {imports.map((row) => (
                   <s-table-row key={row.id}>
                     <s-table-cell>
-                      {row.name} <s-text tone="neutral">({row.currency})</s-text>
+                      {row.name} <s-text color="subdued">({row.currency})</s-text>
                     </s-table-cell>
                     <s-table-cell>{row.createdAt}</s-table-cell>
                     <s-table-cell>{formatCount(row.rowsRead)}</s-table-cell>
@@ -101,7 +101,7 @@ export default function Imports() {
               </s-table-body>
             </s-table>
             <s-paragraph>
-              <s-text tone="neutral">Times are your store&rsquo;s, in {timeZone}.</s-text>
+              <s-text color="subdued">Times are your store&rsquo;s, in {timeZone}.</s-text>
             </s-paragraph>
           </>
         )}

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -144,7 +144,7 @@ export default function Settings() {
           and splitting them across pages is what made the nav sixteen items long. */}
       <s-section>
         <s-stack direction="inline" gap="base">
-          <s-text tone="neutral">Jump to</s-text>
+          <s-text color="subdued">Jump to</s-text>
           <s-link href="#guardrails">Guardrails</s-link>
           <s-link href="#rounding">Rounding</s-link>
           <s-link href="#notifications">Alerts</s-link>


### PR DESCRIPTION
Part of the "use standard Polaris components properly" pass. Kept separate from the tab-semantics change (#362).

## Two props, conflated

| Prop | Carries | Values |
|---|---|---|
| `tone` | **status** | success, warning, critical, caution, info, `neutral` |
| `color` | **emphasis** | base, strong, `subdued` |

`neutral` asserts *"this has no status"*. Fourteen pieces of de-emphasised body text were written as `tone="neutral"` — which renders close enough to pass a glance, and says something different: that a timestamp, a currency code and a "Jump to" label each have a status, and the status is none.

**On a badge it is exactly right**, which is why `<s-badge tone="neutral">Frozen</s-badge>` stays. A neutral badge is how a *state* says it's a state rather than a warning. Sweeping it up would have been the overcorrection, and there's an assertion that it survives.

There is also **no `tone="subdued"`** — `subdued` is a colour — so the version of this mistake that reaches for the right word does nothing at all. Also pinned.

## The native-HTML allow-list

The same test lists the four places native HTML is genuinely unavoidable, each with its reason:

| File | Why |
|---|---|
| `SettingsSaveBar` | `ui-save-bar`'s own types augment `ButtonHTMLAttributes` — native buttons are its documented children |
| `ErrorScreen`, `diagnostics` | Polaris has no monospace or code text; a stack trace needs preserved whitespace |
| `RouteProgress` | no progress bar exists, only an indeterminate `s-spinner` |

**Listing them rather than forbidding them is the point** — the list is what makes a *fifth* one visible in review.

## Mutants

| Mutant | Caught |
|---|---|
| regress one text back to `tone="neutral"` | ✓ |
| over-correct and strip the neutral badge | ✓ |
| introduce native HTML in a new file | ✓ |

## Checks

- `npm test` — 1742 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors