### PR TITLE
The inset reaches the two things that were outside it

### DIFF
--- a/app/components/ErrorScreen.tsx
+++ b/app/components/ErrorScreen.tsx
@@ -12,6 +12,7 @@
  */
 
 import { ActionRow } from "./ActionRow";
+import { PageShell } from "./PageShell";
 import { helpLabelFor, helpPathFor } from "../lib/errors/help-links";
 
 export interface ErrorScreenProps {
@@ -34,7 +35,7 @@ export function ErrorScreen({
   retryHref,
 }: ErrorScreenProps) {
   return (
-    <s-page heading="Something went wrong">
+    <PageShell heading="Something went wrong">
       <s-section>
         <s-banner tone={retryable ? "warning" : "critical"}>
           <s-paragraph>{userMessage}</s-paragraph>
@@ -86,6 +87,6 @@ export function ErrorScreen({
           </details>
         ) : null}
       </s-section>
-    </s-page>
+    </PageShell>
   );
 }

--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -13,6 +13,9 @@
  * `inlineSize` and about where the aside content ended up.
  */
 
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
@@ -193,5 +196,49 @@ describe("what the inset must not break", () => {
     expect(html, "a section still asking for a slot is a section nobody sees").not.toContain(
       'slot="aside"',
     );
+  });
+});
+
+describe("every page in the app goes through the shell", () => {
+  const APP = join(process.cwd(), "app");
+
+  const sources = (dir: string): Array<{ path: string; text: string }> =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return sources(path);
+      if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+      return [{ path: path.replace(`${APP}/`, ""), text: readFileSync(path, "utf8") }];
+    });
+
+  /**
+   * The two surfaces that are deliberately not admin pages.
+   *
+   * `auth.login` is the shop-domain form served *outside* the Shopify admin, where
+   * `s-page`'s own narrow column is right for a single field and 80% of a browser window
+   * is not. `help.$` is the public help centre: plain HTML, its own shell, no Polaris.
+   */
+  const NOT_ADMIN_PAGES = ["routes/auth.login/route.tsx", "routes/help.$.tsx"];
+
+  it("leaves no page rendering s-page for itself", () => {
+    // A page that misses the shell is edge to edge while every other page is inset, and
+    // — because Polaris only renders the real aside slot at `inlineSize="base"` — it
+    // silently drops any aside it has.
+    const bare = sources(APP)
+      .filter(({ path }) => path !== "components/PageShell.tsx")
+      .filter(({ path }) => !NOT_ADMIN_PAGES.includes(path))
+      .filter(({ text }) => text.includes("<s-page"))
+      .map(({ path }) => path);
+
+    expect(bare, "render these through PageShell so they inset and keep their aside").toEqual(
+      [],
+    );
+  });
+
+  it("insets the one thing that renders outside a page", () => {
+    // A section's tabs come from the layout route, above the `Outlet`. They are the only
+    // markup in the app that has to line up with a page without being inside one.
+    const tabs = readFileSync(join(APP, "components", "SectionTabs.tsx"), "utf8");
+
+    expect(tabs).toContain("PageWidth");
   });
 });

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -12,6 +12,28 @@ import { SPACE } from "../lib/ui/spacing";
 const PAGE_WIDTH = "80%";
 
 /**
+ * The inset itself, for the things that sit outside a page and still have to line up
+ * with one.
+ *
+ * There is exactly one: a section's tab bar is rendered by the layout route, above the
+ * `Outlet` that renders the page, so it is not inside any `PageShell`. Left alone it ran
+ * edge to edge while the page below it started a tenth of the way in — the tabs and the
+ * card they belong to visibly detached from each other.
+ *
+ * Both are 80% of the same parent, so they align rather than nesting: this does not
+ * inset something already inset.
+ */
+export function PageWidth({ children }: { children: ReactNode }) {
+  // A grid because `justifyItems` is how a box gets centred here; boxes take padding but
+  // not margins, so `margin: auto` is not available.
+  return (
+    <s-grid justifyItems="center">
+      <s-box inlineSize={PAGE_WIDTH}>{children}</s-box>
+    </s-grid>
+  );
+}
+
+/**
  * Every page in the app, at four fifths of the screen.
  *
  * `s-page` defaults to `inlineSize="base"`, a ~660px column. On a 1300px viewport that
@@ -74,14 +96,6 @@ export function PageShell({
   const aside = all.filter(isAside);
   const main = all.filter((child) => !isAside(child));
 
-  const inset = (page: ReactNode) => (
-    // A grid because `justifyItems` is how a box gets centred here; boxes take padding
-    // but not margins, so `margin: auto` is not available.
-    <s-grid justifyItems="center">
-      <s-box inlineSize={PAGE_WIDTH}>{page}</s-box>
-    </s-grid>
-  );
-
   if (aside.length === 0) {
     // Children go straight into `s-page`, with no wrapper of any kind.
     //
@@ -96,41 +110,45 @@ export function PageShell({
     // in `spacing.ts` applies to content this component nests deliberately. Do not
     // "tidy" this into matching the branch below without loading a page that has no
     // aside — `/app/prices/live` is one — and looking at it.
-    return inset(
-      <s-page heading={heading} inlineSize="large">
-        {main}
-      </s-page>,
+    return (
+      <PageWidth>
+        <s-page heading={heading} inlineSize="large">
+          {main}
+        </s-page>
+      </PageWidth>
     );
   }
 
-  return inset(
-    <s-page heading={heading} inlineSize="large">
-      <s-grid
-        gap={SPACE.page}
-        // The column gap is the page rhythm too, not a smaller one. Two columns set
-        // closer together than the sections stacked within them read as one column of
-        // torn paper, because the strongest gap on the screen would then be running the
-        // wrong way.
-        //
-        // One comma only. Polaris splits a responsive value on the comma to separate
-        // "when the query matches" from "otherwise", so a `minmax(0, 1fr)` in here
-        // takes its own comma as that separator and the whole value stops parsing --
-        // which silently falls back to `none` and stacks the aside underneath, looking
-        // exactly like a layout choice rather than a broken string.
-        gridTemplateColumns="@container (inline-size <= 900px) 1fr, 1fr 22rem"
-        // Without this the aside column stretches to the height of the main content, so
-        // a one-line sidebar next to a long table becomes a very tall empty card.
-        alignItems="start"
-      >
-        <s-stack gap={SPACE.page}>{main}</s-stack>
-        <s-stack gap={SPACE.page}>
-          {aside.map((child) =>
-            // The slot is meaningless now that these are ordinary grid children, and
-            // leaving it on would have them looking for a slot no ancestor provides.
-            isValidElement(child) ? cloneElement(child, { slot: undefined } as never) : child,
-          )}
-        </s-stack>
-      </s-grid>
-    </s-page>,
+  return (
+    <PageWidth>
+      <s-page heading={heading} inlineSize="large">
+        <s-grid
+          gap={SPACE.page}
+          // The column gap is the page rhythm too, not a smaller one. Two columns set
+          // closer together than the sections stacked within them read as one column of
+          // torn paper, because the strongest gap on the screen would then be running the
+          // wrong way.
+          //
+          // One comma only. Polaris splits a responsive value on the comma to separate
+          // "when the query matches" from "otherwise", so a `minmax(0, 1fr)` in here
+          // takes its own comma as that separator and the whole value stops parsing --
+          // which silently falls back to `none` and stacks the aside underneath, looking
+          // exactly like a layout choice rather than a broken string.
+          gridTemplateColumns="@container (inline-size <= 900px) 1fr, 1fr 22rem"
+          // Without this the aside column stretches to the height of the main content, so
+          // a one-line sidebar next to a long table becomes a very tall empty card.
+          alignItems="start"
+        >
+          <s-stack gap={SPACE.page}>{main}</s-stack>
+          <s-stack gap={SPACE.page}>
+            {aside.map((child) =>
+              // The slot is meaningless now that these are ordinary grid children, and
+              // leaving it on would have them looking for a slot no ancestor provides.
+              isValidElement(child) ? cloneElement(child, { slot: undefined } as never) : child,
+            )}
+          </s-stack>
+        </s-grid>
+      </s-page>
+    </PageWidth>
   );
 }

--- a/app/components/SectionTabs.tsx
+++ b/app/components/SectionTabs.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useSearchParams } from "react-router";
 
+import { PageWidth } from "./PageShell";
 import { TabBar } from "./TabBar";
 
 export interface SectionTab {
@@ -39,14 +40,25 @@ export function SectionTabs({ tabs }: { tabs: SectionTab[] }) {
   const query = carried.toString();
 
   return (
-    <TabBar
-      label="Sections"
-      tabs={tabs.map((tab) => ({
-        label: tab.label,
-        badge: tab.badge,
-        current: pathname === tab.href,
-        href: query ? `${tab.href}?${query}` : tab.href,
-      }))}
-    />
+    // Inset to the same width as the pages below it. A section's tabs are rendered by the
+    // layout route, above the `Outlet`, so they are not inside any `PageShell` — and left
+    // alone they ran edge to edge while the page started a tenth of the way in.
+    <PageWidth>
+      {/* `s-page` insets its own contents by this much, so without it the tabs sit a
+          few pixels left of the card they belong to — which after the inset is the only
+          misalignment left on the page, and the kind that reads as sloppiness rather
+          than as a choice. Matched by putting the two side by side and looking. */}
+      <s-box paddingInline="base">
+        <TabBar
+          label="Sections"
+          tabs={tabs.map((tab) => ({
+            label: tab.label,
+            badge: tab.badge,
+            current: pathname === tab.href,
+            href: query ? `${tab.href}?${query}` : tab.href,
+          }))}
+        />
+      </s-box>
+    </PageWidth>
   );
 }

--- a/app/components/TabBar.tsx
+++ b/app/components/TabBar.tsx
@@ -106,8 +106,17 @@ export function TabBar({
             </s-box>
           ) : (
             <s-box key={tab.href} padding={PAD.control}>
+              {/* The label goes through `s-text` because a react-router `Link` renders a
+                  bare `<a>`, and a bare anchor is painted by the browser: these tabs were
+                  the last browser-blue underlined links in the app, and the only ones the
+                  `s-link` sweep could not see.
+
+                  Still a `Link` and not an `s-button href`, which would be the vocabulary
+                  answer everywhere else. A button is an anchor, so it navigates by loading
+                  the document again — and these tabs swap a view several times a minute.
+                  Client-side routing is worth an underline. */}
               <Link to={tab.href} preventScrollReset={preventScrollReset}>
-                {text}
+                <s-text>{text}</s-text>
               </Link>
             </s-box>
           );


### PR DESCRIPTION
Closes #384.

I audited every route: 20 go through `PageShell`, 16 are redirect-only legacy paths from the nav consolidation with no UI, three are layout routes, and two rendered their own `s-page`. After #383 inset the pages to 80%, both of those visibly disagreed with everything around them.

## Section tabs

`SectionTabs` comes from the layout route, above the `Outlet`, so it is not inside any `PageShell`. It ran flush to the left edge while the page below started a tenth of the way in.

`PageShell` now exports `PageWidth`, and `SectionTabs` is its only other caller — both are 80% of the same parent, so they align rather than nesting. It also needed `paddingInline="base"`, which is what `s-page` applies to its own contents; without it the tabs sat ~17px left of the card they belong to. Measured by rendering both side by side.

## The error screen

`ErrorScreen` rendered its own `<s-page>`. Two consequences: it was edge to edge, and a page rendering its own `s-page` silently drops any aside, because Polaris only renders the real slot at `inlineSize="base"`. That is precisely the failure `PageShell` exists to prevent.

## The last blue links

`TabBar` renders a react-router `Link`, which is a bare `<a>` — browser blue, underlined. These were the last unstyled links in the app and the only ones #379's `s-link` sweep could not see, because they are not `s-link`. The label goes through `s-text` now, which kills the blue.

Deliberately **not** an `s-button href`, which the vocabulary would otherwise ask for: a button is an anchor, so it navigates by loading the document again, and these tabs swap a view several times a minute. Client-side routing is worth an underline.

## Guarding it

A source scan fails when a new page renders its own `s-page`. The exemption list is two entries, each with its reason: `auth.login` is served outside the admin where `s-page`'s own narrow column is right for a single field, and `help.$` is the public help centre — plain HTML, its own shell, no Polaris.

## Checks

`npm run typecheck`, `lint` and `build` pass. 1873 tests pass, 4 new; two mutations confirmed the guards fail — reverting `ErrorScreen` to a bare `s-page`, and dropping `PageWidth` from `SectionTabs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)