### PR TITLE
The dashboard stops describing the same things twice

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -78,13 +78,17 @@ describe("pages without an aside", () => {
     </PageShell>,
   );
 
-  it("put their sections straight into the page, with no wrapper", () => {
+  it("put their sections straight into the page, with no wrapper inside it", () => {
     // Not a style preference. Wrapping them — in an `s-stack`, and then in a
     // single-column `s-grid` — rendered the page blank in the admin: heading present,
     // every section gone, no error. Both were found by opening the page, so this
     // assertion is the only thing standing between the next tidy-up and a blank page.
-    expect(html).not.toContain("<s-grid");
-    expect(html).not.toContain("<s-stack");
+    //
+    // *Inside* is the whole rule. The page itself sits in a centring box that insets it
+    // to 80% of the frame, and that is outside `s-page` where it does no harm — checked
+    // by rendering it against the real Polaris components. What must not happen is
+    // anything coming between `s-page` and its sections.
+    expect(html).toMatch(/<s-page[^>]*>\s*<s-section/);
     expect(html).toContain("just rows");
   });
 
@@ -119,7 +123,7 @@ describe("asides that a page renders conditionally", () => {
       </PageShell>,
     );
 
-    expect(html).not.toContain("<s-grid");
+    expect(html).toMatch(/<s-page[^>]*>\s*<s-section/);
   });
 });
 
@@ -151,5 +155,43 @@ describe("the column collapses before it gets unreadable", () => {
   it("asks for two columns when there is room", () => {
     const [, wide] = columns.split(",");
     expect(wide.trim().split(/\s+/), "wide viewports get content plus an aside").toHaveLength(2);
+  });
+});
+
+describe("the inset", () => {
+  const html = render(
+    <PageShell heading="Anchor">
+      <s-section>rows</s-section>
+    </PageShell>,
+  );
+
+  it("leaves a tenth of the frame on each side", () => {
+    expect(html).toContain('inlineSize="80%"');
+  });
+
+  it("insets the heading with the content, not just the content", () => {
+    // A title pinned to the far left of a 1900px screen, with the first card it names
+    // starting a tenth of the way in, reads as two unrelated things. So the box wraps
+    // the whole page rather than its children.
+    expect(html.indexOf('inlineSize="80%"')).toBeLessThan(html.indexOf("<s-page"));
+  });
+});
+
+describe("what the inset must not break", () => {
+  it("keeps the aside, which only exists because this component rebuilds it", () => {
+    // The inset wraps `s-page` from outside. If a future tidy-up moves it inside, the
+    // aside partitioning still runs but Polaris has no aside slot at `large` — and the
+    // sections land in a slot nothing renders, which is how they disappear.
+    const html = render(
+      <PageShell heading="Anchor">
+        <s-section heading="Catalogue">main</s-section>
+        <s-section slot="aside" heading="Store">sidebar</s-section>
+      </PageShell>,
+    );
+
+    expect(html).toContain("sidebar");
+    expect(html, "a section still asking for a slot is a section nobody sees").not.toContain(
+      'slot="aside"',
+    );
   });
 });

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -3,11 +3,31 @@ import { Children, cloneElement, isValidElement, type ReactNode } from "react";
 import { SPACE } from "../lib/ui/spacing";
 
 /**
- * Every page in the app, at the full width of the screen.
+ * How much of the frame a page occupies, leaving a tenth on each side.
+ *
+ * A percentage rather than a maximum in pixels, deliberately: the admin renders this app
+ * in an iframe whose width is not the window's and changes with the merchant's own
+ * sidebar, so a fixed column would be a different fraction of the frame on every screen.
+ */
+const PAGE_WIDTH = "80%";
+
+/**
+ * Every page in the app, at four fifths of the screen.
  *
  * `s-page` defaults to `inlineSize="base"`, a ~660px column. On a 1300px viewport that
  * left roughly half the screen empty while the tables inside it wrapped — which is a
  * strange thing for an app whose whole job is showing a merchant thousands of rows.
+ *
+ * ## Why 80% and not the whole frame
+ *
+ * `large` is edge to edge, and edge to edge turned out to be the other mistake: cards
+ * that touch both sides of the window have nothing holding them, and a heading pinned to
+ * the far left of a 1900px screen is a long way from the first card it names. A tenth of
+ * the frame on each side is enough to make the page read as a page.
+ *
+ * Polaris offers `small`, `base` and `large` and nothing between, so the inset is a
+ * centred box wrapping the whole `s-page` — the heading included. Insetting only the
+ * content leaves the title hanging off the left edge, aligned to nothing.
  *
  * The catch that makes this more than one attribute: Polaris renders the `aside` slot
  * **only** when `inlineSize` is `"base"`. Nineteen sections across thirteen routes use
@@ -54,6 +74,14 @@ export function PageShell({
   const aside = all.filter(isAside);
   const main = all.filter((child) => !isAside(child));
 
+  const inset = (page: ReactNode) => (
+    // A grid because `justifyItems` is how a box gets centred here; boxes take padding
+    // but not margins, so `margin: auto` is not available.
+    <s-grid justifyItems="center">
+      <s-box inlineSize={PAGE_WIDTH}>{page}</s-box>
+    </s-grid>
+  );
+
   if (aside.length === 0) {
     // Children go straight into `s-page`, with no wrapper of any kind.
     //
@@ -68,14 +96,14 @@ export function PageShell({
     // in `spacing.ts` applies to content this component nests deliberately. Do not
     // "tidy" this into matching the branch below without loading a page that has no
     // aside — `/app/prices/live` is one — and looking at it.
-    return (
+    return inset(
       <s-page heading={heading} inlineSize="large">
         {main}
-      </s-page>
+      </s-page>,
     );
   }
 
-  return (
+  return inset(
     <s-page heading={heading} inlineSize="large">
       <s-grid
         gap={SPACE.page}
@@ -103,6 +131,6 @@ export function PageShell({
           )}
         </s-stack>
       </s-grid>
-    </s-page>
+    </s-page>,
   );
 }

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -225,6 +225,9 @@ export default function Dashboard() {
   const result = fetcher.data;
 
   const neverSynced = syncedAt === null;
+  // Something to report is a campaign that exists or a run that happened — not a set of
+  // counters that all read zero.
+  const showLive = campaigns > 0 || lastRun !== null;
 
   return (
     <PageShell heading="Anchor">
@@ -345,41 +348,35 @@ export default function Dashboard() {
             </s-button>
           </fetcher.Form>
         </s-section>
-      ) : (
+      ) : null}
+
+      {/* Only when there is something live to report.
+
+          It used to render unconditionally, so a shop that had synced and not yet made a
+          campaign got four tiles reading 0, 0, 0, 0 and two paragraphs explaining that
+          nothing had happened — the largest block on the page, spent saying "nothing".
+          The checklist above is already answering "what now", and answering it with an
+          action rather than with four zeroes. */}
+      {showLive ? (
         <s-section heading="What is live right now">
           <CountsRow
             items={[
               { label: "Campaigns running", value: live },
               { label: "Scheduled", value: upcoming },
               { label: "Need attention", value: needsAttention },
-              { label: "Prices changed outside the app", value: driftOpen },
+              // Shorter than "Prices changed outside the app", which was the one label
+              // that wrapped to two lines and made its tile taller than the three beside
+              // it once the page stopped running edge to edge.
+              { label: "Changed outside Anchor", value: driftOpen },
             ]}
           />
-
-          {live === 0 && upcoming === 0 && campaigns === 0 ? (
-            <s-paragraph>
-              <s-text>
-                No campaigns yet. A <strong>campaign</strong> is a rule — “20% off
-                everything tagged Summer” — plus when it should run. Anchor computes each
-                price from that variant&rsquo;s baseline, so running it twice changes
-                nothing the second time, and ending it puts prices back exactly.
-              </s-text>
-            </s-paragraph>
-          ) : null}
 
           {lastRun ? (
             <s-stack gap={SPACE.item}>
               <s-text color="subdued">Last run</s-text>
               <LastRunSummary run={lastRun} now={now} timeZone={timeZone} />
             </s-stack>
-          ) : (
-            <s-paragraph>
-              <s-text>
-                Nothing has been applied to your storefront yet. Every run records what it
-                changed, row by row, and stays readable for as long as you have the app.
-              </s-text>
-            </s-paragraph>
-          )}
+          ) : null}
 
           <ActionRow>
             <s-button href="/app/campaigns">Campaigns</s-button>
@@ -387,22 +384,70 @@ export default function Dashboard() {
             <s-button href="/app/activity">Activity log</s-button>
           </ActionRow>
         </s-section>
-      )}
+      ) : null}
+
+      {/* The one case the checklist does not cover: everything on it is done, and the
+          campaigns it was done with have since been deleted. */}
+      {!neverSynced && !showLive && guide.complete ? (
+        <s-section heading="What is live right now">
+          <s-paragraph>
+            <s-text>
+              Nothing is running. A <strong>campaign</strong> is a rule — “20% off
+              everything tagged Summer” — plus when it should run. Anchor computes each
+              price from that variant&rsquo;s baseline, so running it twice changes
+              nothing the second time, and ending it puts prices back exactly.
+            </s-text>
+          </s-paragraph>
+          <ActionRow>
+            <s-button variant="primary" href="/app/campaigns/new">
+              Create a campaign
+            </s-button>
+          </ActionRow>
+        </s-section>
+      ) : null}
 
       {!neverSynced ? (
         <s-section heading="Catalogue">
           {/* The shared component, not a second copy of its markup. This page had
               hand-rolled the same four tiles, so it kept the old flat look after the
               real one gained borders and equal columns -- and it is the first screen
-              after installing, which is the worst place to be a version behind. */}
+              after installing, which is the worst place to be a version behind.
+
+              Three tiles, not four. "Campaigns" was the fourth and it is a fact about
+              campaigns, which the section above is entirely about. */}
           <CountsRow
             items={[
               { label: "Variants", value: health.variants },
-              { label: "With baseline", value: health.withBaseline },
+              { label: "With a baseline", value: health.withBaseline },
               { label: "Not at baseline", value: health.drifted },
-              { label: "Campaigns", value: campaigns },
             ]}
           />
+
+          {/* The baselines were their own card in the sidebar, which meant the catalogue
+              was described in two places — and that card's headline figure was the second
+              tile above, restated. One subject, one card.
+
+              Two columns rather than four stacked lines: a label sitting directly under
+              the value above it reads as belonging to it, and the section's own rhythm
+              between children is not large enough to say otherwise. */}
+          <s-grid
+            gridTemplateColumns="@container (inline-size <= 500px) 1fr, 1fr 1fr"
+            gap={SPACE.section}
+          >
+            <s-stack gap={SPACE.tight}>
+              <s-text color="subdued">Baseline coverage</s-text>
+              <Meter value={health.withBaseline} max={health.variants} />
+            </s-stack>
+
+            <s-stack gap={SPACE.tight}>
+              <s-text color="subdued">Oldest captured</s-text>
+              <s-text>
+                {health.oldestCapturedAt
+                  ? formatDay(health.oldestCapturedAt, timeZone)
+                  : "None captured"}
+              </s-text>
+            </s-stack>
+          </s-grid>
 
           {health.withBaseline > health.variants ? (
             <s-paragraph>
@@ -415,14 +460,15 @@ export default function Dashboard() {
           ) : null}
 
           <ActionRow>
-            <fetcher.Form method="post">
-              <input type="hidden" name="intent" value="sync" />
-              <s-button type="submit" loading={busy || undefined}>
-                Re-sync catalogue
-              </s-button>
-            </fetcher.Form>
             <s-button variant="tertiary" href="/app/prices">
               Browse variants and baselines
+            </s-button>
+            {/* Tertiary, and the only action on this page deliberately kept quiet. One
+                click was not enough ceremony for the most destructive operation in the
+                app, and a bordered button next to the coverage figure would read as the
+                thing to do about it. */}
+            <s-button variant="tertiary" href="/app/imports/recapture">
+              Recapture baselines…
             </s-button>
           </ActionRow>
         </s-section>
@@ -442,53 +488,22 @@ export default function Dashboard() {
             <s-text color="subdued">Last synced</s-text>
             <s-text>{syncedAt ? formatAgo(syncedAt, now, timeZone) : "Not yet synced"}</s-text>
           </s-stack>
+
+          {/* The action belongs with the fact it acts on. It used to sit in the catalogue
+              card, two columns away from the sentence saying how stale the catalogue
+              was. */}
+          {!neverSynced ? (
+            <ActionRow>
+              <fetcher.Form method="post">
+                <input type="hidden" name="intent" value="sync" />
+                <s-button type="submit" loading={busy || undefined}>
+                  Re-sync catalogue
+                </s-button>
+              </fetcher.Form>
+            </ActionRow>
+          ) : null}
         </s-stack>
       </s-section>
-
-      {!neverSynced ? (
-        <s-section slot="aside" heading="Baselines">
-          <s-stack gap={SPACE.section}>
-            <s-stack gap={SPACE.tight}>
-              <s-text color="subdued">Coverage</s-text>
-              <s-text type="strong">
-                {formatCount(health.withBaseline)} of {formatCount(health.variants)} variants
-              </s-text>
-              <Meter value={health.withBaseline} max={health.variants} />
-            </s-stack>
-
-            <s-stack gap={SPACE.tight}>
-              <s-text color="subdued">Oldest captured</s-text>
-              <s-text>
-                {health.oldestCapturedAt
-                  ? formatDay(health.oldestCapturedAt, timeZone)
-                  : "None captured"}
-              </s-text>
-            </s-stack>
-
-            {/* One sentence, not the six it used to be. The full explanation — what a
-                recapture would catch, and which campaigns are running while you do it —
-                is on the page that performs it, where it can name your actual campaigns
-                instead of describing the idea of one. What has to survive the trim is the
-                irreversibility, and that is what is left. */}
-            <s-paragraph>
-              <s-text color="subdued">
-                Recapturing replaces baselines with today&rsquo;s live prices — done during a
-                sale, that makes the sale price the new normal, permanently.
-              </s-text>
-            </s-paragraph>
-
-            {/* Tertiary, and the only action on this page deliberately kept quiet. One
-                click from the dashboard was not enough ceremony for the most destructive
-                operation in the app, and a bordered button beside a warning would read
-                as the thing to do next. */}
-            <ActionRow>
-              <s-button variant="tertiary" href="/app/imports/recapture">
-                Recapture baselines…
-              </s-button>
-            </ActionRow>
-          </s-stack>
-        </s-section>
-      ) : null}
 
       {!neverSynced && recent.length > 0 ? (
         <s-section slot="aside" heading="Recent activity">


### PR DESCRIPTION
Closes #382. Both states rendered against the real Polaris components and looked at.

## Width

Every page is inset to 80% of the frame — a tenth on each side. Polaris offers `small`, `base` and `large` and nothing between, so it is a centred box wrapping the whole `s-page`, **heading included**: insetting only the content leaves the title hanging off the left edge, aligned to nothing.

The existing test asserted "no `<s-grid>` anywhere" to guard a documented hazard — wrapping `s-page`'s *children* rendered the page blank in the admin, no error. That assertion now catches the outer wrapper, so it says what it actually means: nothing may come between `s-page` and its sections. A new test pins the aside surviving the inset, since the aside only exists because `PageShell` rebuilds it.

## Structure

| Before | After |
|---|---|
| "What is live right now" always renders — four `0` tiles and two paragraphs on a new store | Renders when a campaign exists or a run happened |
| Catalogue card *and* a Baselines sidebar card restating its "With baseline" tile | One Catalogue card: three tiles, then coverage and oldest-captured side by side |
| "Re-sync catalogue" in the catalogue card | In the Store card, beside "Last synced 12 hours ago" |
| Four sidebar cards | Two — Store, Recent activity |

The one case the checklist does not cover — everything on it done, and the campaigns it was done with since deleted — is an empty state with a single black "Create a campaign".

"Prices changed outside the app" is now "Changed outside Anchor": it was the one tile label that wrapped to two lines once the page stopped running edge to edge, making its tile taller than the three beside it.

## Not covered by a test

`showLive` is a one-line condition in the route component, which `useLoaderData` makes awkward to render in a test. Mutating it to `true` passes the suite. Worth knowing before someone assumes the zeros can't come back.

## Checks

`npm run typecheck`, `lint` and `build` pass. 1871 tests pass, 3 new. The width test was mutated to 100% to confirm it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)