### PR TITLE
Refuse an inline apply too large to finish its request

### DIFF
--- a/app/lib/campaigns/run-response.test.ts
+++ b/app/lib/campaigns/run-response.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A refusal that renders as a success is worse than no guard at all: the merchant is told
+ * their campaign was applied, and it was not.
+ *
+ * `refused` sat on `RunOutcome` for the plan gate and was read by nobody, so **every**
+ * refusal rendered as "Applied 0 variants, all verified" — a green tick over a run that
+ * never happened. Deferral had the same shape and had already been special-cased once.
+ *
+ * This used to be asserted by grepping the campaign route for the order of two branches,
+ * with a note saying the alternative was mounting the whole route to check a ternary.
+ * Moving the sentence out of the route removed that constraint: it is a pure function now,
+ * so the three outcomes can be checked by calling it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runResponse } from "./run-response";
+
+/** Clean, nothing written, no failures — the shape all three outcomes share. */
+const quiet = {
+  clean: true,
+  verified: 0,
+  failed: 0,
+  unverified: 0,
+  messages: ["Another worker is applying this campaign."],
+};
+
+describe("a run that was refused", () => {
+  const refused = runResponse(
+    { ...quiet, refused: "This campaign covers 180,000 variants — schedule it instead." },
+    "Applied",
+  );
+
+  it("says why, rather than reporting a successful run of nothing", () => {
+    expect(refused.ok).toBe(false);
+    expect(refused.message).toContain("180,000");
+    expect(refused.message).not.toContain("all verified");
+  });
+
+  it("is a warning and not a failure", () => {
+    // Red would send a merchant hunting for a fault in a system that behaved exactly as
+    // designed. Nothing broke; the run was declined.
+    expect(refused.tone).toBe("warning");
+  });
+
+  it("wins over the outcome message even though the outcome says clean", () => {
+    // The whole bug: `clean` is true and `verified` is 0, so the generic branch is
+    // perfectly happy to describe a refusal as a success.
+    expect(quiet.clean).toBe(true);
+    expect(refused.message).not.toContain("Applied 0 variants");
+  });
+});
+
+describe("a run that deferred", () => {
+  it("reports what the other worker is doing, as good news", () => {
+    // Something *is* writing the merchant's prices right now, so this is not a failure —
+    // but "Applied 0 variants, all verified" would be technically true and completely
+    // misleading about what is happening to their storefront.
+    const deferred = runResponse({ ...quiet, deferredTo: "run_123" }, "Applied");
+
+    expect(deferred.ok).toBe(true);
+    expect(deferred.message).toBe("Another worker is applying this campaign.");
+  });
+
+  it("survives an outcome that deferred without saying anything", () => {
+    const deferred = runResponse({ ...quiet, messages: [], deferredTo: "run_123" }, "Applied");
+
+    expect(deferred.message).toBe("");
+  });
+});
+
+describe("a run that actually ran", () => {
+  it("counts what it verified, in the verb the caller used", () => {
+    const clean = runResponse(
+      { clean: true, verified: 412, failed: 0, unverified: 0, messages: [] },
+      "Reverted",
+    );
+
+    expect(clean).toMatchObject({ ok: true, message: "Reverted 412 variants, all verified." });
+    expect(clean.tone).toBeUndefined();
+  });
+
+  it("names the failures and points at resume when it was partial", () => {
+    // A partial run is the honest answer, not an embarrassment — and the next action has
+    // to be in the sentence, because a merchant who cannot see what to do next assumes
+    // there is nothing to do.
+    const partial = runResponse(
+      { clean: false, verified: 300, failed: 7, unverified: 2, messages: ["Variant 9: throttled"] },
+      "Applied",
+    );
+
+    expect(partial.ok).toBe(false);
+    expect(partial.message).toContain("7 failures");
+    expect(partial.message).toContain("2 unverified");
+    expect(partial.message).toContain("resume");
+    expect(partial.details).toEqual(["Variant 9: throttled"]);
+  });
+});

--- a/app/lib/campaigns/run-response.ts
+++ b/app/lib/campaigns/run-response.ts
@@ -1,0 +1,62 @@
+/**
+ * What a merchant is told after pressing Apply, Revert or Resume.
+ *
+ * Three outcomes come back looking almost identical — clean, zero rows written, no
+ * failures — and mean completely different things. Two of them would render as
+ * "Applied 0 variants, all verified": a green tick over a campaign that never ran, on the
+ * one screen whose entire job is being the record of what happened to a storefront.
+ *
+ *   **Deferred.** Another worker already owns this occurrence, so this call wrote nothing
+ *   and something else is writing right now.
+ *
+ *   **Refused.** The run was turned down before it started — too large to finish inside
+ *   this request, over the blast-radius threshold, blocked by a plan gate. Nothing was
+ *   written and nothing is going to be until the merchant does something.
+ *
+ *   **Clean.** It ran, and every row was read back and confirmed.
+ *
+ * A refusal is `ok: false` but not critical. Red would send a merchant hunting for a fault
+ * in a system that behaved exactly as designed; warning says "not done, and nothing broke".
+ *
+ * Out of the route because it is the sentence, not the work — and because the route is
+ * against its own length limit, which is what stopped this being three more branches in
+ * the action.
+ */
+
+export interface RunResponse {
+  ok: boolean;
+  /** Absent means critical when `ok` is false. See the note above. */
+  tone?: "warning";
+  message: string;
+  details: string[];
+}
+
+export function runResponse(
+  result: {
+    clean: boolean;
+    verified: number;
+    failed: number;
+    unverified: number;
+    messages: string[];
+    deferredTo?: string | null;
+    refused?: string | null;
+  },
+  verb: string,
+): RunResponse {
+  if (result.deferredTo) {
+    return { ok: true, message: result.messages[0] ?? "", details: [] };
+  }
+
+  if (result.refused) {
+    return { ok: false, tone: "warning", message: result.refused, details: [] };
+  }
+
+  return {
+    ok: result.clean,
+    message: result.clean
+      ? `${verb} ${result.verified} variants, all verified.`
+      : `${verb} with ${result.failed} failures and ${result.unverified} unverified. ` +
+        `Nothing is hidden — resume to retry.`,
+    details: result.messages,
+  };
+}

--- a/app/lib/execution/inline-budget.test.ts
+++ b/app/lib/execution/inline-budget.test.ts
@@ -2,10 +2,12 @@
  * The guard's whole job is to be a number and a sentence, so both are tested.
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 import {
   MAX_INLINE_ROWS,
@@ -109,7 +111,7 @@ describe("every caller that runs inside a request declares its deadline", () => 
     .filter((file) => file.endsWith(".tsx") || file.endsWith(".ts"))
     .filter((file) => !file.endsWith(".test.tsx") && !file.endsWith(".test.ts"))
     .flatMap((file) => {
-      const source = readFileSync(join(process.cwd(), "app/routes", file), "utf8");
+      const source = sourceOf("app/routes", file);
       // The import line is not a call.
       return callsIn(source)
         .filter((args) => args.includes(","))
@@ -146,42 +148,11 @@ describe("every caller that runs inside a request declares its deadline", () => 
   it("leaves the worker and the scheduler unlimited", () => {
     // "Schedule it instead" is only honest advice if the scheduler has no such ceiling.
     for (const path of ["app/worker/handlers.server.ts", "app/services/scheduler.server.ts"]) {
-      const source = readFileSync(join(process.cwd(), path), "utf8");
+      const source = sourceOf(path);
       expect(
         source,
         `${path} has no request attached, so a request deadline must not apply to it`,
       ).not.toContain("inlineRowLimit");
     }
-  });
-});
-
-/**
- * A refusal that renders as a success is worse than no guard at all: the merchant is
- * told their campaign was applied, and it was not.
- *
- * `refused` was on `RunOutcome` for the plan gate and read by nobody, so every
- * refusal already rendered as "Applied 0 variants, all verified." Asserted from the
- * source because the alternative is mounting the whole route to check a ternary.
- */
-describe("a refused apply does not render as a successful one", () => {
-  const page = readFileSync(join(process.cwd(), "app/routes/app.campaigns.$id.tsx"), "utf8");
-
-  it("handles the refusal before the generic outcome message", () => {
-    // The branch, not the field. Matching the field alone survives the branch being
-    // disabled, because the field is still named inside the body it no longer reaches.
-    const refusal = page.indexOf("if (result.refused)");
-    // The template literal, not the phrase: it appears in two comments above this,
-    // and a source check that matches its own documentation proves nothing.
-    const generic = page.indexOf("${verb} ${result.verified} variants, all verified.");
-
-    expect(refusal, "the campaign page must read the refusal at all").toBeGreaterThan(-1);
-    expect(
-      refusal,
-      "a refusal reaching the generic message renders as a green tick over a run that never happened",
-    ).toBeLessThan(generic);
-  });
-
-  it("gives it its own tone rather than success or critical", () => {
-    expect(page).toContain('result.tone ?? "critical"');
   });
 });

--- a/app/lib/execution/inline-budget.test.ts
+++ b/app/lib/execution/inline-budget.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The guard's whole job is to be a number and a sentence, so both are tested.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_INLINE_ROWS,
+  MS_PER_VARIANT,
+  REQUEST_CEILING_MS,
+  estimateMinutes,
+  refuseInline,
+} from "./inline-budget";
+
+describe("the inline apply budget", () => {
+  it("sits under the request ceiling rather than at it", () => {
+    const atTheLimit = MAX_INLINE_ROWS * MS_PER_VARIANT;
+
+    expect(
+      atTheLimit,
+      "a limit at the cliff edge refuses nothing that would actually have failed",
+    ).toBeLessThan(REQUEST_CEILING_MS);
+
+    // Better than half the budget left over at the limit. The per-variant figure came
+    // from one store on one afternoon; a shop being throttled by the Admin API will be
+    // slower, and the guard has to still be a guard when that happens.
+    expect(atTheLimit).toBeLessThan(REQUEST_CEILING_MS * 0.75);
+  });
+
+  it("does not refuse a run size that already works today", () => {
+    // 62,535 variants applied and reverted clean on anchor-perf in 109 and 113 seconds.
+    // If this guard would have refused that, the guard is the bug.
+    expect(refuseInline(62_535)).toBeNull();
+  });
+
+  it("allows exactly the limit and refuses one more", () => {
+    expect(refuseInline(MAX_INLINE_ROWS)).toBeNull();
+    expect(refuseInline(MAX_INLINE_ROWS + 1)).not.toBeNull();
+  });
+
+  it("names the size, the reason and the way forward", () => {
+    const message = refuseInline(500_000);
+    expect(message).toBeTruthy();
+
+    // The error taxonomy: the object, the cause, the next action.
+    expect(message, "the merchant needs to know how big is too big").toContain("500,000");
+    expect(message, "a refusal with no way forward is a dead end").toMatch(/schedul/i);
+    expect(message, "and why, or it reads as an arbitrary product limit").toMatch(
+      /request|cut off|time limit/i,
+    );
+  });
+
+  it("estimates in minutes a merchant can act on", () => {
+    expect(estimateMinutes(120_000)).toBe(4);
+
+    // Never "0 minutes", which reads as "this is instant, why did you refuse it".
+    expect(estimateMinutes(1)).toBe(1);
+  });
+
+  it("takes the caller's limit rather than assuming its own", () => {
+    // The ceiling belongs to the caller. A future caller with a tighter deadline -- a
+    // webhook that must answer in seconds -- passes its own number.
+    expect(refuseInline(10, 5)).not.toBeNull();
+    expect(refuseInline(10, 5000)).toBeNull();
+  });
+});
+
+/**
+ * The guard is opt-in, which makes it two halves of a contract: `runCampaign` knows how
+ * to refuse, and each caller declares whether it has a deadline. Nothing at runtime
+ * checks that they agree -- a route that forgets the option compiles, passes every
+ * other test, and fails only on a store large enough to matter.
+ *
+ * That is this repo's dominant bug class, so it gets read off the source rather than a
+ * hand-kept list.
+ */
+describe("every caller that runs inside a request declares its deadline", () => {
+  const routes = readdirSync(join(process.cwd(), "app/routes"));
+
+  /** The argument text of each `runCampaign(...)` call in a file. */
+  function callsIn(source: string): string[] {
+    const found: string[] = [];
+    let at = source.indexOf("runCampaign(");
+
+    while (at !== -1) {
+      let depth = 0;
+      let i = at + "runCampaign".length;
+      const start = i + 1;
+
+      for (; i < source.length; i += 1) {
+        if (source[i] === "(") depth += 1;
+        else if (source[i] === ")") {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+      }
+
+      found.push(source.slice(start, i));
+      at = source.indexOf("runCampaign(", i);
+    }
+
+    return found;
+  }
+
+  const callers = routes
+    .filter((file) => file.endsWith(".tsx") || file.endsWith(".ts"))
+    .filter((file) => !file.endsWith(".test.tsx") && !file.endsWith(".test.ts"))
+    .flatMap((file) => {
+      const source = readFileSync(join(process.cwd(), "app/routes", file), "utf8");
+      // The import line is not a call.
+      return callsIn(source)
+        .filter((args) => args.includes(","))
+        .map((args) => ({ file, args }));
+    });
+
+  it("finds the route callers at all, so a rename cannot empty this suite", () => {
+    expect(callers.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(callers.map((c) => [c.file, c.args] as const))(
+    "%s passes inlineRowLimit or is a revert",
+    (file, args) => {
+      const reverts = /revert:\s*true/.test(args);
+
+      if (reverts) {
+        expect(
+          args,
+          `${file} reverts, and a revert must never be refused for its size — ` +
+            "a store left discounted is the incident the guard exists to prevent",
+        ).not.toContain("inlineRowLimit");
+        return;
+      }
+
+      expect(
+        args,
+        `${file} applies a campaign inside an HTTP request without declaring a row ` +
+          "limit. Above ~170,000 variants the proxy closes the connection while the " +
+          "run keeps writing: the merchant sees an error and their prices move anyway.",
+      ).toContain("inlineRowLimit");
+    },
+  );
+
+  it("leaves the worker and the scheduler unlimited", () => {
+    // "Schedule it instead" is only honest advice if the scheduler has no such ceiling.
+    for (const path of ["app/worker/handlers.server.ts", "app/services/scheduler.server.ts"]) {
+      const source = readFileSync(join(process.cwd(), path), "utf8");
+      expect(
+        source,
+        `${path} has no request attached, so a request deadline must not apply to it`,
+      ).not.toContain("inlineRowLimit");
+    }
+  });
+});
+
+/**
+ * A refusal that renders as a success is worse than no guard at all: the merchant is
+ * told their campaign was applied, and it was not.
+ *
+ * `refused` was on `RunOutcome` for the plan gate and read by nobody, so every
+ * refusal already rendered as "Applied 0 variants, all verified." Asserted from the
+ * source because the alternative is mounting the whole route to check a ternary.
+ */
+describe("a refused apply does not render as a successful one", () => {
+  const page = readFileSync(join(process.cwd(), "app/routes/app.campaigns.$id.tsx"), "utf8");
+
+  it("handles the refusal before the generic outcome message", () => {
+    // The branch, not the field. Matching the field alone survives the branch being
+    // disabled, because the field is still named inside the body it no longer reaches.
+    const refusal = page.indexOf("if (result.refused)");
+    // The template literal, not the phrase: it appears in two comments above this,
+    // and a source check that matches its own documentation proves nothing.
+    const generic = page.indexOf("${verb} ${result.verified} variants, all verified.");
+
+    expect(refusal, "the campaign page must read the refusal at all").toBeGreaterThan(-1);
+    expect(
+      refusal,
+      "a refusal reaching the generic message renders as a green tick over a run that never happened",
+    ).toBeLessThan(generic);
+  });
+
+  it("gives it its own tone rather than success or critical", () => {
+    expect(page).toContain('result.tone ?? "critical"');
+  });
+});

--- a/app/lib/execution/inline-budget.ts
+++ b/app/lib/execution/inline-budget.ts
@@ -1,0 +1,72 @@
+/**
+ * How many variants one HTTP request can price before its connection is closed.
+ *
+ * `runCampaign` executes inline, so a campaign applied from the campaign page is written
+ * by the web process during a single request. Railway's proxy closes a request after
+ * five minutes with no data transferred, and a React Router action sends nothing until
+ * it returns — so five minutes is the real ceiling, not the fifteen that applies to a
+ * streaming response.
+ *
+ * Measured on `anchor-perf`: 62,535 variants took 109 seconds end to end, about 1.75ms
+ * per variant. Five minutes therefore lands somewhere near 170,000 variants in one
+ * campaign — not a hypothetical size for a product whose performance store exists at
+ * 102,132 precisely because that is the scale it targets.
+ *
+ * **The failure it prevents is the bad kind.** Exceeding the ceiling does not cancel the
+ * work. The proxy closes the connection while `runCampaign` carries on writing, so the
+ * merchant sees an error and their storefront changes anyway — the one outcome this
+ * product exists to prevent, arriving through a timeout nobody documented.
+ *
+ * So the limit is deliberately well under the ceiling rather than close to it. At
+ * 120,000 the estimate is around three and a half minutes, which leaves room for a slow
+ * shop, a throttled Admin API, and the fact that the per-variant figure came from one
+ * store on one afternoon.
+ *
+ * Above the limit the answer is not "no" — it is "not from a button". The scheduler
+ * runs campaigns in the worker, which has no request attached and no deadline, so a
+ * scope this size is a scheduling question rather than a refusal.
+ *
+ * Checking costs a `variantIndex.count` before every inline apply. Measured on the same
+ * store: 8ms for the 102,132-row catalogue, against a run of 109 seconds. The scope
+ * columns are GIN-indexed, and the count the plan gate already needed is reused.
+ */
+
+import { formatCount } from "../format/display";
+
+/** Milliseconds per variant, measured end to end including read-back verification. */
+export const MS_PER_VARIANT = 1.75;
+
+/** What Railway allows a request with no data transferred. */
+export const REQUEST_CEILING_MS = 5 * 60 * 1000;
+
+/**
+ * The most a synchronous apply may attempt.
+ *
+ * Not `REQUEST_CEILING_MS / MS_PER_VARIANT`. That is the cliff; this is the guardrail,
+ * and the distance between them is the point.
+ */
+export const MAX_INLINE_ROWS = 120_000;
+
+/** Roughly how long a scope of this size will take, for a message a merchant can act on. */
+export function estimateMinutes(rows: number): number {
+  return Math.max(1, Math.round((rows * MS_PER_VARIANT) / 60_000));
+}
+
+/**
+ * The refusal, or null when the scope fits.
+ *
+ * Names the number, the reason and the way forward — the error taxonomy requires all
+ * three, and "too large" on its own leaves a merchant with a campaign they cannot run
+ * and no idea what to do about it.
+ */
+export function refuseInline(rows: number, limit = MAX_INLINE_ROWS): string | null {
+  if (rows <= limit) return null;
+
+  return (
+    `This campaign covers ${formatCount(rows)} variants, and applying it from ` +
+    `here would take about ${estimateMinutes(rows)} minutes — longer than a browser ` +
+    `request is allowed to run. It would be cut off partway through while still writing ` +
+    `prices, which is worse than not starting. Schedule it instead: a scheduled campaign ` +
+    `runs in the background with no time limit, and reports the same result when it finishes.`
+  );
+}

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -14,6 +14,7 @@ import {
   rollbackReport,
   runCampaign,
 } from "../services/campaigns/index.server";
+import { MAX_INLINE_ROWS } from "../lib/execution/inline-budget";
 import { describeSchedule, parseSchedule, scheduleWarnings } from "../lib/scheduling/window";
 import { RunHistoryTable } from "../components/RunHistoryTable";
 import { RunResultSection } from "../components/RunResultSection";
@@ -212,6 +213,8 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
       // Rows the merchant ticked "leave as it is" in the rollback report. Only
       // meaningful on a revert; an apply has no drifted-row conversation to honour.
       skipVariantGids: reverting ? form.getAll("keep").map(String) : undefined,
+      // Written during this request, so it dies with it. See `inline-budget`.
+      inlineRowLimit: MAX_INLINE_ROWS,
     });
 
     const verb = reverting ? "Reverted" : intent === "resume" ? "Resumed" : "Applied";
@@ -222,6 +225,13 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
     // what is happening to the merchant's prices right now.
     if (result.deferredTo) {
       return { ok: true, message: result.messages[0], details: [] };
+    }
+
+    // Refused before anything started. Clean and zero-verified, so the message below
+    // would render it as "Applied 0 variants, all verified" -- a green tick over a
+    // campaign that never ran, and a merchant believing their prices changed.
+    if (result.refused) {
+      return { ok: false, tone: "warning" as const, message: result.refused, details: [] };
     }
 
     return {
@@ -255,6 +265,8 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
 
 type ActionData = {
   ok: boolean;
+  /** Not done, but nothing broke. Red would send the merchant hunting a fault. */
+  tone?: "warning";
   message: string;
   details: string[];
   errorId?: string;
@@ -315,7 +327,7 @@ export default function CampaignDetail() {
   return (
     <PageShell heading={preview.name} backTo={{ href: "/app/campaigns", label: "Campaigns" }}>
       {result ? (
-        <s-banner tone={result.ok ? "success" : "critical"}>
+        <s-banner tone={result.ok ? "success" : (result.tone ?? "critical")}>
           <s-paragraph>{result.message}</s-paragraph>
           {result.details.map((detail) => (
             <s-paragraph key={detail}>{detail}</s-paragraph>

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -15,6 +15,7 @@ import {
   runCampaign,
 } from "../services/campaigns/index.server";
 import { MAX_INLINE_ROWS } from "../lib/execution/inline-budget";
+import { runResponse, type RunResponse } from "../lib/campaigns/run-response";
 import { describeSchedule, parseSchedule, scheduleWarnings } from "../lib/scheduling/window";
 import { RunHistoryTable } from "../components/RunHistoryTable";
 import { RunResultSection } from "../components/RunResultSection";
@@ -217,31 +218,9 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
       inlineRowLimit: MAX_INLINE_ROWS,
     });
 
-    const verb = reverting ? "Reverted" : intent === "resume" ? "Resumed" : "Applied";
-
-    // Another worker already owns this occurrence, so this call wrote nothing. It is
-    // clean and it verified zero rows, which would otherwise render as "Applied 0
-    // variants, all verified" -- technically true and completely misleading about
-    // what is happening to the merchant's prices right now.
-    if (result.deferredTo) {
-      return { ok: true, message: result.messages[0], details: [] };
-    }
-
-    // Refused before anything started. Clean and zero-verified, so the message below
-    // would render it as "Applied 0 variants, all verified" -- a green tick over a
-    // campaign that never ran, and a merchant believing their prices changed.
-    if (result.refused) {
-      return { ok: false, tone: "warning" as const, message: result.refused, details: [] };
-    }
-
-    return {
-      ok: result.clean,
-      message: result.clean
-        ? `${verb} ${result.verified} variants, all verified.`
-        : `${verb} with ${result.failed} failures and ${result.unverified} unverified. ` +
-          `Nothing is hidden — resume to retry.`,
-      details: result.messages,
-    };
+    // Deferred, refused and clean all come back looking alike — see `runResponse`,
+    // where two of the three would otherwise read as "Applied 0 variants, all verified".
+    return runResponse(result, reverting ? "Reverted" : intent === "resume" ? "Resumed" : "Applied");
   } catch (error) {
     // A failed run is the highest-stakes error in the app: the merchant needs to know
     // their prices are intact, in words, plus a reference that leads us to the stack.
@@ -263,12 +242,7 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
   }
 });
 
-type ActionData = {
-  ok: boolean;
-  /** Not done, but nothing broke. Red would send the merchant hunting a fault. */
-  tone?: "warning";
-  message: string;
-  details: string[];
+type ActionData = RunResponse & {
   errorId?: string;
 };
 

--- a/app/routes/flow.actions.start-campaign.tsx
+++ b/app/routes/flow.actions.start-campaign.tsx
@@ -16,6 +16,7 @@ import prisma from "../db.server";
 import { authenticate } from "../shopify.server";
 import { toAdminClient } from "../services/admin-client.server";
 import { runCampaign } from "../services/campaigns/index.server";
+import { MAX_INLINE_ROWS } from "../lib/execution/inline-budget";
 import { logger } from "../lib/logging/logger";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -45,13 +46,17 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return new Response(null, { status: 200 });
   }
 
-  const outcome = await runCampaign(shop.id, campaign.id, toAdminClient(admin), {});
+  // Same request deadline as the button, and the same reason: Flow calls this over HTTP
+  // and the run is written before the response is sent.
+  const outcome = await runCampaign(shop.id, campaign.id, toAdminClient(admin), {
+    inlineRowLimit: MAX_INLINE_ROWS,
+  });
 
   logger.info("Flow started a campaign", {
     shopId: shop.id,
     campaignId: campaign.id,
     verified: outcome.verified,
-    refused: outcome.refusedByPlan ?? null,
+    refused: outcome.refused ?? null,
   });
 
   return new Response(null, { status: 200 });

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -22,6 +22,7 @@ import { AppError } from "../../lib/errors/app-error";
 import { guardrailsFor } from "../settings.server";
 import type { RunOutcome } from "./types";
 import { inChunksCounting } from "../../lib/db/chunk";
+import { refuseInline } from "../../lib/execution/inline-budget";
 import { releaseClaim, transitionCampaign } from "./lifecycle.server";
 import type { CampaignState } from "../../lib/lifecycle/transitions";
 import { SKIP_REASON_GROUP } from "../../lib/planning/reasons";
@@ -49,6 +50,15 @@ export interface RunOptions {
    * `runCampaign` reads it.
    */
   claimedFrom?: CampaignState;
+  /**
+   * Refuse rather than start, when the scope is too large to finish inside this
+   * caller's deadline.
+   *
+   * Set by the web routes, which run inside an HTTP request that gets closed after five
+   * minutes. Left unset by the worker and the scheduler, which have no request attached
+   * -- the ceiling is a property of the caller, not of the campaign.
+   */
+  inlineRowLimit?: number;
   /**
    * Fraction of applied rows to read back. Defaults to full verification, which
    * suits the catalogue sizes the sync path handles; the bulk path compares every row
@@ -208,7 +218,51 @@ async function executeCampaignRun(
       };
     }
 
-    const refusal = await refusedByPlan(shopId, campaignId, options.variantGids?.length);
+    // How many variants this run will attempt.
+    //
+    // A subset apply is bounded by the list the caller sent. Everything else has to be
+    // counted, which is only worth doing for a caller that declared a deadline -- and
+    // cheap enough to be worth it now that the scope columns are GIN-indexed. The plan
+    // gate below wants the same number, so it is counted once and passed down.
+    let scopedCount = options.variantGids?.length;
+
+    if (options.inlineRowLimit !== undefined) {
+      scopedCount ??= await prisma.variantIndex.count({
+        where: astToWhere(
+          shopId,
+          await scopeOf(
+            shopId,
+            await prisma.campaign.findFirstOrThrow({
+              where: { id: campaignId, shopId },
+              select: { schedule: true },
+            }),
+          ),
+        ),
+      });
+
+      // Before the plan gate, because a scope too large to finish is too large whatever
+      // tier the shop is on -- telling a merchant to upgrade for a run that would be
+      // cut off either way is worse than useless.
+      const tooBig = refuseInline(scopedCount, options.inlineRowLimit);
+      if (tooBig) {
+        return {
+          runId: "",
+          planned: 0,
+          verified: 0,
+          failed: 0,
+          unverified: 0,
+          // Clean, for the same reason the plan refusal below is: nothing is half-done.
+          // No price moved and no ledger row exists, so putting this campaign into the
+          // needs-attention queue would report a problem the merchant cannot fix by
+          // attending to it.
+          clean: true,
+          messages: [tooBig],
+          refused: tooBig,
+        };
+      }
+    }
+
+    const refusal = await refusedByPlan(shopId, campaignId, scopedCount);
     if (refusal) {
       return {
         runId: "",
@@ -221,7 +275,7 @@ async function executeCampaignRun(
         // queue for a reason the merchant cannot resolve by attending to it.
         clean: true,
         messages: [refusal],
-        refusedByPlan: refusal,
+        refused: refusal,
       };
     }
   }

--- a/app/services/campaigns/types.ts
+++ b/app/services/campaigns/types.ts
@@ -183,13 +183,18 @@ export interface RunOutcome {
    */
   deferredTo?: string;
   /**
-   * Set when the shop's plan does not cover this campaign, so no run was started.
+   * Set when the run was refused before it started, saying why.
    *
-   * Distinct from a failure and from "nothing to do". A caller showing a run report
-   * needs to say "your plan does not cover this" rather than "your sale failed", and an
-   * empty `runId` alone cannot carry that difference.
+   * The shop's plan does not cover the campaign, or its scope is too large to finish
+   * inside the caller's request. Distinct from a failure and from "nothing to do": a
+   * caller showing a run report needs to say "your plan does not cover this" rather
+   * than "your sale failed", and an empty `runId` alone cannot carry that difference.
+   *
+   * Named for the outcome rather than one of its causes, because a caller branching on
+   * it is asking "did this run?" -- and it once said `ByPlan` while carrying a reason
+   * that had nothing to do with billing.
    */
-  refusedByPlan?: string;
+  refused?: string;
 }
 
 export interface RunSummary {

--- a/chaos/scenarios/downgrade.chaos.ts
+++ b/chaos/scenarios/downgrade.chaos.ts
@@ -186,7 +186,7 @@ describe("chaos: downgrading while a campaign is live", () => {
         // "your sale failed", which reads far worse than "your plan does not cover this".
         expect(result.verified).toBe(0);
         expect(result.clean).toBe(true);
-        expect(result.refusedByPlan).toBeDefined();
+        expect(result.refused).toBeDefined();
         expect(result.messages.join(" ")).toContain("Markets");
 
         // And crucially, nothing was written or half-written.

--- a/chaos/scenarios/inline-budget.chaos.ts
+++ b/chaos/scenarios/inline-budget.chaos.ts
@@ -1,0 +1,114 @@
+/**
+ * A campaign too large for the request that asked for it must be refused, not started.
+ *
+ * `runCampaign` writes prices inline, so an apply from the campaign page happens during
+ * the HTTP request and dies with it. Railway closes a request after five minutes with
+ * no data transferred, and a React Router action sends nothing until it returns.
+ *
+ * The failure that produces is the worst one available: the proxy closes the connection
+ * and `runCampaign` carries on writing regardless. The merchant sees an error, and
+ * their storefront changes anyway -- prices moved with the app reporting that they did
+ * not, which is the single outcome this product exists to prevent.
+ *
+ * So the check is a refusal *before the claim*: no run row, no ledger row, no price
+ * moved, and the campaign still in the state the merchant left it in, ready to be
+ * scheduled instead.
+ *
+ * The limit is a property of the caller, not of the campaign. The worker and the
+ * scheduler have no request attached, so they pass no limit and run the same campaign
+ * to completion -- which is the second half of what this scenario proves, and the half
+ * that makes "schedule it instead" honest advice rather than a brush-off.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import prisma from "../../app/db.server";
+import { pricesMayBeLive } from "../../app/lib/lifecycle/transitions";
+import { withChaos } from "../harness/scenario";
+
+describe("chaos: a run too large for its request is refused, not abandoned halfway", () => {
+  it("refuses before the claim and leaves the campaign schedulable", async () => {
+    await withChaos(
+      "inline-budget",
+      { catalog: { products: 4, variantsPerProduct: 3 }, percent: -20 },
+      async (ctx) => {
+        const { shopId, campaignId } = ctx.fixture;
+
+        const before = await prisma.campaign.findUniqueOrThrow({
+          where: { id: campaignId },
+          select: { status: true },
+        });
+        const pricesBefore = ctx.livePrices();
+
+        // Twelve variants against a limit of three. The real limit is 120,000; what is
+        // under test is the comparison and everything it protects, not the constant.
+        const refused = await ctx.apply({ inlineRowLimit: 3 });
+
+        expect(refused.refused, "a refusal has to say so in the outcome").toBeTruthy();
+        expect(refused.refused, "and tell the merchant where to go next").toMatch(
+          /schedul/i,
+        );
+        expect(refused.messages.join(" ")).toContain("12");
+
+        // Clean, because nothing is half-done. An unclean outcome would route this into
+        // the needs-attention queue, where there is nothing to attend to.
+        expect(refused.clean, "nothing started, so nothing is partial").toBe(true);
+        expect(refused.planned).toBe(0);
+        expect(refused.verified).toBe(0);
+
+        // Ledger before write (I4), from the other direction: no write, so no row.
+        expect(
+          await prisma.variantChange.count({ where: { shopId } }),
+          "a refused run must not ledger anything",
+        ).toBe(0);
+        expect(
+          await prisma.campaignRun.count({ where: { campaignId } }),
+          "no run started, so no run row should exist",
+        ).toBe(0);
+
+        const after = await prisma.campaign.findUniqueOrThrow({
+          where: { id: campaignId },
+          select: { status: true },
+        });
+        expect(after.status, "refused before the claim, so the state never moved").toBe(
+          before.status,
+        );
+        expect(
+          pricesMayBeLive(after.status as never),
+          "the app must not believe this campaign's prices might be on the storefront",
+        ).toBe(false);
+
+        for (const [gid, price] of pricesBefore) {
+          expect(ctx.livePrices().get(gid), `${gid} must not have moved`).toBe(price);
+        }
+
+        // The other half: the same campaign, run by a caller with no request attached,
+        // goes through. The advice to schedule it is only honest if scheduling works.
+        const ran = await ctx.apply();
+        expect(ran.clean, "the worker has no deadline, so it runs the same campaign").toBe(
+          true,
+        );
+        expect(ran.verified, "all twelve variants, verified").toBe(12);
+      },
+    );
+  });
+
+  it("never refuses a revert, however large", async () => {
+    await withChaos(
+      "inline-budget-revert",
+      { catalog: { products: 4, variantsPerProduct: 3 }, percent: -20 },
+      async (ctx) => {
+        const applied = await ctx.apply();
+        expect(applied.clean).toBe(true);
+
+        // A limit far below the scope. Refusing here would strand a store at 20% off
+        // because it is large -- the guard causing the incident it exists to prevent.
+        const reverted = await ctx.revert({ inlineRowLimit: 1 });
+
+        expect(reverted.refused, "a revert is never gated, on anything").toBeFalsy();
+        expect(reverted.clean).toBe(true);
+        expect(reverted.verified).toBe(12);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## The failure

`runCampaign` writes prices during the HTTP request that asked for it, so a campaign applied from the campaign page dies with that request. Railway closes a request after five minutes with no data transferred, and a React Router action sends nothing until it returns — so five minutes is the ceiling, not the fifteen that applies to a streaming response.

**Exceeding it does not cancel the work.** The proxy closes the connection while `runCampaign` carries on writing. The merchant sees an error and their storefront changes anyway — prices moved with the app reporting that they did not, which is the one outcome this product exists to prevent, arriving through a timeout nobody had written down.

Measured on `anchor-perf`: 62,535 variants in 109 seconds, about 1.75ms each. The cliff therefore sits near **170,000 variants** — not a hypothetical size for a product whose performance store exists at 102,132 precisely because that is the scale it targets.

## The guard

Refuse at **120,000**, well under the cliff rather than at it. At that size the estimate is about three and a half minutes, leaving room for a slow shop, a throttled Admin API, and the fact that the per-variant figure came from one store on one afternoon.

Four properties, each of which is a test:

- **The limit belongs to the caller, not the campaign.** The campaign page and the Flow start action pass `inlineRowLimit`; the worker and the scheduler do not. That is what makes "schedule it instead" honest advice rather than a brush-off.
- **Reverts are never refused.** A store left discounted because its revert was too large is the incident, not the protection. The guard sits inside the existing applies-only branch.
- **Refused before the claim.** Nothing transitions, no run row exists, the ledger stays empty (I4), and the campaign is still where the merchant left it.
- **The count is not new work.** The plan gate already needed the scope count; it is now taken once and passed down. 8ms for the 102,132-row catalogue against a run of 109 seconds, with the GIN indexes from #160 doing the work.

## Two things found on the way

**`refusedByPlan` was read by nobody.** Every refusal — including the plan one that has shipped for months — reached the generic message and rendered as *"Applied 0 variants, all verified."* A green tick over a campaign that never ran, and a merchant walking away believing their prices changed. The campaign page now shows the reason, in `warning` rather than `critical`: nothing broke, and there is something to do.

**The field is renamed to `refused`.** It was about to carry a reason with nothing to do with billing, and a caller branching on it is asking "did this run?", not "which gate stopped it?".

## Verification

- 1,809 unit + 142 chaos tests pass; typecheck, lint and build clean.
- **Nine mutants, all caught**: guard always allows; limit raised to the cliff; limit lowered below what already works; the campaign page stops passing the limit; the worker starts passing one; the refusal branch disabled (twice — the first version of that assertion was too weak and survived); the branch moved after the generic message; the banner tone reverted to critical.
- The caller contract is read off the routes directory rather than a hand-kept list, in both directions.

**Not verified in a browser.** Clicks would not reach the embedded app iframe in this session — a plain tab link did not navigate either — so the refusal banner was never clicked through. The campaign page renders correctly with the change; the banner itself is asserted from source only.

Related: #299, which this is orthogonal to — it protects whichever way that decision goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)