### PR TITLE
Step 2 of the editor stops being fifteen full-width bars

### DIFF
--- a/app/lib/ui/editor-layout.test.ts
+++ b/app/lib/ui/editor-layout.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The campaign editor's fields are laid out, not stacked.
+ *
+ * `FieldGrid` was written for this exact failure and its doc comment names it: a "Vendor"
+ * select holding one word rendered as a twelve-hundred-pixel bar, and three of them
+ * stacked is "the single most unstyled-looking thing in this app". Step 1 · Scope used it.
+ * Step 2 · Rule — the longer form, and the one a merchant actually fills in — was a plain
+ * `s-stack` of roughly fifteen full-width controls.
+ *
+ * This is a source check rather than a render because the editor is a route: it reads a
+ * loader, a fetcher and `useState` inside `RuleValueField`. What can be checked without
+ * a browser is the structure — which is what was wrong — and the two things about that
+ * structure that are silently breakable:
+ *
+ * - `RuleValueField` renders *two* fields as a fragment, so it must not be wrapped in a
+ *   `FullRow`, or both land in one cell and stack;
+ * - the rarely-touched four are below the schedule and named optional, not sitting
+ *   between the rule and the thing the merchant came to set.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const EDITOR = readFileSync(join(process.cwd(), "app/routes/app.campaigns.new.tsx"), "utf8");
+
+/** Where a name first appears in the file, or -1. Source order is render order here. */
+const at = (needle: string) => EDITOR.indexOf(needle);
+
+describe("step 2 lays its fields out in columns", () => {
+  it("uses the grid the page's own step 1 already uses", () => {
+    // Three: the rule, the per-currency rounding, and the schedule. Plus advanced.
+    expect((EDITOR.match(/<FieldGrid>/g) ?? []).length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("no longer stacks the whole form in one block", () => {
+    // `s-stack gap="base"` around fifteen fields is what made the column of bars. The
+    // stack is still there — it separates the named blocks — but it takes its rhythm
+    // from the scale and its children are grids.
+    expect(EDITOR).not.toContain('<s-stack gap="base">');
+  });
+
+  it("pairs the adjustment with its amount instead of wrapping both in one cell", () => {
+    const rule = at("<RuleValueField");
+    const before = EDITOR.slice(Math.max(0, rule - 200), rule);
+
+    expect(before).not.toMatch(/<FullRow>\s*(\{\/\*[\s\S]*?\*\/\}\s*)?$/);
+  });
+
+  it("keeps the checkbox and the tag sentence on rows of their own", () => {
+    // A checkbox is a tick and a sentence, not a field: a column sized for a select
+    // leaves it stranded with its label wrapping under the box.
+    const advanced = EDITOR.slice(at("Advanced (optional)"));
+
+    expect(advanced).toMatch(/<FullRow>\s*<s-text-field\s+name="tagKit"/);
+    expect(advanced).toMatch(/<FullRow>\s*<s-checkbox\s+name="autoEnroll"/);
+  });
+});
+
+describe("the rule is what a merchant meets first", () => {
+  it("previews the rule directly under the rule", () => {
+    expect(at("<RuleValueField")).toBeLessThan(at("What this would do"));
+    expect(at("What this would do")).toBeLessThan(at("Markets and catalogues"));
+  });
+
+  it("puts the four rarely-touched settings after the schedule, not before it", () => {
+    for (const field of ['name="priority"', 'name="tagKit"', 'name="autoEnroll"', 'name="revertBuffer"']) {
+      expect(at(field), `${field} is above the schedule`).toBeGreaterThan(at("Schedule (optional)"));
+      expect(at(field), `${field} is outside the advanced block`).toBeGreaterThan(
+        at("Advanced (optional)"),
+      );
+    }
+  });
+
+  it("says the advanced block can be skipped", () => {
+    expect(EDITOR).toContain("Advanced (optional)");
+    expect(EDITOR).toMatch(/Skip them\s*\n?\s*unless you have a reason/);
+  });
+
+  it("still submits after everything, exactly once", () => {
+    expect((EDITOR.match(/type="submit"/g) ?? []).length).toBe(2); // scope's, and the create
+    expect(at("Create and preview")).toBeGreaterThan(at("Advanced (optional)"));
+  });
+});
+
+describe("no stack is wrapped around a single child", () => {
+  it("finds none in the editor", () => {
+    // Two of these: one round the scope form's submit, one round each schedule pair.
+    // A stack with one child lays nothing out; it is the shape left behind when the
+    // other children were moved somewhere else.
+    const singles = [
+      ...EDITOR.matchAll(/<s-stack[^>]*>\s*<([a-zA-Z-]+)[^>]*>[^<]*<\/\1>\s*<\/s-stack>/g),
+    ];
+
+    expect(singles.map((match) => match[1])).toEqual([]);
+  });
+});

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -30,6 +30,7 @@ import { UnsavedChanges } from "../components/UnsavedChanges";
 import { DraftPreview } from "../components/DraftPreview";
 import { RuleValueField } from "../components/RuleValueField";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
+import { SPACE } from "../lib/ui/spacing";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
 export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
@@ -361,9 +362,12 @@ export default function NewCampaign() {
             <s-text-field name="title" label="Title contains" value={selected.title} />
           </FieldGrid>
 
-          <s-stack direction="inline" gap="base">
+          {/* Was an inline stack around exactly one button. A stack with one child lays
+              nothing out; ActionRow is what a row of actions is, and this is a row of
+              one. */}
+          <ActionRow>
             <s-button type="submit">Update match count</s-button>
-          </s-stack>
+          </ActionRow>
         </FilterForm>
 
         <s-paragraph>
@@ -391,65 +395,63 @@ export default function NewCampaign() {
           <input type="hidden" name="vendor" value={selected.vendor} />
           <input type="hidden" name="title" value={selected.title} />
 
-          <s-stack gap="base">
-            <s-text-field name="name" label="Campaign name" value="Sale" required />
+          <s-stack gap={SPACE.section}>
+            {/* The rule, and nothing else, first.
 
-            <RuleValueField currency={currencies[0] ?? "USD"} />
+                This block was one flat stack of about fifteen full-width controls -- name,
+                rule, compare-at, rounding, priority, tags, auto-enrol, a checkbox per
+                market, a select per currency, four schedule fields and a revert buffer.
+                `FieldGrid` exists for exactly that failure and its doc comment names it:
+                a select holding one word rendered twelve hundred pixels wide is "the
+                single most unstyled-looking thing in this app". Step 1 above already used
+                it; the longer form, the one a merchant actually fills in, did not. */}
+            <FieldGrid>
+              {/* The one field that keeps the whole row. It names the thing being made,
+                  and a title above the settings that describe it is the shape every form
+                  of this kind takes. */}
+              <FullRow>
+                <s-text-field name="name" label="Campaign name" value="Sale" required />
+              </FullRow>
 
-            <s-select name="compareAt" label="Compare-at price">
-              <s-option value="set-to-baseline" defaultSelected>
-                Set to baseline (shows a strike-through)
-              </s-option>
-              <s-option value="leave">Leave unchanged</s-option>
-              <s-option value="clear">Clear it</s-option>
-            </s-select>
+              {/* Not wrapped in a `FullRow`, deliberately. This renders *two* fields — the
+                  adjustment and its amount — as a fragment, so as bare grid children they
+                  land side by side, which is the pair a merchant reads as one decision.
+                  Inside a `FullRow` they would both go in one cell and stack. */}
+              <RuleValueField currency={currencies[0] ?? "USD"} />
 
-            <s-select name="rounding.default" label="Rounding">
-              {roundingOptions.map((option) => (
-                <s-option
-                  key={option.value}
-                  value={option.value}
-                  defaultSelected={option.value === storeRounding.default}
-                >
-                  {option.label}
+              <s-select name="compareAt" label="Compare-at price">
+                <s-option value="set-to-baseline" defaultSelected>
+                  Set to baseline (shows a strike-through)
                 </s-option>
-              ))}
-            </s-select>
-            <s-paragraph>
-              <s-text>
-                Starts from your store setting. Change it here to round this campaign
-                differently.
-              </s-text>
-            </s-paragraph>
+                <s-option value="leave">Leave unchanged</s-option>
+                <s-option value="clear">Clear it</s-option>
+              </s-select>
+
+              <s-select
+                name="rounding.default"
+                label="Rounding"
+                details="Starts from your store setting. Change it here to round this campaign differently."
+              >
+                {roundingOptions.map((option) => (
+                  <s-option
+                    key={option.value}
+                    value={option.value}
+                    defaultSelected={option.value === storeRounding.default}
+                  >
+                    {option.label}
+                  </s-option>
+                ))}
+              </s-select>
+            </FieldGrid>
 
             {/* What this rule does to prices, from the same resolver the run uses --
                 not an estimate of it. Sits with the rule rather than at the bottom of
                 the page, because it exists to answer "did I mean -20% or x0.20?" while
-                the merchant is still deciding. */}
+                the merchant is still deciding. With the rarely-touched settings moved to
+                the end, it now lands directly under the rule it is previewing. */}
             <s-divider />
             <s-heading>What this would do</s-heading>
             <DraftPreview preview={previewFetcher.data ?? null} />
-
-            <s-number-field
-              name="priority"
-              label="Priority"
-              value="100"
-              details="Higher wins when two campaigns cover the same variant. They never stack."
-            />
-
-            <s-text-field
-              name="tagKit"
-              label="Storefront tags (optional)"
-              placeholder="SALE, SUMMER"
-              details="Comma separated. Added to each product while the campaign runs and removed when it ends, so your theme can badge sale items. Tags a product already has are never removed."
-            />
-
-            <s-checkbox
-              name="autoEnroll"
-              label="Price products that join this campaign while it runs"
-              checked
-              details="A product you add to the sale later is priced from its own normal price, not the sale price."
-            />
 
             {priceLists.length > 0 ? (
               <>
@@ -508,26 +510,30 @@ export default function NewCampaign() {
                   </s-text>
                 </s-paragraph>
 
-                {currencies.map((code) => (
-                  <s-select key={code} name={`rounding.${code}`} label={`Rounding for ${code}`}>
-                    <s-option
-                      value="inherit"
-                      defaultSelected={!storeRounding.byCurrency[code]}
-                    >
-                      Same as this campaign&rsquo;s rounding (
-                      {ROUNDING_LABELS[profileNameFor(storeRounding, code)].toLowerCase()})
-                    </s-option>
-                    {roundingOptions.map((option) => (
+                {/* One select per currency, in columns. A store selling in six currencies
+                    rendered six full-width bars each holding the phrase "Ends in .99". */}
+                <FieldGrid>
+                  {currencies.map((code) => (
+                    <s-select key={code} name={`rounding.${code}`} label={`Rounding for ${code}`}>
                       <s-option
-                        key={option.value}
-                        value={option.value}
-                        defaultSelected={storeRounding.byCurrency[code] === option.value}
+                        value="inherit"
+                        defaultSelected={!storeRounding.byCurrency[code]}
                       >
-                        {option.label}
+                        Same as this campaign&rsquo;s rounding (
+                        {ROUNDING_LABELS[profileNameFor(storeRounding, code)].toLowerCase()})
                       </s-option>
-                    ))}
-                  </s-select>
-                ))}
+                      {roundingOptions.map((option) => (
+                        <s-option
+                          key={option.value}
+                          value={option.value}
+                          defaultSelected={storeRounding.byCurrency[code] === option.value}
+                        >
+                          {option.label}
+                        </s-option>
+                      ))}
+                    </s-select>
+                  ))}
+                </FieldGrid>
               </>
             ) : null}
 
@@ -544,13 +550,13 @@ export default function NewCampaign() {
             {/* Date and time as two fields, because Polaris has no datetime component:
                 `s-date-field` is date-only. Two Polaris fields beat one native
                 datetime-local that would style itself differently from everything
-                around it, and the two are recombined server-side. */}
-            <s-stack direction="inline" gap="base">
-              <s-date-field
-                name="startDate"
-                label="Start"
-                value={presetStart.slice(0, 10)}
-              />
+                around it, and the two are recombined server-side.
+
+                The grid rather than an inline stack, so the two pairs line up with each
+                other: a stack sizes each child to its content, so End sat a few pixels
+                left of Start and the four fields read as four rather than as two pairs. */}
+            <FieldGrid>
+              <s-date-field name="startDate" label="Start" value={presetStart.slice(0, 10)} />
               <s-text-field
                 name="startTime"
                 label="Start time"
@@ -558,9 +564,6 @@ export default function NewCampaign() {
                 value={presetStart.slice(11)}
                 details="24-hour, in your store's zone."
               />
-            </s-stack>
-
-            <s-stack direction="inline" gap="base">
               <s-date-field name="endDate" label="End (optional)" />
               <s-text-field
                 name="endTime"
@@ -568,18 +571,72 @@ export default function NewCampaign() {
                 placeholder="23:59"
                 details="Defaults to the end of that day."
               />
-            </s-stack>
+            </FieldGrid>
 
-            <s-number-field
-              name="revertBuffer"
-              label="Revert this many minutes early"
-              value="5"
-              details="A busy bulk queue takes time; starting early means prices are back before the window closes."
-            />
+            <s-divider />
 
-            <s-button type="submit" variant="primary">
-              {practice ? "Preview it — nothing will be written" : "Create and preview"}
-            </s-button>
+            {/* The pressure valve.
+
+                Four controls a first campaign never touches, all with defaults that are
+                right for almost everybody: priority only matters once two campaigns
+                overlap, tags only matter if the theme reads them, auto-enrol is on, and
+                the revert buffer is meaningless without an end date. They were sitting
+                between the rule and the schedule, so the merchant read four settings they
+                had no opinion about before reaching the one thing they came to set.
+
+                Named "optional" rather than hidden: Polaris has no disclosure element —
+                all 57 tags checked, there is no `s-details` and no accordion — so a
+                collapsible here would be hand-rolled chrome in an app that has none. A
+                heading that says a block can be skipped does the same job honestly. */}
+            <s-heading>Advanced (optional)</s-heading>
+            <s-paragraph>
+              <s-text color="subdued">
+                Every one of these has a default that suits most campaigns. Skip them
+                unless you have a reason.
+              </s-text>
+            </s-paragraph>
+
+            <FieldGrid>
+              <s-number-field
+                name="priority"
+                label="Priority"
+                value="100"
+                details="Higher wins when two campaigns cover the same variant. They never stack."
+              />
+
+              <s-number-field
+                name="revertBuffer"
+                label="Revert this many minutes early"
+                value="5"
+                details="A busy bulk queue takes time; starting early means prices are back before the window closes."
+              />
+
+              <FullRow>
+                <s-text-field
+                  name="tagKit"
+                  label="Storefront tags (optional)"
+                  placeholder="SALE, SUMMER"
+                  details="Comma separated. Added to each product while the campaign runs and removed when it ends, so your theme can badge sale items. Tags a product already has are never removed."
+                />
+              </FullRow>
+
+              <FullRow>
+                <s-checkbox
+                  name="autoEnroll"
+                  label="Price products that join this campaign while it runs"
+                  checked
+                  details="A product you add to the sale later is priced from its own normal price, not the sale price."
+                />
+              </FullRow>
+            </FieldGrid>
+
+            <s-divider />
+
+            <ActionRow>
+              <s-button type="submit" variant="primary">
+                {practice ? "Preview it — nothing will be written" : "Create and preview"}
+              </s-button>
+            </ActionRow>
           </s-stack>
         </Form>
       </s-section>


### PR DESCRIPTION
Closes #402.

`FieldGrid` was written for this failure and its doc comment names it: a select holding one word rendered twelve hundred pixels wide, and three stacked is *"the single most unstyled-looking thing in this app"*. **Step 1 · Scope used it. Step 2 · Rule — the longer form, and the one a merchant actually fills in — was a plain `s-stack` of roughly fifteen full-width controls.**

Four named blocks now, each a grid: the rule, markets, the schedule, and Advanced. The rule pairs its adjustment with its amount, and the compare-at with the rounding, so each row is one decision. The campaign name keeps a full row — it names the thing being made.

**`RuleValueField` is deliberately not wrapped in `FullRow`.** It renders *two* fields as a fragment, so as bare grid children they land side by side; inside a `FullRow` both would go in one cell and stack. That is invisible in the source, so the test asserts it.

## The pressure valve

Priority, storefront tags, auto-enrol and the revert buffer move into **"Advanced (optional)"** below the schedule. All four have defaults that suit almost every campaign, and they were sitting between the rule and the schedule — so a merchant read four settings they had no opinion about before reaching the thing they came to set. The epic notes recorded the competitor's version of this and why we lacked one: *"our rare options became nav items because we lack a pressure valve."*

**Named optional rather than collapsed.** Polaris has no disclosure element — all 57 tags checked, no `s-details`, no accordion — so a collapsible here would be hand-rolled chrome in an app that has none. A heading that says a block can be skipped does the same job honestly.

With those four gone, **the live preview lands directly under the rule it previews**, which is where its own comment always said it belonged.

## Smaller things in the same file

- The schedule's two date/time pairs were separate inline stacks, so End sat a few pixels left of Start and the four fields read as four rather than as two pairs. One grid now.
- A store selling in six currencies got six full-width bars each holding "Ends in .99". Those are in columns too.
- Two stacks wrapped a single child. A stack with one child lays nothing out; it is the shape left behind when the other children moved somewhere else.

All seven assertions were mutated and confirmed failing: grids removed, the flat stack restored, `RuleValueField` wrapped in a `FullRow`, the checkbox stripped of its own row, priority moved back above the schedule, the advanced block renamed to something that does not say it is skippable, and a single-child stack reintroduced.

1976 tests pass, 9 new. Typecheck, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)