### PR TITLE
Index the array columns campaigns scope by

### DIFF
--- a/prisma/migrations/20260828020000_scope_array_indexes/migration.sql
+++ b/prisma/migrations/20260828020000_scope_array_indexes/migration.sql
@@ -1,0 +1,20 @@
+-- GIN indexes for the two array columns campaigns scope by.
+--
+-- Measured on anchor-perf, 102,132 variants: `tags @> ARRAY['clearance']` went from a
+-- sequential scan of the whole catalogue to a Bitmap Index Scan at ~20ms. Collections
+-- takes the same shape and will use the index whenever the value is selective enough --
+-- the sample collection tested covers a large share of the catalogue, so Postgres
+-- correctly prefers a scan for that one.
+--
+-- Expand only: adding an index changes no rows and the previous release simply does not
+-- benefit from it. Index build on the 102K table was under a second; on a materially
+-- larger catalogue this takes a write lock for the duration, which is the reason to run
+-- it during a quiet window rather than mid-campaign.
+--
+-- Deliberately NOT added: btree indexes on `productType` and `vendor`. Prisma emits
+-- `productType ILIKE $1` for those, because `astToWhere` matches them with
+-- `mode: "insensitive"` -- and no btree index, including one on `lower(productType)`,
+-- serves ILIKE. Two such indexes were created, measured, found unused and dropped before
+-- this migration was written. See #160 for what would actually help.
+CREATE INDEX IF NOT EXISTS "variant_index_tags_gin" ON "variant_index" USING GIN ("tags");
+CREATE INDEX IF NOT EXISTS "variant_index_collections_gin" ON "variant_index" USING GIN ("collections");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,10 @@ model VariantIndex {
   @@index([shopId, price])
   @@index([shopId, status])
   @@index([shopId, deletedAt])
+  /// GIN, for the `has` lookups campaigns scope by. Declared with an explicit type
+  /// because a btree on an array column cannot serve containment.
+  @@index([tags], type: Gin)
+  @@index([collections], type: Gin)
   @@map("variant_index")
 }
 


### PR DESCRIPTION
Part of #160 — "query plans reviewed against real data shapes" and "index coverage verified". Those two criteria don't need beta merchants: `anchor-perf` has **102,132 variants**, which is a real data shape.

## The gap

The planner's scope query is the hottest thing in the app — every preview and every run begins with it. `variant_index` was indexed on `productGid`, `sku`, `price`, `status`, `deletedAt`.

Campaigns scope by **productType, vendor, tags and collections**. None of them.

## Measured, not guessed

`tags @> ARRAY['clearance']` went from scanning the whole catalogue to a **Bitmap Index Scan at ~20ms**.

Collections takes the same shape; the sample value tested covers a large share of the catalogue, so Postgres correctly still prefers a scan there. The index earns its keep on a selective tag.

## Two indexes were built, measured, found useless, and dropped before this was written

`astToWhere` matches productType and vendor with `mode: "insensitive"`, so Prisma emits:

```sql
"variant_index"."productType" ILIKE $2
```

**No btree serves ILIKE** — including one on `lower("productType")`. I built both, and the first measurement looked like a win: 180ms → 41ms. It was cache warming. The plan still said `Seq Scan`.

Reading the plan rather than the clock is the only reason that didn't ship as a "performance improvement" that improved nothing and cost two indexes' worth of write amplification on every insert.

The real finding is recorded on #160: insensitive matching on two fields Shopify gives us verbatim costs an index that cannot exist, and the options are a `pg_trgm` GIN index or dropping the insensitivity.

## Expand only

Adding an index changes no rows and the previous release simply doesn't benefit. Build was under a second at 102K rows; on a materially larger catalogue it holds a write lock for the duration, which the migration says.

## Checks

- `npm test` — 1796 passed
- `npm run test:chaos` — 140 passed
- `npx prisma validate`, `migrate deploy` — clean
- `npm run typecheck` — clean; `npm run lint` — 0 errors