### PR TITLE
The activity log says the same thing twice, in the same words

### DIFF
--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -1,7 +1,7 @@
 import { useSearchParams } from "react-router";
 
-import { formatCount } from "../../lib/format/display";
-import { SPACE } from "../../lib/ui/spacing";
+import { formatCount } from "../lib/format/display";
+import { SPACE } from "../lib/ui/spacing";
 
 /**
  * Paging, and saying where you are in the set.
@@ -21,6 +21,12 @@ import { SPACE } from "../../lib/ui/spacing";
  * The count is `subdued` and tabular. Subdued because it is orientation, not the action;
  * tabular because the digits change on every click, and proportional figures make the
  * two buttons either side of them shuffle sideways each time.
+ *
+ * It lives here rather than under `components/prices/` because it is not the prices
+ * section's. Activity had kept its own to the end -- Previous, "Page 2 of 69", Next --
+ * and a sentence that answers a different question from the one this asks. Two paginations
+ * in one app is the `SectionNav`/`PricesTabs` shape again, and a component sitting in one
+ * section's folder is most of how the second one gets written.
  */
 export function Pagination({
   page,

--- a/app/lib/ui/activity-vocabulary.test.ts
+++ b/app/lib/ui/activity-vocabulary.test.ts
@@ -12,6 +12,12 @@
  * a loader. What can be checked is the property that was broken — that the two sides read
  * their labels through the same function — and that the raw value is still what gets
  * submitted, because a filter that posts a pretty string matches nothing.
+ *
+ * It lives under `lib/ui/` and not beside the route it is about, which is not a filing
+ * preference. React Router's flat-routes reads *every* file in `app/routes/`, so a test
+ * there becomes a route module and gets bundled for the browser — where `node:fs` does not
+ * exist, and the build fails with "readFileSync is not exported by
+ * __vite-browser-external". Vitest is happy either way; only `npm run build` says so.
  */
 
 import { readFileSync } from "node:fs";
@@ -19,7 +25,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { describeAction } from "../lib/audit/action";
+import { describeAction } from "../audit/action";
 
 const ROOT = process.cwd();
 const ROUTE = readFileSync(join(ROOT, "app/routes/app.activity.tsx"), "utf8");

--- a/app/lib/ui/spacing.test.ts
+++ b/app/lib/ui/spacing.test.ts
@@ -103,7 +103,7 @@ const PRIMITIVES = [
   "app/components/AsyncState.tsx",
   "app/components/CountsRow.tsx",
   "app/components/OnboardingCard.tsx",
-  "app/components/prices/Pagination.tsx",
+  "app/components/Pagination.tsx",
   "app/components/prices/VariantSearch.tsx",
 ];
 

--- a/app/routes/activity-page.test.ts
+++ b/app/routes/activity-page.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The activity log says the same thing twice, in the same words.
+ *
+ * #388 fixed `ActivityTable` to render `describeAction(entry.action)`, so the Action
+ * column reads "Campaign transition" the way the dashboard feed does. The **What** filter
+ * directly above that column, in the same card, went on rendering the raw string — so the
+ * page offered `campaign.transition` in a dropdown that filtered a column saying
+ * `Campaign transition`. Two vocabularies for one thing, one element apart, introduced by
+ * the sweep that fixed the first of them.
+ *
+ * A rendered test cannot reach this: the filter and the table are both in a route, behind
+ * a loader. What can be checked is the property that was broken — that the two sides read
+ * their labels through the same function — and that the raw value is still what gets
+ * submitted, because a filter that posts a pretty string matches nothing.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { describeAction } from "../lib/audit/action";
+
+const ROOT = process.cwd();
+const ROUTE = readFileSync(join(ROOT, "app/routes/app.activity.tsx"), "utf8");
+const TABLE = readFileSync(join(ROOT, "app/components/ActivityTable.tsx"), "utf8");
+
+describe("the filter and the column it filters use one vocabulary", () => {
+  it("renders both through describeAction", () => {
+    expect(TABLE).toContain("describeAction(entry.action)");
+    expect(ROUTE).toContain("describeAction(action)");
+  });
+
+  it("still submits the raw action, so the filter matches", () => {
+    // The label is what changed; the value is the key the loader queries by. Prettifying
+    // that too would leave a dropdown where every option selects nothing.
+    expect(ROUTE).toMatch(/<s-option key=\{action\} value=\{action\}/);
+  });
+
+  it("has something to translate, so the check is not vacuous", () => {
+    expect(describeAction("campaign.transition")).toBe("Campaign transition");
+    expect(describeAction("campaign.transition")).not.toBe("campaign.transition");
+  });
+});
+
+describe("the app has one pagination", () => {
+  it("activity uses the shared one", () => {
+    expect(ROUTE).toContain("<Pagination");
+  });
+
+  it("keeps none of the arithmetic it used to duplicate", () => {
+    // "Page 2 of 69" answers a different question from "26–50 of 1,712", and a merchant
+    // scanning for one entry is asking the second. Both the sentence and the ceil() that
+    // produced it are gone.
+    expect(ROUTE).not.toContain("Math.ceil(total");
+    expect(ROUTE).not.toMatch(/Page \{page\} of/);
+  });
+
+  it("is not filed under the one section that no longer owns it", () => {
+    expect(ROUTE).not.toContain("prices/Pagination");
+  });
+});
+
+describe("the count and the export share a line", () => {
+  it("puts a run of text on the row, not a block element", () => {
+    // `s-paragraph` brings its own leading, so an inline stack laid the button out
+    // against a box a line and a half tall and the two never shared a baseline.
+    expect(ROUTE).not.toMatch(/<s-stack direction="inline"[^>]*>\s*<s-paragraph/);
+    expect(ROUTE).toContain("<ActionRow>");
+  });
+});

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -16,10 +16,13 @@ import { ensureShop } from "../services/shop.server";
 import { activity } from "../services/activity.server";
 import { activityCsv } from "../lib/reporting/activity-csv";
 import { ActivityTable } from "../components/ActivityTable";
+import { ActionRow } from "../components/ActionRow";
+import { Pagination } from "../components/Pagination";
 import { EmptyState, NoMatches } from "../components/AsyncState";
 import { FilterForm, clearedSearch } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { downloadCsv } from "../lib/reporting/csv";
+import { describeAction } from "../lib/audit/action";
 import { describeActor } from "../lib/audit/actor";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
@@ -57,16 +60,8 @@ export const loader = withGuard("/app/activity", async ({ request }: LoaderFunct
 export default function Activity() {
   const { entries, total, actors, actions, page, filters, timeZone } =
     useLoaderData<typeof loader>();
-  const [params, setSearchParams] = useSearchParams();
+  const [params] = useSearchParams();
   const filtered = Boolean(filters.actor || filters.action || filters.from || filters.to);
-
-  const pageSize = PAGE_SIZE;
-  const lastPage = Math.max(1, Math.ceil(total / pageSize));
-  const goTo = (next: number) =>
-    setSearchParams((params) => {
-      params.set("page", String(next));
-      return params;
-    });
 
   return (
     <PageShell heading="Activity" backTo={{ href: "/app", label: "Home" }}>
@@ -84,13 +79,18 @@ export default function Activity() {
               ))}
             </s-select>
 
+            {/* `describeAction`, the same call the Action column makes. #388 fixed the
+                column and stopped there, so the page offered `campaign.transition` in
+                this list and rendered "Campaign transition" in the cells it filtered —
+                two vocabularies for one thing, one element apart. The value submitted is
+                still the raw action; only what the merchant reads changes. */}
             <s-select name="action" label="What">
               <s-option value="" defaultSelected={!filters.action}>
                 Any action
               </s-option>
               {actions.map((action) => (
                 <s-option key={action} value={action} defaultSelected={filters.action === action}>
-                  {action}
+                  {describeAction(action)}
                 </s-option>
               ))}
             </s-select>
@@ -117,36 +117,27 @@ export default function Activity() {
           )
         ) : (
           <>
-            <s-stack direction="inline" gap="base">
-              <s-paragraph>
-                <s-text>
-                  {formatCount(total)} entr{total === 1 ? "y" : "ies"} · times shown in {timeZone}
-                </s-text>
-              </s-paragraph>
+            {/* `s-paragraph` is a block element, so an inline stack laid the button out
+                beside a box that owns a whole line of leading and the two never shared a
+                baseline. A run of text is what belongs on a row with a button. */}
+            <ActionRow>
+              <s-text color="subdued" fontVariantNumeric="tabular-nums">
+                {formatCount(total)} entr{total === 1 ? "y" : "ies"} · times shown in{" "}
+                {timeZone}
+              </s-text>
               <s-button
                 type="button"
                 variant="tertiary"
+                icon="download"
                 onClick={() => downloadCsv("anchor-activity.csv", activityCsv(entries))}
               >
                 Export this page (CSV)
               </s-button>
-            </s-stack>
+            </ActionRow>
 
             <ActivityTable entries={entries} timeZone={timeZone} />
 
-            {lastPage > 1 ? (
-              <s-stack direction="inline" gap="base">
-                <s-button disabled={page <= 1} onClick={() => goTo(page - 1)}>
-                  Previous
-                </s-button>
-                <s-text>
-                  Page {page} of {lastPage}
-                </s-text>
-                <s-button disabled={page >= lastPage} onClick={() => goTo(page + 1)}>
-                  Next
-                </s-button>
-              </s-stack>
-            ) : null}
+            <Pagination page={page} total={total} pageSize={PAGE_SIZE} noun="entries" />
           </>
         )}
       </s-section>

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -9,7 +9,7 @@ import { formatMoney, money } from "../lib/money/money";
 import { EmptyState, NoMatches } from "../components/AsyncState";
 import { clearedSearch } from "../components/FilterForm";
 import { VariantSearch } from "../components/prices/VariantSearch";
-import { Pagination } from "../components/prices/Pagination";
+import { Pagination } from "../components/Pagination";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";

--- a/app/routes/app.prices.baselines.tsx
+++ b/app/routes/app.prices.baselines.tsx
@@ -29,7 +29,7 @@ import { ActionRow } from "../components/ActionRow";
 import { EmptyState, NoMatches } from "../components/AsyncState";
 import { clearedSearch } from "../components/FilterForm";
 import { VariantSearch } from "../components/prices/VariantSearch";
-import { Pagination } from "../components/prices/Pagination";
+import { Pagination } from "../components/Pagination";
 import { baselinesCsv } from "../lib/reporting/baselines-csv";
 import { downloadCsv } from "../lib/reporting/csv";
 import { RouteBoundary } from "../components/RouteBoundary";


### PR DESCRIPTION
Closes #400.

#388 fixed `ActivityTable` to render `describeAction(entry.action)`, so the Action column reads "Campaign transition" the way the dashboard feed does. **The What filter directly above that column, in the same card, went on rendering the raw string** — so the page offered `campaign.transition` in a dropdown that filtered a column saying `Campaign transition`. Two vocabularies for one thing, one element apart, introduced by the sweep that fixed the first of them.

Only the label changes. The option's `value` is still the raw action, because a filter that submits a prettified string matches nothing — and a dropdown where every option selects zero rows is a worse bug than the one being fixed. The test checks both halves, and checks that `describeAction` is not the identity, or the whole thing would pass on a page showing raw strings everywhere.

**Activity was also the app's second pagination.** `Pagination` was extracted in #350 to hold arithmetic that had been copied three times, and it deliberately says "26–50 of 1,712" rather than "page 2 of 69", because a merchant scanning for one entry is asking where they are in the *rows*. This page had kept Previous / "Page 2 of 69" / Next with its own `ceil()` and its own `setSearchParams`.

The component **moves out of `components/prices/`** while it is being shared. It is not the prices section's any more, and a component sitting inside one section's folder is most of how the second copy gets written — which is exactly how `SectionNav` and `PricesTabs` happened.

**The count and the CSV export** were an `s-paragraph` and a button in an inline stack. A paragraph is a block element that brings its own leading, so the button sat against a box a line and a half tall and the two never shared a baseline.

All six new assertions were mutated and confirmed failing: the filter reverted to the raw action, the table reverted, the filter made to submit the pretty label, `describeAction` reduced to the identity, the hand-rolled paging restored, and the row put back into an inline stack around a paragraph.

1952 tests pass, 7 new. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)