### PR TITLE
Put a checklist step's actions on one row

### DIFF
--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -53,10 +53,15 @@ describe("a brand new shop", () => {
     expect(html).toContain("Sync catalogue");
   });
 
+  it("keeps a step's actions on one row", () => {
+    // `s-clickable` and `s-link` are block-level, so an inline stack still gave each its
+    // own line: badge and title, then "Why?", then the action — three rows per step,
+    // for a checklist whose whole job is being scannable.
+    expect(html).toContain("<s-button-group>");
+    expect(html).not.toContain("<s-clickable");
+  });
+
   it("keeps each step's Why with its own step, not the one below", () => {
-    // The row wraps on a narrow column. With the toggle last it wrapped onto its own
-    // line and read as belonging to the next step — an explanation attached to the
-    // wrong step is worse than no explanation.
     const step = html.slice(html.indexOf("Capture your baselines"));
     expect(
       step.indexOf("Why?") < step.indexOf("Sync catalogue"),

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -74,19 +74,27 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
             {step.done ? "Done" : isNext ? "Next" : "Later"}
           </s-badge>
           <s-text type="strong">{step.title}</s-text>
-          {/* Progressive disclosure, not a link away. The reasoning belongs next to the
-              step it explains — sending a merchant to a docs page to find out why they
-              are being asked to sync is how they end up not syncing.
-
-              Before the action, deliberately. The row wraps on a narrow column, and when
-              the toggle was last it wrapped onto its own line and read as belonging to
-              the step below it. The action wrapping is harmless; an explanation attached
-              to the wrong step is not. */}
-          <s-clickable onClick={() => setWhy((open) => !open)}>
-            <s-text color="subdued">{why ? "Hide why" : "Why?"}</s-text>
-          </s-clickable>
-          {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
         </s-stack>
+
+        {/* A button group, because `s-clickable` and `s-link` are block-level: inside an
+            inline stack each still took its own line, so a step rendered as three
+            stacked rows — badge and title, then "Why?", then the action.
+            `s-button-group` is the component for a row of actions and lays them out as
+            one, which also keeps the toggle unambiguously inside its own step.
+
+            The toggle is progressive disclosure rather than a link away: the reasoning
+            belongs beside the step it explains, and sending a merchant to a docs page to
+            learn why they are being asked to sync is how they end up not syncing. */}
+        <s-button-group>
+          <s-button variant="tertiary" onClick={() => setWhy((open) => !open)}>
+            {why ? "Hide why" : "Why?"}
+          </s-button>
+          {step.href && step.cta ? (
+            <s-button variant="tertiary" href={step.href}>
+              {step.cta}
+            </s-button>
+          ) : null}
+        </s-button-group>
 
         {why ? (
           <s-paragraph>


### PR DESCRIPTION
Continues the Home pass (#367). Found by looking at the deployed page.

## Three rows to say what fits on one

Each getting-started step rendered as:

```
[Next]  Capture your baselines
Why?
Sync catalogue
```

Three stacked rows, times three steps, on a checklist whose entire job is being scannable.

## Why the markup lied

It already said `direction="inline"`. **`s-clickable` and `s-link` are block-level**, so an inline stack gave each of them its own line regardless — while the badge and title, both inline, sat together exactly as written. That's why it looked like the stack was ignored when only half of it was.

`s-button-group` is the component for a row of actions and lays them out as one. It also settles the earlier worry about the toggle detaching to the next step, since the group sits unambiguously inside its own bordered box.

## On the previous fix here

#357 reordered the items so a wrap couldn't misattach the toggle. That was the right fix for what I could see then and it didn't address the wrap itself — the assertion it added still holds and is kept.

Mutation-tested: putting `s-clickable` and `s-link` back in an inline stack fails *"keeps a step's actions on one row"*.

## Checks

- `npm test` — 1775 passed
- `npm run test:chaos` — 140 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors