### PR TITLE
Size filter controls to what they hold, not to the card

### DIFF
--- a/app/components/prices/VariantSearch.tsx
+++ b/app/components/prices/VariantSearch.tsx
@@ -46,31 +46,58 @@ export function VariantSearch({
 }) {
   return (
     <FilterForm fields={fields}>
-      <s-stack
-        direction={direction}
-        gap={direction === "inline" ? SPACE.item : SPACE.section}
-        alignItems={direction === "inline" ? "end" : undefined}
-      >
-        <s-search-field
-          name="q"
-          label={label}
-          labelAccessibilityVisibility={direction === "inline" ? "exclusive" : undefined}
-          placeholder={placeholder}
-          value={query}
-        />
-        {children}
-        {direction === "inline" ? (
+      {direction === "inline" ? (
+        <s-stack direction="inline" gap={SPACE.item} alignItems="end">
+          <s-search-field
+            name="q"
+            label={label}
+            labelAccessibilityVisibility="exclusive"
+            placeholder={placeholder}
+            value={query}
+          />
+          {children}
           <s-button type="submit">Search</s-button>
-        ) : (
-          // A block stack stretches its children, so the submit button was rendering the
-          // full width of the card -- a Search button the size of the table it filters.
-          // The row wrapper gives it back its own width without narrowing the fields
-          // above it, which is what `alignItems` on the outer stack would have done.
-          <s-stack direction="inline">
+        </s-stack>
+      ) : (
+        // A grid, not a vertical stack.
+        //
+        // Stacked, every control took the full width of the card: a "Surface" select
+        // holding the word "Every" rendered twelve hundred pixels wide. That is the
+        // single most unstyled-looking thing in the app, and it is not a width problem
+        // — the page is exactly as wide as it should be. It is a control that does not
+        // know how much room it needs.
+        //
+        // The earlier comment here warned that three selects inline "wrap into
+        // something unreadable". True of `s-stack direction="inline"`, which wraps
+        // wherever it runs out; a grid places them in named columns and re-flows to one
+        // column below 700px instead.
+        //
+        // `1fr 1fr 1fr`, never `repeat(3, 1fr)`: Polaris splits a responsive value on
+        // the comma to separate the two branches, so a comma inside a value makes the
+        // whole thing unparseable and it silently falls back to `none`.
+        <s-stack gap={SPACE.section}>
+          <s-grid
+            gap={SPACE.section}
+            gridTemplateColumns="@container (inline-size <= 700px) 1fr, 1fr 1fr 1fr"
+          >
+            <s-grid-item gridColumn="span 2">
+              <s-search-field
+                name="q"
+                label={label}
+                placeholder={placeholder}
+                value={query}
+              />
+            </s-grid-item>
+            {children}
+          </s-grid>
+
+          {/* Its own row, so the button keeps its natural width. A block stack stretches
+              its children, which is how this rendered as a full-width submit bar. */}
+          <s-stack direction="inline" gap={SPACE.item}>
             <s-button type="submit">Search</s-button>
           </s-stack>
-        )}
-      </s-stack>
+        </s-stack>
+      )}
     </FilterForm>
   );
 }

--- a/app/components/prices/tabs-layout.test.ts
+++ b/app/components/prices/tabs-layout.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Controls are sized to what they hold.
+ *
+ * Stacked in a block, every Polaris field takes the full width of its card: a "Surface"
+ * select holding the word "Every" rendered twelve hundred pixels wide. That is the most
+ * unstyled-looking thing in the app, and it is not a width problem — the page is exactly
+ * as wide as it should be. It is a control that does not know how much room it needs.
+ *
+ * Fields have no width prop, so the fix is layout: a grid with named columns rather than
+ * a stack that stretches its children.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const search = readFileSync(
+  join(process.cwd(), "app", "components", "prices", "VariantSearch.tsx"),
+  "utf8",
+);
+
+describe("the filter block", () => {
+  it("lays its controls out in a grid, not a stretching stack", () => {
+    expect(search).toContain("<s-grid");
+    expect(search).toContain("<s-grid-item");
+  });
+
+  it("re-flows to one column on a narrow container", () => {
+    expect(search).toMatch(/@container[^"]*inline-size <= 700px/);
+  });
+
+  it("carries exactly one comma, so the value parses", () => {
+    // `repeat(3, 1fr)` is the obvious way to write three columns and it is unparseable:
+    // Polaris splits a responsive value on the comma to separate the two branches, so
+    // the value falls back to `none` and every control goes full width again — which
+    // looks exactly like the bug this fixes.
+    const value = /gridTemplateColumns="([^"]+)"/.exec(search)?.[1] ?? "";
+    expect(value.split(",").length - 1, `"${value}" has a comma inside a value`).toBe(1);
+    expect(value).not.toContain("repeat(");
+  });
+
+  it("keeps the submit button at its natural width", () => {
+    // A block stack stretches its children, which rendered the button as a full-width
+    // bar across the card.
+    const afterGrid = search.slice(search.indexOf("</s-grid>"));
+    expect(afterGrid).toContain('direction="inline"');
+    expect(afterGrid).toContain("Search");
+  });
+});

--- a/app/routes/app.prices.baselines.tsx
+++ b/app/routes/app.prices.baselines.tsx
@@ -101,12 +101,16 @@ export default function Baselines() {
               ))}
             </s-select>
 
-            <s-checkbox
+            {/* Its own full row. A checkbox is a tick and a sentence, not a field, so
+                a column sized for a select leaves it stranded in white space. */}
+            <s-grid-item gridColumn="span 3">
+              <s-checkbox
               name="diverged"
               value="1"
               label="Only variants whose live price differs from their baseline"
               checked={filters.divergedOnly || undefined}
             />
+            </s-grid-item>
 
         </VariantSearch>
 


### PR DESCRIPTION
## The actual problem behind "so much space on either sides"

A **"Surface" select holding the word "Every" rendered ~1230px wide.** So did "Controlled by", "Show", and every search box on the prices tabs.

This is the most unstyled-looking thing in the app, and it is **not a width problem** — the page is exactly as wide as it should be. It's a control that doesn't know how much room it needs. Widening the page further would have made it worse.

## The fix is layout, not width

Polaris fields carry no width prop. So `VariantSearch`'s block mode is now a **grid with named columns** rather than a stack, which stretches its children:

- search spans two columns
- each select takes one
- the whole block re-flows to a single column below 700px

The comment this replaces warned that three selects inline *"wrap into something unreadable"*. True of `s-stack direction="inline"`, which wraps wherever it runs out — a grid places them in columns and re-flows deliberately.

The baselines checkbox gets its own full row: a checkbox is a tick and a sentence, not a field, and a column sized for a select leaves it stranded.

## The trap, guarded

`1fr 1fr 1fr`, **never** `repeat(3, 1fr)`. Polaris splits a responsive value on the comma to separate its two branches, so a comma inside a value makes the whole thing unparseable — it falls back to `none` and every control goes **back to full width**, which looks exactly like the bug being fixed.

The test asserts the comma count and rejects `repeat(`. Mutation-tested:

```
AssertionError: "@container (inline-size <= 700px) 1fr, repeat(3, 1fr)"
has a comma inside a value: expected 2 to be 1
```

## Checks

- `npm test` — 1746 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors