### PR TITLE
The Imports section gets its own landing page back, and one import form

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -300,10 +300,30 @@ describe("pages that can lose typed work", () => {
     "app.imports.costs.tsx",
   ];
 
-  it("guard the ones that hold a form worth keeping", () => {
-    const missing = GUARDED.filter(
-      (route) => !readFileSync(join(APP_ROUTES, route), "utf8").includes("<UnsavedChanges"),
+  /**
+   * A route satisfies this by rendering the guard itself, or by rendering the shared
+   * `ImportForm`, which does.
+   *
+   * The indirection is checked rather than assumed: the assertion below pins the guard
+   * inside `ImportForm`, so "route renders ImportForm" is only accepted while ImportForm
+   * is still the thing that guards.
+   */
+  const PROVIDERS = ["<UnsavedChanges", "<ImportForm"];
+
+  it("the shared import form carries the guard the routes delegate to it", () => {
+    const form = readFileSync(
+      join(process.cwd(), "app", "components", "imports", "ImportForm.tsx"),
+      "utf8",
     );
+
+    expect(form).toContain("<UnsavedChanges");
+  });
+
+  it("guard the ones that hold a form worth keeping", () => {
+    const missing = GUARDED.filter((route) => {
+      const source = readFileSync(join(APP_ROUTES, route), "utf8");
+      return !PROVIDERS.some((provider) => source.includes(provider));
+    });
 
     expect(missing, "these can discard a filled-in form on any navigation").toEqual([]);
   });

--- a/app/components/imports/ImportForm.tsx
+++ b/app/components/imports/ImportForm.tsx
@@ -1,0 +1,235 @@
+import type { ReactNode } from "react";
+import { useRef } from "react";
+import type { FetcherWithComponents } from "react-router";
+
+import { ActionRow } from "../ActionRow";
+import { CountsRow } from "../CountsRow";
+import { EmptyState } from "../AsyncState";
+import { CsvDropZone } from "./CsvDropZone";
+import { UnsavedChanges } from "../UnsavedChanges";
+import { downloadCsv } from "../../lib/reporting/csv";
+import { SPACE } from "../../lib/ui/spacing";
+
+/**
+ * One CSV import, whatever the file is for.
+ *
+ * Prices, baselines and costs were three copies of this: two intro paragraphs, a drop
+ * zone, an `s-text-area` named `csv`, an inline stack of a "check" button and an "import"
+ * button driven by the same hidden `intent` field, then a report of counts and problem
+ * rows. Written a few tickets apart, and already visibly apart:
+ *
+ * | | prices | baselines | costs |
+ * |---|---|---|---|
+ * | commit is a critical button | no | yes | yes |
+ * | commit blocked until a dry run | **no** | yes | **no** |
+ * | problems shown as | a bullet list | a table | a bullet list |
+ * | counts sentence | **none** | four numbers | five numbers |
+ * | errors downloadable | **no** | yes | yes |
+ *
+ * The middle row is the one that matters. "You cannot commit before you have checked"
+ * existed on exactly one of the three paths that write to a merchant's catalogue, and
+ * nothing said the other two were different on purpose. It is here now, so all three have
+ * it and none of them can lose it separately.
+ *
+ * ## What is still per-source
+ *
+ * The words, the sample rows, and what the file does when it lands — passed in. The
+ * shape, the guard, and the order of the two buttons are not.
+ */
+export function ImportForm({
+  heading,
+  description,
+  placeholder,
+  fetcher,
+  busy,
+  checkLabel = "Check the file",
+  commitLabel,
+  ready,
+  children,
+}: {
+  heading: string;
+  /** What this file is, and what happens when it lands. */
+  description: ReactNode;
+  /** Sample rows, shown in the empty textarea. */
+  placeholder: string;
+  fetcher: FetcherWithComponents<unknown>;
+  busy: boolean;
+  checkLabel?: string;
+  /** Says how many rows will be written, which is why it takes the count. */
+  commitLabel: (ready: number) => string;
+  /**
+   * Rows the last dry run found ready, or `null` if it has not run.
+   *
+   * The commit button is disabled until this is a positive number. Not because pressing
+   * it would break anything — the action defaults to a dry run on a missing or
+   * unrecognised intent — but because "import 0 rows" is a button that reports success
+   * for having done nothing, and a merchant who has not looked at the report is exactly
+   * the merchant who should not be writing to their catalogue.
+   */
+  ready: number | null;
+  /** Extra fields this source needs, above the file. */
+  children?: ReactNode;
+}) {
+  const form = useRef<HTMLFormElement>(null);
+  const intent = useRef<HTMLInputElement>(null);
+
+  const submitWith = (value: string) => {
+    if (intent.current) intent.current.value = value;
+    form.current?.requestSubmit();
+  };
+
+  return (
+    <s-section heading={heading}>
+      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
+          the import runs. */}
+      <UnsavedChanges form={form} describe="this import" saved={Boolean(fetcher.data)} />
+
+      {description}
+
+      <fetcher.Form method="post" ref={form}>
+        {/* `s-button` takes no name or value, so the intent rides in a hidden field the
+            buttons set before submitting. One form rather than two, because both actions
+            read the same rows and duplicating the textarea would let them drift apart —
+            which is the mistake this component exists to undo at a larger scale. */}
+        <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
+        <s-stack gap={SPACE.section}>
+          {children}
+          <CsvDropZone target="csv" />
+
+          <s-text-area
+            name="csv"
+            label="Rows"
+            rows={12}
+            placeholder={placeholder}
+            details="Paste straight from a spreadsheet, or drop a file above. A header row is read if there is one."
+          />
+
+          <ActionRow>
+            <s-button
+              type="button"
+              variant="primary"
+              loading={busy || undefined}
+              onClick={() => submitWith("dry-run")}
+            >
+              {checkLabel}
+            </s-button>
+            <s-button
+              type="button"
+              tone="critical"
+              loading={busy || undefined}
+              disabled={!ready || undefined}
+              onClick={() => submitWith("commit")}
+            >
+              {commitLabel(ready ?? 0)}
+            </s-button>
+          </ActionRow>
+        </s-stack>
+      </fetcher.Form>
+    </s-section>
+  );
+}
+
+/** A row this import could not use, and why. */
+export interface ImportProblem {
+  line: number;
+  identifier: string;
+  reason: string;
+  /** What kind of problem, for sources that distinguish them. */
+  kind?: string;
+}
+
+/**
+ * What the file would do, or did.
+ *
+ * The counts first, as tiles, for the same reason the campaign preview shows them that
+ * way: they are the summary of what is about to happen to a live catalogue, and as a run
+ * of text — "412 rows read · 9 ready · 3 need attention" — the reader has to parse it
+ * into pairs themselves. Prices showed no counts at all.
+ *
+ * Problems as a table rather than a bullet list. Two of the three used a list, which puts
+ * the line number, the identifier and the reason into one sentence per row, so nothing
+ * lines up and a file with twenty bad rows cannot be scanned for the one thing they have
+ * in common — which is the question a merchant looking at this list is asking.
+ */
+export function ImportReport({
+  heading,
+  counts,
+  problems,
+  download,
+  limit = 25,
+}: {
+  heading: string;
+  counts: Array<{ label: string; value: number }>;
+  problems: ImportProblem[];
+  /**
+   * Every problem row, not just the ones the table shows.
+   *
+   * A thunk rather than a string: a file with forty thousand bad rows should not have its
+   * error CSV built on every render of the page that offers it.
+   */
+  download?: { filename: string; csv: () => string };
+  limit?: number;
+}) {
+  return (
+    <s-section heading={heading}>
+      <CountsRow items={counts} />
+
+      {problems.length === 0 ? (
+        <EmptyState
+          title="Every row matched a variant and validated"
+          description="Nothing was left out, so the counts above account for the whole file."
+        />
+      ) : (
+        <>
+          <s-paragraph>
+            <s-text>
+              These rows were left out. Everything else is unaffected — one bad row never
+              fails the file.
+            </s-text>
+          </s-paragraph>
+
+          {download ? (
+            <ActionRow>
+              <s-button
+                type="button"
+                variant="tertiary"
+                icon="download"
+                onClick={() => downloadCsv(download.filename, download.csv())}
+              >
+                Download all {problems.length} (CSV)
+              </s-button>
+            </ActionRow>
+          ) : null}
+
+          <s-table>
+            <s-table-header-row>
+              <s-table-header listSlot="kicker" format="numeric">Line</s-table-header>
+              <s-table-header listSlot="primary">Identifier</s-table-header>
+              <s-table-header listSlot="inline">Problem</s-table-header>
+              <s-table-header listSlot="secondary">What to do</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {problems.slice(0, limit).map((problem) => (
+                <s-table-row key={`${problem.line}-${problem.identifier}-${problem.reason}`}>
+                  <s-table-cell>{problem.line}</s-table-cell>
+                  <s-table-cell>{problem.identifier || "—"}</s-table-cell>
+                  <s-table-cell>{problem.kind ?? "Will not import"}</s-table-cell>
+                  <s-table-cell>{problem.reason}</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+
+          {problems.length > limit ? (
+            <s-paragraph>
+              <s-text color="subdued">
+                Showing the first {limit} of {problems.length}.
+                {download ? " The download has all of them." : ""}
+              </s-text>
+            </s-paragraph>
+          ) : null}
+        </>
+      )}
+    </s-section>
+  );
+}

--- a/app/components/imports/imports.test.ts
+++ b/app/components/imports/imports.test.ts
@@ -18,6 +18,10 @@ const dropZone = readFileSync(
   join(process.cwd(), "app", "components", "imports", "CsvDropZone.tsx"),
   "utf8",
 );
+const importForm = readFileSync(
+  join(process.cwd(), "app", "components", "imports", "ImportForm.tsx"),
+  "utf8",
+);
 
 describe("dry run stays the default", () => {
   it.each(routes)("%s commits only when explicitly asked", (name) => {
@@ -43,12 +47,20 @@ describe("recapture keeps its guard", () => {
 });
 
 describe("dropping a file", () => {
-  it.each(routes)("%s accepts a file as well as pasted text", (name) => {
-    const s = source(name);
-    expect(s).toContain("<CsvDropZone");
+  // The three routes rendered their own drop zone and textarea until they were collapsed
+  // onto one `ImportForm`. Checking the route source for `<CsvDropZone` stopped meaning
+  // anything at that point — so the guarantee is checked where it now lives, plus that
+  // each route actually goes through the thing that provides it. Two assertions instead
+  // of one, and neither can pass while the merchant has no way to drop a file.
+  it("the shared form offers a drop zone and keeps the textarea", () => {
+    expect(importForm).toContain("<CsvDropZone");
     // The textarea stays: a merchant fixing three rows after a failed dry run needs it,
     // and it is still what the form submits.
-    expect(s).toContain('name="csv"');
+    expect(importForm).toContain('name="csv"');
+  });
+
+  it.each(routes)("%s accepts a file as well as pasted text", (name) => {
+    expect(source(name)).toContain("<ImportForm");
   });
 
   it("tells the Polaris field its value changed", () => {
@@ -65,5 +77,97 @@ describe("dropping a file", () => {
 
   it("explains itself when the file cannot be read, rather than doing nothing", () => {
     expect(dropZone).toMatch(/paste its contents instead/i);
+  });
+});
+
+describe("the three imports are one import", () => {
+  /**
+   * The guard that existed on one of three paths.
+   *
+   * "You cannot commit before you have checked" was implemented in `app.imports.baselines`
+   * and nowhere else, and nothing in the other two said they were different on purpose.
+   * It lives in `ImportForm` now, which is what makes it true on all three at once — and
+   * what makes it impossible to lose from one of them.
+   */
+  it("blocks the commit until a dry run has found rows", () => {
+    expect(importForm).toMatch(/disabled=\{!ready \|\| undefined\}/);
+  });
+
+  it("still defaults to a dry run, so a missing intent falls safe", () => {
+    expect(importForm).toMatch(/name="intent"[\s\S]{0,80}value="dry-run"/);
+  });
+
+  it("marks the commit as the consequential one on every source", () => {
+    // Prices had a plain secondary button for the action that creates a campaign over a
+    // merchant's catalogue, while the other two used `tone="critical"`.
+    expect(importForm).toContain('tone="critical"');
+  });
+
+  it.each(routes)("%s no longer carries its own copy of the form", (name) => {
+    const s = source(name);
+
+    expect(s).not.toContain("<s-text-area");
+    expect(s).not.toContain("submitWith");
+    expect(s).not.toContain('<input type="hidden" name="intent"');
+  });
+
+  it.each(routes)("%s reports its counts as figures rather than a sentence", (name) => {
+    // Prices showed none at all; the other two ran four and five numbers together into
+    // one line of prose. `CountsRow` is how the campaign preview shows the same thing.
+    expect(source(name)).toContain("<ImportReport");
+  });
+
+  it("shows problem rows as a table, not a bullet list", () => {
+    // Two of the three used a list, which puts the line, the identifier and the reason
+    // into one sentence per row — so nothing lines up, and twenty bad rows cannot be
+    // scanned for the thing they have in common.
+    expect(importForm).toContain("<s-table");
+    expect(importForm).not.toContain("<s-unordered-list");
+  });
+
+  it("says how many rows were left out of the table it truncates", () => {
+    // A silent top-25 reads as "these are all of them".
+    expect(importForm).toMatch(/Showing the first \{limit\} of \{problems\.length\}/);
+  });
+});
+
+/**
+ * Source with its comments taken out.
+ *
+ * The repo has been caught by this before — the compliance check that rejects a native
+ * form element greps for `<form`, so the *word* in a comment trips it. The same thing
+ * happened here on the first run: the doc comment explaining why the two segment cards
+ * were merged quotes both of their old headings and the `variant="primary"` they each
+ * carried, so a check for "those headings are gone" failed on the note saying they had
+ * gone.
+ */
+const code = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+describe("making a segment is one decision", () => {
+  const segments = code(
+    readFileSync(join(process.cwd(), "app", "routes", "app.settings.segments.tsx"), "utf8"),
+  );
+
+  it("offers one create form, not two competing cards", () => {
+    expect(segments).not.toContain("New segment from a filter");
+    expect(segments).not.toContain("New segment from a list");
+    expect(segments).toContain('heading="New segment"');
+  });
+
+  it("has one black button on the page", () => {
+    // Two sibling cards each ending in a primary button is the two-black-buttons failure
+    // spread thin enough that neither card broke the rule on its own.
+    expect((segments.match(/variant="primary"/g) ?? []).length).toBe(1);
+  });
+
+  it("asks how the products are named, which is the only thing that differed", () => {
+    expect(segments).toContain("<s-choice-list");
+    expect(segments).toContain('<s-choice value="filter"');
+    expect(segments).toContain('<s-choice value="list"');
+  });
+
+  it("sends the intent that matches the choice", () => {
+    expect(segments).toMatch(/how === "filter" \? "create-filter" : "create-from-csv"/);
   });
 });

--- a/app/lib/ui/control-vocabulary.test.ts
+++ b/app/lib/ui/control-vocabulary.test.ts
@@ -104,11 +104,23 @@ describe("no button is labelled with a raw value", () => {
   const RAW_LABEL =
     /<s-button\b(?:(?!<\/s-button>)[\s\S])*?>\s*\{([a-z][A-Za-z0-9]*)\}\s*<\/s-button>/g;
 
+  /**
+   * A name that says "label" is somebody having decided the words.
+   *
+   * `ImportForm` takes a `checkLabel` prop and renders `{checkLabel}`, which the pattern
+   * above cannot tell from `{resolution}`. The difference is real and is in the name: a
+   * variable called a label holds a phrase a caller wrote, and the failure this check
+   * exists for is a *domain value* reaching the screen — a status, a kind, an action, a
+   * resolution. Naming the exemption by suffix rather than listing the file keeps the
+   * check meaningful in a component that grows another button.
+   */
+  const isLabel = (name: string) => /label$/i.test(name);
+
   const offenders = tsxFiles(APP).flatMap((path) => {
     const source = readFileSync(path, "utf8");
-    return [...source.matchAll(RAW_LABEL)].map(
-      (match) => `${path.replace(`${APP}/`, "")}: {${match[1]}}`,
-    );
+    return [...source.matchAll(RAW_LABEL)]
+      .filter((match) => !isLabel(match[1]))
+      .map((match) => `${path.replace(`${APP}/`, "")}: {${match[1]}}`);
   });
 
   it("finds none", () => {

--- a/app/lib/ui/section-tabs.test.ts
+++ b/app/lib/ui/section-tabs.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Every section's landing page is reachable from its own tab bar.
+ *
+ * `SectionTabs` matches the current path **exactly**, never by prefix — deliberately, and
+ * for a good reason: a section root like `/app/prices` is a prefix of every tab under it,
+ * so `startsWith` lights up the first tab on every page in the section.
+ *
+ * The consequence nobody checked is that an index route which is not *in* the list can
+ * never be current. `/app/imports` — the list of files a merchant has imported, and where
+ * the nav item points — rendered a bar of four links with nothing selected, and once you
+ * left it there was no way back. Prices and Settings both listed theirs; Imports did not,
+ * and nothing said which was the mistake.
+ *
+ * Derived from the routes directory rather than a second hand-kept list, the way
+ * `legacy-routes.test.ts` is: a list of sections maintained here would go stale in exactly
+ * the way this is checking for.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROUTES = join(process.cwd(), "app", "routes");
+
+/**
+ * Every layout route that renders a `SectionTabs`, with the hrefs it lists.
+ *
+ * A layout route is `app.<section>.tsx` with an `app.<section>._index.tsx` beside it —
+ * which is what having a landing page means in flat-routes.
+ */
+function sections() {
+  const files = readdirSync(ROUTES);
+
+  return files
+    .filter((file) => /^app\.[a-z-]+\.tsx$/.test(file))
+    .map((file) => ({ file, source: readFileSync(join(ROUTES, file), "utf8") }))
+    .filter(({ source }) => source.includes("<SectionTabs"))
+    .map(({ file, source }) => ({
+      file,
+      section: file.replace(/^app\./, "").replace(/\.tsx$/, ""),
+      hasIndex: files.includes(file.replace(/\.tsx$/, "._index.tsx")),
+      hrefs: [...source.matchAll(/href: "([^"]+)"/g)].map((match) => match[1]),
+    }));
+}
+
+const SECTIONS = sections();
+
+describe("a section's tab bar lists the section's own index", () => {
+  it("finds the tabbed sections", () => {
+    // Prices, imports, settings.
+    expect(SECTIONS.map((s) => s.section).sort()).toEqual(["imports", "prices", "settings"]);
+  });
+
+  it("every one of them has a landing page", () => {
+    expect(SECTIONS.filter((s) => !s.hasIndex).map((s) => s.file)).toEqual([]);
+  });
+
+  it("lists that landing page as a tab, so it can be current and can be returned to", () => {
+    const missing = SECTIONS.filter((s) => !s.hrefs.includes(`/app/${s.section}`)).map(
+      (s) => `${s.file}: no tab for /app/${s.section}`,
+    );
+
+    expect(
+      missing,
+      "SectionTabs matches exactly, so an index that is not listed renders a bar with nothing selected",
+    ).toEqual([]);
+  });
+
+  it("puts it first, because it is what the nav item points at", () => {
+    const wrong = SECTIONS.filter((s) => s.hrefs[0] !== `/app/${s.section}`).map((s) => s.file);
+
+    expect(wrong).toEqual([]);
+  });
+
+  it("names every tab a route that exists", () => {
+    const files = readdirSync(ROUTES);
+    const routeFor = (href: string) => {
+      const flat = `${href.replace(/^\//, "").replace(/\//g, ".")}`;
+      return files.includes(`${flat}.tsx`) || files.includes(`${flat}._index.tsx`);
+    };
+
+    const dangling = SECTIONS.flatMap((s) =>
+      s.hrefs.filter((href) => !routeFor(href)).map((href) => `${s.file}: ${href}`),
+    );
+
+    expect(dangling).toEqual([]);
+  });
+});

--- a/app/routes/app.imports.baselines.tsx
+++ b/app/routes/app.imports.baselines.tsx
@@ -10,9 +10,7 @@
  * so reviewing before writing is the normal path rather than the careful one.
  */
 
-import { humanise } from "../lib/format/label";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useRef } from "react";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -21,16 +19,18 @@ import { ensureShop } from "../services/shop.server";
 import { shopCurrency } from "../services/settings.server";
 import { importBaselines, type BaselineImportResult } from "../services/baseline-import.server";
 import { importErrorCsv } from "../lib/reporting/baseline-errors";
-import { downloadCsv } from "../lib/reporting/csv";
 import { linesOf } from "../lib/reporting/lines";
 import { actorFor } from "../lib/audit/actor";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
-import { EmptyState } from "../components/AsyncState";
-import { UnsavedChanges } from "../components/UnsavedChanges";
-import { CsvDropZone } from "../components/imports/CsvDropZone";
+import { formatCount } from "../lib/format/display";
+import {
+  ImportForm,
+  ImportReport,
+  type ImportProblem,
+} from "../components/imports/ImportForm";
 
 export const loader = withGuard("/app/imports/baselines", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -81,23 +81,16 @@ export default function ImportBaselines() {
   const data = fetcher.data;
   const result = data?.result;
 
-  const form = useRef<HTMLFormElement>(null);
-  const intent = useRef<HTMLInputElement>(null);
-
-  const submitWith = (value: string) => {
-    if (intent.current) intent.current.value = value;
-    form.current?.requestSubmit();
-  };
+  const problems: ImportProblem[] = result
+    ? [
+        ...result.invalid.map((p) => ({ ...p, kind: "Will not parse" })),
+        ...result.unmatched.map((p) => ({ ...p, kind: "No match" })),
+        ...result.ambiguous.map((p) => ({ ...p, kind: "Matches several" })),
+      ].sort((a, b) => a.line - b.line)
+    : [];
 
   return (
     <PageShell heading="Import baselines">
-      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
-          the import runs. */}
-      <UnsavedChanges
-        form={form}
-        describe="this import"
-        saved={Boolean(fetcher.data)}
-      />
       {data ? (
         <s-banner tone={data.ok ? "success" : "critical"}>
           <s-paragraph>{data.message}</s-paragraph>
@@ -105,62 +98,51 @@ export default function ImportBaselines() {
         </s-banner>
       ) : null}
 
-      <s-section heading="Your reference prices">
-        <s-paragraph>
-          <s-text>
-            Every campaign computes from a variant&rsquo;s baseline, not from its current
-            price. If you keep an MSRP or list price elsewhere, import it here and
-            &ldquo;20% off&rdquo; will mean 20% off that number — permanently, however
-            many campaigns run in between.
-          </s-text>
-        </s-paragraph>
-        <s-paragraph>
-          <s-text>
-            One row per variant: a SKU, barcode or variant ID, then the price. A
-            compare-at and a currency column are optional. Prices are read in {currency}{" "}
-            unless a row says otherwise, and must be plain numbers — 1299.00, not
-            $1,299.00.
-          </s-text>
-        </s-paragraph>
+      <ImportForm
+        heading="Your reference prices"
+        fetcher={fetcher}
+        busy={busy}
+        ready={result?.ready ?? null}
+        commitLabel={(ready) => `Import ${formatCount(ready)} baselines`}
+        placeholder={"Variant SKU,Price\nCH-1,129.00\nCH-2,149.00"}
+        description={
+          <>
+            <s-paragraph>
+              <s-text>
+                Every campaign computes from a variant&rsquo;s baseline, not from its
+                current price. If you keep an MSRP or list price elsewhere, import it here
+                and &ldquo;20% off&rdquo; will mean 20% off that number — permanently,
+                however many campaigns run in between.
+              </s-text>
+            </s-paragraph>
+            <s-paragraph>
+              <s-text>
+                One row per variant: a SKU, barcode or variant ID, then the price. A
+                compare-at and a currency column are optional. Prices are read in{" "}
+                {currency} unless a row says otherwise, and must be plain numbers —
+                1299.00, not $1,299.00.
+              </s-text>
+            </s-paragraph>
+          </>
+        }
+      />
 
-        <fetcher.Form method="post" ref={form}>
-          {/* `s-button` takes no name/value, so the intent rides in a hidden field the
-              buttons set before submitting. One form, because both actions read the
-              same rows and duplicating the textarea would let them drift apart. */}
-          <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
-          <s-stack gap="base">
-                        <CsvDropZone target="csv" />
-
-                        <s-text-area
-              name="csv"
-              label="Rows"
-              rows={12}
-              details="One variant per line. Paste straight from a spreadsheet."
-            />
-            <s-stack direction="inline" gap="base">
-              <s-button
-                type="button"
-                variant="primary"
-                loading={busy || undefined}
-                onClick={() => submitWith("dry-run")}
-              >
-                Check the file
-              </s-button>
-              <s-button
-                type="button"
-                tone="critical"
-                loading={busy || undefined}
-                disabled={!result || result.ready === 0 || undefined}
-                onClick={() => submitWith("commit")}
-              >
-                Import {result?.ready ?? 0} baselines
-              </s-button>
-            </s-stack>
-          </s-stack>
-        </fetcher.Form>
-      </s-section>
-
-      {result ? <ImportReport result={result} /> : null}
+      {result ? (
+        <ImportReport
+          heading={result.dryRun ? "What would happen" : "What happened"}
+          counts={[
+            { label: "Rows read", value: result.total },
+            { label: "Ready", value: result.ready },
+            { label: "Already correct", value: result.unchanged },
+            { label: "Need attention", value: problems.length },
+          ]}
+          problems={problems}
+          download={{
+            filename: "baseline-import-errors.csv",
+            csv: () => importErrorCsv(result),
+          }}
+        />
+      ) : null}
 
       <s-section slot="aside" heading="Why this is checked first">
         <s-paragraph>
@@ -179,69 +161,6 @@ export default function ImportBaselines() {
         </s-paragraph>
       </s-section>
     </PageShell>
-  );
-}
-
-function ImportReport({ result }: { result: BaselineImportResult }) {
-  const problems = [
-    ...result.invalid.map((p) => ({ ...p, kind: "Will not parse" })),
-    ...result.unmatched.map((p) => ({ ...p, kind: "No match" })),
-    ...result.ambiguous.map((p) => ({ ...p, kind: "Matches several" })),
-  ].sort((a, b) => a.line - b.line);
-
-  return (
-    <s-section heading={result.dryRun ? "What would happen" : "What happened"}>
-      <s-paragraph>
-        <s-text>
-          {result.total} rows read · {result.ready} ready · {result.unchanged} already
-          correct · {problems.length} need attention
-        </s-text>
-      </s-paragraph>
-
-      {problems.length === 0 ? (
-        <EmptyState
-          title="Every row matched a variant and validated"
-          description="Nothing was left out, so the counts above account for the whole file."
-        />
-      ) : (
-        <>
-          <s-stack direction="inline" gap="base">
-            <s-paragraph>
-              <s-text>
-                These rows were left out. Everything else is unaffected — one bad row
-                never fails the file.
-              </s-text>
-            </s-paragraph>
-            <s-button
-              type="button"
-              variant="tertiary"
-              onClick={() => downloadCsv("baseline-import-errors.csv", importErrorCsv(result))}
-            >
-              Download the list
-            </s-button>
-          </s-stack>
-
-          <s-table>
-            <s-table-header-row>
-              <s-table-header listSlot="kicker" format="numeric">Line</s-table-header>
-              <s-table-header listSlot="primary">Identifier</s-table-header>
-              <s-table-header listSlot="inline">Problem</s-table-header>
-              <s-table-header listSlot="secondary">What to do</s-table-header>
-            </s-table-header-row>
-            <s-table-body>
-              {problems.slice(0, 25).map((problem) => (
-                <s-table-row key={`${problem.line}-${problem.identifier}`}>
-                  <s-table-cell>{problem.line}</s-table-cell>
-                  <s-table-cell>{problem.identifier || "—"}</s-table-cell>
-                  <s-table-cell>{humanise(problem.kind)}</s-table-cell>
-                  <s-table-cell>{problem.reason}</s-table-cell>
-                </s-table-row>
-              ))}
-            </s-table-body>
-          </s-table>
-        </>
-      )}
-    </s-section>
   );
 }
 

--- a/app/routes/app.imports.costs.tsx
+++ b/app/routes/app.imports.costs.tsx
@@ -14,7 +14,6 @@
  */
 
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useRef } from "react";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -24,15 +23,18 @@ import { ensureShop } from "../services/shop.server";
 import { shopCurrency } from "../services/settings.server";
 import { importCosts, type CostImportResult } from "../services/cost-import.server";
 import { costErrorCsv } from "../lib/reporting/cost-errors";
-import { downloadCsv } from "../lib/reporting/csv";
 import { actorFor } from "../lib/audit/actor";
 import { linesOf } from "../lib/reporting/lines";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
-import { UnsavedChanges } from "../components/UnsavedChanges";
-import { CsvDropZone } from "../components/imports/CsvDropZone";
+import { formatCount } from "../lib/format/display";
+import {
+  ImportForm,
+  ImportReport,
+  type ImportProblem,
+} from "../components/imports/ImportForm";
 
 export const loader = withGuard("/app/imports/costs", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -90,28 +92,18 @@ export default function ImportCosts() {
   const data = fetcher.data;
   const result = data?.result;
 
-  const form = useRef<HTMLFormElement>(null);
-  const intent = useRef<HTMLInputElement>(null);
-
-  const submitWith = (value: string) => {
-    if (intent.current) intent.current.value = value;
-    form.current?.requestSubmit();
-  };
 
   const coverage = variants === 0 ? 0 : Math.round((withCost / variants) * 100);
-  const problems = result
-    ? [...result.invalid, ...result.unmatched, ...result.ambiguous]
+  const problems: ImportProblem[] = result
+    ? [
+        ...result.invalid.map((p) => ({ ...p, kind: "Will not parse" })),
+        ...result.unmatched.map((p) => ({ ...p, kind: "No match" })),
+        ...result.ambiguous.map((p) => ({ ...p, kind: "Matches several" })),
+      ].sort((a, b) => a.line - b.line)
     : [];
 
   return (
     <PageShell heading="Import costs">
-      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
-          the import runs. */}
-      <UnsavedChanges
-        form={form}
-        describe="this import"
-        saved={Boolean(fetcher.data)}
-      />
       {data ? (
         <s-banner tone={data.ok ? "success" : "critical"}>
           <s-paragraph>{data.message}</s-paragraph>
@@ -119,91 +111,51 @@ export default function ImportCosts() {
         </s-banner>
       ) : null}
 
-      <s-section heading="What your cost floors can protect">
-        <s-paragraph>
-          <s-text>
-            {withCost} of {variants} variants have a cost ({coverage}%). Cost-based
-            guardrails only constrain variants that have one — the rest are skipped, so
-            a low number here means &ldquo;never price below cost&rdquo; is doing less
-            than it looks.
-          </s-text>
-        </s-paragraph>
-        <s-paragraph>
-          <s-text>
-            One row per variant: a SKU, barcode or variant ID, then the cost. Costs are
-            read in {currency} unless a row says otherwise, and must be plain numbers —
-            12.50, not $12.50. A file exported from Matrixify works as it is.
-          </s-text>
-        </s-paragraph>
-
-        <fetcher.Form method="post" ref={form}>
-          {/* `s-button` takes no name/value, so the intent rides in a hidden field the
-              buttons set before submitting. One form, because both actions read the same
-              rows and duplicating the field would let them drift apart. */}
-          <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
-          <s-stack gap="base">
-            <CsvDropZone target="csv" />
-
-            <s-text-area
-              name="csv"
-              label="Rows"
-              rows={12}
-              placeholder={"Variant SKU,Variant Cost\nCH-1,12.50\nCH-2,14.00"}
-              details="Paste straight from a spreadsheet. A header row is read if there is one."
-            />
-
-            <s-stack direction="inline" gap="base">
-              <s-button
-                type="button"
-                variant="primary"
-                loading={busy || undefined}
-                onClick={() => submitWith("dry-run")}
-              >
-                Check without importing
-              </s-button>
-              <s-button
-                type="button"
-                tone="critical"
-                loading={busy || undefined}
-                onClick={() => submitWith("commit")}
-              >
-                Import these costs
-              </s-button>
-            </s-stack>
-          </s-stack>
-        </fetcher.Form>
-      </s-section>
+      <ImportForm
+        heading="What your cost floors can protect"
+        fetcher={fetcher}
+        busy={busy}
+        ready={result?.ready ?? null}
+        checkLabel="Check without importing"
+        commitLabel={(ready) => `Import ${formatCount(ready)} costs`}
+        placeholder={"Variant SKU,Variant Cost\nCH-1,12.50\nCH-2,14.00"}
+        description={
+          <>
+            <s-paragraph>
+              <s-text>
+                {withCost} of {variants} variants have a cost ({coverage}%). Cost-based
+                guardrails only constrain variants that have one — the rest are skipped,
+                so a low number here means &ldquo;never price below cost&rdquo; is doing
+                less than it looks.
+              </s-text>
+            </s-paragraph>
+            <s-paragraph>
+              <s-text>
+                One row per variant: a SKU, barcode or variant ID, then the cost. Costs
+                are read in {currency} unless a row says otherwise, and must be plain
+                numbers — 12.50, not $12.50. A file exported from Matrixify works as it
+                is.
+              </s-text>
+            </s-paragraph>
+          </>
+        }
+      />
 
       {result ? (
-        <s-section heading="What happened">
-          <s-paragraph>
-            <s-text>
-              {result.total} rows read · {result.ready} ready · {result.written} written ·{" "}
-              {result.unchanged} unchanged · {problems.length} need attention
-            </s-text>
-          </s-paragraph>
-
-          {problems.length > 0 ? (
-            <>
-              <s-button
-                type="button"
-                variant="tertiary"
-                onClick={() => downloadCsv("cost-import-errors.csv", costErrorCsv(result))}
-              >
-                Download the rows that need fixing (CSV)
-              </s-button>
-
-              <s-unordered-list>
-                {problems.slice(0, 25).map((problem) => (
-                  <s-list-item key={`${problem.line}-${problem.identifier}`}>
-                    Line {problem.line} ({problem.identifier || "no identifier"}):{" "}
-                    {problem.reason}
-                  </s-list-item>
-                ))}
-              </s-unordered-list>
-            </>
-          ) : null}
-        </s-section>
+        <ImportReport
+          heading={result.dryRun ? "What would happen" : "What happened"}
+          counts={[
+            { label: "Rows read", value: result.total },
+            { label: "Ready", value: result.ready },
+            { label: "Written", value: result.written },
+            { label: "Need attention", value: problems.length },
+          ]}
+          problems={problems}
+          download={{
+            filename: "cost-import-errors.csv",
+            csv: () => costErrorCsv(result),
+          }}
+        />
       ) : null}
     </PageShell>
   );

--- a/app/routes/app.imports.prices.tsx
+++ b/app/routes/app.imports.prices.tsx
@@ -8,7 +8,6 @@
  */
 
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useRef } from "react";
 import { redirect, useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -27,8 +26,12 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import prisma from "../db.server";
 import { PageShell } from "../components/PageShell";
-import { UnsavedChanges } from "../components/UnsavedChanges";
-import { CsvDropZone } from "../components/imports/CsvDropZone";
+import { formatCount } from "../lib/format/display";
+import {
+  ImportForm,
+  ImportReport,
+  type ImportProblem,
+} from "../components/imports/ImportForm";
 
 export const loader = withGuard("/app/imports/prices", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -97,95 +100,63 @@ export default function ImportPrices() {
   const busy = fetcher.state !== "idle";
   const result = fetcher.data?.result;
 
-  const form = useRef<HTMLFormElement>(null);
-  const intent = useRef<HTMLInputElement>(null);
-
-  const submitWith = (value: string) => {
-    if (intent.current) intent.current.value = value;
-    form.current?.requestSubmit();
-  };
-
-  const problems = result
-    ? [...result.invalid, ...result.unmatched, ...result.ambiguous, ...result.duplicates]
+  const problems: ImportProblem[] = result
+    ? [
+        ...result.invalid.map((p) => ({ ...p, kind: "Will not parse" })),
+        ...result.unmatched.map((p) => ({ ...p, kind: "No match" })),
+        ...result.ambiguous.map((p) => ({ ...p, kind: "Matches several" })),
+        ...result.duplicates.map((p) => ({ ...p, kind: "Listed twice" })),
+      ].sort((a, b) => a.line - b.line)
     : [];
 
   return (
     <PageShell heading="Import prices">
-      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
-          the import runs. */}
-      <UnsavedChanges
-        form={form}
-        describe="this import"
-        saved={Boolean(fetcher.data)}
-      />
       {fetcher.data ? (
         <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
           <s-paragraph>{fetcher.data.message}</s-paragraph>
         </s-banner>
       ) : null}
 
-      <s-section heading="Set prices from a spreadsheet">
-        <s-paragraph>
-          <s-text>
-            This creates a campaign rather than changing prices straight away. You get a
-            preview of every product first, your guardrails still apply, and you can undo
-            the whole thing in one click &mdash; none of which a direct import would give
-            you.
-          </s-text>
-        </s-paragraph>
-        <s-paragraph>
-          <s-text>
-            One row per variant: a SKU, barcode or variant ID, then the price. Prices are
-            read in {currency} and must be plain numbers. A Matrixify export works as it
-            is.
-          </s-text>
-        </s-paragraph>
+      <ImportForm
+        heading="Set prices from a spreadsheet"
+        fetcher={fetcher}
+        busy={busy}
+        ready={result?.ready ?? null}
+        commitLabel={(ready) => `Create a campaign from ${formatCount(ready)} rows`}
+        placeholder={"Variant SKU,Variant Price\nCH-1,129.00\nCH-2,149.00"}
+        description={
+          <>
+            <s-paragraph>
+              <s-text>
+                This creates a campaign rather than changing prices straight away. You get
+                a preview of every product first, your guardrails still apply, and you can
+                undo the whole thing in one click &mdash; none of which a direct import
+                would give you.
+              </s-text>
+            </s-paragraph>
+            <s-paragraph>
+              <s-text>
+                One row per variant: a SKU, barcode or variant ID, then the price. Prices
+                are read in {currency} and must be plain numbers. A Matrixify export works
+                as it is.
+              </s-text>
+            </s-paragraph>
+          </>
+        }
+      >
+        <s-text-field name="name" label="Call this" value="Imported prices" />
+      </ImportForm>
 
-        <fetcher.Form method="post" ref={form}>
-          <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
-          <s-stack gap="base">
-            <s-text-field name="name" label="Call this" value="Imported prices" />
-            <CsvDropZone target="csv" />
-
-            <s-text-area
-              name="csv"
-              label="Rows"
-              rows={12}
-              placeholder={"Variant SKU,Variant Price\nCH-1,129.00\nCH-2,149.00"}
-              details="Paste straight from a spreadsheet."
-            />
-
-            <s-stack direction="inline" gap="base">
-              <s-button
-                type="button"
-                variant="primary"
-                loading={busy || undefined}
-                onClick={() => submitWith("dry-run")}
-              >
-                Check the file
-              </s-button>
-              <s-button
-                type="button"
-                loading={busy || undefined}
-                onClick={() => submitWith("commit")}
-              >
-                Create a campaign from it
-              </s-button>
-            </s-stack>
-          </s-stack>
-        </fetcher.Form>
-      </s-section>
-
-      {problems.length > 0 ? (
-        <s-section heading="Rows that need fixing">
-          <s-unordered-list>
-            {problems.slice(0, 25).map((problem) => (
-              <s-list-item key={`${problem.line}-${problem.identifier}`}>
-                Line {problem.line} ({problem.identifier || "no identifier"}): {problem.reason}
-              </s-list-item>
-            ))}
-          </s-unordered-list>
-        </s-section>
+      {result ? (
+        <ImportReport
+          heading={result.dryRun ? "What would happen" : "What happened"}
+          counts={[
+            { label: "Rows read", value: result.total },
+            { label: "Ready", value: result.ready },
+            { label: "Need attention", value: problems.length },
+          ]}
+          problems={problems}
+        />
       ) : null}
     </PageShell>
   );

--- a/app/routes/app.imports.tsx
+++ b/app/routes/app.imports.tsx
@@ -13,8 +13,16 @@ import { SectionTabs } from "../components/SectionTabs";
 export default function ImportsSection() {
   return (
     <>
+      {/* The section's own landing page is the first tab.
+
+          It was not in this list at all, so `/app/imports` — the list of files a merchant
+          has imported, and where the nav item points — rendered a bar of four links with
+          *nothing selected*, and no way back to it once you left. `SectionTabs` matches
+          the current path exactly, deliberately (a section root prefixes every tab under
+          it), which is precisely why an index that is not listed can never be current. */}
       <SectionTabs
         tabs={[
+          { href: "/app/imports", label: "Files" },
           { href: "/app/imports/prices", label: "Prices" },
           { href: "/app/imports/baselines", label: "Baselines" },
           { href: "/app/imports/costs", label: "Costs" },

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -8,6 +8,7 @@
  * watches products join it unreviewed.
  */
 
+import { useState } from "react";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -26,6 +27,9 @@ import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
 import { EmptyState } from "../components/AsyncState";
+import { ActionRow } from "../components/ActionRow";
+import { FieldGrid, FullRow } from "../components/FieldGrid";
+import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings/segments", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -216,86 +220,7 @@ export default function Segments() {
         )}
       </s-section>
 
-      <s-section heading="New segment from a filter">
-        <fetcher.Form method="post">
-          <input type="hidden" name="intent" value="create-filter" />
-          <s-stack gap="base">
-            <s-text-field name="name" label="Name" placeholder="Summer collection" required />
-
-            <s-select name="collection" label="Collection">
-              <s-option value="" defaultSelected>
-                Any collection
-              </s-option>
-              {available.collections.map((c) => (
-                <s-option key={c} value={c}>
-                  {c}
-                </s-option>
-              ))}
-            </s-select>
-
-            <s-select name="tag" label="Tag">
-              <s-option value="" defaultSelected>
-                Any tag
-              </s-option>
-              {available.tags.map((t) => (
-                <s-option key={t} value={t}>
-                  {t}
-                </s-option>
-              ))}
-            </s-select>
-
-            <s-select name="vendor" label="Vendor">
-              <s-option value="" defaultSelected>
-                Any vendor
-              </s-option>
-              {available.vendors.map((v) => (
-                <s-option key={v} value={v}>
-                  {v}
-                </s-option>
-              ))}
-            </s-select>
-
-            <s-select name="kind" label="How it should behave">
-              <s-option value="DYNAMIC" defaultSelected>
-                Dynamic &mdash; re-check the filter every time
-              </s-option>
-              <s-option value="FROZEN">
-                Frozen &mdash; pin the products it matches right now
-              </s-option>
-            </s-select>
-
-            <s-button type="submit" variant="primary" loading={busy || undefined}>
-              Create segment
-            </s-button>
-          </s-stack>
-        </fetcher.Form>
-      </s-section>
-
-      <s-section heading="New segment from a list">
-        <s-paragraph>
-          <s-text>
-            Paste SKUs, barcodes or Shopify IDs — one per line, or the first column of a
-            CSV. This always makes a frozen segment: you are naming specific products,
-            so the list is pinned to exactly those.
-          </s-text>
-        </s-paragraph>
-        <fetcher.Form method="post">
-          <input type="hidden" name="intent" value="create-from-csv" />
-          <s-stack gap="base">
-            <s-text-field name="name" label="Name" placeholder="Clearance list" required />
-            <s-text-area
-              name="csv"
-              label="SKUs, barcodes or IDs"
-              rows={8}
-              placeholder={"SKU-1\nSKU-2\n9781234567897"}
-              details="One per line. Anything we cannot match is reported rather than skipped."
-            />
-            <s-button type="submit" variant="primary" loading={busy || undefined}>
-              Match and create
-            </s-button>
-          </s-stack>
-        </fetcher.Form>
-      </s-section>
+      <NewSegment available={available} fetcher={fetcher} busy={busy} />
 
       <s-section slot="aside" heading="Dynamic or frozen">
         <s-paragraph>
@@ -322,6 +247,158 @@ export default function Segments() {
         </s-paragraph>
       </s-section>
     </PageShell>
+  );
+}
+
+/**
+ * Making a segment, as one decision instead of two cards.
+ *
+ * There were two sibling sections — "New segment from a filter" and "New segment from a
+ * list" — each ending in its own black `variant="primary"` button. A merchant reading
+ * down the page met two equally loud answers to "make a segment" and had to read both
+ * cards to discover they differ only in *how the products are named*. Two black buttons
+ * is the failure `ActionRow` names, spread across two cards so that neither card broke
+ * the rule on its own.
+ *
+ * One card, one name field, and a choice. `s-choice-list` is what a choice between two
+ * mutually exclusive things is — one of the components the epic noted the app had never
+ * used, and this is the case it is for.
+ *
+ * ## Why the behaviour select disappears for a list
+ *
+ * A pasted list of SKUs is always frozen: naming specific products *is* pinning them, and
+ * there is no filter left to re-check. The old CSV card knew that and said so in a
+ * sentence; showing a Dynamic/Frozen select that only applies to one branch would offer a
+ * choice that is not there.
+ */
+function NewSegment({
+  available,
+  fetcher,
+  busy,
+}: {
+  available: { collections: string[]; tags: string[]; vendors: string[] };
+  fetcher: ReturnType<typeof useFetcher<ActionData>>;
+  busy: boolean;
+}) {
+  const [how, setHow] = useState<"filter" | "list">("filter");
+
+  return (
+    <s-section heading="New segment">
+      <fetcher.Form method="post">
+        {/* The two branches were two intents on two forms. One form, and the intent
+            follows the choice — so the name field cannot be filled in on one card and
+            submitted from the other. */}
+        <input
+          type="hidden"
+          name="intent"
+          value={how === "filter" ? "create-filter" : "create-from-csv"}
+        />
+
+        <s-stack gap={SPACE.section}>
+          <FieldGrid>
+            <FullRow>
+              <s-text-field name="name" label="Name" placeholder="Summer collection" required />
+            </FullRow>
+
+            <FullRow>
+              {/* Uncontrolled, like every other field in this app: `defaultSelected` on
+                  the choice, and the state here only decides which fields to render
+                  underneath. Driving the selection from React state as well would put two
+                  owners on one value, and `docs/polaris-notes.md` records what happens
+                  when a Polaris component's own value handling is fought — it wins
+                  quietly. */}
+              <s-choice-list
+                name="how"
+                label="Which products"
+                onChange={(event) =>
+                  setHow(event.currentTarget.values?.includes("list") ? "list" : "filter")
+                }
+              >
+                {/* The supporting line is a slot, not a prop. `s-choice` is one of the
+                    components whose React types `Omit` their `details`, because it is
+                    `ComponentChildren` rather than a string — passing it as an attribute
+                    compiles nowhere and renders nothing. */}
+                <s-choice value="filter" defaultSelected>
+                  Everything matching a filter
+                  <s-text slot="details" color="subdued">
+                    Collection, tag or vendor.
+                  </s-text>
+                </s-choice>
+                <s-choice value="list">
+                  A list of products I name
+                  <s-text slot="details" color="subdued">
+                    SKUs, barcodes or Shopify IDs you paste. Always frozen — you are
+                    naming specific products, so the list is pinned to exactly those.
+                  </s-text>
+                </s-choice>
+              </s-choice-list>
+            </FullRow>
+
+            {how === "filter" ? (
+              <>
+                <s-select name="collection" label="Collection">
+                  <s-option value="" defaultSelected>
+                    Any collection
+                  </s-option>
+                  {available.collections.map((c) => (
+                    <s-option key={c} value={c}>
+                      {c}
+                    </s-option>
+                  ))}
+                </s-select>
+
+                <s-select name="tag" label="Tag">
+                  <s-option value="" defaultSelected>
+                    Any tag
+                  </s-option>
+                  {available.tags.map((t) => (
+                    <s-option key={t} value={t}>
+                      {t}
+                    </s-option>
+                  ))}
+                </s-select>
+
+                <s-select name="vendor" label="Vendor">
+                  <s-option value="" defaultSelected>
+                    Any vendor
+                  </s-option>
+                  {available.vendors.map((v) => (
+                    <s-option key={v} value={v}>
+                      {v}
+                    </s-option>
+                  ))}
+                </s-select>
+
+                <s-select name="kind" label="How it should behave">
+                  <s-option value="DYNAMIC" defaultSelected>
+                    Dynamic &mdash; re-check the filter every time
+                  </s-option>
+                  <s-option value="FROZEN">
+                    Frozen &mdash; pin the products it matches right now
+                  </s-option>
+                </s-select>
+              </>
+            ) : (
+              <FullRow>
+                <s-text-area
+                  name="csv"
+                  label="SKUs, barcodes or IDs"
+                  rows={8}
+                  placeholder={"SKU-1\nSKU-2\n9781234567897"}
+                  details="One per line, or the first column of a CSV. Anything we cannot match is reported rather than skipped."
+                />
+              </FullRow>
+            )}
+          </FieldGrid>
+
+          <ActionRow>
+            <s-button type="submit" variant="primary" loading={busy || undefined}>
+              Create segment
+            </s-button>
+          </ActionRow>
+        </s-stack>
+      </fetcher.Form>
+    </s-section>
   );
 }
 


### PR DESCRIPTION
Closes #403.

## `/app/imports` was not in its own tab bar

`SectionTabs` matches the current path **exactly** — deliberately, because a section root prefixes every tab under it and `startsWith` would light up the first tab everywhere. The consequence nobody checked: an index that is not *listed* can never be current. So the page the nav item points at rendered a bar of four links with **nothing selected**, and once you left it there was no way back. Prices and Settings both listed theirs.

The test derives the tabbed sections from the routes directory rather than a second hand-kept list, and checks every one lists its own index, lists it first, and points every tab at a route that exists.

## The three import forms were one form written three times

They had drifted in five ways. Four are cosmetic. The fifth is not:

| | prices | baselines | costs |
|---|---|---|---|
| commit marked consequential | no | yes | yes |
| **commit blocked until a dry run** | **no** | **yes** | **no** |
| problems shown as | bullet list | table | bullet list |
| counts | **none** | four numbers | five numbers |
| errors downloadable | **no** | yes | yes |

*"You cannot commit before you have checked"* existed on one of the three paths that write to a merchant's catalogue, and nothing said the other two were different on purpose. `ImportForm` has it, so all three do and none of them can lose it separately. Dry run is still what a missing or misspelled intent falls back to.

The report is one component too. Problems are a **table**, not a bullet list — a list puts the line, the identifier and the reason into one sentence per row, so nothing lines up and twenty bad rows cannot be scanned for what they have in common, which is the only question worth asking of that list. The top-25 truncation now says so instead of reading as "these are all of them".

## Segments had the two-black-buttons failure, spread across two cards

"New segment from a filter" and "New segment from a list", each ending in its own `variant="primary"` — so neither card broke the one-primary rule on its own, and a merchant had to read both to discover they differ only in *how the products are named*. One card now, with an `s-choice-list` asking exactly that. The Dynamic/Frozen select appears only for the filter branch, because a pasted list of SKUs is always frozen — naming specific products *is* pinning them.

## Four existing tests caught this refactor

Which is the best thing that happened in it. The drop zone and the unsaved-work guard were asserted against each *route's* source and had moved into the shared component — both now pin the guarantee where it lives **and** check the routes go through it, so "route renders ImportForm" is only accepted while ImportForm still guards. The report's clean case had quietly become a loose paragraph again. And a button labelled `{checkLabel}` tripped the raw-value scan; a name ending in "label" is exempt now, by suffix rather than by filename.

My own new test then tripped the repo's oldest trap: a check for "those two headings are gone" **failed on the doc comment explaining that they had gone**. It strips comments before scanning.

All eight new assertions were mutated and confirmed failing.

2000 tests pass, 20 new. Typecheck, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)