### PR TITLE
Regenerate the pinned Admin API types

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -18,6 +18,16 @@ import { API_VERSION_STRING } from "./app/lib/shopify/api-version";
  * was fine until a second place disagreed — and one did. It now comes from the same
  * constant the app speaks, so the schema these types are generated from is the schema
  * the requests actually hit.
+ *
+ * ## Running this and getting "no changes" while CI disagrees
+ *
+ * `app/types/admin-<version>.schema.json` is a 7MB download and is gitignored, so it is
+ * cached on a developer machine and fetched fresh on every CI run. Codegen reuses the
+ * cache without checking it, which means a schema that has moved upstream produces a
+ * clean local run and a failing pipeline — with the error pointing at the generated
+ * types, which look correct on the machine that generated them.
+ *
+ * Delete the schema file before regenerating to reproduce what CI does.
  */
 function getConfig() {
   const config: IGraphQLConfig = {

--- a/app/types/admin.types.d.ts
+++ b/app/types/admin.types.d.ts
@@ -71961,7 +71961,10 @@ export type StandardMetaobjectDefinitionFieldTemplate = {
   type: MetafieldDefinitionType;
   /** The configured validations for the standard metafield definition. */
   validations: Array<MetafieldDefinitionValidation>;
-  /** Whether metafields for the definition are by default visible using the Storefront API. */
+  /**
+   * Whether metafields for the definition are by default visible using the Storefront API.
+   * @deprecated Access control at the metaobject field definition level is deprecated and will be removed in 2027-01. Use the access field on the definition instead.
+   */
   visibleToStorefrontApi: Scalars['Boolean']['output'];
 };
 


### PR DESCRIPTION
Closes #410.

Shopify annotated `StandardMetaobjectDefinitionFieldTemplate.visibleToStorefrontApi` as deprecated in the pinned `2026-07` schema. `app/types` is committed and CI regenerates it and fails on any diff, so **every open PR was failing at the "GraphQL types match the pinned schema" step** regardless of what it changed.

It is a doc comment on a field this app does not query, so nothing behaves differently — but the check is right to fail. A hand-written interface that quietly disagrees with the schema typechecks perfectly and fails at runtime, in code that writes prices, which is the whole reason these are generated and committed.

**The trap that made this take a while is recorded in `.graphqlrc.ts`**: `admin-<version>.schema.json` is a 7MB download and is gitignored, so it is cached on a developer machine and fetched fresh in CI. Codegen reuses the cache without checking it — so a schema that has moved upstream gives a clean local run and a failing pipeline, with the error pointing at generated types that look correct on the machine that generated them. Delete the schema file before regenerating to reproduce what CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)