### PR TITLE
One empty state, and a way back off a filter that matched nothing

### DIFF
--- a/app/components/AsyncState.tsx
+++ b/app/components/AsyncState.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { PAD, SPACE } from "../lib/ui/spacing";
 
 /**
@@ -13,7 +15,7 @@ export interface EmptyStateProps {
   /** What is missing, in the merchant's words. */
   title: string;
   /** Why it might be missing and what to do about it. */
-  description?: string;
+  description?: ReactNode;
   action?: { label: string; href: string };
 }
 
@@ -27,6 +29,10 @@ export interface EmptyStateProps {
  *
  * The three parts sit at item rhythm: the title, the reason and the way out are one
  * thought, and spacing them apart makes the merchant read three unrelated things.
+ *
+ * The description is capped rather than running the width of the card. This is the one
+ * block on a page that is nothing but body copy, and body copy set across a very wide
+ * column is measurably harder to read.
  */
 export function EmptyState({ title, description, action }: EmptyStateProps) {
   return (
@@ -34,13 +40,55 @@ export function EmptyState({ title, description, action }: EmptyStateProps) {
       <s-stack gap={SPACE.item} alignItems="center">
         <s-heading>{title}</s-heading>
         {description ? (
-          <s-paragraph>
-            <s-text color="subdued">{description}</s-text>
-          </s-paragraph>
+          <s-box maxInlineSize="520px">
+            <s-paragraph>
+              <s-text color="subdued">{description}</s-text>
+            </s-paragraph>
+          </s-box>
         ) : null}
         {action ? <s-button href={action.href}>{action.label}</s-button> : null}
       </s-stack>
     </s-box>
+  );
+}
+
+/**
+ * Empty because of a filter, which is a different situation and needs a different answer.
+ *
+ * Conflating the two is the usual mistake, and the app had been making it on six pages: a
+ * shop with no variants needs telling what a variant is, and a shop whose filter matched
+ * nothing needs the filter taken off. Six of those pages said "nothing matches" and
+ * offered no way to stop matching nothing — one of them, the reconciliation table, went
+ * as far as guessing what the merchant had been looking for.
+ *
+ * A separate export rather than a `filtered` flag on the one above, so the way out cannot
+ * be forgotten: there is no way to call this without saying where Clear filters goes.
+ *
+ * The title names the subject — "No campaigns match those filters" — because the four
+ * pages doing this by hand had four different sentences for one situation, two of which
+ * ("Nothing matches.") did not say what was missing.
+ */
+export function NoMatches({
+  /** Plural, lower case: campaigns, variants, baselines, prices. */
+  noun,
+  /** What clearing them would show. Optional — the title is often the whole of it. */
+  description,
+  /** Where Clear filters goes. See `clearedSearch` in `FilterForm`. */
+  clearHref,
+}: {
+  noun: string;
+  description?: ReactNode;
+  clearHref: string;
+}) {
+  return (
+    <EmptyState
+      title={`No ${noun} match those filters`}
+      description={description}
+      // Secondary, not primary. A page's primary action is its own — Create campaign,
+      // Sync catalogue — and a second black button here would be two answers to "what
+      // should I do next".
+      action={{ label: "Clear filters", href: clearHref }}
+    />
   );
 }
 

--- a/app/components/FilterForm.tsx
+++ b/app/components/FilterForm.tsx
@@ -15,6 +15,24 @@ import { useSearchParams } from "react-router";
  * router means the data request goes through App Bridge's authenticated fetch rather
  * than around it.
  */
+/**
+ * The same URL with this form's fields taken out of it — where "Clear filters" goes.
+ *
+ * Removing named keys rather than rebuilding the query string is the whole point. `host`,
+ * `embedded`, `id_token` and `shop` are in there too, App Bridge put them there, and a
+ * link that drops them lands the merchant on a blank page — the same trap a native
+ * `<form method="get">` falls into, reached from the other direction.
+ *
+ * `page` goes as well, for the reason it goes on submit: page four of the old filter is
+ * meaningless without it.
+ */
+export function clearedSearch(params: URLSearchParams, fields: readonly string[]): string {
+  const next = new URLSearchParams(params);
+  for (const field of fields) next.delete(field);
+  next.delete("page");
+  return `?${next}`;
+}
+
 export function FilterForm({
   /** Field names this form owns. Anything else in the URL is left untouched. */
   fields,

--- a/app/components/PreviewTable.tsx
+++ b/app/components/PreviewTable.tsx
@@ -1,4 +1,5 @@
 import { humanise } from "../lib/format/label";
+import { EmptyState } from "./AsyncState";
 import type { MarketPreview, PreviewRow } from "../services/campaigns/index.server";
 import { PREVIEW_TONE, toneFor } from "./tone";
 
@@ -18,10 +19,10 @@ export function PreviewTable({
 }) {
   if (rows.length === 0) {
     return (
-      <s-paragraph>
-        Nothing to change. Either every variant already shows the target price, or the
-        scope matched no variants with baselines.
-      </s-paragraph>
+      <EmptyState
+        title="Nothing to change"
+        description="Either every variant in scope already shows the price this rule computes, or the scope matched no variants that have a baseline to compute from."
+      />
     );
   }
 

--- a/app/components/ReconciliationTable.tsx
+++ b/app/components/ReconciliationTable.tsx
@@ -1,3 +1,4 @@
+import { NoMatches } from "./AsyncState";
 import type { ReconciliationRow } from "../services/reconciliation.server";
 import { stateLabel } from "../lib/reporting/reconciliation-csv";
 
@@ -11,13 +12,25 @@ import { stateLabel } from "../lib/reporting/reconciliation-csv";
  * looks repetitive until the day the base price reverted and the Japanese one did not —
  * the case a collapsed view could not show at all.
  */
-export function ReconciliationTable({ rows }: { rows: ReconciliationRow[] }) {
+export function ReconciliationTable({
+  rows,
+  clearHref,
+}: {
+  rows: ReconciliationRow[];
+  /** Where Clear filters goes. The route owns the field list, so it builds the link. */
+  clearHref: string;
+}) {
   if (rows.length === 0) {
+    // The old copy guessed: "if you were looking for drifted prices, that is good news."
+    // On a page with four filters, an empty result far more often means the filters
+    // exclude each other -- a campaign on one surface, a state that surface is never in
+    // -- and being congratulated for it is how a merchant concludes the page is broken.
     return (
-      <s-paragraph>
-        Nothing matches these filters. If you were looking for drifted prices, that is
-        good news.
-      </s-paragraph>
+      <NoMatches
+        noun="prices"
+        description="This page lists every variant on every surface it sells on, so a filter that narrows two of those at once can exclude everything."
+        clearHref={clearHref}
+      />
     );
   }
 

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -1,8 +1,9 @@
 import { humanise } from "../../lib/format/label";
 import { ActionRow } from "../ActionRow";
+import { EmptyState, NoMatches } from "../AsyncState";
 import { FilterForm } from "../FilterForm";
 import { TabBar } from "../TabBar";
-import { PAD, SPACE } from "../../lib/ui/spacing";
+import { SPACE } from "../../lib/ui/spacing";
 import type { listCampaigns, CampaignFilters } from "../../services/campaigns/list.server";
 
 type List = Awaited<ReturnType<typeof listCampaigns>>;
@@ -105,7 +106,18 @@ export function CampaignListView({
         </FilterForm>
 
         {list.campaigns.length === 0 ? (
-          <EmptyState filtered={filtered} clearHref={linkTo({ q: "", status: "" })} />
+          filtered ? (
+            <NoMatches
+              noun="campaigns"
+              description="Nothing here matches the status and search you have set. Clearing them shows every campaign in the shop."
+              clearHref={linkTo({ q: "", status: "" })}
+            />
+          ) : (
+            <EmptyState
+              title="No campaigns yet"
+              description="A campaign is a rule (“20% off this collection”) plus the set of variants it applies to. Nothing is written to your storefront until you apply it, and you can preview the exact result first."
+            />
+          )
         ) : (
           <>
             {/* Every header says what it becomes when the table collapses to a list.
@@ -183,56 +195,5 @@ export function CampaignListView({
         )}
       </s-stack>
     </s-section>
-  );
-}
-
-/**
- * What the card says instead of rows.
- *
- * Two different situations, and conflating them is the usual mistake: a shop with no
- * campaigns needs to be told what a campaign *is*, and a shop whose filter matched
- * nothing needs the filter taken off. The second used to be a sentence saying "clear the
- * filters" with no way to do it.
- *
- * Laid out as an empty state rather than a loose paragraph — a title, a measure short
- * enough to read, and vertical room. A single line of body text flush against the control
- * above it reads as a caption on that control, not as the answer to "where are my rows".
- */
-function EmptyState({ filtered, clearHref }: { filtered: boolean; clearHref: string }) {
-  return (
-    <s-box paddingBlock={PAD.block}>
-      <s-stack direction="block" gap={SPACE.section}>
-        <s-heading>{filtered ? "No campaigns match those filters" : "No campaigns yet"}</s-heading>
-
-        {/* Capped rather than running the width of the card. Body copy set across a wide
-            column is measurably harder to read, and this is the one block on the page
-            that is nothing but body copy. */}
-        <s-box maxInlineSize="520px">
-          <s-paragraph>
-            {filtered ? (
-              <s-text>
-                Nothing here matches the status and search you have set. Clearing them
-                shows every campaign in the shop.
-              </s-text>
-            ) : (
-              <s-text>
-                A campaign is a rule (&ldquo;20% off this collection&rdquo;) plus the set
-                of variants it applies to. Nothing is written to your storefront until you
-                apply it, and you can preview the exact result first.
-              </s-text>
-            )}
-          </s-paragraph>
-        </s-box>
-
-        {filtered ? (
-          <ActionRow>
-            {/* Secondary, not primary. The page's primary action is Create campaign, at
-                the top of the page and still visible from here; a second black button
-                would be two answers to "what should I do next". */}
-            <s-button href={clearHref}>Clear filters</s-button>
-          </ActionRow>
-        ) : null}
-      </s-stack>
-    </s-box>
   );
 }

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * What a page says when it has no rows, and the two situations it must not confuse.
+ *
+ * `EmptyState` existed and one page called it. Everywhere else the same moment was a bare
+ * `s-paragraph` flush against the control above it — which is the exact shape that
+ * component's own doc comment says it exists to prevent, because a title and one sentence
+ * left-aligned at the top of a card read as the beginning of content that did not arrive.
+ *
+ * The distinction worth testing is the other one. A shop with no variants and a shop
+ * whose filter matched nothing need opposite things: the first needs telling what a
+ * variant is, the second needs the filter taken off. Six pages said "nothing matches" and
+ * offered no way to stop matching nothing, so `NoMatches` cannot be called without
+ * saying where Clear filters goes — and that is what the last block here checks, on every
+ * empty branch in the app rather than on the ones somebody remembered.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { StaticRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { EmptyState, NoMatches } from "./AsyncState";
+import { clearedSearch } from "./FilterForm";
+import { CampaignListView } from "./campaign/CampaignListView";
+
+const render = (node: React.ReactElement) =>
+  renderToStaticMarkup(<StaticRouter location="/app/prices">{node}</StaticRouter>);
+
+describe("an empty state is an answer, not a missing table", () => {
+  it("centres the title and gives it room, so it does not read as a render that failed", () => {
+    const html = render(<EmptyState title="No baselines captured yet" />);
+
+    expect(html).toContain("No baselines captured yet");
+    expect(html).toMatch(/alignitems="center"/i);
+    // Block padding: the words have to sit in space that was obviously left for them.
+    expect(html).toMatch(/paddingblock="large-200"/i);
+  });
+
+  it("caps the measure of its body copy", () => {
+    const html = render(<EmptyState title="No variants yet" description={"a ".repeat(200)} />);
+
+    expect(html).toMatch(/maxinlinesize="520px"/i);
+  });
+
+  it("renders a way out only when there is one", () => {
+    expect(render(<EmptyState title="No drift detected" />)).not.toContain("<s-button");
+    expect(
+      render(<EmptyState title="No variants yet" action={{ label: "Sync", href: "/app" }} />),
+    ).toContain('href="/app"');
+  });
+});
+
+describe("empty because of a filter is a different thing, and always offers the way back", () => {
+  const html = render(<NoMatches noun="campaigns" clearHref="?status=" />);
+
+  it("names what is missing rather than saying 'nothing matches'", () => {
+    expect(html).toContain("No campaigns match those filters");
+  });
+
+  it("always offers to clear the filters", () => {
+    expect(html).toContain("Clear filters");
+    expect(html).toContain('href="?status="');
+  });
+
+  it("keeps Clear filters secondary, so it does not compete with the page's own action", () => {
+    expect(html).not.toContain('variant="primary"');
+  });
+});
+
+describe("the campaigns index picks the right one of the two", () => {
+  const list = (campaigns: unknown[]) => ({
+    campaigns: campaigns as never,
+    total: campaigns.length,
+    attentionCount: 0,
+    page: 1,
+    pages: 1,
+  });
+
+  const view = (filters: { q: string; status: string }) =>
+    renderToStaticMarkup(
+      <StaticRouter location="/app/campaigns">
+        <CampaignListView
+          list={list([])}
+          filters={{ ...filters, page: 1 }}
+          linkTo={(next) => `?${new URLSearchParams(next)}`}
+        />
+      </StaticRouter>,
+    );
+
+  it("explains what a campaign is when the shop has none", () => {
+    const html = view({ q: "", status: "" });
+
+    expect(html).toContain("No campaigns yet");
+    expect(html).toContain("20% off this collection");
+    expect(html).not.toContain("Clear filters");
+  });
+
+  it("offers to clear the filters when a filter is what emptied it", () => {
+    const html = view({ q: "", status: "DRAFT" });
+
+    expect(html).toContain("No campaigns match those filters");
+    expect(html).toContain("Clear filters");
+  });
+
+  it("counts a search as a filter, not only a status", () => {
+    expect(view({ q: "summer", status: "" })).toContain("Clear filters");
+  });
+
+  it("no longer carries a second EmptyState of its own", () => {
+    const source = readFileSync(join(process.cwd(), "app/components/campaign/CampaignListView.tsx"), "utf8");
+
+    expect(source).not.toMatch(/function EmptyState/);
+  });
+});
+
+describe("clearing a filter keeps the parameters App Bridge needs", () => {
+  const params = () =>
+    new URLSearchParams("host=abc&id_token=xyz&shop=s.myshopify.com&q=tee&vendor=Acme&page=4");
+
+  it("removes only the fields the form owns", () => {
+    const next = new URLSearchParams(clearedSearch(params(), ["q", "vendor"]));
+
+    expect(next.get("q")).toBeNull();
+    expect(next.get("vendor")).toBeNull();
+    expect(next.get("host")).toBe("abc");
+    expect(next.get("id_token")).toBe("xyz");
+    expect(next.get("shop")).toBe("s.myshopify.com");
+  });
+
+  it("drops the page, because page four of the old filter means nothing without it", () => {
+    expect(new URLSearchParams(clearedSearch(params(), ["q"])).get("page")).toBeNull();
+  });
+});
+
+const APP = join(process.cwd(), "app");
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") && !entry.name.includes(".test.")
+      ? [path]
+      : [];
+  });
+}
+
+describe("no page answers 'where are my rows' with a loose paragraph", () => {
+  /**
+   * Both spellings of the empty branch: the ternary a route renders inline, and the
+   * early return a table component takes before it renders a header row.
+   */
+  const BRANCHES = [
+    // `(?:\w+\s*\?\s*\(\s*)*` steps over the inner ternary that picks between the two
+    // states. Without it a page that got this *right* — filtered one way, empty the other
+    // — is the one the check cannot see.
+    /(\w+)(?:\.length)? === 0\s*\?\s*\(\s*(?:\w+\s*\?\s*\(\s*)*(<[A-Za-z][\w.-]*)/g,
+    /(\w+)(?:\.length)? === 0\)\s*\{\s*return\s*\(\s*(<[A-Za-z][\w.-]*)/g,
+  ];
+
+  /**
+   * Collections that are not rows.
+   *
+   * `PageShell` branches on `aside.length === 0` to choose between a one-column and a
+   * two-column page. It is the same expression and a completely different question, and
+   * an empty state there would be a heading announcing that a page has no sidebar.
+   */
+  const NOT_DATA = ["aside"];
+
+  const ALLOWED = ["<EmptyState", "<NoMatches", "<>"];
+
+  /** Rendered outside the embedded admin, with their own CSS and no Polaris. */
+  const OUTSIDE_THE_ADMIN = ["routes/help.$", "routes/_index"];
+
+  /**
+   * Not a page reporting that it has no rows.
+   *
+   * `DraftPreview` is the panel beside the rule in the campaign editor, and it re-renders
+   * on a debounce while the merchant is typing. "Nothing matches this scope yet" there is
+   * a hint under a control, not an answer to "where are my rows" — and a centred empty
+   * state with `large-200` block padding would shove the rest of the form down and back
+   * up again on the way to a rule that matches something.
+   */
+  const NOT_A_PAGE = ["components/DraftPreview.tsx"];
+
+  const admin = tsxFiles(APP).filter(
+    (path) => ![...OUTSIDE_THE_ADMIN, ...NOT_A_PAGE].some((skip) => path.includes(skip)),
+  );
+
+  /**
+   * Whole-line `//` comments removed before matching.
+   *
+   * Two of the nine branches explain themselves in a comment between the `(` and the
+   * component — which is the house style, and it hid them from the first version of this
+   * check entirely. A rule that stops seeing the code as soon as somebody documents it is
+   * worse than no rule. Only lines that are *nothing but* a comment go, so the `//` in an
+   * `https://` href is left alone.
+   */
+  const scannable = (source: string) =>
+    source
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("//"))
+      .join("\n");
+
+  const offenders = admin.flatMap((path) => {
+    const source = scannable(readFileSync(path, "utf8"));
+    return BRANCHES.flatMap((pattern) =>
+      [...source.matchAll(pattern)]
+        .filter((match) => !NOT_DATA.includes(match[1]) && !ALLOWED.includes(match[2]))
+        .map((match) => `${path.replace(`${APP}/`, "")}: ${match[2]}`),
+    );
+  });
+
+  it("finds the empty branches to check", () => {
+    const found = admin.flatMap((path) => {
+      const source = scannable(readFileSync(path, "utf8"));
+      return BRANCHES.flatMap((pattern) =>
+        [...source.matchAll(pattern)].filter((match) => !NOT_DATA.includes(match[1])),
+      );
+    });
+
+    expect(found.length).toBeGreaterThanOrEqual(11);
+  });
+
+  it("renders an empty state in every one of them", () => {
+    expect(
+      offenders,
+      "these open their no-rows branch with something other than EmptyState or NoMatches",
+    ).toEqual([]);
+  });
+});

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -16,7 +16,8 @@ import { ensureShop } from "../services/shop.server";
 import { activity } from "../services/activity.server";
 import { activityCsv } from "../lib/reporting/activity-csv";
 import { ActivityTable } from "../components/ActivityTable";
-import { FilterForm } from "../components/FilterForm";
+import { EmptyState, NoMatches } from "../components/AsyncState";
+import { FilterForm, clearedSearch } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { downloadCsv } from "../lib/reporting/csv";
 import { describeActor } from "../lib/audit/actor";
@@ -56,7 +57,8 @@ export const loader = withGuard("/app/activity", async ({ request }: LoaderFunct
 export default function Activity() {
   const { entries, total, actors, actions, page, filters, timeZone } =
     useLoaderData<typeof loader>();
-  const [, setSearchParams] = useSearchParams();
+  const [params, setSearchParams] = useSearchParams();
+  const filtered = Boolean(filters.actor || filters.action || filters.from || filters.to);
 
   const pageSize = PAGE_SIZE;
   const lastPage = Math.max(1, Math.ceil(total / pageSize));
@@ -101,11 +103,18 @@ export default function Activity() {
         </FilterForm>
 
         {total === 0 ? (
-          <s-paragraph>
-            Nothing has been recorded yet for these filters. Every action that changes
-            state — applying a campaign, editing a guardrail, resolving drift — is
-            written here as it happens, with who did it and what it changed.
-          </s-paragraph>
+          filtered ? (
+            <NoMatches
+              noun="entries"
+              description="Every action that changes state is written here as it happens — applying a campaign, editing a guardrail, resolving drift — so a narrow window or a specific actor can easily land between two of them."
+              clearHref={clearedSearch(params, FILTER_FIELDS)}
+            />
+          ) : (
+            <EmptyState
+              title="Nothing has been recorded yet"
+              description="Every action that changes state — applying a campaign, editing a guardrail, resolving drift — is written here as it happens, with who did it and what it changed."
+            />
+          )
         ) : (
           <>
             <s-stack direction="inline" gap="base">

--- a/app/routes/app.imports._index.tsx
+++ b/app/routes/app.imports._index.tsx
@@ -4,6 +4,7 @@ import { useLoaderData } from "react-router";
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
 import { PageShell } from "../components/PageShell";
+import { EmptyState } from "../components/AsyncState";
 import { formatCount, formatWhen } from "../lib/format/display";
 import prisma from "../db.server";
 
@@ -59,13 +60,10 @@ export default function Imports() {
     <PageShell heading="Imports">
       <s-section heading="Price files you have imported">
         {imports.length === 0 ? (
-          <s-paragraph>
-            <s-text>
-              Nothing imported yet. Pick a source above — a price file sets prices
-              directly, a baseline file sets the reference every campaign computes from,
-              and a cost file feeds the margin guardrails.
-            </s-text>
-          </s-paragraph>
+          <EmptyState
+            title="Nothing imported yet"
+            description="A price file sets prices directly, a baseline file sets the reference every campaign computes from, and a cost file feeds the margin guardrails. Pick a source above."
+          />
         ) : (
           <>
             <s-table>

--- a/app/routes/app.imports.baselines.tsx
+++ b/app/routes/app.imports.baselines.tsx
@@ -28,6 +28,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { EmptyState } from "../components/AsyncState";
 import { UnsavedChanges } from "../components/UnsavedChanges";
 import { CsvDropZone } from "../components/imports/CsvDropZone";
 
@@ -198,9 +199,10 @@ function ImportReport({ result }: { result: BaselineImportResult }) {
       </s-paragraph>
 
       {problems.length === 0 ? (
-        <s-paragraph>
-          <s-text>Every row matched a variant and validated.</s-text>
-        </s-paragraph>
+        <EmptyState
+          title="Every row matched a variant and validated"
+          description="Nothing was left out, so the counts above account for the whole file."
+        />
       ) : (
         <>
           <s-stack direction="inline" gap="base">

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -1,11 +1,13 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
 import { ensureShop } from "../services/shop.server";
 import { formatMoney, money } from "../lib/money/money";
+import { EmptyState, NoMatches } from "../components/AsyncState";
+import { clearedSearch } from "../components/FilterForm";
 import { VariantSearch } from "../components/prices/VariantSearch";
 import { Pagination } from "../components/prices/Pagination";
 import { RouteBoundary } from "../components/RouteBoundary";
@@ -13,6 +15,9 @@ import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
 
 const PAGE_SIZE = 50;
+
+/** What the search box on this tab owns, and therefore what Clear filters removes. */
+const CATALOGUE_FIELDS = ["q"] as const;
 
 export const loader = withGuard("/app/prices", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -89,17 +94,27 @@ export const loader = withGuard("/app/prices", async ({ request }: LoaderFunctio
 
 export default function Catalog() {
   const { rows, total, page, query, pageSize } = useLoaderData<typeof loader>();
+  const [params] = useSearchParams();
+
   return (
     <PageShell heading="Catalogue">
       <s-section>
-        <VariantSearch fields={["q"]} query={query} />
+        <VariantSearch fields={CATALOGUE_FIELDS} query={query} />
 
         {total === 0 ? (
-          <s-paragraph>
-            {query
-              ? `No variants match “${query}”.`
-              : "No variants yet. Sync your catalogue from the dashboard."}
-          </s-paragraph>
+          query ? (
+            <NoMatches
+              noun="variants"
+              description={`Nothing in your catalogue has “${query}” in its title or SKU.`}
+              clearHref={clearedSearch(params, CATALOGUE_FIELDS)}
+            />
+          ) : (
+            <EmptyState
+              title="No variants yet"
+              description="Anchor mirrors your catalogue so a campaign can be priced without asking Shopify for every variant first. Syncing captures a baseline for each one at the same time."
+              action={{ label: "Sync your catalogue", href: "/app" }}
+            />
+          )
         ) : (
           <>
             <s-table>

--- a/app/routes/app.prices.baselines.tsx
+++ b/app/routes/app.prices.baselines.tsx
@@ -25,6 +25,8 @@ import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
 import { baselineHistory, browseBaselines } from "../services/baseline-browser.server";
 import { BaselineTable } from "../components/BaselineTable";
+import { EmptyState, NoMatches } from "../components/AsyncState";
+import { clearedSearch } from "../components/FilterForm";
 import { VariantSearch } from "../components/prices/VariantSearch";
 import { Pagination } from "../components/prices/Pagination";
 import { baselinesCsv } from "../lib/reporting/baselines-csv";
@@ -61,7 +63,12 @@ export const loader = withGuard("/app/prices/baselines", async ({ request }: Loa
 export default function Baselines() {
   const { rows, total, vendors, sources, page, filters, variantGid, history, timeZone } =
     useLoaderData<typeof loader>();
-  const [, setSearchParams] = useSearchParams();
+  const [params, setSearchParams] = useSearchParams();
+
+  // `variant` is in FILTER_FIELDS but is not a filter the merchant set — it is which row
+  // they asked the history for. Counting it here would make an empty result claim to be
+  // filtered on a page where nothing is.
+  const filtered = Boolean(filters.q || filters.vendor || filters.source || filters.divergedOnly);
 
 
   const show = (gid: string) =>
@@ -116,10 +123,19 @@ export default function Baselines() {
         </VariantSearch>
 
         {rows.length === 0 ? (
-          <s-paragraph>
-            Nothing matches. A baseline is the reference price every campaign computes
-            from — captured at install, or imported from your own list.
-          </s-paragraph>
+          filtered ? (
+            <NoMatches
+              noun="baselines"
+              description="A baseline is the reference price every campaign computes from — captured at install, or imported from your own list."
+              clearHref={clearedSearch(params, FILTER_FIELDS)}
+            />
+          ) : (
+            <EmptyState
+              title="No baselines captured yet"
+              description="A baseline is the reference price every campaign computes from, which is what stops a second sale discounting the first one's price. Syncing your catalogue captures one for every variant."
+              action={{ label: "Sync your catalogue", href: "/app" }}
+            />
+          )
         ) : (
           <>
             <s-paragraph>

--- a/app/routes/app.prices.drift.tsx
+++ b/app/routes/app.prices.drift.tsx
@@ -8,6 +8,7 @@ import { pendingDrift, resolveDrift, type DriftResolution } from "../services/dr
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { EmptyState } from "../components/AsyncState";
 
 export const loader = withGuard("/app/prices/drift", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -51,9 +52,13 @@ export default function DriftQueue() {
 
       <s-section>
         {events.length === 0 ? (
-          <s-paragraph>
-            No drift detected. Prices set by your campaigns are still in place.
-          </s-paragraph>
+          // Not a NoMatches: this page has no filters, and it is the one empty state in
+          // the app that is good news. It says so, rather than reading as a page that
+          // failed to load.
+          <EmptyState
+            title="No drift detected"
+            description="Every price your campaigns set is still what they set. If somebody edits one in the Shopify admin while a campaign is running, it is held here for your decision rather than overwritten."
+          />
         ) : (
           <>
             <s-paragraph>

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -1,6 +1,6 @@
 import { formatCount } from "../lib/format/display";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData } from "react-router";
+import { useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -11,6 +11,7 @@ import { toAdminClient } from "../services/admin-client.server";
 import { reconciliationCsv } from "../lib/reporting/reconciliation-csv";
 import { downloadCsv } from "../lib/reporting/csv";
 import { ReconciliationTable } from "../components/ReconciliationTable";
+import { clearedSearch } from "../components/FilterForm";
 import { VariantSearch } from "../components/prices/VariantSearch";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
@@ -75,6 +76,7 @@ export const action = withGuard("/app/prices/live", async ({ request }: ActionFu
 
 export default function Reconciliation() {
   const { rows, total, surfaces, campaigns, counts, selected } = useLoaderData<typeof loader>();
+  const [params] = useSearchParams();
   const fetcher = useFetcher<{ ok: boolean; message: string }>();
   const busy = fetcher.state !== "idle";
 
@@ -189,7 +191,7 @@ export default function Reconciliation() {
       </s-section>
 
       <s-section heading="Prices">
-        <ReconciliationTable rows={rows} />
+        <ReconciliationTable rows={rows} clearHref={clearedSearch(params, RECONCILE_FIELDS)} />
 
         <s-button
           type="button"

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -25,6 +25,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { EmptyState } from "../components/AsyncState";
 
 export const loader = withGuard("/app/settings/segments", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -165,10 +166,10 @@ export default function Segments() {
 
       <s-section heading="Your segments">
         {segments.length === 0 ? (
-          <s-paragraph>
-            No segments yet. A segment is a saved way of describing which products a
-            campaign covers, so you do not rebuild the same filter for every sale.
-          </s-paragraph>
+          <EmptyState
+            title="No segments yet"
+            description="A segment is a saved way of describing which products a campaign covers, so you do not rebuild the same filter for every sale. Make one below."
+          />
         ) : (
           <s-table>
             <s-table-header-row>


### PR DESCRIPTION
Closes #397.

`AsyncState` exported `EmptyState` — centred, given block padding, because *"the failure mode of an empty state is looking like a rendering accident"* — and exactly one page called it. Eight others answered "where are my rows" with a bare `s-paragraph` flush against the control above it, which is the shape it exists to stop. The campaigns index had written a **second, better one of its own** in #394 without noticing the first — the `SectionNav`/`PricesTabs` failure again.

The distinction worth keeping is the one those nine pages were losing. A shop with no variants needs telling what a variant *is*; a shop whose filter matched nothing needs the filter taken off — and six of them said "nothing matches" with no way to stop matching nothing. So `NoMatches` is a **separate export rather than a flag**: there is no way to call it without saying where Clear filters goes. It also names the subject, because the four pages doing this by hand had four sentences for one situation and two of them ("Nothing matches.") did not say what was missing.

`clearedSearch` lives beside `FilterForm` because that is what owns the notion of which fields a page has. It removes named keys rather than rebuilding the query string — `host`, `id_token` and `shop` are in there too, and a Clear filters link that drops them is the blank-page trap reached from the other direction.

Two pages changed more than their markup:

- **Reconciliation's empty state guessed** — *"if you were looking for drifted prices, that is good news"* — on a page with four filters, where an empty result far more often means two of them exclude each other, and being congratulated for it is how a merchant concludes the page is broken.
- **Drift keeps a plain `EmptyState`** with no clear link: it has no filters, and it is the one empty state in the app that really is good news.

## The test found two pages I had missed, then found a hole in itself

It checks every empty branch in `app/` rather than the ones I remembered, and turned up Activity and the baselines import report. Its first version then could not see a branch whose author had put a comment between the `(` and the component — the house style — so two of the nine were invisible to it. A rule that stops looking as soon as somebody documents the code is worse than no rule.

Two named exceptions, both with reasons in the file: `PageShell` branches on `aside.length` to choose a layout, and `DraftPreview` is a hint under a control that re-renders on a debounce while the merchant types — a centred state with `large-200` padding there would shove the form down and back up on the way to a rule that matches something.

All seven new assertions were mutated and confirmed failing: a page reverted to a bare paragraph, `NoMatches` stripped of its action, centring removed, the measure cap removed, `clearedSearch` rebuilding the query string from scratch, `clearedSearch` keeping `page`, and the campaigns index no longer counting a search as a filter.

1938 tests pass, 14 new. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)