### PR TITLE
Home's rules about itself, in one place that is checked

### DIFF
--- a/app/lib/dashboard/home.test.ts
+++ b/app/lib/dashboard/home.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The decisions Home makes about itself.
+ *
+ * Each exists because of a way the page had previously embarrassed itself, and until now
+ * every one was an untested conditional in JSX. The `live` rule was mutated to `true`
+ * during review of the change that introduced it and the whole suite passed — which is
+ * how a page goes back to opening with four zeroes.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { homeSections } from "./home";
+
+const shop = (over: Partial<Parameters<typeof homeSections>[0]> = {}) =>
+  homeSections({
+    neverSynced: false,
+    campaigns: 0,
+    hasRun: false,
+    onboardingComplete: false,
+    ...over,
+  });
+
+describe("a shop that has just installed", () => {
+  const sections = shop({ neverSynced: true });
+
+  it("is not shown a catalogue it has not synced", () => {
+    expect(sections.catalogue).toBe(false);
+  });
+
+  it("is not shown four counters reading zero", () => {
+    expect(sections.live).toBe(false);
+  });
+
+  it("is not shown an empty state either, because the checklist is the page", () => {
+    expect(sections.emptyState).toBe(false);
+  });
+});
+
+describe("a shop part-way through the checklist", () => {
+  const sections = shop({ campaigns: 0 });
+
+  it("still gets no live section", () => {
+    expect(sections.live).toBe(false);
+  });
+
+  it("leaves the black button to the checklist's own next step", () => {
+    expect(sections.createIsPrimary).toBe(false);
+  });
+});
+
+describe("a shop with something to report", () => {
+  it("shows the live section for a campaign that exists", () => {
+    expect(shop({ campaigns: 1 }).live).toBe(true);
+  });
+
+  it("shows it for a run that happened even if the campaign is gone", () => {
+    // The last run is a thing a merchant opens the page to check, and deleting the
+    // campaign does not make it not have happened.
+    expect(shop({ campaigns: 0, hasRun: true }).live).toBe(true);
+  });
+});
+
+describe("a shop that finished the checklist and deleted its campaigns", () => {
+  const sections = shop({ onboardingComplete: true });
+
+  it("gets the empty state, which is the one case the checklist cannot cover", () => {
+    expect(sections.emptyState).toBe(true);
+  });
+
+  it("gets a black Create campaign, because nothing else is pointing anywhere", () => {
+    expect(sections.createIsPrimary).toBe(true);
+  });
+});
+
+describe("whatever the shop", () => {
+  const every = [
+    shop({ neverSynced: true }),
+    shop(),
+    shop({ campaigns: 1 }),
+    shop({ hasRun: true }),
+    shop({ onboardingComplete: true }),
+    shop({ onboardingComplete: true, campaigns: 3, hasRun: true }),
+  ];
+
+  it("never shows the empty state and the live section together", () => {
+    // They answer the same question, and a page rendering both says "nothing is running"
+    // directly above a list of what is running.
+    expect(every.filter((sections) => sections.emptyState && sections.live)).toEqual([]);
+  });
+});

--- a/app/lib/dashboard/home.ts
+++ b/app/lib/dashboard/home.ts
@@ -1,0 +1,62 @@
+/**
+ * What Home shows, and why.
+ *
+ * These decisions were four conditionals scattered through the route's JSX, and nothing
+ * checked any of them. That matters more than it looks: each exists because of a specific
+ * way the page had previously embarrassed itself, and a conditional with no test is one
+ * tidy-up away from being simplified back into the thing it was written to fix. The first
+ * of them was mutated to `true` during review and the entire suite passed.
+ *
+ * Derived from facts rather than flags, the same way `onboarding()` is: a shop that has a
+ * campaign has one whether or not anybody set a boolean saying so.
+ */
+
+export interface HomeFacts {
+  /** The catalogue has never been synced, so there is nothing to count yet. */
+  neverSynced: boolean;
+  /** Campaigns that exist at all, in any state. */
+  campaigns: number;
+  /** Whether any run has ever happened. */
+  hasRun: boolean;
+  /** The getting-started checklist has retired itself. */
+  onboardingComplete: boolean;
+}
+
+export interface HomeSections {
+  /**
+   * "What is live right now".
+   *
+   * It used to render unconditionally, so a shop that had synced and not yet made a
+   * campaign got four tiles reading 0, 0, 0, 0 and two paragraphs explaining that nothing
+   * had happened — the largest block on the page, spent on the absence of news.
+   */
+  live: boolean;
+  /**
+   * The empty state, for the single case the checklist cannot cover: a merchant who
+   * finished it and has since deleted the campaigns they finished it with. Any other
+   * empty shop is already being told what to do by the checklist itself.
+   */
+  emptyState: boolean;
+  /**
+   * Whether "Create campaign" is the black button.
+   *
+   * Only once the checklist has gone. While it is up, its own next step is what the page
+   * is pointing at, and two black buttons point at nothing.
+   */
+  createIsPrimary: boolean;
+  /** The catalogue card, which has nothing to count before a sync. */
+  catalogue: boolean;
+}
+
+export function homeSections(facts: HomeFacts): HomeSections {
+  // Something to report is a campaign that exists or a run that happened — not a set of
+  // counters that all read zero.
+  const live = facts.campaigns > 0 || facts.hasRun;
+
+  return {
+    live,
+    emptyState: !facts.neverSynced && !live && facts.onboardingComplete,
+    createIsPrimary: facts.onboardingComplete,
+    catalogue: !facts.neverSynced,
+  };
+}

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -20,6 +20,7 @@ import { LastRunSummary } from "../components/LastRunSummary";
 import { UpcomingCampaigns } from "../components/UpcomingCampaigns";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { onboarding } from "../lib/onboarding/steps";
+import { homeSections } from "../lib/dashboard/home";
 import { nextMoments } from "../lib/scheduling/upcoming";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
@@ -253,9 +254,15 @@ export default function Dashboard() {
   const result = fetcher.data;
 
   const neverSynced = syncedAt === null;
-  // Something to report is a campaign that exists or a run that happened — not a set of
-  // counters that all read zero.
-  const showLive = campaigns > 0 || lastRun !== null;
+  // Which sections this page shows, decided in one tested place rather than in four
+  // conditionals spread through the markup below. Each of those rules exists because of
+  // a specific way this page used to embarrass itself; see `homeSections`.
+  const sections = homeSections({
+    neverSynced,
+    campaigns,
+    hasRun: lastRun !== null,
+    onboardingComplete: guide.complete,
+  });
 
   return (
     <PageShell heading="Home">
@@ -385,7 +392,7 @@ export default function Dashboard() {
           nothing had happened — the largest block on the page, spent saying "nothing".
           The checklist above is already answering "what now", and answering it with an
           action rather than with four zeroes. */}
-      {showLive ? (
+      {sections.live ? (
         <s-section heading="What is live right now">
           <CountsRow
             items={[
@@ -412,7 +419,7 @@ export default function Dashboard() {
               point at nothing. */}
           <ActionRow>
             <s-button
-              variant={guide.complete ? "primary" : "secondary"}
+              variant={sections.createIsPrimary ? "primary" : "secondary"}
               href="/app/campaigns/new"
             >
               Create campaign
@@ -439,7 +446,7 @@ export default function Dashboard() {
 
       {/* The one case the checklist does not cover: everything on it is done, and the
           campaigns it was done with have since been deleted. */}
-      {!neverSynced && !showLive && guide.complete ? (
+      {sections.emptyState ? (
         <s-section heading="What is live right now">
           <s-paragraph>
             <s-text>
@@ -457,7 +464,7 @@ export default function Dashboard() {
         </s-section>
       ) : null}
 
-      {!neverSynced ? (
+      {sections.catalogue ? (
         <s-section heading="Catalogue">
           {/* The shared component, not a second copy of its markup. This page had
               hand-rolled the same four tiles, so it kept the old flat look after the


### PR DESCRIPTION
Closes #390. This closes the gap I flagged twice while shipping the Home work and never went back for.

## The gap

Four conditionals decided what Home shows, all inline in the route's JSX where `useLoaderData` makes them awkward to render in a test. Each exists because of a specific way the page used to embarrass itself:

- four tiles reading `0` on a shop with no campaigns
- an empty state beside the checklist that was already saying the same thing
- two black buttons pointing at nothing
- a catalogue card counting a catalogue that had not been synced

**Not theoretical.** Reviewing #383 I mutated the first rule to `true` and the entire suite passed. That is how the page goes back to opening with four zeroes — the thing this whole run of work started from.

## The change

`homeSections(facts)` derives all four the way `onboarding()` already derives the checklist, and the route reads its result instead of recomputing the conditions inline. Each rule carries the reason it exists in the doc comment beside it, so the next tidy-up has to read why before simplifying it away.

The one invariant worth stating separately: no shop, in any state, is shown both the empty state and the live section. They answer the same question, and a page rendering both says "nothing is running" directly above a list of what is running. The test walks all six shop states rather than asserting it case by case.

## Checks

`npm run typecheck`, `lint` and `build` pass. 1888 tests pass, 10 new. Each of the three interesting rules was mutated and confirmed to fail its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)