### PR TITLE
The dashboard uses the shared counts row instead of its own copy

### DIFF
--- a/app/components/counts-row.test.ts
+++ b/app/components/counts-row.test.ts
@@ -1,0 +1,51 @@
+/**
+ * One implementation of the counts row, not two.
+ *
+ * The dashboard hand-rolled the same four tiles the shared component renders — an
+ * `s-box` with a label and a figure, in an inline stack. When `CountsRow` gained borders,
+ * padding and equal columns, the dashboard kept the old flat look, because it had never
+ * been using it.
+ *
+ * That is the first screen after installing, so it is the worst place in the app to be a
+ * version behind. And the duplication is invisible: both render four numbers, and only a
+ * side-by-side comparison shows one of them is the old one.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const APP = join(process.cwd(), "app");
+
+function sources(dir: string): Array<{ path: string; text: string }> {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.endsWith(".test.tsx")) return [];
+    return [{ path: path.replace(`${APP}/`, ""), text: readFileSync(path, "utf8") }];
+  });
+}
+
+describe("the counts row", () => {
+  it("is rendered by the shared component wherever it appears", () => {
+    // A label in an `s-box` immediately above a figure in an `s-heading` is the shape of
+    // a stat tile. Anywhere but CountsRow itself, it is a second copy.
+    const handRolled = sources(APP)
+      .filter(({ path }) => path !== "components/CountsRow.tsx")
+      .filter(({ text }) => /<s-box>\s*<s-text>[^<]+<\/s-text>\s*<s-heading>/.test(text))
+      .map(({ path }) => path);
+
+    expect(
+      handRolled,
+      "these draw their own stat tiles, so they will not pick up changes to CountsRow",
+    ).toEqual([]);
+  });
+
+  it("is actually used by the dashboard", () => {
+    // Guards the other direction: deleting the duplicate without adopting the component
+    // would leave the first screen with no counts at all and still pass the check above.
+    const dashboard = readFileSync(join(APP, "routes", "app._index.tsx"), "utf8");
+    expect(dashboard).toContain("<CountsRow");
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -13,6 +13,7 @@ import { syncMarkets } from "../services/markets-sync.server";
 import { syncCatalogViaBulk } from "../services/catalog-bulk-sync.server";
 import { toAdminClient } from "../services/admin-client.server";
 import { OnboardingCard } from "../components/OnboardingCard";
+import { CountsRow } from "../components/CountsRow";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { onboarding } from "../lib/onboarding/steps";
 import { withGuard } from "../lib/errors/guard.server";
@@ -249,24 +250,18 @@ export default function Dashboard() {
         </s-section>
       ) : (
         <s-section heading="Catalogue">
-          <s-stack direction="inline" gap="large">
-            <s-box>
-              <s-text>Variants</s-text>
-              <s-heading>{formatCount(health.variants)}</s-heading>
-            </s-box>
-            <s-box>
-              <s-text>With baseline</s-text>
-              <s-heading>{formatCount(health.withBaseline)}</s-heading>
-            </s-box>
-            <s-box>
-              <s-text>Not at baseline</s-text>
-              <s-heading>{formatCount(health.drifted)}</s-heading>
-            </s-box>
-            <s-box>
-              <s-text>Campaigns</s-text>
-              <s-heading>{formatCount(campaigns)}</s-heading>
-            </s-box>
-          </s-stack>
+          {/* The shared component, not a second copy of its markup. This page had
+              hand-rolled the same four tiles, so it kept the old flat look after the
+              real one gained borders and equal columns -- and it is the first screen
+              after installing, which is the worst place to be a version behind. */}
+          <CountsRow
+            items={[
+              { label: "Variants", value: health.variants },
+              { label: "With baseline", value: health.withBaseline },
+              { label: "Not at baseline", value: health.drifted },
+              { label: "Campaigns", value: campaigns },
+            ]}
+          />
 
           {health.withBaseline > health.variants ? (
             <s-paragraph>
@@ -323,7 +318,7 @@ export default function Dashboard() {
           {health.missing > 0 ? (
             <s-banner tone="warning">
               <s-paragraph>
-                {health.missing} variants have no baseline yet and cannot be included
+                {formatCount(health.missing)} variants have no baseline yet and cannot be included
                 in a campaign. Re-sync to capture them.
               </s-paragraph>
             </s-banner>
@@ -343,24 +338,14 @@ export default function Dashboard() {
 
       {!neverSynced ? (
         <s-section heading="What is live right now">
-          <s-stack direction="inline" gap="large">
-            <s-box>
-              <s-text>Campaigns running</s-text>
-              <s-heading>{formatCount(live)}</s-heading>
-            </s-box>
-            <s-box>
-              <s-text>Scheduled</s-text>
-              <s-heading>{formatCount(upcoming)}</s-heading>
-            </s-box>
-            <s-box>
-              <s-text>Need attention</s-text>
-              <s-heading>{formatCount(needsAttention)}</s-heading>
-            </s-box>
-            <s-box>
-              <s-text>Prices changed outside the app</s-text>
-              <s-heading>{formatCount(driftOpen)}</s-heading>
-            </s-box>
-          </s-stack>
+          <CountsRow
+            items={[
+              { label: "Campaigns running", value: live },
+              { label: "Scheduled", value: upcoming },
+              { label: "Need attention", value: needsAttention },
+              { label: "Prices changed outside the app", value: driftOpen },
+            ]}
+          />
 
           {live === 0 && upcoming === 0 && campaigns === 0 ? (
             <s-paragraph>
@@ -376,7 +361,7 @@ export default function Dashboard() {
           {needsAttention > 0 ? (
             <s-banner tone="warning">
               <s-paragraph>
-                {needsAttention} campaign{needsAttention === 1 ? "" : "s"} did not finish
+                {formatCount(needsAttention)} campaign{needsAttention === 1 ? "" : "s"} did not finish
                 cleanly. Every row that did not complete has a reason recorded, and
                 resuming retries only those.
               </s-paragraph>
@@ -386,7 +371,7 @@ export default function Dashboard() {
           {driftOpen > 0 ? (
             <s-banner tone="info">
               <s-paragraph>
-                {driftOpen} price{driftOpen === 1 ? " was" : "s were"} changed somewhere
+                {formatCount(driftOpen)} price{driftOpen === 1 ? " was" : "s were"} changed somewhere
                 other than Anchor while a campaign was running. Those edits were
                 deliberate, so nothing has been overwritten — each is waiting on your
                 decision.


### PR DESCRIPTION
Continues the per-page UI pass — this one is Home, the first screen after installing.

## Two copies of the same component

Home hand-rolled the four stat tiles `CountsRow` renders — an `s-box` with a label above a figure, in an inline stack — **in two places**. When the shared component gained borders, padding and equal columns, the dashboard kept the flat version, because it had never been using it.

The inline stack was also exactly what the shared component was fixed to stop doing: it sizes each tile to its content, so "Scheduled 0" got a fraction of the width of "Prices changed outside the app 12", and the row read as a ranking rather than four equal facts.

The duplication is invisible — both render four numbers, and only a side-by-side comparison shows one is the old one. So `counts-row.test.ts` fails on the *shape*: a label in a box directly above a figure in a heading, anywhere but the component itself.

**That's how the second occurrence was found.** My first fix passed its mutation test and then failed on restore — because another copy sat further down the same file that I hadn't seen.

## `display.test.ts` caught a real gap I was about to ship

Moving the tiles out left the page with no `formatCount` call, and my first instinct was that the assertion now pointed at the wrong file.

It didn't. **Three counts remained in prose** — *"{health.missing} variants have no baseline yet"* and two more — which on a hundred-thousand-variant store render as **"3412"** rather than "3,412". The test was asserting the property, not the location, and weakening it would have shipped the bug.

## Checks

- `npm test` — 1775 passed
- `npm run test:chaos` — 140 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors