### PR TITLE
The drift page asks a question a merchant can answer

### DIFF
--- a/app/lib/ui/control-vocabulary.test.ts
+++ b/app/lib/ui/control-vocabulary.test.ts
@@ -1,0 +1,120 @@
+/**
+ * A control says what pressing it does, in the merchant's words.
+ *
+ * #379 took the app's actions out of blue links and gave them a vocabulary of button
+ * variants; #381 took SCREAMING_SNAKE out of the badges. Neither looked at the *labels*,
+ * and the drift page was still rendering its enum straight into three buttons — `adopt`
+ * `reassert` `ignore`, lower case, on the page whose whole job is a considered decision
+ * about somebody's storefront.
+ *
+ * Two things are checked here, and the second is the one that will catch the next
+ * instance:
+ *
+ * - the drift page offers the three decisions in the wording the help centre uses, and
+ *   marks exactly the one the aside says is consequential;
+ * - no button anywhere renders a bare identifier as its label.
+ *
+ * The second is a source scan rather than a render, because the failure is a `{value}`
+ * interpolation and the value only exists at runtime. What it looks for is a button whose
+ * entire label is a lone lower-case interpolated expression — which is what
+ * `{resolution}` was, and what a label written on purpose never is.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const APP = join(process.cwd(), "app");
+const DRIFT = readFileSync(join(APP, "routes/app.prices.drift.tsx"), "utf8");
+const HELP = readFileSync(join(process.cwd(), "docs/help/concepts/drift.md"), "utf8");
+
+/** The three labels, extracted from the table the page renders them from. */
+function resolutions(): { value: string; label: string; tone: string }[] {
+  const block = /const RESOLUTIONS = \[([\s\S]*?)\] as const/.exec(DRIFT);
+  if (!block) throw new Error("the drift page no longer declares its resolutions in one place");
+
+  return [
+    ...block[1].matchAll(
+      /\{\s*value:\s*"([^"]+)",\s*label:\s*"([^"]+)",\s*tone:\s*"([^"]+)"\s*\}/g,
+    ),
+  ].map((match) => ({ value: match[1], label: match[2], tone: match[3] }));
+}
+
+describe("the drift page asks a question a merchant can answer", () => {
+  const all = resolutions();
+
+  it("offers all three resolutions the service accepts", () => {
+    expect(all.map((r) => r.value)).toEqual(["adopt", "reassert", "ignore"]);
+  });
+
+  it("labels none of them with its own enum value", () => {
+    for (const resolution of all) {
+      expect(resolution.label.toLowerCase()).not.toContain(resolution.value);
+    }
+  });
+
+  it("uses the wording the help centre already documents", () => {
+    // The help page had "Keep the change" and "Put it back" before this page existed.
+    // Two vocabularies for one decision is how a merchant following the documentation
+    // ends up looking for a button that is not there.
+    const documented = all.filter((r) => HELP.includes(`**${r.label}**`));
+
+    expect(documented.map((r) => r.value)).toEqual(["adopt", "reassert", "ignore"]);
+  });
+
+  it("marks exactly the one that changes what future campaigns compute from", () => {
+    expect(all.filter((r) => r.tone === "critical").map((r) => r.value)).toEqual(["adopt"]);
+  });
+
+  it("defaults the hidden field to the choice that changes nothing", () => {
+    expect(DRIFT).toMatch(/name="resolution"[^>]*value="ignore"/);
+  });
+
+  it("shows the drifted price as a value, not inside a badge", () => {
+    expect(DRIFT).not.toMatch(/<s-badge[^>]*>\{event\.observed/);
+  });
+});
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") && !entry.name.includes(".test.")
+      ? [path]
+      : [];
+  });
+}
+
+describe("no button is labelled with a raw value", () => {
+  /**
+   * A button whose whole label is one interpolated lower-case identifier.
+   *
+   * `{resolution}` and `{kind}` match; `{choice.label}`, `{formatCount(n)}` and any
+   * label with words around it do not — a property access or a call is somebody having
+   * decided what the words are, even when the decision lives elsewhere.
+   *
+   * The attribute part is a tempered `[\s\S]` rather than `[^>]`, and that is the whole
+   * difference between this check working and not: half the buttons in the app carry an
+   * `onClick={() => …}`, whose arrow contains a `>`, so `[^>]*` stopped inside the
+   * attribute list and matched nothing. Mutating a real button to `{row}` is what
+   * surfaced it — the first version of this test passed on a file it should have failed.
+   * `(?!<\/s-button>)` keeps the match from running past one button into the next.
+   */
+  const RAW_LABEL =
+    /<s-button\b(?:(?!<\/s-button>)[\s\S])*?>\s*\{([a-z][A-Za-z0-9]*)\}\s*<\/s-button>/g;
+
+  const offenders = tsxFiles(APP).flatMap((path) => {
+    const source = readFileSync(path, "utf8");
+    return [...source.matchAll(RAW_LABEL)].map(
+      (match) => `${path.replace(`${APP}/`, "")}: {${match[1]}}`,
+    );
+  });
+
+  it("finds none", () => {
+    expect(
+      offenders,
+      "a button labelled with a bare value shows the merchant whatever the database calls it",
+    ).toEqual([]);
+  });
+});

--- a/app/routes/app.prices.baselines.tsx
+++ b/app/routes/app.prices.baselines.tsx
@@ -16,7 +16,7 @@
  */
 
 import { humanise } from "../lib/format/label";
-import { formatWhen } from "../lib/format/display";
+import { formatCount, formatWhen } from "../lib/format/display";
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -25,6 +25,7 @@ import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
 import { baselineHistory, browseBaselines } from "../services/baseline-browser.server";
 import { BaselineTable } from "../components/BaselineTable";
+import { ActionRow } from "../components/ActionRow";
 import { EmptyState, NoMatches } from "../components/AsyncState";
 import { clearedSearch } from "../components/FilterForm";
 import { VariantSearch } from "../components/prices/VariantSearch";
@@ -34,6 +35,7 @@ import { downloadCsv } from "../lib/reporting/csv";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { SPACE } from "../lib/ui/spacing";
 
 const FILTER_FIELDS = ["q", "vendor", "source", "diverged", "variant"] as const;
 
@@ -80,13 +82,16 @@ export default function Baselines() {
   return (
     <PageShell heading="Baselines">
       <s-section>
-        <VariantSearch
-          fields={FILTER_FIELDS}
-          query={filters.q ?? ""}
-          label="Title, SKU or variant ID"
-          direction="block"
-        >
-
+        {/* The card's blocks at section rhythm. It was set nowhere, so they ran together:
+            the count landed directly under the Search button, close enough to read as a
+            caption on the control above it rather than as the size of what came back. */}
+        <s-stack direction="block" gap={SPACE.section}>
+          <VariantSearch
+            fields={FILTER_FIELDS}
+            query={filters.q ?? ""}
+            label="Title, SKU or variant ID"
+            direction="block"
+          >
             <s-select name="vendor" label="Vendor">
               <s-option value="" defaultSelected={!filters.vendor}>
                 Any vendor
@@ -113,53 +118,57 @@ export default function Baselines() {
                 a column sized for a select leaves it stranded in white space. */}
             <s-grid-item gridColumn="span 3">
               <s-checkbox
-              name="diverged"
-              value="1"
-              label="Only variants whose live price differs from their baseline"
-              checked={filters.divergedOnly || undefined}
-            />
+                name="diverged"
+                value="1"
+                label="Only variants whose live price differs from their baseline"
+                checked={filters.divergedOnly || undefined}
+              />
             </s-grid-item>
+          </VariantSearch>
 
-        </VariantSearch>
-
-        {rows.length === 0 ? (
-          filtered ? (
-            <NoMatches
-              noun="baselines"
-              description="A baseline is the reference price every campaign computes from — captured at install, or imported from your own list."
-              clearHref={clearedSearch(params, FILTER_FIELDS)}
-            />
+          {rows.length === 0 ? (
+            filtered ? (
+              <NoMatches
+                noun="baselines"
+                description="A baseline is the reference price every campaign computes from — captured at install, or imported from your own list."
+                clearHref={clearedSearch(params, FILTER_FIELDS)}
+              />
+            ) : (
+              <EmptyState
+                title="No baselines captured yet"
+                description="A baseline is the reference price every campaign computes from, which is what stops a second sale discounting the first one's price. Syncing your catalogue captures one for every variant."
+                action={{ label: "Sync your catalogue", href: "/app" }}
+              />
+            )
           ) : (
-            <EmptyState
-              title="No baselines captured yet"
-              description="A baseline is the reference price every campaign computes from, which is what stops a second sale discounting the first one's price. Syncing your catalogue captures one for every variant."
-              action={{ label: "Sync your catalogue", href: "/app" }}
-            />
-          )
-        ) : (
-          <>
-            <s-paragraph>
-              <s-text>
-                {total} variants
-              </s-text>
-            </s-paragraph>
+            <>
+              {/* The count and the export on one baseline, at item rhythm, because the
+                  count is exactly what the export exports — saying that on one line is the
+                  whole relationship between the two controls. Stacked, as they were, the
+                  button read as belonging to the sentence above it. */}
+              <ActionRow>
+                <s-text fontVariantNumeric="tabular-nums">
+                  {formatCount(total)} {total === 1 ? "baseline" : "baselines"}
+                </s-text>
+                {/* Exports what the filters currently show, not the whole catalogue. A
+                    merchant who narrowed to one vendor means that vendor, and handing them
+                    500K rows instead is not being generous. */}
+                <s-button
+                  type="button"
+                  variant="tertiary"
+                  icon="download"
+                  onClick={() => downloadCsv("anchor-baselines.csv", baselinesCsv(rows))}
+                >
+                  Export these (CSV)
+                </s-button>
+              </ActionRow>
 
-            {/* Exports what the filters currently show, not the whole catalogue. A
-                merchant who narrowed to one vendor means that vendor, and handing them
-                500K rows instead is not being generous. */}
-            <s-button
-              type="button"
-              variant="tertiary"
-              onClick={() => downloadCsv("anchor-baselines.csv", baselinesCsv(rows))}
-            >
-              Export these baselines (CSV)
-            </s-button>
+              <BaselineTable rows={rows} onShowHistory={show} />
 
-            <BaselineTable rows={rows} onShowHistory={show} />
-
-            <Pagination page={page} total={total} pageSize={25} noun="baselines" />
-          </>
-        )}
+              <Pagination page={page} total={total} pageSize={25} noun="baselines" />
+            </>
+          )}
+        </s-stack>
       </s-section>
 
       {variantGid && history.length > 0 ? (

--- a/app/routes/app.prices.drift.tsx
+++ b/app/routes/app.prices.drift.tsx
@@ -1,14 +1,27 @@
-import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import type { ComponentProps } from "react";
+import { useRef } from "react";
+import type {
+  ActionFunctionArgs,
+  FetcherWithComponents,
+  HeadersFunction,
+  LoaderFunctionArgs,
+} from "react-router";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
-import { pendingDrift, resolveDrift, type DriftResolution } from "../services/drift.server";
+import {
+  pendingDrift,
+  resolveDrift,
+  type DriftResolution,
+  type DriftRow,
+} from "../services/drift.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
 import { EmptyState } from "../components/AsyncState";
+import { ActionRow } from "../components/ActionRow";
 
 export const loader = withGuard("/app/prices/drift", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -77,27 +90,7 @@ export default function DriftQueue() {
               </s-table-header-row>
               <s-table-body>
                 {events.map((event) => (
-                  <s-table-row key={event.id}>
-                    <s-table-cell>{event.title}</s-table-cell>
-                    <s-table-cell>{event.expected ?? "—"}</s-table-cell>
-                    <s-table-cell>
-                      <s-badge tone="warning">{event.observed ?? "—"}</s-badge>
-                    </s-table-cell>
-                    <s-table-cell>{event.campaignName ?? "—"}</s-table-cell>
-                    <s-table-cell>
-                      <s-stack direction="inline" gap="small">
-                        {(["adopt", "reassert", "ignore"] as const).map((resolution) => (
-                          <fetcher.Form method="post" key={resolution}>
-                            <input type="hidden" name="eventId" value={event.id} />
-                            <input type="hidden" name="resolution" value={resolution} />
-                            <s-button type="submit" loading={busy || undefined}>
-                              {resolution}
-                            </s-button>
-                          </fetcher.Form>
-                        ))}
-                      </s-stack>
-                    </s-table-cell>
-                  </s-table-row>
+                  <DriftDecision key={event.id} event={event} fetcher={fetcher} busy={busy} />
                 ))}
               </s-table-body>
             </s-table>
@@ -107,20 +100,21 @@ export default function DriftQueue() {
 
       <s-section slot="aside" heading="What the three choices do">
         <s-paragraph>
-          <strong>Adopt</strong> makes the new price the baseline. Use it when the edit
-          was a permanent repricing — every future campaign will compute from it.
+          <strong>Keep the change</strong> makes the new price the baseline. Use it when
+          the edit was a permanent repricing — every future campaign will compute from it.
         </s-paragraph>
         <s-paragraph>
-          <strong>Reassert</strong> puts the campaign price back on the next run. Use it
-          when the edit was a mistake.
+          <strong>Put it back</strong> rewrites the campaign price on the next run. Use
+          it when the edit was a mistake.
         </s-paragraph>
         <s-paragraph>
-          <strong>Ignore</strong> leaves the price alone this time and closes the alert.
+          <strong>Leave it for now</strong> changes nothing and closes this alert. The
+          baseline is untouched, so the next campaign still computes from the old price.
         </s-paragraph>
         <s-paragraph>
           <s-text>
-            Only adopt changes what future campaigns compute from, so it is the one
-            worth being sure about.
+            Only the first of those changes what future campaigns compute from, which is
+            why it is the one marked as consequential.
           </s-text>
         </s-paragraph>
       </s-section>
@@ -135,3 +129,97 @@ export function ErrorBoundary() {
 export const headers: HeadersFunction = (headersArgs) => {
   return boundary.headers(headersArgs);
 };
+
+/**
+ * The three decisions, in the words the help centre already uses for them.
+ *
+ * They were rendered straight out of the enum — `adopt` `reassert` `ignore`, lower case,
+ * on the page whose entire job is a considered choice about somebody's storefront.
+ * `docs/help/concepts/drift.md` has had merchant wording for two of them since before
+ * this page existed; the page and the documentation of the page had never been read next
+ * to each other.
+ *
+ * `tone` is doing real work in the third field rather than decorating. The aside says
+ * only one of the three changes what future campaigns compute from, and until now the
+ * page rendered all three identically while the panel beside it explained that one of
+ * them was different. It is the same treatment Revert carries on a campaign, which is
+ * also less destruction than a decision worth being sure about.
+ */
+const RESOLUTIONS = [
+  { value: "adopt", label: "Keep the change", tone: "critical" },
+  { value: "reassert", label: "Put it back", tone: "auto" },
+  { value: "ignore", label: "Leave it for now", tone: "auto" },
+] as const satisfies readonly {
+  value: DriftResolution;
+  label: string;
+  tone: ComponentProps<"s-button">["tone"];
+}[];
+
+/**
+ * One drifted price, and the choice about it.
+ *
+ * Named for the decision rather than the row, so it does not collide with the
+ * `DriftRow` the service returns — one is what we know, the other is what to do.
+ *
+ * Its own component so that the row can own a ref. `s-button` takes no `name` or `value`,
+ * so the app's pattern for a form with several submits is a hidden field the buttons set
+ * before submitting — which needs a ref, and a ref created inside a `.map()` is a new ref
+ * on every render.
+ *
+ * Worth the component rather than the three separate `fetcher.Form`s it replaces. Three
+ * forms in one cell is three elements laying themselves out independently, and they
+ * carried `gap="small"` — which the spacing scale documents as *larger* than `small-100`,
+ * so the three halves of one decision sat further apart than the parts of any other row
+ * in the app.
+ */
+function DriftDecision({
+  event,
+  fetcher,
+  busy,
+}: {
+  event: DriftRow;
+  fetcher: FetcherWithComponents<ActionData>;
+  busy: boolean;
+}) {
+  const form = useRef<HTMLFormElement>(null);
+  const resolution = useRef<HTMLInputElement>(null);
+
+  const resolve = (value: DriftResolution) => {
+    if (resolution.current) resolution.current.value = value;
+    form.current?.requestSubmit();
+  };
+
+  return (
+    <s-table-row>
+      <s-table-cell>{event.title}</s-table-cell>
+      <s-table-cell>{event.expected ?? "—"}</s-table-cell>
+      {/* Was a warning badge wrapped round the price. A badge is a status and a price is
+          a value, so the column could not align with the one beside it and the number a
+          merchant came here to compare rendered as a label. Every row on this page is
+          drift; the page says so once, at the top, rather than once per row. */}
+      <s-table-cell>{event.observed ?? "—"}</s-table-cell>
+      <s-table-cell>{event.campaignName ?? "—"}</s-table-cell>
+      <s-table-cell>
+        <fetcher.Form method="post" ref={form}>
+          <input type="hidden" name="eventId" value={event.id} />
+          {/* Defaults to the choice that changes nothing. A missing or unrecognised
+              intent should fall safe, the way the imports' dry run does. */}
+          <input type="hidden" name="resolution" ref={resolution} value="ignore" readOnly />
+          <ActionRow>
+            {RESOLUTIONS.map((choice) => (
+              <s-button
+                key={choice.value}
+                type="button"
+                tone={choice.tone}
+                loading={busy || undefined}
+                onClick={() => resolve(choice.value)}
+              >
+                {choice.label}
+              </s-button>
+            ))}
+          </ActionRow>
+        </fetcher.Form>
+      </s-table-cell>
+    </s-table-row>
+  );
+}

--- a/docs/help/concepts/drift.md
+++ b/docs/help/concepts/drift.md
@@ -1,6 +1,6 @@
 # What drift means
 
-![The drift page with nothing to review: a single line reading "No drift detected. Prices set by your campaigns are still in place.", beside a panel explaining what Adopt, Reassert and Ignore each do.](../images/drift-empty.png)
+![The drift page with nothing to review: a heading reading "No drift detected", beside a panel explaining what each of the three choices does.](../images/drift-empty.png)
 
 **Drift** is when a price on your storefront is not what this app last wrote.
 
@@ -19,11 +19,24 @@ So drift is surfaced and you decide.
 
 ## What to do about it
 
-On the **What is live** page, anything drifted is flagged with both numbers: what we wrote
-and what is there now.
+Every drifted price waits for you on **Prices → Drift**, with both numbers side by side:
+what the campaign set, and what the storefront shows now. Anything drifted is flagged on
+the **What is live** page too.
 
-- **Keep the change** — the app adopts the new price and stops flagging it.
-- **Put it back** — the app rewrites what the campaign says it should be.
+There are three answers, and the first is the only one that changes anything permanently:
+
+- **Keep the change** — the new price becomes the baseline. Use it when the edit was a
+  permanent repricing: every future campaign computes its discount from this number
+  instead of the old one. This is the one worth being sure about, and it is the only one
+  the page marks as consequential.
+- **Put it back** — the campaign rewrites its own price on the next run. Use it when the
+  edit was a mistake.
+- **Leave it for now** — nothing changes and the alert closes. The baseline is untouched,
+  so the next campaign still computes from the old price and the edit stands until
+  something else changes it.
+
+Nothing is decided for you and nothing expires: a price stays on this page until you
+answer.
 
 When you revert a campaign, drifted products are listed separately with a tick box, so
 ending a sale never silently discards a price you set on purpose.


### PR DESCRIPTION
Closes #399.

Drift is the page a merchant reaches *from an alert* to decide about a price somebody changed by hand. It rendered its enum straight into the labels — `adopt` `reassert` `ignore`, lower case — so the highest-stakes list in the app read as a debug view.

**`docs/help/concepts/drift.md` has had merchant wording for two of the three since before this page existed**: "Keep the change" and "Put it back". The page and the documentation of the page had simply never been read next to each other. They use the same words now, and a test keeps them agreeing. The help page also documents all three choices, which it did not — it described two, and pointed at the wrong page for them.

**All three were the same default button**, while the aside beside them said *"only adopt changes what future campaigns compute from, so it is the one worth being sure about."* The page knew one of the three was different and rendered it identically to the others. It carries `tone="critical"` now — the same treatment Revert has on a campaign, which is likewise less destruction than a decision worth being sure about.

**The observed price was wrapped in a warning badge.** A badge is a status and a price is a value, so the column could not align with the one beside it and the number a merchant came here to compare rendered as a label.

**Three `fetcher.Form`s per row become one**, which is what lets the buttons be a real `ActionRow`. Three forms lay themselves out independently and carried `gap="small"` — which the spacing scale documents as *larger* than `small-100` — so the three halves of one decision sat further apart than the parts of any other row in the app. The hidden intent field defaults to the choice that changes nothing, so a missing intent falls safe, the way the imports' dry run does.

**Baselines tab**: the count, the export and the table were three siblings with no rhythm set between them, so the count landed directly under the Search button and read as a caption on the filter rather than as the size of the result. The card's blocks sit at section rhythm now, and the count and its export share one line — the count is exactly what the export exports.

## The mutation pass found a hole in the new test

A raw-labelled button planted in `BaselineTable` **did not fail** the new scan. Half the buttons in the app carry an `onClick={() => …}`, and the `>` in that arrow ended the `[^>]*` attribute match early, so the pattern never reached the label. It is a tempered `[\s\S]` now, and the mutant fails.

Every other assertion was mutated too: enum label restored, nothing marked consequential, the wrong one marked consequential, a choice dropped, the hidden field defaulted to `adopt`, the price put back in a badge, and the help doc drifted from the buttons.

1945 tests pass, 7 new. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)