### PR TITLE
The dashboard says what it knows, in rows rather than in boxes

### DIFF
--- a/app/components/ActivityFeed.test.tsx
+++ b/app/components/ActivityFeed.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The sidebar's activity list, which was five identical lines.
+ *
+ * `market.added · Scheduler · 27/08/2026, 12:40:38`, five times, in a column 22rem wide.
+ * Each of the three problems is fixed in the rendering rather than in the query, because
+ * the data was never wrong — the audit log is right to store machine strings and exact
+ * timestamps, and right to record every market it added.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ActivityFeed } from "./ActivityFeed";
+
+const NOW = "2026-08-27T15:00:00.000Z";
+
+const render = (entries: Array<{ id: string; actor: string | null; action: string; at: string }>) =>
+  renderToStaticMarkup(<ActivityFeed entries={entries} now={NOW} timeZone="Europe/London" />);
+
+const scheduled = (id: string, action: string, at: string) => ({ id, actor: null, action, at });
+
+describe("a sync that added several markets", () => {
+  const html = render([
+    scheduled("1", "market.added", "2026-08-27T13:00:00.000Z"),
+    scheduled("2", "market.added", "2026-08-27T13:00:00.000Z"),
+    scheduled("3", "market.added", "2026-08-27T12:59:59.000Z"),
+  ]);
+
+  it("says it once, with a count", () => {
+    expect(html).toContain("×3");
+    expect(html.match(/Market added/g)).toHaveLength(1);
+  });
+
+  it("never shows the merchant the machine string", () => {
+    expect(html).not.toContain("market.added");
+  });
+
+  it("says the time is the latest of the run rather than implying it is the only one", () => {
+    expect(html).toContain("latest");
+    expect(html).toContain("2 hours ago");
+  });
+
+  it("still says who, because that is half of what an audit trail is for", () => {
+    expect(html).toContain("Scheduler");
+  });
+});
+
+describe("a mixed log", () => {
+  const html = render([
+    scheduled("1", "market.added", "2026-08-27T14:30:00.000Z"),
+    { id: "2", actor: "staff:8812", action: "campaign.transition", at: "2026-08-27T09:00:00.000Z" },
+    scheduled("3", "market.added", "2026-08-27T08:00:00.000Z"),
+  ]);
+
+  it("keeps the two separated events separate, in order", () => {
+    // Folding by action across the whole list would move the older market entry up next
+    // to the newer one and imply they happened together.
+    expect(html.match(/Market added/g)).toHaveLength(2);
+    expect(html).not.toContain("×");
+  });
+
+  it("attributes staff work to staff", () => {
+    expect(html).toContain("Staff 8812");
+  });
+
+  it("times each row relative to when the page was loaded", () => {
+    expect(html).toContain("30 minutes ago");
+    expect(html).toContain("6 hours ago");
+  });
+});
+
+describe("an empty log", () => {
+  it("renders nothing rather than an empty state the card already provides", () => {
+    // The card that holds this is only rendered when there is something to put in it.
+    expect(render([])).not.toContain("s-icon");
+  });
+});

--- a/app/components/ActivityFeed.tsx
+++ b/app/components/ActivityFeed.tsx
@@ -1,0 +1,65 @@
+import { describeAction, iconForAction } from "../lib/audit/action";
+import { describeActor } from "../lib/audit/actor";
+import { collapseRuns, type Loggable } from "../lib/audit/collapse";
+import { formatAgo } from "../lib/format/display";
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * The last few things that happened, in the sidebar.
+ *
+ * It was five lines of `market.added · Scheduler · 27/08/2026, 12:40:38` — the same
+ * sentence five times, in a column 22rem wide. Three separate problems wearing one
+ * coat, and all three are fixed here rather than in the loader, because the data was
+ * never wrong:
+ *
+ * - **The action was a machine string.** `market.added` is what the audit table stores
+ *   and it is the right thing to store; it is not a thing to show a merchant.
+ * - **The timestamp was absolute, to the second.** Five of those stacked vertically are
+ *   five nearly identical strings that have to be diffed character by character to
+ *   answer "was this recent?".
+ * - **Repeats were repeated.** One sync writes one entry per market it finds, so the
+ *   whole list was routinely one event, five times.
+ *
+ * What is deliberately kept: the actor on every row. This is an audit trail, and "who"
+ * is half of what it is for — a feed that folded staff and the scheduler together to
+ * look tidier would be answering a different question than the one being asked.
+ */
+export function ActivityFeed<T extends Loggable>({
+  entries,
+  now,
+  timeZone,
+}: {
+  entries: T[];
+  now: string;
+  timeZone: string;
+}) {
+  return (
+    <s-stack gap={SPACE.section}>
+      {collapseRuns(entries).map(({ entry, count }) => (
+        <s-grid
+          key={entry.id}
+          // The glyph column is fixed by its content and the text takes the rest, so a
+          // long action name wraps under itself rather than under the icon.
+          gridTemplateColumns="auto 1fr"
+          gap={SPACE.item}
+          alignItems="start"
+        >
+          <s-icon type={iconForAction(entry.action)} color="subdued" />
+          <s-stack gap={SPACE.tight}>
+            <s-stack direction="inline" gap={SPACE.item} alignItems="center">
+              <s-text type="strong">{describeAction(entry.action)}</s-text>
+              {count > 1 ? <s-badge tone="neutral">{`×${count}`}</s-badge> : null}
+            </s-stack>
+            <s-text color="subdued">
+              {/* "latest" only when the row stands for several entries. Without it the
+                  time reads as *the* time this happened, which for a folded run is true
+                  of exactly one of them. */}
+              {describeActor(entry.actor)} · {count > 1 ? "latest " : ""}
+              {formatAgo(entry.at, now, timeZone)}
+            </s-text>
+          </s-stack>
+        </s-grid>
+      ))}
+    </s-stack>
+  );
+}

--- a/app/components/LastRunSummary.tsx
+++ b/app/components/LastRunSummary.tsx
@@ -1,0 +1,73 @@
+import { formatAgo, formatCount } from "../lib/format/display";
+import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
+import { RUN_TONE, toneFor } from "./tone";
+
+/**
+ * The last thing the app did to the storefront.
+ *
+ * This is the sentence a merchant opens the dashboard to read, and it used to be an
+ * actual sentence: *Last run: apply of "Summer sale" — completed, 412 verified on
+ * 27/08/2026, 12:40:38.* Everything is in there, in the order the code happened to have
+ * it, and the two things being looked for — did it go cleanly, and was that recently —
+ * are the fifth and last words of a clause.
+ *
+ * As a row those two are the first and last things on it: the outcome as a toned badge on
+ * the left, where a status belongs, and the time on the right in words. What is left in
+ * the middle is the campaign's name, which is the only part that was ever prose.
+ *
+ * `PARTIAL` is a warning and never a success, per `RUN_TONE` — a run that did not verify
+ * every row is the exact state this product exists to make visible.
+ */
+export function LastRunSummary({
+  run,
+  now,
+  timeZone,
+}: {
+  run: {
+    kind: string;
+    status: string;
+    verified: number;
+    failed: number;
+    finishedAt: string | null;
+    campaignId: string;
+    campaignName: string;
+  };
+  now: string;
+  timeZone: string;
+}) {
+  return (
+    <s-box
+      padding={PAD.card}
+      borderWidth={HAIRLINE.borderWidth}
+      borderStyle={HAIRLINE.borderStyle}
+      borderColor={HAIRLINE.borderColor}
+      borderRadius="base"
+    >
+      <s-grid
+        // One comma only: Polaris reads the comma as the separator between the responsive
+        // value and the default, so a second one anywhere stops the value parsing.
+        gridTemplateColumns="@container (inline-size <= 560px) auto 1fr, auto 1fr auto"
+        gap={SPACE.item}
+        alignItems="center"
+      >
+        <s-badge tone={toneFor(RUN_TONE, run.status)}>{sentence(run.status)}</s-badge>
+
+        <s-stack gap={SPACE.tight}>
+          <s-text type="strong">{run.campaignName}</s-text>
+          <s-text color="subdued">
+            {run.kind.toLowerCase()} · {formatCount(run.verified)} verified
+            {run.failed > 0 ? `, ${formatCount(run.failed)} failed` : ""}
+            {run.finishedAt ? ` · ${formatAgo(run.finishedAt, now, timeZone)}` : " · still running"}
+          </s-text>
+        </s-stack>
+
+        <s-link href={`/app/campaigns/${run.campaignId}`}>View campaign</s-link>
+      </s-grid>
+    </s-box>
+  );
+}
+
+/** `COMPLETED` is a database value; "Completed" is a word. */
+function sentence(value: string): string {
+  return value.charAt(0) + value.slice(1).toLowerCase();
+}

--- a/app/components/Meter.test.tsx
+++ b/app/components/Meter.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * The bar is decoration that has to be honest: it sits beside a figure, and a bar that
+ * disagrees with the number next to it is worse than no bar.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Meter } from "./Meter";
+
+/**
+ * The fill's width is the only thing this component says.
+ *
+ * The *last* `inlineSize` in the markup, not the first: the track is also a box and it is
+ * always 100%, so a lazier match reads the container and reports every meter as full.
+ */
+const width = (value: number, max: number) => {
+  const sizes = [
+    ...renderToStaticMarkup(<Meter value={value} max={max} />).matchAll(/inlineSize="(\d+%)"/g),
+  ];
+  return sizes[sizes.length - 1]?.[1];
+};
+
+describe("the meter", () => {
+  it("fills in proportion", () => {
+    expect(width(1, 4)).toBe("25%");
+    expect(width(3, 4)).toBe("75%");
+  });
+
+  it("is empty rather than NaN when there is nothing to measure", () => {
+    // A shop with no variants yet is a real state, not a bug.
+    expect(width(0, 0)).toBe("0%");
+  });
+
+  it("clamps past full, because more baselines than variants is expected here", () => {
+    // Baselines are kept for deleted products, so the numerator legitimately exceeds the
+    // denominator — and a 104% bar would overflow its track.
+    expect(width(9200, 9145)).toBe("100%");
+  });
+
+  it("clamps a negative to empty", () => {
+    expect(width(-5, 10)).toBe("0%");
+  });
+});

--- a/app/components/Meter.tsx
+++ b/app/components/Meter.tsx
@@ -1,0 +1,62 @@
+import { HAIRLINE } from "../lib/ui/spacing";
+
+/**
+ * A proportion, drawn.
+ *
+ * ## Why this exists
+ *
+ * "9,081 of 9,145 variants" is precise, and it is also the slowest possible way to answer
+ * the only question being asked of it, which is *nearly all, or barely any?* A bar answers
+ * that before the reader has finished arriving at it.
+ *
+ * The figure stays. This is deliberately not a replacement for saying the number: a bar
+ * alone is unreadable to anybody using a screen reader and imprecise for everybody else,
+ * so it is always rendered next to the sentence it illustrates and never instead of it.
+ * That is also why it takes no accessibility label — labelling it would announce the same
+ * fact twice.
+ *
+ * ## Why the fill is outlined
+ *
+ * Polaris has no progress element in this version, so the bar is built from the box
+ * primitives that are in it rather than from a hardcoded colour that would not follow the
+ * merchant's theme. The catch is that every background token available to a box —
+ * `subdued`, `base`, `strong` — is a near-white grey, and they were checked side by side:
+ * a strong fill on a subdued track is a boundary you have to hunt for, which is a
+ * progress bar that does not report progress.
+ *
+ * The hairline around the fill is what makes it a shape rather than a smudge. It is the
+ * same border the stat tiles use, so the bar belongs to the same drawing as the rest of
+ * the app, and it stays legible in dark mode where a fixed grey would not.
+ */
+
+/** Bar height. Thick enough for the fill's outline to close, thin enough to read as a rule. */
+const THICKNESS = "10px";
+
+export function Meter({ value, max }: { value: number; max: number }) {
+  // A zero denominator is a real state here — a shop with no variants yet — and it is
+  // an empty bar, not a division by zero rendered as `NaN%`.
+  const filled = max > 0 ? Math.min(100, Math.max(0, Math.round((value / max) * 100))) : 0;
+
+  return (
+    <s-box
+      background="subdued"
+      borderRadius="large"
+      blockSize={THICKNESS}
+      inlineSize="100%"
+      overflow="hidden"
+    >
+      {/* The template literal is cast because Polaris types sizes as `${number}%`, and a
+          string built from a variable widens to `string`. The clamp above is what makes
+          the cast true. */}
+      <s-box
+        background="strong"
+        borderWidth={HAIRLINE.borderWidth}
+        borderStyle={HAIRLINE.borderStyle}
+        borderColor="strong"
+        borderRadius="large"
+        blockSize={THICKNESS}
+        inlineSize={`${filled}%` as `${number}%`}
+      />
+    </s-box>
+  );
+}

--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -77,6 +77,39 @@ describe("a shop part-way through", () => {
     // the new normal, permanently — so a finished step must not invite a repeat.
     expect(html).not.toContain("Sync catalogue");
   });
+
+  it("offers no explanation on a completed step either", () => {
+    // The one row with nothing to do had a lone "Why?" hanging off its right edge,
+    // offering to explain work the merchant had already finished.
+    const step = html.slice(
+      html.indexOf("Capture your baselines"),
+      html.indexOf("Try one in practice mode"),
+    );
+    expect(step).not.toContain("Why?");
+  });
+});
+
+describe("how a step is drawn", () => {
+  const html = render(fresh);
+
+  it("is a row, not a card", () => {
+    // Each step used to be a bordered box holding a stack, which rendered the title, the
+    // toggle and the action on three separate lines — nine lines and three borders for
+    // three short sentences. The cells of a grid are what put them on one line.
+    expect(html).toContain("<s-grid");
+    expect(html).not.toContain("borderWidth");
+  });
+
+  it("draws the status as a glyph rather than a badge on every row", () => {
+    // Three badges to say what three glyphs say, and the two loudest words on the card
+    // were "Done" and "Later".
+    expect(html).not.toContain("Later");
+    expect(html).toContain("<s-icon");
+  });
+
+  it("still marks exactly one step as the one to do next", () => {
+    expect(html.match(/Next/g)).toHaveLength(1);
+  });
 });
 
 describe("a shop that has finished", () => {

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import type { OnboardingState, OnboardingStep } from "../lib/onboarding/steps";
-import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
+import { SPACE } from "../lib/ui/spacing";
 
 /**
  * The checklist, until the first campaign has run cleanly.
@@ -22,12 +22,19 @@ import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
  * The state comes from what the shop has actually done, never from "steps dismissed", so
  * there is nothing here to dismiss: the card retires itself when the work is real.
  *
- * Three rhythms, nested, and they are what make it scan as a checklist rather than a
- * paragraph with badges in it: section rhythm between the progress line and the list,
- * item rhythm between the steps, item rhythm again inside a step. The steps are bounded
- * boxes for the same reason the stat tiles are — a checklist whose items have no edges
- * is just four lines of text, and the merchant has to count the badges to work out where
- * one step stops.
+ * ## Why the steps are rows and not boxes
+ *
+ * Each step used to be a bordered box holding a stack, and the result was three tall
+ * cards inside a card, each with a title on one line, a lone "Why?" on the next and its
+ * action on a third — because `s-clickable` and `s-link` are block-level and an inline
+ * stack does not change that. Nine lines and three borders to carry three short
+ * sentences, with the right two-thirds of every box empty.
+ *
+ * A grid changes that, where a stack could not: block-level children placed in separate
+ * *cells* sit side by side, because it is the cell that decides where they go. So a step
+ * is one row — status, title, action — and the steps are separated by hairlines rather
+ * than each being drawn as its own card. Same information, a third of the height, and
+ * the eye can run down the status column to see where it is up to.
  */
 export function OnboardingCard({ state }: { state: OnboardingState }) {
   if (state.complete) return null;
@@ -48,8 +55,14 @@ export function OnboardingCard({ state }: { state: OnboardingState }) {
         </s-stack>
 
         <s-stack gap={SPACE.item}>
-          {state.steps.map((step) => (
-            <Step key={step.id} step={step} isNext={step.id === state.next?.id} />
+          {state.steps.map((step, index) => (
+            <s-stack key={step.id} gap={SPACE.item}>
+              {/* A rule between steps rather than a border around each. The separator is
+                  the same information as the box — where one step stops — at a fraction
+                  of the ink, and it does not nest a card inside a card. */}
+              {index > 0 ? <s-divider /> : null}
+              <Step step={step} isNext={step.id === state.next?.id} />
+            </s-stack>
           ))}
         </s-stack>
       </s-stack>
@@ -57,50 +70,80 @@ export function OnboardingCard({ state }: { state: OnboardingState }) {
   );
 }
 
+/**
+ * The status glyph.
+ *
+ * A checked circle, an open one and a dashed one: the standard vocabulary for done, now
+ * and not yet, which means the column reads as a progress track without anybody having
+ * to label it. The badge that used to say "Done" / "Next" / "Later" on every row is gone
+ * with it — three badges to say what three glyphs say, and the two loudest words on the
+ * card were "Done" and "Later".
+ *
+ * "Next" survives as a badge on exactly one row, because that one is not a status the
+ * eye should merely be able to find. It is the instruction.
+ */
+function StatusIcon({ done, isNext }: { done: boolean; isNext: boolean }) {
+  if (done) return <s-icon type="check-circle-filled" tone="success" />;
+  if (isNext) return <s-icon type="circle" />;
+  return <s-icon type="circle-dashed" color="subdued" />;
+}
+
 function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
   const [why, setWhy] = useState(false);
 
   return (
-    <s-box
-      padding={PAD.card}
-      borderWidth={HAIRLINE.borderWidth}
-      borderStyle={HAIRLINE.borderStyle}
-      borderColor={HAIRLINE.borderColor}
-      borderRadius="base"
-    >
-      <s-stack gap={SPACE.item}>
+    <s-stack gap={SPACE.tight}>
+      <s-grid
+        // Three columns, collapsing to two. `auto 1fr auto` keeps the status glyph and
+        // the action tight to their content and gives the title everything left over,
+        // which is what stops the row from breaking into three.
+        //
+        // One comma only. Polaris splits a responsive value on the comma to separate
+        // "when the query matches" from "otherwise", so a second one anywhere in the
+        // value stops the whole thing parsing and it falls back to `none`.
+        gridTemplateColumns="@container (inline-size <= 500px) auto 1fr, auto 1fr auto"
+        gap={SPACE.item}
+        alignItems="center"
+      >
+        <StatusIcon done={step.done} isNext={isNext} />
+
         <s-stack direction="inline" gap={SPACE.item} alignItems="center">
-          <s-badge tone={step.done ? "success" : isNext ? "info" : "neutral"}>
-            {step.done ? "Done" : isNext ? "Next" : "Later"}
-          </s-badge>
-          <s-text type="strong">{step.title}</s-text>
-          {/* Progressive disclosure, not a link away. The reasoning belongs next to the
-              step it explains — sending a merchant to a docs page to find out why they
-              are being asked to sync is how they end up not syncing.
-
-              These render on their own lines, because `s-clickable` and `s-link` are
-              block-level and an inline stack does not change that. It is not pretty and
-              it is what works: replacing them with `s-button-group` laid the row out
-              correctly and rendered no buttons at all, so the first screen after install
-              offered no way to sync. A checklist that looks slightly loose beats one
-              whose actions are missing.
-
-              Before the action, deliberately. The row wraps on a narrow column, and when
-              the toggle was last it wrapped onto its own line and read as belonging to
-              the step below it. The action wrapping is harmless; an explanation attached
-              to the wrong step is not. */}
-          <s-clickable onClick={() => setWhy((open) => !open)}>
-            <s-text color="subdued">{why ? "Hide why" : "Why?"}</s-text>
-          </s-clickable>
-          {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
+          {/* Subdued once done. A finished step should still be findable — it is the
+              evidence the checklist is being honest — without competing with the step
+              the merchant is actually being asked to do. */}
+          <s-text type={step.done ? undefined : "strong"} color={step.done ? "subdued" : undefined}>
+            {step.title}
+          </s-text>
+          {isNext ? <s-badge tone="info">Next</s-badge> : null}
         </s-stack>
 
-        {why ? (
-          <s-paragraph>
-            <s-text color="subdued">{step.detail}</s-text>
-          </s-paragraph>
-        ) : null}
-      </s-stack>
-    </s-box>
+        {/* Both actions in one cell, as their own grid: two block-level elements in a
+            single cell would stack, and this is the pair that used to. Why before the
+            action, deliberately — when the row wraps it is the action that should fall
+            to the next line, not the explanation, which would then read as belonging to
+            the step below it. */}
+        <s-grid gridTemplateColumns="auto auto" gap={SPACE.item} alignItems="center">
+          {/* Not on a finished step. The reasoning for work already done is the one
+              thing on this card nobody needs, and on a completed row — which has no
+              action beside it — it was also the only thing left hanging off the right
+              edge, so the column of actions read as ragged. */}
+          {step.done ? null : (
+            <s-clickable onClick={() => setWhy((open) => !open)}>
+              <s-text color="subdued">{why ? "Hide why" : "Why?"}</s-text>
+            </s-clickable>
+          )}
+          {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
+        </s-grid>
+      </s-grid>
+
+      {/* Progressive disclosure, not a link away. The reasoning belongs next to the step
+          it explains — sending a merchant to a docs page to find out why they are being
+          asked to sync is how they end up not syncing. */}
+      {why ? (
+        <s-paragraph>
+          <s-text color="subdued">{step.detail}</s-text>
+        </s-paragraph>
+      ) : null}
+    </s-stack>
   );
 }

--- a/app/lib/audit/action.test.ts
+++ b/app/lib/audit/action.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The activity feed's words, and why they are computed rather than looked up.
+ *
+ * Several audit actions are built at the call site from a variable — `market.${kind}`,
+ * `drift.${resolution}` — so there is no closed list of them to write a table against.
+ * A table would therefore be permanently one release behind the app, and its failure
+ * mode is silent: an unmapped action falls through to the raw string and the merchant
+ * reads `mirror.divergence_rate` in their sidebar.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { describeAction, iconForAction } from "./action";
+
+describe("describing an action", () => {
+  it("turns the dotted machine string into a phrase", () => {
+    expect(describeAction("market.added")).toBe("Market added");
+    expect(describeAction("baselines.recapture")).toBe("Baselines recapture");
+  });
+
+  it("treats hyphens and underscores as word breaks too", () => {
+    expect(describeAction("market.notice-resolved")).toBe("Market notice resolved");
+    expect(describeAction("campaign.auto_enroll")).toBe("Campaign auto enroll");
+  });
+
+  it("reads a three-part namespace as one phrase", () => {
+    expect(describeAction("settings.guardrails.update")).toBe("Settings guardrails update");
+  });
+
+  it("has an answer for an action nobody has written yet", () => {
+    // The property that a lookup table cannot have: this cannot be missing an entry.
+    expect(describeAction("something.entirely.new")).toBe("Something entirely new");
+  });
+
+  it("does not blank out on an empty or punctuation-only action", () => {
+    expect(describeAction("")).toBe("");
+    expect(describeAction("...")).toBe("...");
+  });
+});
+
+describe("choosing an icon", () => {
+  it("keys on the namespace, which is the stable half of the string", () => {
+    expect(iconForAction("market.added")).toBe("markets");
+    expect(iconForAction("market.removed")).toBe("markets");
+    expect(iconForAction("drift.accepted")).toBe("alert-triangle");
+  });
+
+  it("gives an unknown namespace a real icon rather than nothing", () => {
+    // A feed where some rows have a glyph and others have a hole reads as a failure to
+    // load, which is worse than a feed with no glyphs at all.
+    expect(iconForAction("something.new")).toBe("note");
+    expect(iconForAction("")).toBe("note");
+  });
+});

--- a/app/lib/audit/action.ts
+++ b/app/lib/audit/action.ts
@@ -1,0 +1,64 @@
+/**
+ * What happened, in words a merchant recognises.
+ *
+ * Audit actions are written as namespaced machine strings — `market.added`,
+ * `drift.accepted`, `settings.guardrails.update` — and several are built at the call site
+ * from a variable (`market.${change.kind}`), so there is no closed list of them anywhere
+ * and any lookup table here would go stale silently the first time somebody adds a kind.
+ *
+ * So this is a transformation, not a mapping: it cannot be missing an entry. Dots,
+ * hyphens and underscores are word breaks, and the first word is capitalised. That turns
+ * every action the app writes today into a readable phrase, and every action it writes
+ * tomorrow into a readable phrase without anybody remembering to come back here.
+ *
+ * The trade is that the phrasing is mechanical rather than composed — "Campaign
+ * transition" rather than "Campaign status changed". Worth it: a plausible sentence for
+ * an action nobody anticipated beats a polished one for six actions and a raw
+ * `mirror.divergence_rate` for the seventh.
+ */
+export function describeAction(action: string): string {
+  const words = action.split(/[.\-_]+/).filter(Boolean).join(" ");
+  if (words.length === 0) return action;
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * The icon for an action's subject.
+ *
+ * Keyed on the namespace — everything before the first dot — because that is the part
+ * that names *what* the entry is about, and it is the stable half of the string. A
+ * namespace with no icon gets a neutral one rather than nothing: an activity list where
+ * some rows have a leading glyph and others have a hole is worse than one with no icons
+ * at all, because the hole reads as a failure to load.
+ */
+// No return annotation, deliberately: the inferred union of literals is what makes these
+// assignable to Polaris' `IconType`, and a typo becomes a build error at the call site.
+// Annotating `string` here would push the mistake to runtime, where a bad name renders
+// nothing at all.
+export function iconForAction(action: string) {
+  const subject = action.split(".")[0];
+  switch (subject) {
+    case "market":
+      return "markets";
+    case "campaign":
+      return "megaphone";
+    case "drift":
+      return "alert-triangle";
+    case "baselines":
+      return "price-list";
+    case "cost":
+      return "product-cost";
+    case "settings":
+      return "settings";
+    case "billing":
+      return "credit-card";
+    case "notification":
+      return "notification";
+    case "approval":
+      return "shield-pending";
+    case "mirror":
+      return "globe";
+    default:
+      return "note";
+  }
+}

--- a/app/lib/audit/collapse.test.ts
+++ b/app/lib/audit/collapse.test.ts
@@ -1,0 +1,66 @@
+/**
+ * One sync writes one audit entry per market it finds, so the dashboard's five most
+ * recent entries were routinely five copies of the same event — five rows spent saying
+ * one thing, and five rows not spent on the four other things that happened.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { collapseRuns } from "./collapse";
+
+const entry = (id: string, action: string, actor: string | null, at: string) => ({
+  id,
+  action,
+  actor,
+  at,
+});
+
+describe("collapsing a run of repeats", () => {
+  it("folds consecutive identical actions into one row with a count", () => {
+    const runs = collapseRuns([
+      entry("1", "market.added", null, "2026-08-27T12:40:38.000Z"),
+      entry("2", "market.added", null, "2026-08-27T12:40:37.000Z"),
+      entry("3", "market.added", null, "2026-08-27T12:40:36.000Z"),
+    ]);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].count).toBe(3);
+  });
+
+  it("keeps the newest entry of the run, because that is the timestamp worth showing", () => {
+    const runs = collapseRuns([
+      entry("newest", "market.added", null, "2026-08-27T12:40:38.000Z"),
+      entry("older", "market.added", null, "2026-08-27T12:40:37.000Z"),
+    ]);
+
+    expect(runs[0].entry.id).toBe("newest");
+  });
+
+  it("does not fold across a different actor", () => {
+    // Same event, different accountability. The audit log exists for the accountability.
+    const runs = collapseRuns([
+      entry("1", "market.added", "staff:1", "2026-08-27T12:00:00.000Z"),
+      entry("2", "market.added", null, "2026-08-27T11:00:00.000Z"),
+    ]);
+
+    expect(runs).toHaveLength(2);
+    expect(runs.every((run) => run.count === 1)).toBe(true);
+  });
+
+  it("only folds neighbours, so a folded row is still a true stretch of history", () => {
+    // Grouping by action across the whole list would reorder events and imply an
+    // adjacency that was not there.
+    const runs = collapseRuns([
+      entry("1", "market.added", null, "2026-08-27T12:00:00.000Z"),
+      entry("2", "drift.accepted", null, "2026-08-27T11:00:00.000Z"),
+      entry("3", "market.added", null, "2026-08-27T10:00:00.000Z"),
+    ]);
+
+    expect(runs.map((run) => run.entry.id)).toEqual(["1", "2", "3"]);
+    expect(runs.map((run) => run.count)).toEqual([1, 1, 1]);
+  });
+
+  it("has nothing to say about an empty log", () => {
+    expect(collapseRuns([])).toEqual([]);
+  });
+});

--- a/app/lib/audit/collapse.ts
+++ b/app/lib/audit/collapse.ts
@@ -1,0 +1,46 @@
+/**
+ * Folding a repeated action into one line.
+ *
+ * The dashboard shows the five most recent audit entries, and a single sync writes one
+ * entry per market it discovers — so the whole list is routinely five copies of "market
+ * added, scheduler, 12:40:38", and the merchant learns nothing except that the app is
+ * busy. Five rows spent on one event is also five rows *not* spent on the four other
+ * things that happened.
+ *
+ * Only *consecutive* runs fold, and the log is ordered, so a folded row is a true
+ * statement about a contiguous stretch of history: nothing else happened in between. The
+ * alternative — grouping by action across the whole list — would silently reorder events
+ * and imply an adjacency that was not there.
+ */
+
+export interface Loggable {
+  id: string;
+  actor: string | null;
+  action: string;
+  at: string;
+}
+
+export interface CollapsedRun<T extends Loggable> {
+  /** The most recent entry of the run; its timestamp is the one worth showing. */
+  entry: T;
+  /** How many consecutive entries folded into it. One means nothing was folded. */
+  count: number;
+}
+
+export function collapseRuns<T extends Loggable>(entries: T[]): Array<CollapsedRun<T>> {
+  const runs: Array<CollapsedRun<T>> = [];
+
+  for (const entry of entries) {
+    const previous = runs[runs.length - 1];
+    // Actor as well as action: the scheduler adding a market and a member of staff adding
+    // one are the same event with different accountability, and the audit log exists for
+    // the accountability.
+    if (previous && previous.entry.action === entry.action && previous.entry.actor === entry.actor) {
+      previous.count += 1;
+      continue;
+    }
+    runs.push({ entry, count: 1 });
+  }
+
+  return runs;
+}

--- a/app/lib/format/display.test.ts
+++ b/app/lib/format/display.test.ts
@@ -16,7 +16,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { formatCount, formatDay, formatWhen } from "./display";
+import { formatAgo, formatCount, formatDay, formatWhen } from "./display";
 
 describe("counts group the same way everywhere", () => {
   it("groups in thousands, whatever the machine's locale is", () => {
@@ -133,5 +133,47 @@ describe("counts a merchant reads are grouped, wherever they appear", () => {
     const source = readFileSync(join(process.cwd(), file), "utf8");
 
     expect(source, `${file} shows counts without grouping them`).toContain("formatCount");
+  });
+});
+
+describe("how long ago", () => {
+  const now = "2026-08-27T15:00:00.000Z";
+  const ago = (value: string) => formatAgo(value, now, "Europe/London");
+
+  it("says just now rather than 0 minutes", () => {
+    expect(ago("2026-08-27T14:59:40.000Z")).toBe("just now");
+  });
+
+  it("counts minutes, and does not say 1 minutes", () => {
+    expect(ago("2026-08-27T14:59:00.000Z")).toBe("1 minute ago");
+    expect(ago("2026-08-27T14:43:00.000Z")).toBe("17 minutes ago");
+  });
+
+  it("counts hours and days", () => {
+    expect(ago("2026-08-27T13:00:00.000Z")).toBe("2 hours ago");
+    expect(ago("2026-08-25T15:00:00.000Z")).toBe("2 days ago");
+  });
+
+  it("falls back to a date once relative stops helping", () => {
+    // "47 days ago" is a subtraction the reader has to undo to place it against
+    // anything else they know.
+    expect(ago("2026-06-02T09:00:00.000Z")).toBe("02/06/2026");
+  });
+
+  it("handles a timestamp in the future, which a scheduled run is", () => {
+    expect(ago("2026-08-27T18:00:00.000Z")).toBe("in 3 hours");
+  });
+
+  it("takes its clock from the caller, so the server and the browser agree", () => {
+    // The whole point of passing `now` in: two renders of the same page must produce
+    // the same string, not two readings of two different clocks.
+    const earlier = formatAgo("2026-08-27T14:00:00.000Z", "2026-08-27T15:00:00.000Z", "UTC");
+    const later = formatAgo("2026-08-27T14:00:00.000Z", "2026-08-27T16:00:00.000Z", "UTC");
+    expect(earlier).toBe("1 hour ago");
+    expect(later).toBe("2 hours ago");
+  });
+
+  it("returns the raw value rather than throwing on an unparseable date", () => {
+    expect(formatAgo("not a date", now, "UTC")).toBe("not a date");
   });
 });

--- a/app/lib/format/display.ts
+++ b/app/lib/format/display.ts
@@ -56,3 +56,50 @@ export function formatDay(value: Date | string, timeZone: string): string {
     return String(value);
   }
 }
+
+/**
+ * How long ago something happened, in words.
+ *
+ * ## Why a `now` is passed in rather than read
+ *
+ * Calling `Date.now()` inside this function would compute the string twice — once on the
+ * server rendering the HTML, once in the browser hydrating it — at two different
+ * instants. Most of the time that agrees; around a boundary it does not, and React
+ * patches over a difference it should never have been shown. Taking `now` from the
+ * loader makes both renders read the same clock, which also gives the phrase an honest
+ * meaning: *as of when this page was loaded*.
+ *
+ * ## Why relative at all
+ *
+ * A dashboard's activity list is five timestamps stacked vertically, and rendered
+ * absolutely they are five nearly identical strings — "27/08/2026, 12:40:38" five times.
+ * The reader has to diff them character by character to learn the only thing they wanted
+ * to know, which is whether this happened recently. Relative time answers that in a
+ * glance and stops the column being noise.
+ *
+ * Anything older than a week falls back to a date, because "47 days ago" is a subtraction
+ * the reader now has to undo to place it against anything else they know.
+ */
+export function formatAgo(value: Date | string, now: Date | string, timeZone: string): string {
+  const then = new Date(value).getTime();
+  const at = new Date(now).getTime();
+  if (Number.isNaN(then) || Number.isNaN(at)) return String(value);
+
+  const seconds = Math.round((at - then) / 1000);
+  const future = seconds < 0;
+  const size = Math.abs(seconds);
+
+  // Cast rather than pluralised by hand at four call sites: the unit is singular when
+  // the count is one, and "1 minutes ago" is the kind of detail that makes a UI look
+  // unattended.
+  const phrase = (count: number, unit: string) =>
+    `${count} ${unit}${count === 1 ? "" : "s"}`;
+
+  const relative = (body: string) => (future ? `in ${body}` : `${body} ago`);
+
+  if (size < 45) return future ? "in a moment" : "just now";
+  if (size < 3600) return relative(phrase(Math.round(size / 60), "minute"));
+  if (size < 86_400) return relative(phrase(Math.round(size / 3600), "hour"));
+  if (size < 604_800) return relative(phrase(Math.round(size / 86_400), "day"));
+  return formatDay(value, timeZone);
+}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -1,4 +1,4 @@
-import { formatCount, formatDay, formatWhen } from "../lib/format/display";
+import { formatAgo, formatCount, formatDay } from "../lib/format/display";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -13,11 +13,15 @@ import { syncMarkets } from "../services/markets-sync.server";
 import { syncCatalogViaBulk } from "../services/catalog-bulk-sync.server";
 import { toAdminClient } from "../services/admin-client.server";
 import { OnboardingCard } from "../components/OnboardingCard";
+import { ActivityFeed } from "../components/ActivityFeed";
 import { CountsRow } from "../components/CountsRow";
+import { LastRunSummary } from "../components/LastRunSummary";
+import { Meter } from "../components/Meter";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { onboarding } from "../lib/onboarding/steps";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -67,6 +71,10 @@ export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) 
   ]);
 
   return {
+    // The page's clock, sent with the page. Relative times ("2 hours ago") are computed
+    // from this rather than from `Date.now()` at render, so the server's HTML and the
+    // browser's hydration agree instead of straddling a minute boundary.
+    now: new Date().toISOString(),
     timeZone: shop.timezone,
     shopDomain: shop.domain,
     syncedAt: shop.initialSyncCompletedAt?.toISOString() ?? null,
@@ -196,6 +204,7 @@ type ActionData = { ok: boolean; message: string; errors: string[] };
 
 export default function Dashboard() {
   const {
+    now,
     shopDomain,
     syncedAt,
     health,
@@ -227,6 +236,92 @@ export default function Dashboard() {
         </s-banner>
       ) : null}
 
+      {/* Everything that wants the merchant, at the top and together.
+
+          These four used to be filed inside whichever section they were about — two in
+          Catalogue, two in what-is-live — which meant "2 campaigns did not finish
+          cleanly" was reachable by scrolling and reading the section headings to work out
+          where it would have been put. Grouping them is not decoration: a dashboard's
+          first job is to say whether anything needs doing, and it cannot do that while
+          the answer is distributed. */}
+      {needsAttention > 0 ? (
+        <s-banner tone="warning" heading="Some campaigns did not finish cleanly">
+          <s-paragraph>
+            {formatCount(needsAttention)} campaign{needsAttention === 1 ? "" : "s"} stopped part
+            way. Every row that did not complete has a reason recorded, and resuming retries only
+            those.
+          </s-paragraph>
+          <s-link href="/app/campaigns">Review campaigns</s-link>
+        </s-banner>
+      ) : null}
+
+      {notices.length > 0 ? (
+        <s-banner tone="warning" heading="Your markets changed">
+          {notices.map((notice) => (
+            <s-stack key={notice.id} gap={SPACE.item}>
+              <s-paragraph>{notice.detail}</s-paragraph>
+              {/* A grid, not an inline stack: the forms are block-level, and in a stack
+                  each one takes its own line — which turned a two-choice question into a
+                  column of buttons that reads as a list of unrelated actions. */}
+              <s-grid gridTemplateColumns="auto auto 1fr" gap={SPACE.item} alignItems="center">
+                {notice.kind === "added" ? (
+                  <fetcher.Form method="post">
+                    <input type="hidden" name="intent" value="resolve-notice" />
+                    <input type="hidden" name="noticeId" value={notice.id} />
+                    <input type="hidden" name="resolution" value="extended" />
+                    <s-button type="submit" loading={busy || undefined}>
+                      Add it to {notice.campaigns === 1 ? "that campaign" : "those campaigns"}
+                    </s-button>
+                  </fetcher.Form>
+                ) : (
+                  <fetcher.Form method="post">
+                    <input type="hidden" name="intent" value="resolve-notice" />
+                    <input type="hidden" name="noticeId" value={notice.id} />
+                    <input type="hidden" name="resolution" value="removed" />
+                    <s-button type="submit" loading={busy || undefined}>
+                      Remove it from{" "}
+                      {notice.campaigns === 1 ? "that campaign" : "those campaigns"}
+                    </s-button>
+                  </fetcher.Form>
+                )}
+
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="resolve-notice" />
+                  <input type="hidden" name="noticeId" value={notice.id} />
+                  <input type="hidden" name="resolution" value="ignored" />
+                  <s-button type="submit" variant="tertiary" loading={busy || undefined}>
+                    Leave it as it is
+                  </s-button>
+                </fetcher.Form>
+              </s-grid>
+            </s-stack>
+          ))}
+        </s-banner>
+      ) : null}
+
+      {health.missing > 0 ? (
+        <s-banner tone="warning" heading="Some variants have no baseline">
+          <s-paragraph>
+            {formatCount(health.missing)} variants cannot be included in a campaign until they have
+            one. Re-syncing captures them.
+          </s-paragraph>
+        </s-banner>
+      ) : null}
+
+      {driftOpen > 0 ? (
+        <s-banner tone="info" heading="Prices changed outside Anchor">
+          <s-paragraph>
+            {formatCount(driftOpen)} price{driftOpen === 1 ? " was" : "s were"} changed somewhere
+            else while a campaign was running. Those edits were deliberate, so nothing has been
+            overwritten — each is waiting on your decision.
+          </s-paragraph>
+          <s-link href="/app/prices/drift">Open the drift queue</s-link>
+        </s-banner>
+      ) : null}
+
+      {/* Before the numbers while it is unfinished, and gone once it is. The card
+          retires itself, so this ordering says "your next step first" to a new shop and
+          "your storefront first" to an established one without a conditional. */}
       <OnboardingCard state={guide} />
 
       {neverSynced ? (
@@ -249,94 +344,6 @@ export default function Dashboard() {
           </fetcher.Form>
         </s-section>
       ) : (
-        <s-section heading="Catalogue">
-          {/* The shared component, not a second copy of its markup. This page had
-              hand-rolled the same four tiles, so it kept the old flat look after the
-              real one gained borders and equal columns -- and it is the first screen
-              after installing, which is the worst place to be a version behind. */}
-          <CountsRow
-            items={[
-              { label: "Variants", value: health.variants },
-              { label: "With baseline", value: health.withBaseline },
-              { label: "Not at baseline", value: health.drifted },
-              { label: "Campaigns", value: campaigns },
-            ]}
-          />
-
-          {health.withBaseline > health.variants ? (
-            <s-paragraph>
-              <s-text>
-                More baselines than variants is expected: baselines are kept for products
-                you have deleted, so a campaign that priced them can still be explained
-                and reverted.
-              </s-text>
-            </s-paragraph>
-          ) : null}
-
-          {notices.length > 0 ? (
-            <s-banner tone="warning">
-              <s-heading>Your markets changed</s-heading>
-              {notices.map((notice) => (
-                <s-stack key={notice.id} gap="small">
-                  <s-paragraph>{notice.detail}</s-paragraph>
-                  <s-stack direction="inline" gap="base">
-                    {notice.kind === "added" ? (
-                      <fetcher.Form method="post">
-                        <input type="hidden" name="intent" value="resolve-notice" />
-                        <input type="hidden" name="noticeId" value={notice.id} />
-                        <input type="hidden" name="resolution" value="extended" />
-                        <s-button type="submit" loading={busy || undefined}>
-                          Add it to {notice.campaigns === 1 ? "that campaign" : "those campaigns"}
-                        </s-button>
-                      </fetcher.Form>
-                    ) : (
-                      <fetcher.Form method="post">
-                        <input type="hidden" name="intent" value="resolve-notice" />
-                        <input type="hidden" name="noticeId" value={notice.id} />
-                        <input type="hidden" name="resolution" value="removed" />
-                        <s-button type="submit" loading={busy || undefined}>
-                          Remove it from{" "}
-                          {notice.campaigns === 1 ? "that campaign" : "those campaigns"}
-                        </s-button>
-                      </fetcher.Form>
-                    )}
-
-                    <fetcher.Form method="post">
-                      <input type="hidden" name="intent" value="resolve-notice" />
-                      <input type="hidden" name="noticeId" value={notice.id} />
-                      <input type="hidden" name="resolution" value="ignored" />
-                      <s-button type="submit" variant="tertiary" loading={busy || undefined}>
-                        Leave it as it is
-                      </s-button>
-                    </fetcher.Form>
-                  </s-stack>
-                </s-stack>
-              ))}
-            </s-banner>
-          ) : null}
-
-          {health.missing > 0 ? (
-            <s-banner tone="warning">
-              <s-paragraph>
-                {formatCount(health.missing)} variants have no baseline yet and cannot be included
-                in a campaign. Re-sync to capture them.
-              </s-paragraph>
-            </s-banner>
-          ) : null}
-
-          <s-stack direction="inline" gap="base">
-            <fetcher.Form method="post">
-              <input type="hidden" name="intent" value="sync" />
-              <s-button type="submit" loading={busy || undefined}>
-                Re-sync catalogue
-              </s-button>
-            </fetcher.Form>
-            <s-link href="/app/prices">Browse variants and baselines</s-link>
-          </s-stack>
-        </s-section>
-      )}
-
-      {!neverSynced ? (
         <s-section heading="What is live right now">
           <CountsRow
             items={[
@@ -358,39 +365,11 @@ export default function Dashboard() {
             </s-paragraph>
           ) : null}
 
-          {needsAttention > 0 ? (
-            <s-banner tone="warning">
-              <s-paragraph>
-                {formatCount(needsAttention)} campaign{needsAttention === 1 ? "" : "s"} did not finish
-                cleanly. Every row that did not complete has a reason recorded, and
-                resuming retries only those.
-              </s-paragraph>
-            </s-banner>
-          ) : null}
-
-          {driftOpen > 0 ? (
-            <s-banner tone="info">
-              <s-paragraph>
-                {formatCount(driftOpen)} price{driftOpen === 1 ? " was" : "s were"} changed somewhere
-                other than Anchor while a campaign was running. Those edits were
-                deliberate, so nothing has been overwritten — each is waiting on your
-                decision.
-              </s-paragraph>
-            </s-banner>
-          ) : null}
-
           {lastRun ? (
-            <s-paragraph>
-              <s-text>
-                Last run: {lastRun.kind.toLowerCase()} of “{lastRun.campaignName}” —{" "}
-                {lastRun.status.toLowerCase()}, {lastRun.verified} verified
-                {lastRun.failed > 0 ? `, ${lastRun.failed} failed` : ""}
-                {lastRun.finishedAt
-                  ? ` on ${formatWhen(lastRun.finishedAt, timeZone)}`
-                  : " (still running)"}
-                .
-              </s-text>
-            </s-paragraph>
+            <s-stack gap={SPACE.item}>
+              <s-text color="subdued">Last run</s-text>
+              <LastRunSummary run={lastRun} now={now} timeZone={timeZone} />
+            </s-stack>
           ) : (
             <s-paragraph>
               <s-text>
@@ -400,57 +379,117 @@ export default function Dashboard() {
             </s-paragraph>
           )}
 
-          <s-stack direction="inline" gap="base">
+          {/* A grid rather than an inline stack, for the same reason as everywhere else
+              on this page: `s-link` is block-level, so a stack gives three links three
+              lines. The trailing `1fr` is what keeps them tight to the left instead of
+              spread across the card. */}
+          <s-grid gridTemplateColumns="auto auto auto 1fr" gap={SPACE.section} alignItems="center">
             <s-link href="/app/campaigns">Campaigns</s-link>
             <s-link href="/app/prices/drift">Drift queue</s-link>
             <s-link href="/app/activity">Activity log</s-link>
-          </s-stack>
+          </s-grid>
+        </s-section>
+      )}
+
+      {!neverSynced ? (
+        <s-section heading="Catalogue">
+          {/* The shared component, not a second copy of its markup. This page had
+              hand-rolled the same four tiles, so it kept the old flat look after the
+              real one gained borders and equal columns -- and it is the first screen
+              after installing, which is the worst place to be a version behind. */}
+          <CountsRow
+            items={[
+              { label: "Variants", value: health.variants },
+              { label: "With baseline", value: health.withBaseline },
+              { label: "Not at baseline", value: health.drifted },
+              { label: "Campaigns", value: campaigns },
+            ]}
+          />
+
+          {health.withBaseline > health.variants ? (
+            <s-paragraph>
+              <s-text color="subdued">
+                More baselines than variants is expected: baselines are kept for products
+                you have deleted, so a campaign that priced them can still be explained
+                and reverted.
+              </s-text>
+            </s-paragraph>
+          ) : null}
+
+          <s-grid gridTemplateColumns="auto auto 1fr" gap={SPACE.section} alignItems="center">
+            <fetcher.Form method="post">
+              <input type="hidden" name="intent" value="sync" />
+              <s-button type="submit" loading={busy || undefined}>
+                Re-sync catalogue
+              </s-button>
+            </fetcher.Form>
+            <s-link href="/app/prices">Browse variants and baselines</s-link>
+          </s-grid>
         </s-section>
       ) : null}
 
       <s-section slot="aside" heading="Store">
-        <s-paragraph>{shopDomain}</s-paragraph>
-        <s-paragraph>
-          <s-text>
-            {syncedAt ? `Last synced ${formatWhen(syncedAt, timeZone)}` : "Not yet synced"}
-          </s-text>
-        </s-paragraph>
-      </s-section>
+        <s-stack gap={SPACE.section}>
+          <s-grid gridTemplateColumns="auto 1fr" gap={SPACE.item} alignItems="center">
+            <s-icon type="store" color="subdued" />
+            <s-text type="strong">{shopDomain}</s-text>
+          </s-grid>
 
-      {!neverSynced && recent.length > 0 ? (
-        <s-section slot="aside" heading="Recent activity">
-          {recent.map((entry) => (
-            <s-paragraph key={entry.id}>
-              <s-text>
-                {entry.action} · {entry.actor ?? "Scheduler"} ·{" "}
-                {formatWhen(entry.at, timeZone)}
-              </s-text>
-            </s-paragraph>
-          ))}
-          <s-link href="/app/activity">See everything</s-link>
-        </s-section>
-      ) : null}
+          {/* Label above value, the same shape as a stat tile without the box. Two loose
+              paragraphs said the same words and left the reader to work out which of them
+              was the label. */}
+          <s-stack gap={SPACE.tight}>
+            <s-text color="subdued">Last synced</s-text>
+            <s-text>{syncedAt ? formatAgo(syncedAt, now, timeZone) : "Not yet synced"}</s-text>
+          </s-stack>
+        </s-stack>
+      </s-section>
 
       {!neverSynced ? (
         <s-section slot="aside" heading="Baselines">
-          <s-paragraph>
-            <s-text>
-              {health.oldestCapturedAt
-                ? `Oldest captured ${formatDay(health.oldestCapturedAt, timeZone)}`
-                : "None captured"}
-            </s-text>
-          </s-paragraph>
-          <s-paragraph>
-            <s-text>
-              Recapturing replaces baselines with today&rsquo;s live prices. Done while a
-              sale is running it makes the sale price the new normal, permanently — so it
-              has its own page, which shows you which campaigns your scope would catch
-              before anything is replaced.
-            </s-text>
-          </s-paragraph>
-          {/* A link, not a button. One click from the dashboard was not enough ceremony
-              for the most destructive operation in the app. */}
-          <s-link href="/app/imports/recapture">Recapture baselines…</s-link>
+          <s-stack gap={SPACE.section}>
+            <s-stack gap={SPACE.tight}>
+              <s-text color="subdued">Coverage</s-text>
+              <s-text type="strong">
+                {formatCount(health.withBaseline)} of {formatCount(health.variants)} variants
+              </s-text>
+              <Meter value={health.withBaseline} max={health.variants} />
+            </s-stack>
+
+            <s-stack gap={SPACE.tight}>
+              <s-text color="subdued">Oldest captured</s-text>
+              <s-text>
+                {health.oldestCapturedAt
+                  ? formatDay(health.oldestCapturedAt, timeZone)
+                  : "None captured"}
+              </s-text>
+            </s-stack>
+
+            {/* One sentence, not the six it used to be. The full explanation — what a
+                recapture would catch, and which campaigns are running while you do it —
+                is on the page that performs it, where it can name your actual campaigns
+                instead of describing the idea of one. What has to survive the trim is the
+                irreversibility, and that is what is left. */}
+            <s-paragraph>
+              <s-text color="subdued">
+                Recapturing replaces baselines with today&rsquo;s live prices — done during a
+                sale, that makes the sale price the new normal, permanently.
+              </s-text>
+            </s-paragraph>
+
+            {/* A link, not a button. One click from the dashboard was not enough ceremony
+                for the most destructive operation in the app. */}
+            <s-link href="/app/imports/recapture">Recapture baselines…</s-link>
+          </s-stack>
+        </s-section>
+      ) : null}
+
+      {!neverSynced && recent.length > 0 ? (
+        <s-section slot="aside" heading="Recent activity">
+          <s-stack gap={SPACE.section}>
+            <ActivityFeed entries={recent} now={now} timeZone={timeZone} />
+            <s-link href="/app/activity">See everything</s-link>
+          </s-stack>
         </s-section>
       ) : null}
     </PageShell>


### PR DESCRIPTION
Closes #376.

Verified by rendering the components against the real Polaris script (`cdn.shopify.com/shopifycloud/polaris.js`, which `AppProvider` loads independently of App Bridge) and looking at them. The first render reproduced the reported screenshot exactly, so everything after it could be judged by eye rather than guessed at.

## The checklist

Three bordered boxes inside a card, each breaking onto three lines — title, a lone "Why?", then the action — because `s-clickable` and `s-link` are block-level and an inline stack does not change that. `OnboardingCard` conceded as much in a comment.

A grid does change it: block-level children placed in separate *cells* sit side by side. A step is one row now — status, title, action — separated by hairlines instead of each being drawn as its own card, and the status is a glyph rather than a badge on every row. ~390px to ~130px. "Why?" is gone from completed steps: it offered to explain finished work, and on a row with no action beside it, it was the only thing hanging off the right edge.

## Recent activity

Five copies of `market.added · Scheduler · 27/08/2026, 12:40:38`, because a sync writes one audit entry per market it finds. Three separate problems, all fixed in the rendering — the audit log is right to store machine strings and exact timestamps:

- `describeAction` humanises by transformation, not a lookup table. Several actions are built at the call site from a variable (`market.${kind}`), so a table would be permanently one release behind and would fail silently.
- `collapseRuns` folds *consecutive* identical entries into one row with a count. Only neighbours, so a folded row remains a true statement about a contiguous stretch of history; actor is part of the key, because the scheduler and a staff member doing the same thing is the distinction the audit log exists for.
- `formatAgo` takes `now` from the loader rather than reading the clock, so the server render and hydration cannot straddle a minute boundary.

## The rest

- Alerts grouped at the top with banner headings. They used to be filed inside whichever section they were about, so whether anything needed doing was only answerable by scrolling.
- Last run is a row — status badge, campaign name, `apply · 412 verified, 3 failed · 2 hours ago`, "View campaign" — not a sentence ending in a timestamp.
- Asides gained label/value structure and a baseline coverage `Meter`. The recapture warning is one sentence; the rest belongs on the page that performs it, where it can name your actual campaigns.

## What got cut

A meter in the checklist. All three box background tokens (`subdued`/`base`/`strong`) are near-white — four variants side by side confirmed a fill only reads once it is outlined with the tile hairline — and the checklist's glyph column was already drawing the progress a bar would have restated. Kept for baseline coverage, where it says something the text does not.

## Checks

`npm run typecheck`, `lint` and `build` pass. 1853 tests pass, 35 of them new; four were mutated to confirm they fail when the behaviour breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)