### PR TITLE
A way back, and something worth going back to

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -242,3 +242,69 @@ describe("every page in the app goes through the shell", () => {
     expect(tabs).toContain("PageWidth");
   });
 });
+
+describe("the way back", () => {
+  it("is offered on a page the nav menu cannot reach", () => {
+    // A campaign, the editor and the activity log are opened *from* somewhere and have no
+    // nav entry. Before this the only ways back were the browser's button and guessing
+    // which nav item was the parent.
+    const html = render(
+      <PageShell heading="Summer sale" backTo={{ href: "/app/campaigns", label: "Campaigns" }}>
+        <s-section>detail</s-section>
+      </PageShell>,
+    );
+
+    expect(html).toContain('href="/app/campaigns"');
+    expect(html).toContain("Campaigns");
+    expect(html).toContain('icon="arrow-left"');
+  });
+
+  it("sits above the title rather than inside the page", () => {
+    // Under the heading it reads as the first thing *in* the page rather than the way
+    // out of it, and `s-page` takes no slot for one in this version.
+    const html = render(
+      <PageShell heading="Summer sale" backTo={{ href: "/app/campaigns", label: "Campaigns" }}>
+        <s-section>detail</s-section>
+      </PageShell>,
+    );
+
+    expect(html.indexOf('href="/app/campaigns"')).toBeLessThan(html.indexOf("<s-page"));
+  });
+
+  it("is absent on a page that has a tab bar, which is already the way back", () => {
+    const html = render(
+      <PageShell heading="Variants">
+        <s-section>rows</s-section>
+      </PageShell>,
+    );
+
+    expect(html).not.toContain('icon="arrow-left"');
+  });
+});
+
+describe("pages that can lose typed work", () => {
+  const APP_ROUTES = join(process.cwd(), "app", "routes");
+
+  /**
+   * A page holding fields nobody has saved yet needs the guard, or its own back link
+   * becomes the fastest way to throw the work away.
+   *
+   * Settings is exempt: it has the App Bridge save bar, which blocks navigation itself.
+   * Recapture is exempt: its one field is a typed confirmation that costs a second to
+   * retype, and the page it guards is destructive enough that leaving is the good outcome.
+   */
+  const GUARDED = [
+    "app.campaigns.new.tsx",
+    "app.imports.prices.tsx",
+    "app.imports.baselines.tsx",
+    "app.imports.costs.tsx",
+  ];
+
+  it("guard the ones that hold a form worth keeping", () => {
+    const missing = GUARDED.filter(
+      (route) => !readFileSync(join(APP_ROUTES, route), "utf8").includes("<UnsavedChanges"),
+    );
+
+    expect(missing, "these can discard a filled-in form on any navigation").toEqual([]);
+  });
+});

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -1,5 +1,6 @@
 import { Children, cloneElement, isValidElement, type ReactNode } from "react";
 
+import { ActionRow } from "./ActionRow";
 import { SPACE } from "../lib/ui/spacing";
 
 /**
@@ -82,11 +83,47 @@ export function PageWidth({ children }: { children: ReactNode }) {
  *   it, some route eventually sets it smaller than the gaps inside its own sections, and
  *   the page stops having visible structure at all.
  */
+/**
+ * The way back, above the title.
+ *
+ * Above rather than beside: `s-page` renders its own heading and takes no slot for this
+ * in the version pinned here, and a back link under the title would read as the first
+ * thing *in* the page rather than as the way out of it. The padding matches what `s-page`
+ * insets its own contents by, so it lines up with the heading below it.
+ */
+function BackLink({ backTo }: { backTo?: { href: string; label: string } }) {
+  if (!backTo) return null;
+
+  return (
+    <s-box paddingInline="base">
+      <ActionRow>
+        <s-button variant="tertiary" icon="arrow-left" href={backTo.href}>
+          {backTo.label}
+        </s-button>
+      </ActionRow>
+    </s-box>
+  );
+}
+
 export function PageShell({
   heading,
+  backTo,
   children,
 }: {
   heading: string;
+  /**
+   * Where this page came from, for pages the nav menu cannot reach.
+   *
+   * A campaign, the campaign editor and the activity log are all opened *from* somewhere
+   * and have no entry of their own, so until this existed the only ways back were the
+   * browser's button and guessing which nav item was the parent. On a form that is not
+   * merely inconvenient: a merchant who has typed a rule and a scope, and cannot see a
+   * way back, will find one that loses it.
+   *
+   * Pages inside a tabbed section do not take this. Their tab bar is already the way
+   * back, and a second one above it would be two answers to one question.
+   */
+  backTo?: { href: string; label: string };
   children: ReactNode;
 }) {
   const all = Children.toArray(children);
@@ -112,6 +149,7 @@ export function PageShell({
     // aside — `/app/prices/live` is one — and looking at it.
     return (
       <PageWidth>
+        <BackLink backTo={backTo} />
         <s-page heading={heading} inlineSize="large">
           {main}
         </s-page>
@@ -121,6 +159,7 @@ export function PageShell({
 
   return (
     <PageWidth>
+      <BackLink backTo={backTo} />
       <s-page heading={heading} inlineSize="large">
         <s-grid
           gap={SPACE.page}

--- a/app/components/UnsavedChanges.tsx
+++ b/app/components/UnsavedChanges.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from "react";
+import { useBlocker, useNavigation } from "react-router";
+
+import { hasChanged, snapshotOf } from "../lib/ui/dirty";
+import { ActionRow } from "./ActionRow";
+
+/**
+ * Stops a half-filled form being thrown away by a click.
+ *
+ * The campaign editor takes a name, a scope, a rule, rounding, surfaces and a schedule
+ * before it is worth submitting, and every one of those lives in the form rather than in
+ * anything persisted. Any navigation — the back link above the title, a nav item, the
+ * browser's own back button — unmounts the route and takes the lot with it. That is the
+ * trap this exists to close, and it is the reason the back link could not simply be
+ * added on its own.
+ *
+ * ## Why a banner and not a dialog
+ *
+ * The app confirms destructive things inline — the recapture page asks for a typed
+ * confirmation rather than opening a modal — and a browser `confirm()` inside the admin's
+ * iframe is both ugly and not guaranteed to be permitted. So the block renders as the
+ * app's own banner, and scrolls itself into view: a warning at the top of a page the
+ * merchant has scrolled to the bottom of would look exactly like the click doing nothing.
+ *
+ * ## What it does not cover
+ *
+ * `useBlocker` sees client-side navigation. A full page load — the browser's reload
+ * button, a typed URL — is outside it, and `beforeunload` is deliberately not added: the
+ * admin renders this app in an iframe, and a browser-level "leave site?" prompt on a
+ * click inside an embedded app is more alarming than the loss it prevents.
+ */
+export function UnsavedChanges({
+  form,
+  /** What the merchant would be walking away from, in their words. */
+  describe = "what you have entered",
+  /**
+   * The form's contents have been accepted, so they are no longer only in the form.
+   *
+   * Without this the guard raises a false alarm on the way out of a page whose work is
+   * already done — an import that has run, and whose CSV is still sitting in the
+   * textarea. A warning that fires when nothing is at stake is how merchants learn to
+   * click through the one that matters.
+   */
+  saved = false,
+}: {
+  form: React.RefObject<HTMLFormElement | null>;
+  describe?: string;
+  saved?: boolean;
+}) {
+  const pristine = useRef<string | null>(null);
+  const banner = useRef<HTMLElement | null>(null);
+  const submitting = useRef(false);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    if (form.current) pristine.current = snapshotOf(form.current);
+  }, [form]);
+
+  // Whatever is in the form now is what was accepted, so it is the new starting point.
+  useEffect(() => {
+    if (saved && form.current) pristine.current = snapshotOf(form.current);
+  }, [saved, form]);
+
+  // A page's own submit is not somebody walking away from their work — it is the work
+  // being done. The campaign editor posts and is redirected to the campaign it created,
+  // and without this the guard would stop that redirect to ask whether to discard a
+  // campaign that now exists.
+  useEffect(() => {
+    const element = form.current;
+    if (!element) return;
+
+    const onSubmit = () => {
+      submitting.current = true;
+    };
+    element.addEventListener("submit", onSubmit);
+    return () => element.removeEventListener("submit", onSubmit);
+  }, [form]);
+
+  // Re-armed once the submission settles without leaving: an action that came back with
+  // an error leaves the merchant on the page, still holding everything they typed.
+  useEffect(() => {
+    if (navigation.state === "idle") submitting.current = false;
+  }, [navigation.state]);
+
+  const blocker = useBlocker(
+    // Same-URL navigations are not leaving: a fetcher re-running or a search param the
+    // page sets itself would otherwise raise this over the merchant's own typing.
+    ({ currentLocation, nextLocation }) =>
+      !submitting.current &&
+      currentLocation.pathname !== nextLocation.pathname &&
+      hasChanged(form.current ? snapshotOf(form.current) : null, pristine.current),
+  );
+
+  useEffect(() => {
+    if (blocker.state === "blocked") banner.current?.scrollIntoView({ block: "center" });
+  }, [blocker.state]);
+
+  if (blocker.state !== "blocked") return null;
+
+  return (
+    <s-banner
+      ref={banner as never}
+      tone="warning"
+      heading={`Leave without keeping ${describe}?`}
+    >
+      <s-paragraph>
+        Nothing here has been saved yet, so leaving this page discards it. Going back is
+        the only thing that keeps it.
+      </s-paragraph>
+      <ActionRow>
+        <s-button variant="primary" onClick={() => blocker.reset?.()}>
+          Stay on this page
+        </s-button>
+        <s-button variant="tertiary" onClick={() => blocker.proceed?.()}>
+          Leave and discard
+        </s-button>
+      </ActionRow>
+    </s-banner>
+  );
+}

--- a/app/lib/ui/dirty.test.ts
+++ b/app/lib/ui/dirty.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether a form still holds what somebody typed.
+ *
+ * The answer decides whether they are warned before losing it, so the case that matters
+ * is the one that is wrong in the dangerous direction: a form that has changed, reported
+ * clean, lets the work go silently.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { hasChanged } from "./dirty";
+
+describe("comparing a form to how it started", () => {
+  it("is clean when the fields still say what they said", () => {
+    expect(hasChanged("name=&pct=", "name=&pct=")).toBe(false);
+  });
+
+  it("is dirty the moment one field differs", () => {
+    expect(hasChanged("name=Summer+sale&pct=", "name=&pct=")).toBe(true);
+  });
+
+  it("notices a field being emptied, not only filled", () => {
+    // Clearing a name is still work: it was typed, and it is gone if nobody warns.
+    expect(hasChanged("name=&pct=-20", "name=Summer+sale&pct=-20")).toBe(true);
+  });
+
+  it("says there is nothing to lose when no snapshot was ever taken", () => {
+    // Blocking every navigation off a page that never rendered a field is its own trap.
+    expect(hasChanged(null, null)).toBe(false);
+    expect(hasChanged("name=Summer", null)).toBe(false);
+    expect(hasChanged(null, "name=Summer")).toBe(false);
+  });
+});

--- a/app/lib/ui/dirty.ts
+++ b/app/lib/ui/dirty.ts
@@ -1,0 +1,35 @@
+/**
+ * Whether a form still holds what the merchant typed.
+ *
+ * Read from the form's own fields rather than mirrored into React state, the same way
+ * `SettingsSaveBar` reads it: mirroring means two sources of truth for "has this
+ * changed", and the one that goes stale is the one deciding whether somebody is warned
+ * before losing their work.
+ *
+ * Split into a DOM read and a comparison, because the comparison is the part that can be
+ * wrong in the dangerous direction — reporting a changed form as clean lets the work go
+ * silently — and it can only be tested on its own if it does not need a document to run.
+ */
+
+/**
+ * The form, serialised the way a submit would send it.
+ *
+ * Through `FormData` rather than by walking the fields, so it sees exactly what would be
+ * posted: fields added after mount, checkboxes in their submitted form, and nothing that
+ * is disabled.
+ */
+export function snapshotOf(form: HTMLFormElement): string {
+  return new URLSearchParams(new FormData(form) as unknown as string[][]).toString();
+}
+
+/**
+ * Whether the form differs from how it started.
+ *
+ * Either value being null means there is nothing to compare — the form had not mounted
+ * when the snapshot was taken — and the honest answer there is "nothing to lose" rather
+ * than blocking every navigation off a page that never rendered a field.
+ */
+export function hasChanged(current: string | null, pristine: string | null): boolean {
+  if (current === null || pristine === null) return false;
+  return current !== pristine;
+}

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -67,7 +67,7 @@ export default function Activity() {
     });
 
   return (
-    <PageShell heading="Activity">
+    <PageShell heading="Activity" backTo={{ href: "/app", label: "Home" }}>
       <s-section>
         <FilterForm fields={FILTER_FIELDS}>
           <s-stack gap="base">

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -307,7 +307,7 @@ export default function CampaignDetail() {
 
 
   return (
-    <PageShell heading={preview.name}>
+    <PageShell heading={preview.name} backTo={{ href: "/app/campaigns", label: "Campaigns" }}>
       {result ? (
         <s-banner tone={result.ok ? "success" : "critical"}>
           <s-paragraph>{result.message}</s-paragraph>

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -26,6 +26,7 @@ import prisma from "../db.server";
 import { segmentToAst } from "../services/segments.server";
 import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/draft-form";
 import { PageShell } from "../components/PageShell";
+import { UnsavedChanges } from "../components/UnsavedChanges";
 import { DraftPreview } from "../components/DraftPreview";
 import { RuleValueField } from "../components/RuleValueField";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
@@ -263,7 +264,14 @@ export default function NewCampaign() {
 
 
   return (
-    <PageShell heading={practice ? "Practice campaign" : guided ? "Your first campaign" : "New campaign"}>
+    <PageShell
+      heading={practice ? "Practice campaign" : guided ? "Your first campaign" : "New campaign"}
+      backTo={{ href: "/app/campaigns", label: "Campaigns" }}
+    >
+      {/* Before anything else on the page, because it is the answer to a click that has
+          already happened. Nothing here is persisted until the campaign is created, so
+          any navigation away is a discard. */}
+      <UnsavedChanges form={formRef} describe="this campaign" />
       {practice ? (
         <s-banner tone="info">
           <s-paragraph>

--- a/app/routes/app.imports.baselines.tsx
+++ b/app/routes/app.imports.baselines.tsx
@@ -28,6 +28,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { UnsavedChanges } from "../components/UnsavedChanges";
 import { CsvDropZone } from "../components/imports/CsvDropZone";
 
 export const loader = withGuard("/app/imports/baselines", async ({ request }: LoaderFunctionArgs) => {
@@ -89,6 +90,13 @@ export default function ImportBaselines() {
 
   return (
     <PageShell heading="Import baselines">
+      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
+          the import runs. */}
+      <UnsavedChanges
+        form={form}
+        describe="this import"
+        saved={Boolean(fetcher.data)}
+      />
       {data ? (
         <s-banner tone={data.ok ? "success" : "critical"}>
           <s-paragraph>{data.message}</s-paragraph>

--- a/app/routes/app.imports.costs.tsx
+++ b/app/routes/app.imports.costs.tsx
@@ -31,6 +31,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { UnsavedChanges } from "../components/UnsavedChanges";
 import { CsvDropZone } from "../components/imports/CsvDropZone";
 
 export const loader = withGuard("/app/imports/costs", async ({ request }: LoaderFunctionArgs) => {
@@ -104,6 +105,13 @@ export default function ImportCosts() {
 
   return (
     <PageShell heading="Import costs">
+      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
+          the import runs. */}
+      <UnsavedChanges
+        form={form}
+        describe="this import"
+        saved={Boolean(fetcher.data)}
+      />
       {data ? (
         <s-banner tone={data.ok ? "success" : "critical"}>
           <s-paragraph>{data.message}</s-paragraph>

--- a/app/routes/app.imports.prices.tsx
+++ b/app/routes/app.imports.prices.tsx
@@ -27,6 +27,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import prisma from "../db.server";
 import { PageShell } from "../components/PageShell";
+import { UnsavedChanges } from "../components/UnsavedChanges";
 import { CsvDropZone } from "../components/imports/CsvDropZone";
 
 export const loader = withGuard("/app/imports/prices", async ({ request }: LoaderFunctionArgs) => {
@@ -110,6 +111,13 @@ export default function ImportPrices() {
 
   return (
     <PageShell heading="Import prices">
+      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
+          the import runs. */}
+      <UnsavedChanges
+        form={form}
+        describe="this import"
+        saved={Boolean(fetcher.data)}
+      />
       {fetcher.data ? (
         <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
           <s-paragraph>{fetcher.data.message}</s-paragraph>


### PR DESCRIPTION
Closes #392.

## Where a back link goes, and where it does not

I walked every route. Three are reachable only *from* somewhere else with no nav entry, and those get `backTo`:

| Page | Back to |
|---|---|
| `/app/campaigns/:id` | Campaigns |
| `/app/campaigns/new` | Campaigns |
| `/app/activity` | Home |

Everything else is either a nav item itself or sits inside a tabbed section, where the tab bar is already the way back and a second one above it would be two answers to one question.

It renders above the title: `s-page` owns its heading and offers no slot for this in the pinned version, and a back link *under* the title reads as the first thing in the page rather than the way out of it.

## Why the link needed the guard first

The editor takes a name, a scope, a rule, rounding, surfaces and a schedule, and none of it exists anywhere until the campaign is created. A back link on its own would have been the fastest way to throw that away — so `UnsavedChanges` blocks *any* navigation off a dirty form, not only the affordance I added: the back link, a nav item, the browser's own back button.

It asks with the app's own banner rather than a dialog. This codebase confirms destructive things inline — the recapture page uses a typed confirmation, not a modal — and a browser `confirm()` inside the admin's iframe is neither pretty nor guaranteed to be permitted. The banner scrolls itself into view, because a warning at the top of a page somebody has scrolled to the bottom of looks exactly like the click doing nothing.

Also applied to the three CSV import pages, where a pasted file can be fifty thousand rows that exist nowhere else.

## Two false alarms it must not raise

Neither was found by a test; both come from asking what happens next.

1. **The editor's own submit.** It posts and is redirected to the campaign it just created — a navigation off a still-dirty form. Unguarded, the blocker would have stopped that redirect to ask whether to discard a campaign that now exists. A `submit` listener stands the guard down, and `useNavigation` re-arms it if the action comes back with an error and the merchant is still sitting there holding their work.
2. **An import that has already run.** The CSV stays in the textarea afterwards. A warning that fires when nothing is at stake is how merchants learn to click through the one that matters, so `saved` re-baselines the snapshot.

## A design change the tests forced

`isDirty(form, pristine)` read the DOM and compared in one function, so it could not be tested without a document — and this repo deliberately runs its component tests without one. It is `snapshotOf` (the DOM read) plus `hasChanged` (pure) now. The comparison is the half that can be wrong in the dangerous direction.

## Checks

`npm run typecheck`, `lint` and `build` pass. 1900 tests pass, 12 new. Four mutations confirmed the new tests fail: the comparison always-false, the back link never rendering, and the guard removed from an import page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)