### PR TITLE
Size form fields to what they hold, in the two longest forms

### DIFF
--- a/app/components/FieldGrid.tsx
+++ b/app/components/FieldGrid.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * Form fields laid out in columns, so a control is the size of what it holds.
+ *
+ * A Polaris field in a block stack takes the full width of its card, whatever it
+ * contains. A "Vendor" select holding one word, a "Tag" select holding one word and a
+ * "Collection" select holding one word therefore rendered as three twelve-hundred-pixel
+ * bars stacked on top of each other.
+ *
+ * That is the single most unstyled-looking thing in this app, and it is not a width
+ * problem — the page is exactly as wide as it should be. It is a control that does not
+ * know how much room it needs, and widening the page makes it worse.
+ *
+ * Fields carry no width prop, so the fix has to be layout.
+ *
+ * Two columns rather than three: these are labelled fields, not filter chips, and a
+ * label plus a select needs enough room to avoid the label wrapping onto two lines,
+ * which costs more than the space saved. Below 700px it becomes one column — a phone
+ * showing two columns of half-width selects is worse than a stack.
+ */
+export function FieldGrid({ children }: { children: ReactNode }) {
+  return (
+    <s-grid
+      gap={SPACE.section}
+      // One comma. Polaris splits a responsive value on it to separate "when the query
+      // matches" from "otherwise", so `repeat(2, 1fr)` is unparseable and falls back to
+      // `none` — which stacks everything full width again, i.e. looks exactly like the
+      // bug this component exists to fix.
+      gridTemplateColumns="@container (inline-size <= 700px) 1fr, 1fr 1fr"
+    >
+      {children}
+    </s-grid>
+  );
+}
+
+/**
+ * A field that needs the whole row.
+ *
+ * Checkboxes and anything with a sentence attached: a checkbox is a tick and a label,
+ * not a field, so a column sized for a select leaves it stranded in white space with its
+ * text wrapping under the box.
+ */
+export function FullRow({ children }: { children: ReactNode }) {
+  return <s-grid-item gridColumn="span 2">{children}</s-grid-item>;
+}

--- a/app/components/field-grid.test.ts
+++ b/app/components/field-grid.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Form controls are sized to what they hold.
+ *
+ * A Polaris field in a block stack takes the full width of its card whatever it
+ * contains, so a "Vendor" select holding one word rendered twelve hundred pixels wide —
+ * and three of them stacked read as three grey bars.
+ *
+ * It is not a width problem. The page is exactly as wide as it should be; the control
+ * does not know how much room it needs, and widening the page makes it worse. Fields
+ * carry no width prop, so the fix is layout, and this pins the two ways it silently
+ * reverts: the comma trap, and a checkbox left in a column.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const grid = readFileSync(join(process.cwd(), "app", "components", "FieldGrid.tsx"), "utf8");
+const settings = readFileSync(
+  join(process.cwd(), "app", "routes", "app.settings._index.tsx"),
+  "utf8",
+);
+const editor = readFileSync(
+  join(process.cwd(), "app", "routes", "app.campaigns.new.tsx"),
+  "utf8",
+);
+
+describe("the field grid", () => {
+  it("carries exactly one comma, so the value parses", () => {
+    // `repeat(2, 1fr)` is the obvious way to write it and is unparseable: Polaris splits
+    // a responsive value on the comma, so the whole thing falls back to `none` and every
+    // field goes full width again — which looks exactly like the bug being fixed.
+    const value = /gridTemplateColumns="([^"]+)"/.exec(grid)?.[1] ?? "";
+    expect(value.split(",").length - 1, `"${value}" has a comma inside a value`).toBe(1);
+    expect(value).not.toContain("repeat(");
+  });
+
+  it("collapses to one column on a narrow container", () => {
+    expect(grid).toMatch(/inline-size <= 700px/);
+  });
+
+  it("offers a full-row escape hatch", () => {
+    // A checkbox is a tick and a sentence, not a field. In a column sized for a select
+    // its label wraps under the box.
+    expect(grid).toContain('gridColumn="span 2"');
+  });
+});
+
+describe("the two longest forms use it", () => {
+  it.each([
+    ["settings", settings],
+    ["the campaign editor", editor],
+  ])("%s lays its fields out in the grid", (_name, source) => {
+    expect(source).toContain("<FieldGrid>");
+  });
+
+  it("gives the guardrail checkbox its own row", () => {
+    const block = settings.slice(settings.indexOf("<FieldGrid>"));
+    const checkbox = block.indexOf("neverBelowCost");
+    const fullRow = block.indexOf("<FullRow>");
+    expect(fullRow, "the checkbox is not wrapped").toBeGreaterThanOrEqual(0);
+    expect(fullRow).toBeLessThan(checkbox);
+  });
+});

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -27,6 +27,7 @@ import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/dr
 import { PageShell } from "../components/PageShell";
 import { DraftPreview } from "../components/DraftPreview";
 import { RuleValueField } from "../components/RuleValueField";
+import { FieldGrid, FullRow } from "../components/FieldGrid";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
 export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
@@ -288,7 +289,8 @@ export default function NewCampaign() {
           with AND.
         </s-paragraph>
         <FilterForm fields={SCOPE_FIELDS}>
-          <s-stack gap="base">
+          <FieldGrid>
+            <FullRow>
             <s-select name="segment" label="Saved segment">
               <s-option value="" defaultSelected={!selected.segment}>
                 Build a filter below instead
@@ -303,6 +305,7 @@ export default function NewCampaign() {
                 </s-option>
               ))}
             </s-select>
+            </FullRow>
 
             {usingSegment ? (
               <s-banner tone="info">
@@ -347,6 +350,9 @@ export default function NewCampaign() {
               ))}
             </s-select>
             <s-text-field name="title" label="Title contains" value={selected.title} />
+          </FieldGrid>
+
+          <s-stack direction="inline" gap="base">
             <s-button type="submit">Update match count</s-button>
           </s-stack>
         </FilterForm>

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -18,6 +18,7 @@ import {
 } from "../lib/money/rounding-policy";
 import { PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
+import { FieldGrid, FullRow } from "../components/FieldGrid";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -170,12 +171,14 @@ export default function Settings() {
           </s-banner>
         ) : null}
 
-          <s-stack gap="base">
+          <FieldGrid>
+            <FullRow>
             <s-checkbox
               name="neverBelowCost"
               label="Never price at or below cost"
               checked={settings.neverBelowCost || undefined}
             />
+            </FullRow>
 
             <s-number-field
               name="minMarginPercent"
@@ -218,7 +221,7 @@ export default function Settings() {
                 Fail the campaign
               </s-option>
             </s-select>
-          </s-stack>
+          </FieldGrid>
       </s-section>
 
       <s-section id="rounding" heading="Rounding">


### PR DESCRIPTION
Continues the per-page UI pass. The prices tabs got this in #364; this is settings and the campaign editor — the two longest forms in the app.

## The problem

A Polaris field in a block stack takes the **full width of its card**, whatever it contains. So "Collection", "Vendor" and "Tag" — each holding one word — rendered as three ~1200px grey bars stacked on each other.

It is **not a width problem**. The page is exactly as wide as it should be; the control doesn't know how much room it needs, and widening the page makes it worse.

## `FieldGrid`

Two columns, collapsing to one below 700px.

**Two rather than three** — these are labelled fields, not filter chips, and a label plus a select needs enough room that the label doesn't wrap onto a second line, which costs more than the space saved.

`FullRow` is the escape hatch:

- **the guardrail checkbox** — a checkbox is a tick and a sentence, not a field; in a column sized for a select its label wraps under the box
- **the saved-segment select** — it governs every other field in that block rather than sitting beside them

## The trap, guarded again

`1fr 1fr`, never `repeat(2, 1fr)`. Polaris splits a responsive value on the comma, so a comma inside a value makes the whole thing unparseable and it falls back to `none` — putting every field back to full width.

**That failure looks exactly like the bug being fixed**, which is why the test asserts the comma count rather than trusting the string. Mutation-tested, along with the checkbox losing its full row.

## Checks

- `npm test` — 1767 passed
- `npm run test:chaos` — 140 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors