### PR TITLE
The stuck-run runbook covers the case with no run

### DIFF
--- a/app/lib/lifecycle/transitions.ts
+++ b/app/lib/lifecycle/transitions.ts
@@ -61,7 +61,7 @@ const LEGAL: Record<CampaignState, readonly CampaignState[]> = {
 };
 
 /** States where prices this campaign wrote may be live on the storefront. */
-const PRICES_MAY_BE_LIVE: ReadonlySet<CampaignState> = new Set<CampaignState>([
+export const PRICES_MAY_BE_LIVE: ReadonlySet<CampaignState> = new Set<CampaignState>([
   "APPLYING",
   "ACTIVE",
   "HELD",

--- a/app/lib/observability/runbook-coverage.test.ts
+++ b/app/lib/observability/runbook-coverage.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The stuck-run runbook covers the case with no run.
+ *
+ * Every diagnostic step in that section began from `campaign_runs`, and a campaign can be
+ * stuck without having one: `runCampaign` moves it to APPLYING before it plans, so a
+ * failure between the transition and the run row leaves a campaign claiming to be
+ * applying with nothing behind it.
+ *
+ * The reaper reads `campaign_runs`, so it cannot see this. An operator following the
+ * runbook found nothing in flight and concluded nothing was stuck, while the merchant
+ * looked at a campaign that had been "applying" for hours with revert refused.
+ *
+ * A runbook is only as good as the failure it anticipates, and this one is the failure
+ * that actually happened (#325), so it needs to be findable by someone searching the doc
+ * at the moment it bites.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { PRICES_MAY_BE_LIVE } from "../lifecycle/transitions";
+
+const runbooks = readFileSync(join(process.cwd(), "docs", "runbooks.md"), "utf8");
+const section = runbooks.slice(
+  runbooks.indexOf("## Stuck run recovery"),
+  runbooks.indexOf("## Data restore"),
+);
+
+describe("stuck run recovery", () => {
+  it("has a section at all", () => {
+    expect(section.length).toBeGreaterThan(500);
+  });
+
+  it("tells an operator how to find a campaign with no run", () => {
+    // The query has to start from `campaigns`, because starting from `campaign_runs` is
+    // exactly what misses this.
+    expect(section).toMatch(/FROM campaigns/i);
+    expect(section).toMatch(/HAVING count\(/i);
+  });
+
+  it("says the reaper cannot fix it, so nobody waits for a tick that never helps", () => {
+    expect(section).toMatch(/reaper cannot help|reaper cannot|invisible to it/i);
+  });
+
+  it("names both claim states, not only the one that is easier to hit", () => {
+    // A revert strands the same way an apply does. A runbook that named only APPLYING
+    // would leave the operator with no match for the state in front of them.
+    // Read from the state machine itself. A second list here would be the same
+    // contract-drift shape this codebase keeps paying for — two halves nothing
+    // validates — in a test written to guard against exactly that.
+    const claimStates = [...PRICES_MAY_BE_LIVE].filter(
+      (state) => state === "APPLYING" || state === "REVERTING",
+    );
+    expect(claimStates).toHaveLength(2);
+
+    for (const state of claimStates) {
+      expect(section, `${state} is not mentioned`).toContain(state);
+    }
+  });
+
+  it("warns against the fix that looks obvious and is wrong", () => {
+    // Moving the campaign out of APPLYING by hand, while a run may be writing prices.
+    expect(section).toMatch(/Do not.*UPDATE|UPDATE.*Do not/is);
+  });
+});

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -274,6 +274,52 @@ how they got there.
 **Resume** from the campaign page. A resumed run reads the ledger and continues from the
 rows that never settled — it does not replan.
 
+### The case with no run at all
+
+Everything above starts from `campaign_runs`. A campaign can be stuck without having one.
+
+`runCampaign` moves the campaign to APPLYING *before* it plans, so that an illegal action
+is refused before a price moves. Planning can then fail — a guardrail blocks the run, the
+session expires, a catalogue outgrows one statement — and the crash lands in the window
+between that transition and the run row being created.
+
+**The reaper cannot help.** It reads `campaign_runs`, so a campaign with none is invisible
+to it. An operator working through the steps above finds nothing in flight and concludes
+nothing is stuck, while the merchant sees a campaign that has been "applying" for hours.
+
+**Recognise it.** A campaign in a claim state with no run behind it:
+
+```sql
+SELECT c.id, c.name, c.status
+FROM campaigns c
+LEFT JOIN campaign_runs r ON r."campaignId" = c.id
+WHERE c.status IN ('APPLYING','REVERTING')
+GROUP BY c.id, c.name, c.status
+HAVING count(r.id) = 0;
+```
+
+**What the merchant sees.** Revert is refused — APPLYING → REVERTING is not a legal
+transition — so the only control that appears to work is Apply, which is the one that
+sounds most dangerous. `PRICES_MAY_BE_LIVE` includes APPLYING, so the rest of the app
+also believes the storefront may be carrying this campaign's prices. It is not: the
+ledger is empty and nothing was written.
+
+**Remediate.** Since #339 this self-heals — `releaseClaim` puts the campaign back where
+the claim took it from and records "claim released without running" in the audit log, so
+a campaign in this state now means either an older stranding or a case where a run *is*
+live and the release correctly refused. Check the second before doing anything:
+
+```sql
+SELECT status, count(*) FROM campaign_runs WHERE "campaignId" = '<id>' GROUP BY status;
+```
+
+If that returns nothing, retrying Apply is safe and is what the merchant would do anyway
+— the resolver is idempotent and the ledger is empty, so there is nothing to write twice.
+
+**Do not** move the campaign out of APPLYING with an UPDATE. If a run *is* live, that
+tells the app nothing is happening while prices are being written, which is worse than
+the stuck state. Let `releaseClaim` decide; it refuses while any run is in flight.
+
 ---
 
 ## Data restore


### PR DESCRIPTION
One of #161's buildable criteria — "stuck-run recovery procedure documented".

## The gap

Every diagnostic step in that section began from `campaign_runs`. **A campaign can be stuck without having one.**

`runCampaign` moves a campaign to APPLYING *before* it plans, so an illegal action is refused before a price moves. A failure between that transition and the run row — a blocking guardrail, an expired session, a catalogue too large for one statement — leaves a campaign claiming to be applying with nothing behind it.

**The reaper cannot see it.** `reclaimStaleRuns` starts from `campaignRun.findMany`. So an operator working through the runbook finds nothing in flight and concludes nothing is stuck — while the merchant looks at a campaign that has been "applying" for hours with revert refused.

And revert *is* refused: APPLYING → REVERTING isn't a legal transition, so the only control that appears to work is Apply — the one that sounds most dangerous.

## What the new section does

- **The query that finds it** — from `campaigns`, left-joined, having no runs. Starting from `campaign_runs` is precisely what misses it.
- **Says the reaper won't help**, so nobody waits for a tick that never comes.
- **Distinguishes the two cases** now that #339 makes this self-heal: an older stranding, versus a run that *is* live and `releaseClaim` correctly refused.
- **Warns against the obvious wrong fix** — moving the campaign out of APPLYING by hand tells the app nothing is happening while a run may be writing prices.

## One thing I caught in my own work

The first draft of the test carried **its own copy** of the `PRICES_MAY_BE_LIVE` state list — the same contract-drift shape this codebase keeps paying for, inside a test written to guard against exactly that. It's exported from the state machine now and read from there.

Mutation-tested: dropping the campaigns-side query, dropping the REVERTING case, and dropping the warning each fail.

## Still needs staging

Running the chaos suite against staging with alerting live, confirming each alert routes to a human, and rehearsing the restore end to end.

## Checks

- `npm test` — 1796 passed
- `npm run test:chaos` — 140 passed
- `npm run typecheck` — clean; `npm run lint` — 0 errors