### PR TITLE
Actions look like what they are, instead of all looking like links

### DIFF
--- a/app/components/ActionRow.tsx
+++ b/app/components/ActionRow.tsx
@@ -1,0 +1,67 @@
+import { Children, type ReactNode } from "react";
+
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * A row of actions, and the app's vocabulary for what an action looks like.
+ *
+ * ## The vocabulary
+ *
+ * The app was written almost entirely in links. Every way out of a card — a page to
+ * visit, a row to open, a queue to review, a spreadsheet to import — was the same blue
+ * underlined phrase, so a screen with four of them offered four things of apparently
+ * equal weight and no clue which one it wanted you to press. Blue text is also the one
+ * treatment Polaris reserves for *inline* links, where colour is the only thing marking a
+ * word inside a sentence as clickable; spending it on standalone actions wastes it and
+ * leaves a page looking like a bibliography.
+ *
+ * Four treatments, in descending loudness:
+ *
+ * - **`variant="primary"`** — the black button. The one thing a page or card most wants
+ *   done: the next step in getting started, "Create campaign", "Sync catalogue". At most
+ *   one per card; two black buttons is the same failure as four blue links.
+ * - **`variant="secondary"`** (the default) — a real alternative, and every action inside
+ *   a banner. Bordered, quiet, unmistakably pressable.
+ * - **`variant="tertiary"`** — dark text with no chrome. Navigation and row-level actions
+ *   that must not compete: "See everything", "Open", "View ledger", a product name that
+ *   leads to the Shopify admin. This is the replacement for most of the old links, and
+ *   the reason the pages stopped being blue.
+ * - **`s-link`** — kept for exactly two things: a link *inside a sentence*, where colour
+ *   is doing necessary work, and the App Bridge nav menu, which must be anchors.
+ *
+ * `s-button` takes an `href`, so a tertiary button that navigates is still an anchor —
+ * middle-click and "open in new tab" behave the way a merchant expects.
+ *
+ * ## Why the row is a grid
+ *
+ * `s-button`, `s-link` and `s-clickable` are block-level, and an inline `s-stack` does
+ * not change that: a stack of three actions renders as three lines. The cells of a grid
+ * do, because it is the cell that decides where its child sits. Every action row in the
+ * app had been rebuilding that grid by hand, one comma away from silently falling back to
+ * a stacked column, which is what this exists to stop.
+ *
+ * `s-button-group` would be the obvious answer and is not usable here: it lays the row
+ * out correctly and renders none of the buttons.
+ */
+export function ActionRow({ children }: { children: ReactNode }) {
+  // Conditional actions are the norm — a Previous that only exists on page two — and
+  // `false`/`null` children must not each claim a column, or the row develops gaps where
+  // the actions that were not rendered would have been.
+  const count = Children.toArray(children).length;
+
+  return (
+    <s-grid
+      // A trailing `1fr` soaks up the slack so the actions stay tight to the left
+      // instead of spreading across the card.
+      //
+      // One comma only. Polaris reads the comma as the separator between the responsive
+      // value and the default, so a second one anywhere stops the whole value parsing and
+      // it falls back to `none` — which stacks the row and looks like a layout choice.
+      gridTemplateColumns={`@container (inline-size <= 460px) 1fr, ${"auto ".repeat(count)}1fr`}
+      gap={SPACE.item}
+      alignItems="center"
+    >
+      {children}
+    </s-grid>
+  );
+}

--- a/app/components/BaselineTable.tsx
+++ b/app/components/BaselineTable.tsx
@@ -46,9 +46,17 @@ export function BaselineTable({
                 <s-button variant="tertiary" onClick={() => onShowHistory(row.variantGid)}>
                   History
                 </s-button>
-                <s-link href={row.adminUrl} target="_blank">
+                {/* The same treatment as History beside it, which it was not: one cell
+                    held a tertiary button and a blue link doing the same kind of job.
+                    The icon is what says this one leaves the app. */}
+                <s-button
+                  variant="tertiary"
+                  icon="external"
+                  href={row.adminUrl}
+                  target="_blank"
+                >
                   Shopify
-                </s-link>
+                </s-button>
               </s-stack>
             </s-table-cell>
           </s-table-row>

--- a/app/components/ErrorScreen.tsx
+++ b/app/components/ErrorScreen.tsx
@@ -11,6 +11,7 @@
  * screen tells a merchant nothing and tells an attacker something.
  */
 
+import { ActionRow } from "./ActionRow";
 import { helpLabelFor, helpPathFor } from "../lib/errors/help-links";
 
 export interface ErrorScreenProps {
@@ -50,19 +51,18 @@ export function ErrorScreen({
 
           {/* Every merchant-visible error links to the page that explains it. Somebody
               hitting this at 9pm before a sale wants the sentence that says what to do,
-              one click from here — not a search box. */}
-          <s-paragraph>
-            <s-link href={helpPathFor(code)} target="_blank">
-              {helpLabelFor(code)}
-            </s-link>
-          </s-paragraph>
-
-          <s-stack direction="inline" gap="base">
+              one click from here — not a search box. It sits in the row with the other
+              two actions rather than a paragraph above them, because it is one of the
+              three things they might do next. */}
+          <ActionRow>
             <s-button href={retryHref ?? "."} variant="primary">
               Try again
             </s-button>
             <s-button href="/app">Back to dashboard</s-button>
-          </s-stack>
+            <s-button variant="tertiary" href={helpPathFor(code)} target="_blank">
+              {helpLabelFor(code)}
+            </s-button>
+          </ActionRow>
 
           <s-divider />
 

--- a/app/components/LastRunSummary.tsx
+++ b/app/components/LastRunSummary.tsx
@@ -61,7 +61,9 @@ export function LastRunSummary({
           </s-text>
         </s-stack>
 
-        <s-link href={`/app/campaigns/${run.campaignId}`}>View campaign</s-link>
+        <s-button variant="tertiary" href={`/app/campaigns/${run.campaignId}`}>
+          View campaign
+        </s-button>
       </s-grid>
     </s-box>
   );

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -128,11 +128,19 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
               action beside it — it was also the only thing left hanging off the right
               edge, so the column of actions read as ragged. */}
           {step.done ? null : (
-            <s-clickable onClick={() => setWhy((open) => !open)}>
-              <s-text color="subdued">{why ? "Hide why" : "Why?"}</s-text>
-            </s-clickable>
+            <s-button variant="tertiary" onClick={() => setWhy((open) => !open)}>
+              {why ? "Hide why" : "Why?"}
+            </s-button>
           )}
-          {step.href && step.cta ? <s-link href={step.href}>{step.cta}</s-link> : null}
+          {/* Black on the step being asked for, bordered on the ones after it. A
+              checklist whose every row shouts equally is a checklist that has not said
+              what to do next — which is the only thing it is for. See `ActionRow` for
+              the vocabulary. */}
+          {step.href && step.cta ? (
+            <s-button href={step.href} variant={isNext ? "primary" : "secondary"}>
+              {step.cta}
+            </s-button>
+          ) : null}
         </s-grid>
       </s-grid>
 

--- a/app/components/ReconciliationTable.tsx
+++ b/app/components/ReconciliationTable.tsx
@@ -37,9 +37,13 @@ export function ReconciliationTable({ rows }: { rows: ReconciliationRow[] }) {
         {rows.map((row) => (
           <s-table-row key={`${row.variantGid}-${row.priceListGid}`}>
             <s-table-cell>
-              <s-link href={row.adminUrl} target="_blank">
+              {/* A whole column of blue is what makes a table read as link soup — and
+                  this table is the one a merchant scans when prices disagree, so its
+                  names should read as names. The icon carries "this opens the Shopify
+                  admin", which the colour never did. */}
+              <s-button variant="tertiary" icon="external" href={row.adminUrl} target="_blank">
                 {row.title}
-              </s-link>
+              </s-button>
             </s-table-cell>
             <s-table-cell>{row.surface}</s-table-cell>
             <s-table-cell>{row.live ?? "—"}</s-table-cell>

--- a/app/components/RunHistoryTable.tsx
+++ b/app/components/RunHistoryTable.tsx
@@ -40,7 +40,9 @@ export function RunHistoryTable({ runs, selectedRunId, timeZone }: Props) {
               {run.id === selectedRunId ? (
                 <s-text>Showing</s-text>
               ) : (
-                <s-link href={`?run=${run.id}`}>View ledger</s-link>
+                <s-button variant="tertiary" href={`?run=${run.id}`}>
+                  View ledger
+                </s-button>
               )}
             </s-table-cell>
           </s-table-row>

--- a/app/components/action-row.test.tsx
+++ b/app/components/action-row.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * The app's action vocabulary, guarded.
+ *
+ * Every way out of a card used to be the same blue underlined phrase, so a screen with
+ * four of them offered four things of equal weight and no clue which one it wanted
+ * pressed. `ActionRow` documents the replacement — primary, secondary, tertiary — and
+ * this is what stops the links growing back one route at a time, which is exactly how
+ * they arrived.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ActionRow } from "./ActionRow";
+
+const APP = join(process.cwd(), "app");
+
+/**
+ * Where a bare `s-link` is still correct.
+ *
+ * The App Bridge nav menu must be anchors — Shopify reads them to build the sidebar, and
+ * a button there renders nothing.
+ *
+ * A link *inside a sentence* is the other legitimate use, where colour is the only thing
+ * marking a word mid-paragraph as clickable. There are none today. Adding one means
+ * adding the file here, which is the point: it should be a decision somebody made, not a
+ * habit that returned.
+ */
+const MAY_USE_LINKS = ["routes/app.tsx"];
+
+function sources(dir: string): Array<{ path: string; text: string }> {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [{ path: path.replace(`${APP}/`, ""), text: readFileSync(path, "utf8") }];
+  });
+}
+
+describe("the action vocabulary", () => {
+  it("keeps blue links out of everything but the nav", () => {
+    const linking = sources(APP)
+      .filter(({ text }) => text.includes("<s-link"))
+      .map(({ path }) => path)
+      .filter((path) => !MAY_USE_LINKS.includes(path));
+
+    expect(
+      linking,
+      "use a button — primary, secondary or tertiary — and see ActionRow for which",
+    ).toEqual([]);
+  });
+
+  it("offers at most one black button per card", () => {
+    // Two black buttons on one card is the same failure as four blue links: nothing is
+    // being pointed at. Per *card*, not per file — a settings page with two independent
+    // forms in two sections is two surfaces, and each is entitled to its own.
+    //
+    // Found the campaign Actions card rendering "Apply to storefront" and "Resume" in
+    // black at once, one of them disabled.
+    const offenders = sources(APP)
+      .flatMap(({ path, text }) =>
+        text
+          .split("<s-section")
+          .slice(1)
+          .map((card) => ({ path, primaries: (card.match(/variant="primary"/g) ?? []).length })),
+      )
+      .filter(({ primaries }) => primaries > 1)
+      .map(({ path }) => path);
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("the row itself", () => {
+  const columns = (markup: string) => markup.match(/gridTemplateColumns="([^"]+)"/)?.[1];
+
+  it("gives every action its own column, and the slack to a trailing one", () => {
+    const markup = renderToStaticMarkup(
+      <ActionRow>
+        <s-button>One</s-button>
+        <s-button>Two</s-button>
+      </ActionRow>,
+    );
+
+    expect(columns(markup)).toContain("auto auto 1fr");
+  });
+
+  it("does not hand a column to an action that was not rendered", () => {
+    // Conditional actions are the norm — a Previous that only exists on page two — and a
+    // `false` child claiming a column leaves a gap where it would have been.
+    const markup = renderToStaticMarkup(
+      <ActionRow>
+        {false}
+        <s-button>Only</s-button>
+      </ActionRow>,
+    );
+
+    expect(columns(markup)).toContain("auto 1fr");
+    expect(columns(markup)).not.toContain("auto auto");
+  });
+
+  it("keeps one comma in the responsive value", () => {
+    // Polaris splits on the comma to separate "when the query matches" from "otherwise".
+    // A second comma anywhere stops the value parsing and it falls back to `none`, which
+    // stacks the row into a column that looks like a deliberate layout.
+    const markup = renderToStaticMarkup(
+      <ActionRow>
+        <s-button>One</s-button>
+        <s-button>Two</s-button>
+        <s-button>Three</s-button>
+      </ActionRow>,
+    );
+
+    expect(columns(markup)?.split(",")).toHaveLength(2);
+  });
+});

--- a/app/components/campaign/CampaignActions.tsx
+++ b/app/components/campaign/CampaignActions.tsx
@@ -25,9 +25,13 @@ export function CampaignActions({ rollback, practice, lifecycle, fetcher, busy, 
         <s-stack gap="base">
           <fetcher.Form method="post">
             <input type="hidden" name="intent" value="apply" />
+            {/* Black only while it can actually be pressed. A partial run shows Resume
+                as well, and this card was rendering two black buttons at once — one of
+                them disabled, which is the loudest possible way to offer something that
+                cannot be done. The primary follows what the lifecycle says is next. */}
             <s-button
               type="submit"
-              variant="primary"
+              variant={canApply ? "primary" : "secondary"}
               loading={busy || undefined}
               disabled={!canApply}
             >

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -1,3 +1,4 @@
+import { ActionRow } from "../ActionRow";
 import { FilterForm } from "../FilterForm";
 import type { listCampaigns, CampaignFilters } from "../../services/campaigns/list.server";
 
@@ -56,9 +57,13 @@ export function CampaignListView({
               {chip.label}
             </s-badge>
           ) : (
-            <s-link key={chip.value || "all"} href={linkTo({ status: chip.value })}>
+            <s-button
+              key={chip.value || "all"}
+              variant="tertiary"
+              href={linkTo({ status: chip.value })}
+            >
               {chip.label}
-            </s-link>
+            </s-button>
           ),
         )}
       </s-stack>
@@ -109,7 +114,9 @@ export function CampaignListView({
                       : "—"}
                   </s-table-cell>
                   <s-table-cell>
-                    <s-link href={`/app/campaigns/${campaign.id}`}>Open</s-link>
+                    <s-button variant="tertiary" href={`/app/campaigns/${campaign.id}`}>
+                      Open
+                    </s-button>
                   </s-table-cell>
                 </s-table-row>
               ))}
@@ -117,17 +124,23 @@ export function CampaignListView({
           </s-table>
 
           {list.pages > 1 ? (
-            <s-stack direction="inline" gap="base">
+            <ActionRow>
               {list.page > 1 ? (
-                <s-link href={linkTo({ page: String(list.page - 1) })}>Previous</s-link>
+                <s-button icon="chevron-left" href={linkTo({ page: String(list.page - 1) })}>
+                  Previous
+                </s-button>
               ) : null}
-              <s-text color="subdued">
+              {/* Tabular figures: the page number changes in place, and proportional
+                  digits make the sentence around it jump every time it does. */}
+              <s-text color="subdued" fontVariantNumeric="tabular-nums">
                 Page {list.page} of {list.pages} · {list.total} campaigns
               </s-text>
               {list.page < list.pages ? (
-                <s-link href={linkTo({ page: String(list.page + 1) })}>Next</s-link>
+                <s-button icon="chevron-right" href={linkTo({ page: String(list.page + 1) })}>
+                  Next
+                </s-button>
               ) : null}
-            </s-stack>
+            </ActionRow>
           ) : null}
         </>
       )}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -13,6 +13,7 @@ import { syncMarkets } from "../services/markets-sync.server";
 import { syncCatalogViaBulk } from "../services/catalog-bulk-sync.server";
 import { toAdminClient } from "../services/admin-client.server";
 import { OnboardingCard } from "../components/OnboardingCard";
+import { ActionRow } from "../components/ActionRow";
 import { ActivityFeed } from "../components/ActivityFeed";
 import { CountsRow } from "../components/CountsRow";
 import { LastRunSummary } from "../components/LastRunSummary";
@@ -251,7 +252,9 @@ export default function Dashboard() {
             way. Every row that did not complete has a reason recorded, and resuming retries only
             those.
           </s-paragraph>
-          <s-link href="/app/campaigns">Review campaigns</s-link>
+          <ActionRow>
+            <s-button href="/app/campaigns">Review campaigns</s-button>
+          </ActionRow>
         </s-banner>
       ) : null}
 
@@ -315,7 +318,9 @@ export default function Dashboard() {
             else while a campaign was running. Those edits were deliberate, so nothing has been
             overwritten — each is waiting on your decision.
           </s-paragraph>
-          <s-link href="/app/prices/drift">Open the drift queue</s-link>
+          <ActionRow>
+            <s-button href="/app/prices/drift">Open the drift queue</s-button>
+          </ActionRow>
         </s-banner>
       ) : null}
 
@@ -379,15 +384,11 @@ export default function Dashboard() {
             </s-paragraph>
           )}
 
-          {/* A grid rather than an inline stack, for the same reason as everywhere else
-              on this page: `s-link` is block-level, so a stack gives three links three
-              lines. The trailing `1fr` is what keeps them tight to the left instead of
-              spread across the card. */}
-          <s-grid gridTemplateColumns="auto auto auto 1fr" gap={SPACE.section} alignItems="center">
-            <s-link href="/app/campaigns">Campaigns</s-link>
-            <s-link href="/app/prices/drift">Drift queue</s-link>
-            <s-link href="/app/activity">Activity log</s-link>
-          </s-grid>
+          <ActionRow>
+            <s-button href="/app/campaigns">Campaigns</s-button>
+            <s-button href="/app/prices/drift">Drift queue</s-button>
+            <s-button href="/app/activity">Activity log</s-button>
+          </ActionRow>
         </s-section>
       )}
 
@@ -416,15 +417,17 @@ export default function Dashboard() {
             </s-paragraph>
           ) : null}
 
-          <s-grid gridTemplateColumns="auto auto 1fr" gap={SPACE.section} alignItems="center">
+          <ActionRow>
             <fetcher.Form method="post">
               <input type="hidden" name="intent" value="sync" />
               <s-button type="submit" loading={busy || undefined}>
                 Re-sync catalogue
               </s-button>
             </fetcher.Form>
-            <s-link href="/app/prices">Browse variants and baselines</s-link>
-          </s-grid>
+            <s-button variant="tertiary" href="/app/prices">
+              Browse variants and baselines
+            </s-button>
+          </ActionRow>
         </s-section>
       ) : null}
 
@@ -477,9 +480,15 @@ export default function Dashboard() {
               </s-text>
             </s-paragraph>
 
-            {/* A link, not a button. One click from the dashboard was not enough ceremony
-                for the most destructive operation in the app. */}
-            <s-link href="/app/imports/recapture">Recapture baselines…</s-link>
+            {/* Tertiary, and the only action on this page deliberately kept quiet. One
+                click from the dashboard was not enough ceremony for the most destructive
+                operation in the app, and a bordered button beside a warning would read
+                as the thing to do next. */}
+            <ActionRow>
+              <s-button variant="tertiary" href="/app/imports/recapture">
+                Recapture baselines…
+              </s-button>
+            </ActionRow>
           </s-stack>
         </s-section>
       ) : null}
@@ -488,7 +497,11 @@ export default function Dashboard() {
         <s-section slot="aside" heading="Recent activity">
           <s-stack gap={SPACE.section}>
             <ActivityFeed entries={recent} now={now} timeZone={timeZone} />
-            <s-link href="/app/activity">See everything</s-link>
+            <ActionRow>
+              <s-button variant="tertiary" icon="arrow-right" href="/app/activity">
+                See everything
+              </s-button>
+            </ActionRow>
           </s-stack>
         </s-section>
       ) : null}

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -4,6 +4,7 @@ import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
+import { ActionRow } from "../components/ActionRow";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
@@ -97,9 +98,13 @@ export default function Campaigns() {
           <s-paragraph>
             {list.attentionCount === 1
               ? "One campaign needs a decision."
-              : `${list.attentionCount} campaigns need a decision.`}{" "}
-            <s-link href={linkTo({ status: "attention", view: "list" })}>Show them</s-link>
+              : `${list.attentionCount} campaigns need a decision.`}
           </s-paragraph>
+          {/* Out of the sentence and onto its own line. A banner's whole job is to be
+              acted on, and its action was three words of blue inside a paragraph. */}
+          <ActionRow>
+            <s-button href={linkTo({ status: "attention", view: "list" })}>Show them</s-button>
+          </ActionRow>
         </s-banner>
       ) : null}
 
@@ -109,11 +114,14 @@ export default function Campaigns() {
           tabs and the campaign tabs because it is the same control. */}
       <s-section>
         <s-stack direction="block" gap={SPACE.section}>
-          <s-stack direction="inline" gap="base" alignItems="center">
-            <s-link href="/app/campaigns/new">
-              <s-button variant="primary">Create campaign</s-button>
-            </s-link>
-          </s-stack>
+          {/* `s-button` takes an href, so this is one anchor styled as a button rather
+              than a button nested inside a link — which is what it was, and which no
+              browser is obliged to make sense of. */}
+          <ActionRow>
+            <s-button variant="primary" href="/app/campaigns/new">
+              Create campaign
+            </s-button>
+          </ActionRow>
 
           <TabBar
             label="Campaign views"

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -15,6 +15,7 @@ import {
   readRoundingPolicy,
   ROUNDING_LABELS,
 } from "../lib/money/rounding-policy";
+import { ActionRow } from "../components/ActionRow";
 import { FilterForm } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
@@ -486,7 +487,9 @@ export default function NewCampaign() {
                       already running keeps running, and reverts always work whatever
                       plan you are on.
                     </s-paragraph>
-                    <s-link href="/app/settings/plan">See the plans</s-link>
+                    <ActionRow>
+                      <s-button href="/app/settings/plan">See the plans</s-button>
+                    </ActionRow>
                   </s-banner>
                 ) : null}
 

--- a/app/routes/app.prices.costs.tsx
+++ b/app/routes/app.prices.costs.tsx
@@ -26,6 +26,7 @@ import { money } from "../lib/money/money";
 import { format } from "../lib/money/format";
 import { facets, type FilterAst } from "../services/segments.server";
 import { actorFor } from "../lib/audit/actor";
+import { ActionRow } from "../components/ActionRow";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
@@ -147,9 +148,9 @@ export default function Costs() {
             price below cost&rdquo; is doing less than it looks.
           </s-text>
         </s-paragraph>
-        <s-paragraph>
-          <s-link href="/app/imports/costs">Import costs from a spreadsheet</s-link>
-        </s-paragraph>
+        <ActionRow>
+          <s-button href="/app/imports/costs">Import costs from a spreadsheet</s-button>
+        </ActionRow>
       </s-section>
 
       <s-section heading="Change costs in bulk">

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -9,6 +9,7 @@ import { ensureShop } from "../services/shop.server";
 import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
 import { readPreferences, writePreferences } from "../services/notifications.server";
 import { actorFor } from "../lib/audit/actor";
+import { ActionRow } from "../components/ActionRow";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import {
@@ -144,12 +145,12 @@ export default function Settings() {
           that pushes a price under a floor is a conversation between two of them —
           and splitting them across pages is what made the nav sixteen items long. */}
       <s-section>
-        <s-stack direction="inline" gap="base">
+        <ActionRow>
           <s-text color="subdued">Jump to</s-text>
-          <s-link href="#guardrails">Guardrails</s-link>
-          <s-link href="#rounding">Rounding</s-link>
-          <s-link href="#notifications">Alerts</s-link>
-        </s-stack>
+          <s-button variant="tertiary" href="#guardrails">Guardrails</s-button>
+          <s-button variant="tertiary" href="#rounding">Rounding</s-button>
+          <s-button variant="tertiary" href="#notifications">Alerts</s-button>
+        </ActionRow>
       </s-section>
 
       <s-section id="guardrails" heading="Guardrails">

--- a/app/routes/app.settings.diagnostics.tsx
+++ b/app/routes/app.settings.diagnostics.tsx
@@ -149,7 +149,12 @@ export default function Debug() {
               {recent.map((row) => (
                 <s-table-row key={row.errorId}>
                   <s-table-cell>
-                    <s-link href={`/app/settings/diagnostics?id=${row.errorId}`}>{row.errorId}</s-link>
+                    <s-button
+                      variant="tertiary"
+                      href={`/app/settings/diagnostics?id=${row.errorId}`}
+                    >
+                      {row.errorId}
+                    </s-button>
                   </s-table-cell>
                   <s-table-cell>
                     <s-badge tone={row.retryable ? "warning" : "critical"}>


### PR DESCRIPTION
Closes #378.

26 of 32 `s-link` uses were standalone actions. They are buttons now, chosen by variant rather than all rendering as the same blue phrase. Verified by rendering the real Polaris components and looking at them.

## The vocabulary

Documented on `ActionRow`, which is also where the layout lives:

| Treatment | For | Examples |
|---|---|---|
| `variant="primary"` | the one thing a card most wants done | the next getting-started step, Create campaign, Sync catalogue |
| `variant="secondary"` | a real alternative, and every action inside a banner | Review campaigns, Drift queue, Previous/Next |
| `variant="tertiary"` | navigation and row actions that must not compete | Open, View ledger, See everything, a variant name that opens the Shopify admin |
| `s-link` | the App Bridge nav, and links inside a sentence | the nav menu — nothing else today |

`s-button` takes an `href`, so a tertiary button that navigates is still an anchor: middle-click and open-in-new-tab behave as expected.

**`tone="neutral"` is not an option.** It was the obvious first answer — and rendered in exactly the same blue as the default. Tertiary buttons are the only way to de-blue an action while keeping it obviously pressable.

## Why the row is a grid

`s-button`, `s-link` and `s-clickable` are block-level, and an inline `s-stack` does not change that — a stack of three actions renders as three lines. Every action row in the app had been rebuilding the same grid by hand, each one a comma away from silently falling back to a stacked column. `s-button-group` would be the obvious answer and is unusable here: it lays the row out correctly and renders none of the buttons.

## Two defects the survey turned up

- **A button nested inside a link.** `app.campaigns._index` wrapped `<s-button variant="primary">` in an `<s-link>` — an anchor containing a button, which no browser is obliged to make sense of. It is one `s-button href` now.
- **Two black buttons on one card.** The campaign Actions card could show "Apply to storefront" and "Resume" in black simultaneously, with Apply disabled — the loudest possible way to offer something that cannot be done. The black one now follows what the lifecycle says is next.

## Guarding it

`action-row.test.tsx` scans the sources and fails when a bare `s-link` appears outside the nav, or when one `s-section` grows a second black button. The allowed-files list is deliberately short: adding an inline prose link means adding the file there, so it is a decision rather than a habit returning. The second defect above is what the per-card rule found — an earlier per-file version flagged a settings page with two independent forms, which is legitimate.

## Checks

`npm run typecheck`, `lint` and `build` pass. 1861 tests pass, 5 new; three were mutated to confirm they fail — a link put back into a route, a second primary added to a card, and a second comma in the responsive grid value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)