### PR TITLE
Revert the button group: it rendered no buttons at all

### DIFF
--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -53,15 +53,10 @@ describe("a brand new shop", () => {
     expect(html).toContain("Sync catalogue");
   });
 
-  it("keeps a step's actions on one row", () => {
-    // `s-clickable` and `s-link` are block-level, so an inline stack still gave each its
-    // own line: badge and title, then "Why?", then the action — three rows per step,
-    // for a checklist whose whole job is being scannable.
-    expect(html).toContain("<s-button-group>");
-    expect(html).not.toContain("<s-clickable");
-  });
-
   it("keeps each step's Why with its own step, not the one below", () => {
+    // The row wraps on a narrow column. With the toggle last it wrapped onto its own
+    // line and read as belonging to the next step — an explanation attached to the
+    // wrong step is worse than no explanation.
     const step = html.slice(html.indexOf("Capture your baselines"));
     expect(
       step.indexOf("Why?") < step.indexOf("Sync catalogue"),

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -74,27 +74,26 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
             {step.done ? "Done" : isNext ? "Next" : "Later"}
           </s-badge>
           <s-text type="strong">{step.title}</s-text>
+          {/* Progressive disclosure, not a link away. The reasoning belongs next to the
+              step it explains — sending a merchant to a docs page to find out why they
+              are being asked to sync is how they end up not syncing.
+
+              These render on their own lines, because `s-clickable` and `s-link` are
+              block-level and an inline stack does not change that. It is not pretty and
+              it is what works: replacing them with `s-button-group` laid the row out
+              correctly and rendered no buttons at all, so the first screen after install
+              offered no way to sync. A checklist that looks slightly loose beats one
+              whose actions are missing.
+
+              Before the action, deliberately. The row wraps on a narrow column, and when
+              the toggle was last it wrapped onto its own line and read as belonging to
+              the step below it. The action wrapping is harmless; an explanation attached
+              to the wrong step is not. */}
+          <s-clickable onClick={() => setWhy((open) => !open)}>
+            <s-text color="subdued">{why ? "Hide why" : "Why?"}</s-text>
+          </s-clickable>
+          {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
         </s-stack>
-
-        {/* A button group, because `s-clickable` and `s-link` are block-level: inside an
-            inline stack each still took its own line, so a step rendered as three
-            stacked rows — badge and title, then "Why?", then the action.
-            `s-button-group` is the component for a row of actions and lays them out as
-            one, which also keeps the toggle unambiguously inside its own step.
-
-            The toggle is progressive disclosure rather than a link away: the reasoning
-            belongs beside the step it explains, and sending a merchant to a docs page to
-            learn why they are being asked to sync is how they end up not syncing. */}
-        <s-button-group>
-          <s-button variant="tertiary" onClick={() => setWhy((open) => !open)}>
-            {why ? "Hide why" : "Why?"}
-          </s-button>
-          {step.href && step.cta ? (
-            <s-button variant="tertiary" href={step.href}>
-              {step.cta}
-            </s-button>
-          ) : null}
-        </s-button-group>
 
         {why ? (
           <s-paragraph>


### PR DESCRIPTION
Reverts #368.

## What happened

#368 replaced the checklist step's `s-clickable` and `s-link` with `s-button-group`, to stop each taking its own line.

The row laid out correctly and **rendered nothing**. "Why?" and "Sync catalogue" disappeared from every step — so the first screen after installing offered no way to sync.

A checklist that looks slightly loose beats one whose actions are missing.

## Second time, same mistake

This is the second regression I've shipped by reasoning about how a Polaris element will lay out instead of loading the page. The first wrapped `PageShell`'s no-aside branch and rendered those pages blank (#361).

The pattern is identical: the markup is plausible, it serialises fine, no test fails, and **the browser is the only place the truth shows up**. Polaris' layout runs client-side inside a cross-origin admin iframe the accessibility tree can't see into, so a screenshot is the only instrument — and I have to take it before merging, not after.

## The assertion changed shape

It no longer asks *which element renders the row*. It asks whether the toggle and the call to action are **on the page at all**:

```ts
expect(html).toContain("Why?");
expect(html).toContain("Sync catalogue");
```

That's the property worth defending. Whether they share a line is a preference, and a preference should not be able to delete a button. Mutation-tested by removing the CTA.

## Checks

- `npm test` — 1775 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors