### PR TITLE
Give the calendar cells room, and check Polaris prop names

### DIFF
--- a/app/components/CalendarGrid.tsx
+++ b/app/components/CalendarGrid.tsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router";
 
+import { SPACE } from "../lib/ui/spacing";
+
 import type { CalendarDay } from "../lib/scheduling/calendar";
 import { CAMPAIGN_TONE, toneFor } from "./tone";
 
@@ -21,14 +23,19 @@ export function CalendarGrid({ days, today }: { days: CalendarDay[]; today: stri
   }
 
   return (
-    <s-stack gap="small">
+    <s-stack gap={SPACE.item}>
       {/* Which column is which day. Without it the grid is seven anonymous boxes and a
           merchant has to count from the first date to work out whether a sale lands on
           a weekend — which is usually the thing they came to check. */}
-      <s-grid gridTemplateColumns="repeat(7, 1fr)" gap="small-200">
+      {/* `repeat(7, 1fr)` is safe here because this is not a responsive value. Polaris
+          only splits on the comma when the value begins `@container`, so the ban on
+          commas applies there and not to a plain template. */}
+      <s-grid gridTemplateColumns="repeat(7, 1fr)" gap={SPACE.item}>
         {WEEKDAYS.map((weekday) => (
-          <s-box key={weekday} padding="small-200">
-            <s-text color="subdued">{weekday}</s-text>
+          <s-box key={weekday} paddingInline={SPACE.tight}>
+            <s-text color="subdued" type="strong">
+              {weekday}
+            </s-text>
           </s-box>
         ))}
       </s-grid>
@@ -37,14 +44,28 @@ export function CalendarGrid({ days, today }: { days: CalendarDay[]; today: stri
           columns line up under their weekday. Stacked boxes sized themselves to their
           contents, which put a busy Tuesday under Wednesday's heading. */}
       {chunk(days, 7).map((week) => (
-        <s-grid key={week[0].date} gridTemplateColumns="repeat(7, 1fr)" gap="small-200">
+        <s-grid key={week[0].date} gridTemplateColumns="repeat(7, 1fr)" gap={SPACE.item}>
           {week.map((day) => (
-            <s-box key={day.date} padding="small-200" borderWidth="base" borderRadius="base">
-              <s-stack gap="small-500">
+            <s-box
+              key={day.date}
+              padding={SPACE.tight}
+              borderWidth="base"
+              borderRadius="base"
+              // Today gets a filled cell, and days outside the month being viewed are
+              // dimmed. A merchant opens a calendar to place a sale relative to now, so
+              // "which square is today" has to be answerable without reading -- it used
+              // to be a "· today" suffix in the same weight as every other date.
+              background={day.date === today ? "subdued" : undefined}
+              // px, not rem: Polaris sizes accept `${number}px`, a percentage or `0`.
+              minBlockSize="64px"
+            >
+              <s-stack gap={SPACE.tight}>
                 <Link to={`/app/campaigns/new?startAt=${day.date}`}>
-                  <s-text tone={day.date === today ? "info" : day.inFocus ? "auto" : "neutral"}>
+                  <s-text
+                    type={day.date === today ? "strong" : "generic"}
+                    color={day.inFocus ? "base" : "subdued"}
+                  >
                     {dayNumber(day.date)}
-                    {day.date === today ? " · today" : ""}
                   </s-text>
                 </Link>
 

--- a/app/lib/ui/polaris-attributes.test.ts
+++ b/app/lib/ui/polaris-attributes.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Every prop passed to a Polaris element is one Polaris actually has.
+ *
+ * TypeScript does not check this. The `s-*` elements are custom elements whose React
+ * props are declared loosely, so an attribute Polaris has never heard of typechecks,
+ * builds, serialises, and then makes the element render **nothing** in the browser —
+ * taking its children with it.
+ *
+ * Two real instances of that in this codebase, both found only by loading the page:
+ * wrapping `s-page`'s children in an `s-stack` blanked every sidebar-less route, and
+ * `s-button-group` laid a row out correctly while rendering none of its buttons. Both
+ * passed typecheck, the unit suite and lint.
+ *
+ * A third suspected instance was a misdiagnosis worth recording, because it cost more
+ * than the bug. The calendar rendered blank right after an edit, `paddingInline` on
+ * `s-box` looked like the culprit, and it is not — Polaris declares it, and the page
+ * renders with it restored. It was a transient, most likely stale hot-reload state. The
+ * lesson is that "I changed X and the page went blank" is not evidence about X, and the
+ * cheap way to find out is to put X back and reload.
+ *
+ * So this checks the thing that is actually checkable: the compiler will not tell you
+ * whether a prop name exists, and the types will.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const POLARIS_TYPES = join(
+  process.cwd(),
+  "node_modules",
+  "@shopify",
+  "polaris-types",
+  "dist",
+  "polaris.d.ts",
+);
+
+/** Every property name Polaris declares anywhere in its type surface. */
+function polarisProps(): Set<string> {
+  const source = readFileSync(POLARIS_TYPES, "utf8");
+  const names = new Set<string>();
+  for (const match of source.matchAll(/^\s*([a-zA-Z][a-zA-Z0-9]*)\??:/gm)) names.add(match[1]);
+  return names;
+}
+
+/** Props React itself handles, plus ours. None of these reach Polaris as attributes. */
+const NOT_POLARIS = new Set([
+  "key",
+  "ref",
+  "className",
+  "style",
+  "children",
+  "slot",
+  "dangerouslySetInnerHTML",
+]);
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+/** `<s-thing propA={…} propB="…">` → every propA/propB, with where it was used. */
+function propsUsed(): Array<{ file: string; element: string; prop: string }> {
+  const found: Array<{ file: string; element: string; prop: string }> = [];
+  const app = join(process.cwd(), "app");
+
+  for (const path of tsxFiles(app)) {
+    const source = readFileSync(path, "utf8");
+    for (const tag of source.matchAll(/<(s-[a-z-]+)((?:\s+[^<>]*?)?)\/?>/g)) {
+      const [, element, attrs] = tag;
+      if (!attrs) continue;
+      // `=(?!=)` so a comparison inside a JSX expression is not read as an attribute.
+      // `kind === "set-exact"` in a `label={…}` looked exactly like `kind=` otherwise,
+      // and the first version of this check reported it as an unknown prop.
+      for (const attr of attrs.matchAll(/(?:^|\s)([a-zA-Z][a-zA-Z0-9]*)\s*=(?!=)/g)) {
+        const prop = attr[1];
+        if (NOT_POLARIS.has(prop) || prop.startsWith("on") || prop.startsWith("data")) continue;
+        found.push({ file: path.replace(`${app}/`, ""), element, prop });
+      }
+    }
+  }
+  return found;
+}
+
+describe("props passed to Polaris elements", () => {
+  const declared = polarisProps();
+  const used = propsUsed();
+
+  it("finds elements to check, so this cannot pass by matching nothing", () => {
+    expect(declared.size).toBeGreaterThan(100);
+    expect(used.length).toBeGreaterThan(80);
+  });
+
+  it("are all props Polaris declares", () => {
+    const unknown = used
+      .filter(({ prop }) => !declared.has(prop))
+      .map(({ file, element, prop }) => `${file}: <${element} ${prop}=…>`);
+
+    expect(
+      [...new Set(unknown)],
+      "Polaris does not declare these anywhere. TypeScript will not complain and the " +
+        "build will succeed, because these are custom elements whose React props are " +
+        "declared loosely — so the first sign is an element rendering nothing in the " +
+        "browser, taking its children with it",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Continues the per-page UI pass. **Verified in the browser before merging** — which is the process change that matters most here.

## The calendar

Seven columns of cramped boxes with a bare number in each, and "today" was a `· today` suffix in the same weight as every other date. A merchant opens a calendar to place a sale *relative to now*, so which square is today has to be answerable without reading.

Cells now have a minimum height, today is a filled cell, out-of-month days are subdued, weekday headers are strong. Spacing comes from the scale rather than four hand-picked values.

`repeat(7, 1fr)` stays — the comma ban applies to **responsive** values only (Polaris splits on the comma when the value begins `@container`), and this is a plain template, which is why it has always worked.

## `polaris-attributes.test.ts`

The `s-*` elements are custom elements whose React props are declared loosely, so **a prop Polaris has never heard of typechecks, builds, and then makes the element render nothing at all** — taking its children with it.

Two real instances this session: an `s-stack` wrapping `s-page`'s children blanked every sidebar-less route, and `s-button-group` laid a row out correctly while rendering none of its buttons. Both passed typecheck, unit tests and lint; both were found only by loading the page.

The names are checkable against the types even though the compiler declines to check them. Mutation-tested with an invented `paddingSideways`.

## A misdiagnosis worth recording, because it cost more than the bug

The calendar rendered blank right after an edit, and `paddingInline` on `s-box` looked like the culprit. **It isn't.** Polaris declares it, and the page renders with it restored — it was a transient, most likely stale hot-reload state.

I had a test written and a commit message drafted asserting that wrong root cause before checking. *"I changed X and the page went blank"* is not evidence about X, and putting X back is cheap. The test now claims only what it can actually check.

## Checks

- `npm test` — 1777 passed
- `npm run test:chaos` — 140 passed
- `npm run typecheck`, `npm run build` — clean; `npm run lint` — 0 errors