### PR TITLE
Merchants stop reading the database

### DIFF
--- a/app/components/ActionRow.tsx
+++ b/app/components/ActionRow.tsx
@@ -1,4 +1,4 @@
-import { Children, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { SPACE } from "../lib/ui/spacing";
 
@@ -32,36 +32,29 @@ import { SPACE } from "../lib/ui/spacing";
  * `s-button` takes an `href`, so a tertiary button that navigates is still an anchor —
  * middle-click and "open in new tab" behave the way a merchant expects.
  *
- * ## Why the row is a grid
+ * ## Why a component rather than a stack written out each time
  *
- * `s-button`, `s-link` and `s-clickable` are block-level, and an inline `s-stack` does
- * not change that: a stack of three actions renders as three lines. The cells of a grid
- * do, because it is the cell that decides where its child sits. Every action row in the
- * app had been rebuilding that grid by hand, one comma away from silently falling back to
- * a stacked column, which is what this exists to stop.
+ * Not because a stack does not work — it does, and this is one. The app had been writing
+ * that stack out at twenty-odd call sites with four different gaps between them, and a
+ * row of actions is exactly the kind of thing whose spacing has to be the same everywhere
+ * or the pages stop looking like one app. Naming it also gives the vocabulary above
+ * somewhere to live that a reader will actually pass through.
  *
- * `s-button-group` would be the obvious answer and is not usable here: it lays the row
- * out correctly and renders none of the buttons.
+ * ## What is block-level here, precisely
+ *
+ * The checklist carried a comment saying `s-link` and `s-clickable` are block-level and
+ * that an inline stack cannot lay them out in a row, and the first version of this
+ * component repeated it and used a grid to work around it. Checked against the rendered
+ * components, only **`s-clickable`** is: three of them in an inline stack render as three
+ * lines, while buttons and links render as one row and *wrap* when they run out of width,
+ * which a grid of fixed columns does not. So an inline stack is the right primitive, and
+ * a grid is for the cases that genuinely need columns to line up — a status glyph, a
+ * title, and an action pushed to the far edge, as the checklist rows do.
  */
 export function ActionRow({ children }: { children: ReactNode }) {
-  // Conditional actions are the norm — a Previous that only exists on page two — and
-  // `false`/`null` children must not each claim a column, or the row develops gaps where
-  // the actions that were not rendered would have been.
-  const count = Children.toArray(children).length;
-
   return (
-    <s-grid
-      // A trailing `1fr` soaks up the slack so the actions stay tight to the left
-      // instead of spreading across the card.
-      //
-      // One comma only. Polaris reads the comma as the separator between the responsive
-      // value and the default, so a second one anywhere stops the whole value parsing and
-      // it falls back to `none` — which stacks the row and looks like a layout choice.
-      gridTemplateColumns={`@container (inline-size <= 460px) 1fr, ${"auto ".repeat(count)}1fr`}
-      gap={SPACE.item}
-      alignItems="center"
-    >
+    <s-stack direction="inline" gap={SPACE.item} alignItems="center">
       {children}
-    </s-grid>
+    </s-stack>
   );
 }

--- a/app/components/BaselineTable.tsx
+++ b/app/components/BaselineTable.tsx
@@ -1,3 +1,4 @@
+import { humanise } from "../lib/format/label";
 import type { BaselineRow } from "../services/baseline-browser.server";
 
 /**
@@ -40,7 +41,7 @@ export function BaselineTable({
                 </>
               ) : null}
             </s-table-cell>
-            <s-table-cell>{row.source?.toLowerCase().replace(/_/g, " ") ?? "—"}</s-table-cell>
+            <s-table-cell>{row.source ? humanise(row.source) : "—"}</s-table-cell>
             <s-table-cell>
               <s-stack direction="inline" gap="small">
                 <s-button variant="tertiary" onClick={() => onShowHistory(row.variantGid)}>

--- a/app/components/LedgerTable.tsx
+++ b/app/components/LedgerTable.tsx
@@ -1,3 +1,4 @@
+import { humanise } from "../lib/format/label";
 import type { ReactNode } from "react";
 
 import type { LedgerRow } from "../services/campaigns/index.server";
@@ -40,7 +41,7 @@ export function LedgerTable({
             <s-table-cell>{row.before ?? "—"}</s-table-cell>
             <s-table-cell>{row.intended ?? "—"}</s-table-cell>
             <s-table-cell>
-              <s-badge tone={toneFor(LEDGER_TONE, row.status)}>{row.status}</s-badge>
+              <s-badge tone={toneFor(LEDGER_TONE, row.status)}>{humanise(row.status)}</s-badge>
             </s-table-cell>
             <s-table-cell>{row.failureReason ?? "—"}</s-table-cell>
             {renderAction ? <s-table-cell>{renderAction(row)}</s-table-cell> : null}

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import type { OnboardingState, OnboardingStep } from "../lib/onboarding/steps";
 import { SPACE } from "../lib/ui/spacing";
+import { ActionRow } from "./ActionRow";
 
 /**
  * The checklist, until the first campaign has run cleanly.
@@ -26,15 +27,21 @@ import { SPACE } from "../lib/ui/spacing";
  *
  * Each step used to be a bordered box holding a stack, and the result was three tall
  * cards inside a card, each with a title on one line, a lone "Why?" on the next and its
- * action on a third — because `s-clickable` and `s-link` are block-level and an inline
- * stack does not change that. Nine lines and three borders to carry three short
- * sentences, with the right two-thirds of every box empty.
+ * action on a third. Nine lines and three borders to carry three short sentences, with
+ * the right two-thirds of every box empty.
  *
- * A grid changes that, where a stack could not: block-level children placed in separate
- * *cells* sit side by side, because it is the cell that decides where they go. So a step
- * is one row — status, title, action — and the steps are separated by hairlines rather
- * than each being drawn as its own card. Same information, a third of the height, and
- * the eye can run down the status column to see where it is up to.
+ * The line breaks were `s-clickable`, which is block-level — it was the "Why?" toggle,
+ * and a block element in the middle of an inline stack breaks the line before it and
+ * after it, which is what put the action on a third row. It is a button now, and buttons
+ * are not block-level. (An earlier version of this comment said `s-link` was too. It is
+ * not; only `s-clickable` is, checked against the rendered components.)
+ *
+ * The grid is still here, and for a different reason than working around that: it lines
+ * the *columns* up across rows. A stack would put each step's action wherever its title
+ * happened to end, and three actions at three different distances from the edge read as
+ * three unrelated things. So a step is one row — status, title, action — the steps are
+ * separated by hairlines rather than each being drawn as its own card, and the eye can
+ * run down the status column to see where it is up to.
  */
 export function OnboardingCard({ state }: { state: OnboardingState }) {
   if (state.complete) return null;
@@ -117,12 +124,10 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
           {isNext ? <s-badge tone="info">Next</s-badge> : null}
         </s-stack>
 
-        {/* Both actions in one cell, as their own grid: two block-level elements in a
-            single cell would stack, and this is the pair that used to. Why before the
-            action, deliberately — when the row wraps it is the action that should fall
-            to the next line, not the explanation, which would then read as belonging to
-            the step below it. */}
-        <s-grid gridTemplateColumns="auto auto" gap={SPACE.item} alignItems="center">
+        {/* Why before the action, deliberately: when the row wraps it is the action
+            that should fall to the next line, not the explanation, which would then read
+            as belonging to the step below it. */}
+        <ActionRow>
           {/* Not on a finished step. The reasoning for work already done is the one
               thing on this card nobody needs, and on a completed row — which has no
               action beside it — it was also the only thing left hanging off the right
@@ -141,7 +146,7 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
               {step.cta}
             </s-button>
           ) : null}
-        </s-grid>
+        </ActionRow>
       </s-grid>
 
       {/* Progressive disclosure, not a link away. The reasoning belongs next to the step

--- a/app/components/PreviewTable.tsx
+++ b/app/components/PreviewTable.tsx
@@ -1,3 +1,4 @@
+import { humanise } from "../lib/format/label";
 import type { MarketPreview, PreviewRow } from "../services/campaigns/index.server";
 import { PREVIEW_TONE, toneFor } from "./tone";
 
@@ -52,7 +53,7 @@ export function PreviewTable({
             ))}
             <s-table-cell>
               <s-badge tone={toneFor(PREVIEW_TONE, row.status)}>
-                {row.status}
+                {humanise(row.status)}
                 {row.reason ? ` \u00b7 ${row.reason}` : ""}
               </s-badge>
             </s-table-cell>
@@ -75,7 +76,7 @@ function describeCell(row: PreviewRow, priceListGid: string): string {
   if (!cell) return "Not sold here";
 
   if (cell.status !== "pending") {
-    return cell.reason ? `${cell.status} \u00b7 ${cell.reason}` : cell.status;
+    return cell.reason ? `${humanise(cell.status)} \u00b7 ${cell.reason}` : humanise(cell.status);
   }
 
   const price = cell.after ?? "\u2014";

--- a/app/components/RunHistoryTable.tsx
+++ b/app/components/RunHistoryTable.tsx
@@ -1,3 +1,4 @@
+import { humanise } from "../lib/format/label";
 import { formatWhen } from "../lib/format/display";
 import type { RunSummary } from "../services/campaigns/index.server";
 import { RUN_TONE, toneFor } from "./tone";
@@ -26,9 +27,9 @@ export function RunHistoryTable({ runs, selectedRunId, timeZone }: Props) {
       <s-table-body>
         {runs.map((run) => (
           <s-table-row key={run.id}>
-            <s-table-cell>{run.kind}</s-table-cell>
+            <s-table-cell>{humanise(run.kind)}</s-table-cell>
             <s-table-cell>
-              <s-badge tone={toneFor(RUN_TONE, run.status)}>{run.status}</s-badge>
+              <s-badge tone={toneFor(RUN_TONE, run.status)}>{humanise(run.status)}</s-badge>
             </s-table-cell>
             <s-table-cell>{run.planned}</s-table-cell>
             <s-table-cell>{run.verified}</s-table-cell>

--- a/app/components/action-row.test.tsx
+++ b/app/components/action-row.test.tsx
@@ -14,6 +14,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { ActionRow } from "./ActionRow";
+import { SPACE } from "../lib/ui/spacing";
 
 const APP = join(process.cwd(), "app");
 
@@ -74,45 +75,24 @@ describe("the action vocabulary", () => {
 });
 
 describe("the row itself", () => {
-  const columns = (markup: string) => markup.match(/gridTemplateColumns="([^"]+)"/)?.[1];
+  const markup = renderToStaticMarkup(
+    <ActionRow>
+      <s-button>One</s-button>
+      <s-button>Two</s-button>
+    </ActionRow>,
+  );
 
-  it("gives every action its own column, and the slack to a trailing one", () => {
-    const markup = renderToStaticMarkup(
-      <ActionRow>
-        <s-button>One</s-button>
-        <s-button>Two</s-button>
-      </ActionRow>,
-    );
-
-    expect(columns(markup)).toContain("auto auto 1fr");
+  it("lays its actions out in a row that can wrap", () => {
+    // An inline stack, not a grid of fixed columns. Checked against the rendered
+    // components: buttons and links are not block-level — only `s-clickable` is — and a
+    // stack wraps onto a second line when it runs out of width, where a grid overflows.
+    expect(markup).toContain('direction="inline"');
+    expect(markup).not.toContain("gridTemplateColumns");
   });
 
-  it("does not hand a column to an action that was not rendered", () => {
-    // Conditional actions are the norm — a Previous that only exists on page two — and a
-    // `false` child claiming a column leaves a gap where it would have been.
-    const markup = renderToStaticMarkup(
-      <ActionRow>
-        {false}
-        <s-button>Only</s-button>
-      </ActionRow>,
-    );
-
-    expect(columns(markup)).toContain("auto 1fr");
-    expect(columns(markup)).not.toContain("auto auto");
-  });
-
-  it("keeps one comma in the responsive value", () => {
-    // Polaris splits on the comma to separate "when the query matches" from "otherwise".
-    // A second comma anywhere stops the value parsing and it falls back to `none`, which
-    // stacks the row into a column that looks like a deliberate layout.
-    const markup = renderToStaticMarkup(
-      <ActionRow>
-        <s-button>One</s-button>
-        <s-button>Two</s-button>
-        <s-button>Three</s-button>
-      </ActionRow>,
-    );
-
-    expect(columns(markup)?.split(",")).toHaveLength(2);
+  it("puts one gap between actions everywhere in the app", () => {
+    // The reason this is a component at all: twenty-odd call sites had been writing this
+    // row out with four different gaps between them.
+    expect(markup).toContain(`gap="${SPACE.item}"`);
   });
 });

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -1,3 +1,4 @@
+import { humanise } from "../../lib/format/label";
 import { ActionRow } from "../ActionRow";
 import { FilterForm } from "../FilterForm";
 import type { listCampaigns, CampaignFilters } from "../../services/campaigns/list.server";
@@ -106,7 +107,7 @@ export function CampaignListView({
                   <s-table-cell>{campaign.priority}</s-table-cell>
                   <s-table-cell>
                     {campaign.lastRun
-                      ? `${campaign.lastRun.kind} · ${campaign.lastRun.status} · ${campaign.lastRun.verified} verified${
+                      ? `${humanise(campaign.lastRun.kind)} · ${humanise(campaign.lastRun.status)} · ${campaign.lastRun.verified} verified${
                           campaign.lastRun.failed > 0
                             ? `, ${campaign.lastRun.failed} failed`
                             : ""

--- a/app/lib/audit/action.ts
+++ b/app/lib/audit/action.ts
@@ -1,3 +1,5 @@
+import { humanise } from "../format/label";
+
 /**
  * What happened, in words a merchant recognises.
  *
@@ -6,8 +8,7 @@
  * from a variable (`market.${change.kind}`), so there is no closed list of them anywhere
  * and any lookup table here would go stale silently the first time somebody adds a kind.
  *
- * So this is a transformation, not a mapping: it cannot be missing an entry. Dots,
- * hyphens and underscores are word breaks, and the first word is capitalised. That turns
+ * So this is a transformation, not a mapping: it cannot be missing an entry. That turns
  * every action the app writes today into a readable phrase, and every action it writes
  * tomorrow into a readable phrase without anybody remembering to come back here.
  *
@@ -15,11 +16,13 @@
  * transition" rather than "Campaign status changed". Worth it: a plausible sentence for
  * an action nobody anticipated beats a polished one for six actions and a raw
  * `mirror.divergence_rate` for the seventh.
+ *
+ * The transformation itself is `humanise`, which the app's database enums go through too:
+ * `market.added` and `CSV_IMPORT` are the same problem with different separators, and
+ * having two implementations of it is how they would drift apart.
  */
 export function describeAction(action: string): string {
-  const words = action.split(/[.\-_]+/).filter(Boolean).join(" ");
-  if (words.length === 0) return action;
-  return words.charAt(0).toUpperCase() + words.slice(1);
+  return humanise(action);
 }
 
 /**

--- a/app/lib/format/display.test.ts
+++ b/app/lib/format/display.test.ts
@@ -177,3 +177,12 @@ describe("how long ago", () => {
     expect(formatAgo("not a date", now, "UTC")).toBe("not a date");
   });
 });
+
+describe("a timestamp in a table", () => {
+  it("stops at the minute", () => {
+    // A column of "27/08/2026, 12:40:38" asks the reader to skip two characters on every
+    // row to reach a distinction nobody is making — nothing here happens on a schedule
+    // finer than a minute.
+    expect(formatWhen("2026-08-27T12:40:38.000Z", "Europe/London")).toBe("27/08/2026, 13:40");
+  });
+});

--- a/app/lib/format/display.ts
+++ b/app/lib/format/display.ts
@@ -42,7 +42,15 @@ export function formatCount(value: number): string {
  */
 export function formatWhen(value: Date | string, timeZone: string): string {
   try {
-    return new Date(value).toLocaleString(LOCALE, { timeZone });
+    // Explicit styles rather than the default, which spells the time out to the second.
+    // A column of "27/08/2026, 12:40:38" is asking the reader to skip two characters on
+    // every row to reach a distinction no merchant is making — nothing in this app
+    // happens on a schedule finer than a minute.
+    return new Date(value).toLocaleString(LOCALE, {
+      timeZone,
+      dateStyle: "short",
+      timeStyle: "short",
+    });
   } catch {
     return String(value);
   }

--- a/app/lib/format/label.test.ts
+++ b/app/lib/format/label.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Every database state a merchant can see, rendered.
+ *
+ * The app stores states as Prisma enums and used to put a lot of them straight into
+ * badges: `VERIFIED`, `CSV_IMPORT`, `DRIFT_ADOPTION`. Three places had grown their own
+ * `toLowerCase().replace(/_/g, " ")` to cope, which lowercases `CSV` into `csv` and
+ * leaves the badge starting mid-sentence.
+ *
+ * The interesting test is the last one. A transformation cannot be missing an entry, but
+ * it also cannot know which tokens are said rather than spelled — so this reads the enums
+ * out of `schema.prisma` and renders all of them. Somebody adding `EU_VAT_ADJUSTMENT`
+ * gets a failing expectation naming the label it would produce, rather than shipping
+ * "Eu vat adjustment" to a badge.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { humanise } from "./label";
+
+describe("rendering a stored value", () => {
+  it("turns SCREAMING_SNAKE into a sentence", () => {
+    expect(humanise("INSTALL_CAPTURE")).toBe("Install capture");
+    expect(humanise("VERIFIED")).toBe("Verified");
+  });
+
+  it("says acronyms rather than spelling them wrong", () => {
+    // The failure the hand-rolled `toLowerCase()` had at three call sites.
+    expect(humanise("CSV_IMPORT")).toBe("CSV import");
+    expect(humanise("B2B")).toBe("B2B");
+  });
+
+  it("capitalises a value that arrives already lowercase", () => {
+    // The preview's statuses are lowercase strings rather than Prisma enums, and read as
+    // sloppy next to a Polaris badge that says "Fulfilled".
+    expect(humanise("clamped")).toBe("Clamped");
+  });
+
+  it("serves the dotted audit actions too, which differ only in their separator", () => {
+    expect(humanise("market.notice-resolved")).toBe("Market notice resolved");
+  });
+
+  it("gives back anything it cannot make words of", () => {
+    expect(humanise("")).toBe("");
+    expect(humanise("...")).toBe("...");
+  });
+});
+
+describe("every enum in the schema", () => {
+  const schema = readFileSync(join(process.cwd(), "prisma", "schema.prisma"), "utf8");
+
+  const values = [...schema.matchAll(/enum\s+\w+\s*\{([^}]*)\}/g)]
+    .flatMap((block) => block[1].split("\n"))
+    .map((line) => line.trim())
+    .filter((line) => /^[A-Z][A-Z0-9_]*$/.test(line));
+
+  it("finds the enums, so the checks below are not vacuous", () => {
+    expect(values.length).toBeGreaterThan(30);
+    expect(values).toContain("CSV_IMPORT");
+  });
+
+  it("shows the words for every stored state, and names any new one", () => {
+    // Written out rather than checked by a rule, because the one thing the
+    // transformation cannot work out for itself is which tokens are said rather than
+    // spelled — and every rule for guessing that is wrong somewhere. The first attempt
+    // here was "a token with no vowels is an acronym", which flagged `SYNC`.
+    //
+    // So this is the table of every state the database can hold and the words a merchant
+    // would read for it. Adding an enum value fails this test and shows the label it
+    // would have shipped, which is the moment to notice `EU_VAT_ADJUSTMENT` renders as
+    // "Eu vat adjustment" and add the acronym.
+    const rendered = Object.fromEntries(values.map((value) => [value, humanise(value)]));
+
+    expect(rendered).toEqual({
+      FREE: "Free",
+      GROWTH: "Growth",
+      MARKETS: "Markets",
+      WHOLESALE: "Wholesale",
+      ACTIVE: "Active",
+      ARCHIVED: "Archived",
+      DRAFT: "Draft",
+      BASE: "Base",
+      MARKET: "Market",
+      B2B: "B2B",
+      INSTALL_CAPTURE: "Install capture",
+      RECAPTURE: "Recapture",
+      CSV_IMPORT: "CSV import",
+      DRIFT_ADOPTION: "Drift adoption",
+      AUTO_ENROLL: "Auto enroll",
+      DYNAMIC: "Dynamic",
+      FROZEN: "Frozen",
+      SCHEDULED: "Scheduled",
+      APPLYING: "Applying",
+      HELD: "Held",
+      REVERTING: "Reverting",
+      COMPLETED: "Completed",
+      PARTIAL: "Partial",
+      CANCELLED: "Cancelled",
+      APPLY: "Apply",
+      REVERT: "Revert",
+      REASSERT: "Reassert",
+      ENROLL: "Enroll",
+      PLANNING: "Planning",
+      QUEUED: "Queued",
+      EXECUTING: "Executing",
+      VERIFYING: "Verifying",
+      FAILED: "Failed",
+      SYNC: "Sync",
+      BULK: "Bulk",
+      PENDING: "Pending",
+      WRITING: "Writing",
+      APPLIED: "Applied",
+      VERIFIED: "Verified",
+      SKIPPED: "Skipped",
+      CLAMPED: "Clamped",
+      REVERTED: "Reverted",
+      ADOPTED: "Adopted",
+      REASSERTED: "Reasserted",
+      IGNORED: "Ignored",
+      CHARM: "Charm",
+      STEP: "Step",
+      RECEIVED: "Received",
+      PROCESSING: "Processing",
+      PROCESSED: "Processed",
+      QUERY: "Query",
+      MUTATION: "Mutation",
+      CREATED: "Created",
+      RUNNING: "Running",
+      CANCELED: "Canceled",
+      EXPIRED: "Expired",
+    });
+  });
+});

--- a/app/lib/format/label.ts
+++ b/app/lib/format/label.ts
@@ -1,0 +1,50 @@
+/**
+ * Database values, as words.
+ *
+ * The app stores states as Prisma enums — `VERIFIED`, `CSV_IMPORT`, `INSTALL_CAPTURE` —
+ * and rendered a lot of them straight into badges and table cells. SCREAMING_SNAKE in a
+ * merchant-facing badge reads as an internal detail that leaked, and next to Polaris'
+ * own sentence-case badges ("Fulfilled", "Paid") it reads as a different app.
+ *
+ * Three places had grown their own `toLowerCase().replace(/_/g, " ")` to cope, which is
+ * this function with two of its three problems missing: it lowercases acronyms into
+ * nonsense, and it leaves the first letter lowercase so a badge starts mid-sentence.
+ *
+ * ## Why a transformation and not a table of labels
+ *
+ * The same reason as the audit actions: a table is a thing that can be missing an entry,
+ * and its failure mode is silent — a new enum value falls through to the raw string and a
+ * merchant reads `DRIFT_ADOPTION`. A transformation cannot be missing an entry. The trade
+ * is that the phrasing is mechanical rather than composed, which for state names is
+ * exactly what is wanted: they should read the same way everywhere.
+ *
+ * The one thing a transformation genuinely cannot know is which tokens are acronyms, so
+ * that is the one thing spelled out. `label.test.ts` renders every enum value in
+ * `schema.prisma` through this, so a new value with an unlisted acronym shows up as a
+ * failing expectation rather than as "Csv import" in production.
+ */
+
+/**
+ * Tokens that are said, not spelled.
+ *
+ * Short and deliberately not speculative: every entry is a token that appears in an enum,
+ * a CSV header or a field label this app actually renders.
+ */
+const ACRONYMS = new Set(["B2B", "CSV", "SKU", "ID", "GID", "API", "URL", "VAT"]);
+
+/** `CSV_IMPORT` → "CSV import". `market.notice-resolved` → "Market notice resolved". */
+export function humanise(value: string): string {
+  // Dots, hyphens and underscores are all word breaks: the same function serves enum
+  // values and the dotted audit actions, which differ only in their separator.
+  const words = value
+    .split(/[.\-_\s]+/)
+    .filter(Boolean)
+    .map((word) => (ACRONYMS.has(word.toUpperCase()) ? word.toUpperCase() : word.toLowerCase()));
+
+  if (words.length === 0) return value;
+
+  const [first, ...rest] = words;
+  const opening = ACRONYMS.has(first) ? first : first.charAt(0).toUpperCase() + first.slice(1);
+
+  return [opening, ...rest].join(" ");
+}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -263,10 +263,7 @@ export default function Dashboard() {
           {notices.map((notice) => (
             <s-stack key={notice.id} gap={SPACE.item}>
               <s-paragraph>{notice.detail}</s-paragraph>
-              {/* A grid, not an inline stack: the forms are block-level, and in a stack
-                  each one takes its own line — which turned a two-choice question into a
-                  column of buttons that reads as a list of unrelated actions. */}
-              <s-grid gridTemplateColumns="auto auto 1fr" gap={SPACE.item} alignItems="center">
+              <ActionRow>
                 {notice.kind === "added" ? (
                   <fetcher.Form method="post">
                     <input type="hidden" name="intent" value="resolve-notice" />
@@ -296,7 +293,7 @@ export default function Dashboard() {
                     Leave it as it is
                   </s-button>
                 </fetcher.Form>
-              </s-grid>
+              </ActionRow>
             </s-stack>
           ))}
         </s-banner>

--- a/app/routes/app.imports.baselines.tsx
+++ b/app/routes/app.imports.baselines.tsx
@@ -10,6 +10,7 @@
  * so reviewing before writing is the normal path rather than the careful one.
  */
 
+import { humanise } from "../lib/format/label";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useRef } from "react";
 import { useFetcher, useLoaderData } from "react-router";
@@ -222,7 +223,7 @@ function ImportReport({ result }: { result: BaselineImportResult }) {
                 <s-table-row key={`${problem.line}-${problem.identifier}`}>
                   <s-table-cell>{problem.line}</s-table-cell>
                   <s-table-cell>{problem.identifier || "—"}</s-table-cell>
-                  <s-table-cell>{problem.kind}</s-table-cell>
+                  <s-table-cell>{humanise(problem.kind)}</s-table-cell>
                   <s-table-cell>{problem.reason}</s-table-cell>
                 </s-table-row>
               ))}

--- a/app/routes/app.prices.baselines.tsx
+++ b/app/routes/app.prices.baselines.tsx
@@ -15,6 +15,7 @@
  * both the import and recapture pages into showing this table instead.
  */
 
+import { humanise } from "../lib/format/label";
 import { formatWhen } from "../lib/format/display";
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useLoaderData, useSearchParams } from "react-router";
@@ -96,7 +97,7 @@ export default function Baselines() {
               </s-option>
               {sources.map((source) => (
                 <s-option key={source} value={source} defaultSelected={filters.source === source}>
-                  {source.toLowerCase().replace(/_/g, " ")}
+                  {humanise(source)}
                 </s-option>
               ))}
             </s-select>
@@ -166,7 +167,7 @@ export default function Baselines() {
                     {entry.current ? " (current)" : ""}
                   </s-table-cell>
                   <s-table-cell>{entry.compareAt ?? "—"}</s-table-cell>
-                  <s-table-cell>{entry.source.toLowerCase().replace(/_/g, " ")}</s-table-cell>
+                  <s-table-cell>{humanise(entry.source)}</s-table-cell>
                   <s-table-cell>{formatWhen(entry.capturedAt, timeZone)}</s-table-cell>
                   <s-table-cell>
                     {entry.supersededAt ? formatWhen(entry.supersededAt, timeZone) : "—"}


### PR DESCRIPTION
Closes #380.

## States, as words

Ten places rendered a Prisma enum straight into a badge or a table cell. `humanise` is now the one transformation for them, and the audit actions go through it too — `market.added` and `CSV_IMPORT` are the same problem with different separators, and keeping two implementations is how they drift apart.

| Was | Is |
|---|---|
| `VERIFIED` `CLAMPED` `SKIPPED` `FAILED` | Verified · Clamped · Skipped · Failed |
| `APPLY · COMPLETED` | Apply · Completed |
| `install_capture`, `csv import` (hand-rolled) | Install capture, CSV import |

A transformation rather than a table of labels, for the same reason as the audit actions: a table can be missing an entry, and its failure mode is silent — a new enum value falls through to the raw string and a merchant reads `DRIFT_ADOPTION`.

## The acronym problem, and how it is guarded

The one thing a transformation cannot work out for itself is which tokens are said rather than spelled, so `ACRONYMS` is spelled out. The guard is the interesting part: `label.test.ts` reads every enum out of `prisma/schema.prisma` and writes down the words for each of the 56 values. Adding an enum value fails the test and shows the label it would have shipped — which is the moment to notice `EU_VAT_ADJUSTMENT` renders as "Eu vat adjustment".

The first version of that test tried to guess acronyms with "a token with no vowels is an acronym". It flagged `SYNC`. Every rule for guessing this is wrong somewhere, so the table is written out instead.

## Timestamps stop at the minute

`formatWhen` spelled every timestamp to the second, so a run history is a column of `27/08/2026, 12:40:38`. It is display-only — five UI call sites, no export contract — and nothing in this app happens on a schedule finer than a minute.

## A correction

`OnboardingCard` carried a comment claiming `s-link` and `s-clickable` are both block-level and that an inline stack cannot lay them out in a row. #379's `ActionRow` repeated it and used a grid to work around it. Checked against the rendered components: **only `s-clickable` is.** Three of them in an inline stack render as three lines; buttons and links render as one row and *wrap* when they run out of width, which a grid of fixed columns does not.

So `ActionRow` is an inline stack now — simpler, wraps properly on a narrow column, and no responsive-value comma to get wrong. The grids that remain are the ones lining columns up across rows, which is a real job and a different one. The 20 other inline stacks holding buttons, which the wrong comment implied were all broken, are fine as they are.

## Checks

`npm run typecheck`, `lint` and `build` pass. 1868 tests pass, 8 new; two mutations confirmed the schema guard fails — removing `CSV` from the acronym list, and adding an enum value to the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)