### PR TITLE
Every distance in the app is named

### DIFF
--- a/app/components/BaselineTable.tsx
+++ b/app/components/BaselineTable.tsx
@@ -1,4 +1,5 @@
 import { humanise } from "../lib/format/label";
+import { ActionRow } from "./ActionRow";
 import type { BaselineRow } from "../services/baseline-browser.server";
 
 /**
@@ -47,7 +48,11 @@ export function BaselineTable({
             </s-table-cell>
             <s-table-cell>{row.source ? humanise(row.source) : "—"}</s-table-cell>
             <s-table-cell>
-              <s-stack direction="inline" gap="small">
+              {/* `gap="small"` -- which the scale documents as *larger* than
+                  `small-100` -- so the two halves of one cell sat further apart than
+                  anything else on the row. Two buttons that do the same kind of job are
+                  an ActionRow. */}
+              <ActionRow>
                 <s-button variant="tertiary" onClick={() => onShowHistory(row.variantGid)}>
                   History
                 </s-button>
@@ -62,7 +67,7 @@ export function BaselineTable({
                 >
                   Shopify
                 </s-button>
-              </s-stack>
+              </ActionRow>
             </s-table-cell>
           </s-table-row>
         ))}

--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -46,7 +46,7 @@ export function DraftPreview({ preview }: { preview: Preview | null }) {
   }
 
   return (
-    <s-stack gap="base">
+    <s-stack gap={SPACE.section}>
       <s-paragraph>
         <s-text>
           <strong>{formatCount(preview.changing)}</strong> of {formatCount(preview.matched)}{" "}

--- a/app/components/ErrorScreen.tsx
+++ b/app/components/ErrorScreen.tsx
@@ -14,6 +14,7 @@
 import { ActionRow } from "./ActionRow";
 import { PageShell } from "./PageShell";
 import { helpLabelFor, helpPathFor } from "../lib/errors/help-links";
+import { SPACE } from "../lib/ui/spacing";
 
 export interface ErrorScreenProps {
   errorId: string;
@@ -41,7 +42,7 @@ export function ErrorScreen({
           <s-paragraph>{userMessage}</s-paragraph>
         </s-banner>
 
-        <s-stack gap="base">
+        <s-stack gap={SPACE.section}>
           <s-paragraph>
             <s-text>
               No prices were changed by this error. If a run was in progress, open the

--- a/app/components/FeedbackForm.tsx
+++ b/app/components/FeedbackForm.tsx
@@ -1,4 +1,5 @@
 import { useFetcher } from "react-router";
+import { SPACE } from "../lib/ui/spacing";
 
 /**
  * The feedback box, on every screen.
@@ -28,7 +29,7 @@ export function FeedbackForm({ route }: { route: string }) {
 
       <fetcher.Form method="post" action="/app/settings/feedback">
         <input type="hidden" name="route" value={route} />
-        <s-stack gap="base">
+        <s-stack gap={SPACE.section}>
           <s-select name="sentiment" label="What kind of thing is this?">
             <s-option value="problem" defaultSelected>
               Something is wrong

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -1,7 +1,7 @@
 import { Children, cloneElement, isValidElement, type ReactNode } from "react";
 
 import { ActionRow } from "./ActionRow";
-import { SPACE } from "../lib/ui/spacing";
+import { PAGE_INSET, SPACE } from "../lib/ui/spacing";
 
 /**
  * How much of the frame a page occupies, leaving a tenth on each side.
@@ -95,7 +95,7 @@ function BackLink({ backTo }: { backTo?: { href: string; label: string } }) {
   if (!backTo) return null;
 
   return (
-    <s-box paddingInline="base">
+    <s-box paddingInline={PAGE_INSET}>
       <ActionRow>
         <s-button variant="tertiary" icon="arrow-left" href={backTo.href}>
           {backTo.label}

--- a/app/components/RunResultSection.tsx
+++ b/app/components/RunResultSection.tsx
@@ -8,6 +8,7 @@
  */
 
 import { formatCount } from "../lib/format/display";
+import { CountsRow } from "./CountsRow";
 import type { CampaignResult } from "../services/campaigns/result.server";
 
 export function RunResultSection({ result }: { result: CampaignResult }) {
@@ -22,15 +23,32 @@ export function RunResultSection({ result }: { result: CampaignResult }) {
         <s-paragraph>{result.summary}</s-paragraph>
       </s-banner>
 
-      <s-stack direction="inline" gap="base">
-        <Count label="Verified" value={counts.verified} />
-        {counts.clamped > 0 ? <Count label="Clamped by a guardrail" value={counts.clamped} /> : null}
-        {counts.skipped > 0 ? <Count label="Needed no change" value={counts.skipped} /> : null}
-        {counts.reverted > 0 ? <Count label="Reverted since" value={counts.reverted} /> : null}
-        {counts.unverified > 0 ? <Count label="Not read back" value={counts.unverified} /> : null}
-        {counts.failed > 0 ? <Count label="Failed" value={counts.failed} /> : null}
-        {counts.pending > 0 ? <Count label="Still to run" value={counts.pending} /> : null}
-      </s-stack>
+      {/* `CountsRow`, not a second implementation of it.
+      
+          This was seven bare label-over-figure stacks in an inline stack — the exact
+          shape `CountsRow`'s own doc comment describes replacing, down to the reason: an
+          inline stack sizes each tile to its own content, so "Failed 3" gets a fraction
+          of the width of "Clamped by a guardrail 1,204" and a row of unequal boxes reads
+          as a ranking, with the widest looking the most important. That has nothing to do
+          with what these numbers mean, and on this page — the report a merchant reads
+          after a run that did not go cleanly — the widest label is usually the least
+          urgent number on the row.
+
+          A zero count is left out rather than shown as 0. On a preview, four fixed
+          figures including zeroes are a shape a merchant learns; here the row is the
+          answer to "what happened", and "Failed 0" is not one of the things that
+          happened. */}
+      <CountsRow
+        items={[
+          { label: "Verified", value: counts.verified },
+          { label: "Clamped by a guardrail", value: counts.clamped },
+          { label: "Needed no change", value: counts.skipped },
+          { label: "Reverted since", value: counts.reverted },
+          { label: "Not read back", value: counts.unverified },
+          { label: "Failed", value: counts.failed },
+          { label: "Still to run", value: counts.pending },
+        ].filter((item) => item.value > 0 || item.label === "Verified")}
+      />
 
       {margin.covered > 0 ? (
         <>
@@ -97,14 +115,5 @@ export function RunResultSection({ result }: { result: CampaignResult }) {
         <s-text color="subdued">{result.unavailable}</s-text>
       </s-paragraph>
     </s-section>
-  );
-}
-
-function Count({ label, value }: { label: string; value: number }) {
-  return (
-    <s-stack gap="none">
-      <s-text type="strong">{formatCount(value)}</s-text>
-      <s-text color="subdued">{label}</s-text>
-    </s-stack>
   );
 }

--- a/app/components/SectionTabs.tsx
+++ b/app/components/SectionTabs.tsx
@@ -2,6 +2,7 @@ import { useLocation, useSearchParams } from "react-router";
 
 import { PageWidth } from "./PageShell";
 import { TabBar } from "./TabBar";
+import { PAGE_INSET } from "../lib/ui/spacing";
 
 export interface SectionTab {
   href: string;
@@ -48,7 +49,7 @@ export function SectionTabs({ tabs }: { tabs: SectionTab[] }) {
           few pixels left of the card they belong to — which after the inset is the only
           misalignment left on the page, and the kind that reads as sloppiness rather
           than as a choice. Matched by putting the two side by side and looking. */}
-      <s-box paddingInline="base">
+      <s-box paddingInline={PAGE_INSET}>
         <TabBar
           label="Sections"
           tabs={tabs.map((tab) => ({

--- a/app/components/imports/CsvDropZone.tsx
+++ b/app/components/imports/CsvDropZone.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import { SPACE } from "../../lib/ui/spacing";
+
 /**
  * Dropping a CSV file instead of opening it and pasting its contents.
  *
@@ -56,7 +58,10 @@ export function CsvDropZone({
   };
 
   return (
-    <s-stack gap="small-200">
+    // The zone and the line reporting what landed in it are one object, so they sit at
+    // item rhythm. `small-200` was a step off the scale entirely — between item and
+    // tight, and therefore telling the reader nothing either of them would have.
+    <s-stack gap={SPACE.item}>
       <s-drop-zone
         label={label}
         accept=".csv,text/csv,text/plain"

--- a/app/lib/ui/spacing.test.ts
+++ b/app/lib/ui/spacing.test.ts
@@ -17,7 +17,7 @@
  * on every unrevisited route would be turned off within the week.
  */
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -93,42 +93,93 @@ describe("section padding stays inside what s-section allows", () => {
 });
 
 /**
- * The shared primitives. Every page in the app is assembled from these, so a literal that
- * creeps back in here is not one component drifting — it is the flat rhythm returning
- * everywhere at once.
+ * Nothing in the app sets a distance by hand.
+ *
+ * This checked seven shared primitives when it landed, on the argument that a literal
+ * creeping back into those is the flat rhythm returning everywhere at once. True, and it
+ * left thirty-nine literals across twenty-two other files — every page in the Prices,
+ * Imports and Settings sections, and both halves of the campaign page.
+ *
+ * `gap="base"` is not *wrong*: it is `SPACE.section`. That is what made it survive four
+ * design passes. It says "whatever base happens to be" where `gap={SPACE.section}` says
+ * which relationship is being drawn — and the places that meant **item** rhythm (a row of
+ * buttons, a field and the button that acts on it) were written `base` too, so they
+ * rendered at section rhythm and a row of controls read as a list of unrelated blocks.
+ * A rule that only applies to seven files cannot catch that; there is nothing to compare.
+ *
+ * The exceptions are named, and there are two kinds. Neither is "this one is fine".
  */
-const PRIMITIVES = [
-  "app/components/PageShell.tsx",
-  "app/components/SectionTabs.tsx",
-  "app/components/AsyncState.tsx",
-  "app/components/CountsRow.tsx",
-  "app/components/OnboardingCard.tsx",
-  "app/components/Pagination.tsx",
-  "app/components/prices/VariantSearch.tsx",
-];
 
-describe("the shared primitives take their spacing from the scale", () => {
-  it("is looking at files that exist, so it cannot pass by checking nothing", () => {
-    for (const file of PRIMITIVES) {
-      expect(readFileSync(join(ROOT, file), "utf8").length).toBeGreaterThan(0);
-    }
+/** Rendered outside the embedded admin, with their own CSS and no Polaris scale. */
+const OUTSIDE_THE_ADMIN = ["routes/help.$", "routes/_index"];
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") && !entry.name.includes(".test.")
+      ? [path]
+      : [];
+  });
+}
+
+const APP = join(ROOT, "app");
+
+const CHECKED = tsxFiles(APP)
+  .map((path) => path.replace(`${ROOT}/`, ""))
+  .filter((file) => !OUTSIDE_THE_ADMIN.some((skip) => file.includes(skip)))
+  .sort();
+
+/**
+ * Attribute values a component is allowed to spell out.
+ *
+ * `s-section` takes only `base` or `none` and there is no finer control, so `padding="none"`
+ * on a full-bleed table is naming the only other option Polaris offers rather than
+ * choosing a distance. Everything else has to come from the scale.
+ */
+const NOT_A_RHYTHM = ['padding="none"', 'gap="none"'];
+
+describe("nothing in the app sets a distance by hand", () => {
+  it("is looking at the whole app, so it cannot pass by checking nothing", () => {
+    expect(CHECKED.length).toBeGreaterThan(40);
+    expect(CHECKED).toContain("app/components/PageShell.tsx");
+    expect(CHECKED).toContain("app/routes/app.campaigns.new.tsx");
   });
 
-  it.each(PRIMITIVES)("%s", (file) => {
-    const source = readFileSync(join(ROOT, file), "utf8");
+  it.each(CHECKED)("%s", (file) => {
+    // Comments stripped first. The repo has been caught by this twice — the compliance
+    // check that rejects a native form element greps for `<form`, so the word in a
+    // comment trips it — and half the files here explain in prose which literal they
+    // replaced and why.
+    const source = readFileSync(join(ROOT, file), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
 
-    // A literal is how the flat rhythm got in: `gap="base"` is invisible in review and
-    // means "whatever base happens to be" rather than "this is the section rhythm".
-    // `gap={SPACE.section}` says which relationship is being drawn, and moves when the
-    // scale moves.
     const literals = [
-      ...source.matchAll(/\s(gap|padding|paddingBlock|paddingBlockEnd)="([^"]*)"/g),
-    ].map((match) => `${match[1]}="${match[2]}"`);
+      ...source.matchAll(
+        /\s(gap|padding|paddingBlock|paddingBlockEnd|paddingInline)="([^"]*)"/g,
+      ),
+    ]
+      .map((match) => `${match[1]}="${match[2]}"`)
+      .filter((literal) => !NOT_A_RHYTHM.some((allowed) => literal.endsWith(allowed)));
 
     expect(
       literals,
-      `${file} hardcodes spacing — use SPACE or PAD from app/lib/ui/spacing, so the ` +
-        `rhythm is named rather than guessed`,
+      `${file} hardcodes spacing — use SPACE, PAD or PAGE_INSET from app/lib/ui/spacing, ` +
+        `so the rhythm is named rather than guessed`,
     ).toEqual([]);
+  });
+});
+
+describe("the page rhythm is set in exactly one place", () => {
+  it("is PageShell's, and no route sets it", () => {
+    // "Page rhythm has to be the largest gap on the screen to do its job. If a route can
+    // set it, some route eventually sets it smaller than the gaps inside its own
+    // sections, and the page stops having visible structure at all."
+    const offenders = CHECKED.filter(
+      (file) => !file.endsWith("PageShell.tsx") && readFileSync(join(ROOT, file), "utf8").includes("SPACE.page"),
+    );
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/app/lib/ui/spacing.ts
+++ b/app/lib/ui/spacing.ts
@@ -41,6 +41,14 @@
  * existing `gap="base"` uses already meant, so the routes that have not been revisited
  * yet stay correct rather than becoming subtly wrong while this lands.
  *
+ * That grace period is over. `spacing.test.ts` now rejects a hardcoded `gap` or `padding`
+ * anywhere in `app/`, rather than in the seven shared primitives it started with. The
+ * argument for widening it is the thing the literal hides: `gap="base"` is *correct* where
+ * section rhythm was meant, which is why it survived four design passes — and it is
+ * indistinguishable in a diff from the places that meant **item** rhythm and got section
+ * rhythm instead, so a row of buttons rendered as a list of unrelated blocks. A rule that
+ * covers seven files cannot see that; there is nothing to compare against.
+ *
  * ## Applying it
  *
  * - **Page rhythm** belongs to `PageShell` and nothing else. A route should never set the
@@ -158,6 +166,20 @@ export const PAD = {
   /** Content that must reach the card's edge. A full-bleed table, and little else. */
   flush: "none",
 } as const;
+
+/**
+ * How far `s-page` insets its own contents.
+ *
+ * Not one of the four rhythms, and deliberately separate from `PAD.card` even though the
+ * value is the same today: this is not a decision about how much room something needs, it
+ * is a number belonging to Polaris that two of our components have to match. `PageShell`'s
+ * back link and `SectionTabs`' bar both render *outside* `s-page` and have to line up with
+ * the heading and the card below them.
+ *
+ * If the four rhythms are ever retuned, this must not move with them — it moves when
+ * Polaris moves. Naming it is how those two facts stay separable.
+ */
+export const PAGE_INSET = "base" satisfies Space;
 
 /**
  * The hairline used for tiles and sub-navigation rules.

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -26,6 +26,7 @@ import { describeAction } from "../lib/audit/action";
 import { describeActor } from "../lib/audit/actor";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { SPACE } from "../lib/ui/spacing";
 
 const FILTER_FIELDS = ["actor", "action", "from", "to"] as const;
 
@@ -67,7 +68,7 @@ export default function Activity() {
     <PageShell heading="Activity" backTo={{ href: "/app", label: "Home" }}>
       <s-section>
         <FilterForm fields={FILTER_FIELDS}>
-          <s-stack gap="base">
+          <s-stack gap={SPACE.section}>
             <s-select name="actor" label="Who">
               <s-option value="" defaultSelected={!filters.actor}>
                 Anyone

--- a/app/routes/app.imports.recapture.tsx
+++ b/app/routes/app.imports.recapture.tsx
@@ -24,6 +24,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/imports/recapture", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -115,7 +116,7 @@ export default function Recapture() {
         </s-paragraph>
 
         <fetcher.Form method="get">
-          <s-stack gap="base">
+          <s-stack gap={SPACE.section}>
             <s-select name="segment" label="Scope">
               <s-option value="" defaultSelected={!segmentId}>
                 The whole catalogue
@@ -169,7 +170,7 @@ export default function Recapture() {
       <s-section heading="Recapture">
         <fetcher.Form method="post">
           <input type="hidden" name="segment" value={segmentId} />
-          <s-stack gap="base">
+          <s-stack gap={SPACE.section}>
             {assessment.confirmationPhrase ? (
               <s-text-field
                 name="confirmation"

--- a/app/routes/app.prices.costs.tsx
+++ b/app/routes/app.prices.costs.tsx
@@ -30,6 +30,7 @@ import { ActionRow } from "../components/ActionRow";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/prices/costs", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -165,7 +166,7 @@ export default function Costs() {
               buttons set before submitting. One form, because both actions read the same
               rule and duplicating the fields would let them drift apart. */}
           <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
-          <s-stack gap="base">
+          <s-stack gap={SPACE.section}>
             <s-select name="vendor" label="Which products">
               <s-option value="" defaultSelected>
                 Every product
@@ -195,7 +196,7 @@ export default function Costs() {
               details="Products with no cost are skipped by the first two rules rather than treated as zero."
             />
 
-            <s-stack direction="inline" gap="base">
+            <ActionRow>
               <s-button
                 type="button"
                 variant="primary"
@@ -212,7 +213,7 @@ export default function Costs() {
               >
                 Change these costs
               </s-button>
-            </s-stack>
+            </ActionRow>
           </s-stack>
         </fetcher.Form>
 

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -16,6 +16,7 @@ import { VariantSearch } from "../components/prices/VariantSearch";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { SPACE } from "../lib/ui/spacing";
 
 /** Filters that ride in the query string, so a merchant can bookmark a view. */
 export const RECONCILE_FIELDS = ["q", "surface", "campaign", "state"] as const;
@@ -181,7 +182,10 @@ export default function Reconciliation() {
 
         <fetcher.Form method="post">
           <input type="hidden" name="intent" value="spot-check" />
-          <s-stack direction="inline" gap="base">
+          {/* A field and the button that acts on it are one control, so they share a
+              baseline at item rhythm. At section rhythm they read as two separate
+              things that happen to be adjacent. */}
+          <s-stack direction="inline" gap={SPACE.item} alignItems="end">
             <s-number-field name="size" label="How many to check" value="100" />
             <s-button type="submit" loading={busy || undefined}>
               Check now

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -20,6 +20,7 @@ import {
 import { PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
+import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -233,7 +234,7 @@ export default function Settings() {
           </s-text>
         </s-paragraph>
 
-          <s-stack gap="base">
+          <s-stack gap={SPACE.section}>
             <s-select name="rounding.default" label="Everywhere, unless overridden">
               {roundingOptions.map((option) => (
                 <s-option
@@ -307,7 +308,7 @@ export default function Settings() {
           </s-banner>
         ) : null}
 
-          <s-stack gap="base">
+          <s-stack gap={SPACE.section}>
             <s-text-field
               name="email"
               label="Send to"

--- a/app/routes/app.settings.diagnostics.tsx
+++ b/app/routes/app.settings.diagnostics.tsx
@@ -19,6 +19,7 @@ import { EmptyState } from "../components/AsyncState";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings/diagnostics", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -69,7 +70,10 @@ export default function Debug() {
         </s-paragraph>
 
         <Form method="get">
-          <s-stack direction="inline" gap="base">
+          {/* The field and its button are one control. `alignItems="end"` because the
+              field carries a label above it and the button does not, so without it the
+              button floats level with the label rather than with the box. */}
+          <s-stack direction="inline" gap={SPACE.item} alignItems="end">
             <s-text-field name="id" label="Reference" value={query} />
             <s-button type="submit" variant="primary">
               Find
@@ -95,7 +99,7 @@ export default function Debug() {
         ) : null}
 
         {match ? (
-          <s-stack gap="base">
+          <s-stack gap={SPACE.section}>
             <s-divider />
             <s-heading>{match.errorId}</s-heading>
             <s-paragraph>


### PR DESCRIPTION
Closes #398.

`spacing.ts` defines four rhythms; `spacing.test.ts` checked **seven shared primitives**, which left thirty-nine literals across twenty-two other files — every page in Prices, Imports and Settings, and both halves of the campaign page. The test covers all of `app/` now, and there are zero hardcoded distances left in it.

The argument for widening it is exactly what the literal hides. `gap="base"` is *correct* where section rhythm was meant — which is why it survived four design passes — and it is **indistinguishable in a diff** from the places that meant *item* rhythm and got section rhythm instead. Those are the ones worth finding, and this sweep corrected rather than transliterated them:

- `BaselineTable`'s History and Shopify buttons sat at `gap="small"`, which the scale documents as *larger* than `small-100`, so the two halves of one cell were further apart than anything else on the row.
- The costs form's two submits, the reconciliation spot-check's field-and-button, and the diagnostics lookup were all at section rhythm, so a field and the button that acts on it read as two adjacent things rather than one control. The last two also gained `alignItems="end"` — the field carries a label above it and the button does not, so without it the button floated level with the label.
- `CsvDropZone` used `small-200`, a step off the scale entirely: between item and tight, and therefore saying neither.

## Two things came out of the sweep that are not spacing

**`PAGE_INSET`** is now a named constant for how far `s-page` insets its own contents. `PageShell`'s back link and `SectionTabs`' bar render *outside* `s-page` and have to match it. Deliberately separate from `PAD.card` even though the value is the same today: this is a number belonging to Polaris, and if the four rhythms are ever retuned it must not move with them.

**`RunResultSection` had a second implementation of `CountsRow`** — seven bare label-over-figure stacks in an inline stack. That is the exact shape `CountsRow`'s own doc comment describes replacing, down to the reason: an inline stack sizes each tile to its content, so "Failed 3" gets a fraction of the width of "Clamped by a guardrail 1,204" and a row of unequal boxes reads as a ranking. On the report a merchant opens *after a run that did not go cleanly*, the widest label is usually the least urgent number on it.

## A second assertion the ticket asked for

No route sets the page rhythm. `PageShell` owns it, because it has to be the largest gap on the screen to do its job, and a route that sets it smaller than the gaps inside its own sections leaves the page with no visible structure at all.

Both scans strip comments before matching — half these files explain in prose which literal they replaced, and the repo has been caught by that twice already.

Four mutants confirmed failing: a route hardcoding a gap, a hardcoded `paddingInline`, a component that was outside the old seven-file list, and a route setting `SPACE.page`.

2091 tests pass, 91 new — the widened check is one case per file. Typecheck, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)