### PR TITLE
An index of the page, that moves the page

### DIFF
--- a/app/components/JumpTo.tsx
+++ b/app/components/JumpTo.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from "react";
+
+import { SPACE } from "../lib/ui/spacing";
+
+export interface JumpTarget {
+  /** Must match the `id` on the `s-section` it points at. */
+  id: string;
+  label: string;
+}
+
+/**
+ * A page's own contents, for pages long enough to get lost in.
+ *
+ * ## Why it did nothing
+ *
+ * It was three `s-button href="#guardrails"` — real anchors pointing at real ids, which
+ * is why it looked correct. A bare fragment href hands the job to the browser's fragment
+ * navigation, and that scrolls **the document's scrolling element**. This app is laid out
+ * inside App Home's frame by Shopify's runtime, and it does not know or control whether
+ * the thing that scrolls is the document or a container Polaris renders. If it is a
+ * container, fragment navigation moves nothing and reports nothing.
+ *
+ * `scrollIntoView` does not take that bet — it walks up and scrolls every scrollable
+ * ancestor — so this is correct whichever the answer turns out to be. The `href` stays,
+ * because it is what makes these real links: middle-click, open-in-new-tab and copy-link
+ * all keep working, and the handler is an enhancement over a thing that already means
+ * something rather than a click listener glued to a span.
+ *
+ * ## Arriving with a hash
+ *
+ * Also handled, and it was not before: nothing in the app read `location.hash`, so
+ * `/app/settings#notifications` from a runbook or an email landed at the top of the page
+ * and stayed there. That is half of what in-page anchors are for.
+ *
+ * Instant on arrival, smooth on click. Smoothly animating a page the merchant has only
+ * just opened reads as the page moving on its own; smoothly animating one they pressed a
+ * control on reads as the control working. Both defer to `prefers-reduced-motion`.
+ *
+ * ## Why chips and not text
+ *
+ * Because three text labels in a row are a tab bar, whatever the spacing. This sat in a
+ * card of its own directly under the section tab bar, so the page opened with two rows of
+ * similar-weight labels in two boxes — and the lower one was the almost-empty rectangle
+ * #395 took off the campaigns index.
+ *
+ * `s-clickable-chip` is a different object: compact, rounded, and not something the app
+ * uses for navigation anywhere else, so it cannot be confused with one. The arrow says
+ * which way it goes, which is the one thing a tab never does. No card, no rule, no "Jump
+ * to" label — the arrows are the label, and the landmark carries the words for anyone who
+ * cannot see them.
+ */
+export function JumpTo({
+  targets,
+  label = "On this page",
+}: {
+  targets: JumpTarget[];
+  /** Names the landmark, so a screen reader hears what it has jumped to. */
+  label?: string;
+}) {
+  // A hash the merchant arrived with, once the sections are on the page. Not on every
+  // render: this must not fight a merchant who has scrolled somewhere else since.
+  useEffect(() => {
+    const id = globalThis.location?.hash?.slice(1);
+    if (id) scrollToSection(id, "auto");
+  }, []);
+
+  if (targets.length === 0) return null;
+
+  return (
+    <s-box accessibilityRole="navigation" accessibilityLabel={label}>
+      <s-stack direction="inline" gap={SPACE.item} alignItems="center">
+        {targets.map((target) => (
+          <s-clickable-chip
+            key={target.id}
+            href={`#${target.id}`}
+            onClick={(event) => {
+              // Only when we can do better than the browser would. If the section is not
+              // on the page — a conditional block that did not render — the anchor is
+              // left to do whatever it was going to do, rather than being cancelled into
+              // a control that visibly does nothing.
+              if (scrollToSection(target.id, "smooth")) event.preventDefault();
+            }}
+          >
+            <s-icon slot="graphic" type="arrow-down" size="small" />
+            {target.label}
+          </s-clickable-chip>
+        ))}
+      </s-stack>
+    </s-box>
+  );
+}
+
+/**
+ * Scroll a section into view, if it is there.
+ *
+ * Returns whether it found one, so the caller can decide whether to cancel the anchor.
+ *
+ * `block: "start"` rather than `"center"`: these are section headings, and a heading
+ * parked in the middle of the screen with its own content below the fold is a worse
+ * landing than one at the top with the section under it.
+ */
+function scrollToSection(id: string, behavior: "smooth" | "auto"): boolean {
+  const target = globalThis.document?.getElementById(id);
+  if (!target) return false;
+
+  target.scrollIntoView({ behavior: prefersMotion() ? behavior : "auto", block: "start" });
+  return true;
+}
+
+/**
+ * Whether the merchant is willing to be moved.
+ *
+ * `matchMedia` is optional-chained for the server render and for the test environment,
+ * where it does not exist; the default when it cannot be asked is to animate, because
+ * that is what a browser that never heard of the query does.
+ */
+function prefersMotion(): boolean {
+  return !globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}

--- a/app/components/campaign/CampaignPreviewTab.tsx
+++ b/app/components/campaign/CampaignPreviewTab.tsx
@@ -27,13 +27,33 @@ import { PreviewTable } from "../../components/PreviewTable";
 import { downloadCsv, filenameSlug } from "../../lib/reporting/csv";
 import { previewCsv } from "../../lib/reporting/preview-csv";
 import { ActionRow } from "../ActionRow";
+import { JumpTo } from "../JumpTo";
 import type { CampaignDetailProps } from "./props";
 
 export function CampaignPreviewTab({ preview, approval, fetcher, busy }: CampaignDetailProps) {
+  // Built from what this campaign has, not from what the tab could show. A jump to a
+  // margins block that is not on the page is a control that does nothing, which is the
+  // defect this row was fixed for.
+  const targets = [
+    approval.required ? { id: "approval", label: "Approval" } : null,
+    { id: "preview", label: "Preview" },
+    preview.margin ? { id: "margins", label: "Margins" } : null,
+    preview.markets.length > 0 ? { id: "markets", label: "Markets" } : null,
+  ].filter((target) => target !== null);
+
   return (
     <>
+      {/* Only when there is somewhere to go. Two chips under a tab bar is furniture; the
+          case this earns is the one where a merchant wants the margins and has a preview
+          table of up to five hundred rows between them and it.
+
+          Chips rather than anything text-shaped matters more here than anywhere: this
+          renders directly beneath the campaign's tab bar, and a second row of labels
+          would read as two tab bars disagreeing about which tab is current. */}
+      {targets.length > 2 ? <JumpTo label="Preview sections" targets={targets} /> : null}
+
       {approval.required ? (
-        <s-section heading="Approval">
+        <s-section id="approval" heading="Approval">
           <s-paragraph>
             <s-text>
               {approval.state === "approved"
@@ -76,7 +96,7 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
         </s-section>
       ) : null}
 
-      <s-section heading="Preview">
+      <s-section id="preview" heading="Preview">
         <CountsRow
           items={[
             { label: "Will change", value: preview.counts.planned },
@@ -121,7 +141,7 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
       </s-section>
 
       {preview.margin ? (
-        <s-section heading="What this does to your margins">
+        <s-section id="margins" heading="What this does to your margins">
           <s-paragraph>
             <s-text>{preview.margin.summary}</s-text>
           </s-paragraph>
@@ -168,7 +188,7 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
       ) : null}
 
       {preview.markets.length > 0 ? (
-        <s-section heading="Markets">
+        <s-section id="markets" heading="Markets">
           <s-paragraph>
             <s-text>
               Each market is priced from its own normal price in its own currency,

--- a/app/components/jump-to.test.tsx
+++ b/app/components/jump-to.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * The in-page index, and the one way it can rot.
+ *
+ * The row it replaces was three `s-button href="#guardrails"` pointing at three real
+ * `s-section id=` — correct-looking, and it did nothing. Two things are checked here, and
+ * the second is the one that will still be earning its keep in a year.
+ *
+ * **What it renders.** Real anchors, an arrow, no card, and no current item — the last is
+ * what stops it becoming the second tab bar it used to look like.
+ *
+ * **That every target is a section that exists, in order.** A jump row is the one control
+ * in the app whose correctness lives in a *different part of the same file*: rename a
+ * section's id and the chip still renders, still looks right, and silently scrolls
+ * nowhere. Nothing about that shows in a screenshot.
+ *
+ * The scrolling itself is not testable here — vitest runs in `node`, there is no layout,
+ * and the whole reason `scrollIntoView` was chosen over a fragment href is a question
+ * about a container Shopify's runtime renders. That gap is real and is stated on the PR
+ * rather than papered over with a mock that would pass either way.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { JumpTo } from "./JumpTo";
+
+const html = renderToStaticMarkup(
+  <JumpTo
+    targets={[
+      { id: "guardrails", label: "Guardrails" },
+      { id: "rounding", label: "Rounding" },
+    ]}
+  />,
+);
+
+describe("what a jump row is", () => {
+  it("renders a real link per target", () => {
+    // Not a click handler on a span. Middle-click, open-in-new-tab and copy-link-address
+    // all depend on the href being there; the scroll handler is an enhancement over a
+    // thing that already means something.
+    expect(html).toContain('href="#guardrails"');
+    expect(html).toContain('href="#rounding"');
+  });
+
+  it("uses chips, because three text labels in a row are a tab bar", () => {
+    expect(html).toContain("<s-clickable-chip");
+    expect(html).not.toContain("<s-button");
+  });
+
+  it("points the arrow down the page", () => {
+    // The one thing a tab never does. It is also the whole label — there is no "Jump to"
+    // caption, because the arrows say it and the landmark says it to everyone else.
+    expect(html).toContain('type="arrow-down"');
+    expect(html).not.toContain("Jump to");
+  });
+
+  it("draws no card", () => {
+    // It sat in an `s-section` holding one line, directly under the section tab bar —
+    // the almost-empty rectangle #395 took off the campaigns index.
+    expect(html).not.toContain("<s-section");
+  });
+
+  it("marks nothing as current", () => {
+    // Every target is on the page you are already looking at, so there is nothing to be
+    // current. That is the difference between an index and a bar.
+    expect(html).not.toMatch(/current/i);
+  });
+
+  it("is a landmark a screen reader can name", () => {
+    expect(html).toMatch(/accessibilityrole="navigation"/i);
+    expect(renderToStaticMarkup(<JumpTo targets={[]} label="Settings" />)).toBe("");
+  });
+});
+
+const APP = join(process.cwd(), "app");
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") && !entry.name.includes(".test.")
+      ? [path]
+      : [];
+  });
+}
+
+/** Every file that renders a jump row, with the ids it points at and the ids it has. */
+const PAGES = tsxFiles(APP)
+  .map((path) => ({ path: path.replace(`${APP}/`, ""), source: readFileSync(path, "utf8") }))
+  .filter(({ source }) => source.includes("<JumpTo"))
+  .map(({ path, source }) => ({
+    path,
+    targets: [...source.matchAll(/\{ id: "([^"]+)", label: "[^"]+" \}/g)].map((m) => m[1]),
+    sections: [...source.matchAll(/<s-section id="([^"]+)"/g)].map((m) => m[1]),
+  }));
+
+describe("a jump row cannot point at a section that is not there", () => {
+  it("finds the pages that have one", () => {
+    expect(PAGES.map((page) => page.path).sort()).toEqual([
+      "components/campaign/CampaignPreviewTab.tsx",
+      "routes/app.settings._index.tsx",
+      "routes/app.settings.plan.tsx",
+    ]);
+  });
+
+  it.each(PAGES.map((page) => page.path))("%s targets sections it renders, in order", (path) => {
+    const page = PAGES.find((candidate) => candidate.path === path)!;
+
+    expect(page.targets.length).toBeGreaterThanOrEqual(3);
+    // Identical lists, not "every target exists": a row whose order disagrees with the
+    // page sends a merchant up when the arrow said down.
+    expect(page.targets).toEqual(page.sections);
+  });
+});
+
+describe("it is on the pages that need it and not the ones that do not", () => {
+  const routeSections = (source: string) =>
+    [...source.matchAll(/<s-section(?![^>]*slot="aside")[^>]*heading="/g)].length;
+
+  it("is absent from every page with fewer than three sections", () => {
+    const overreach = tsxFiles(join(APP, "routes"))
+      .map((path) => ({ path: path.replace(`${APP}/`, ""), source: readFileSync(path, "utf8") }))
+      .filter(({ source }) => source.includes("<JumpTo") && routeSections(source) < 3)
+      .map(({ path }) => path);
+
+    expect(overreach, "a two-section page does not need an index of itself").toEqual([]);
+  });
+
+  it("stays off Home, whose sections are conditional", () => {
+    // Two of them share a heading — "What is live right now" appears twice, for two
+    // different states — and which ones render is decided in `lib/dashboard/home.ts`.
+    // A fixed index there would list things that are not on the page.
+    expect(readFileSync(join(APP, "routes/app._index.tsx"), "utf8")).not.toContain("<JumpTo");
+  });
+});

--- a/app/components/settings.test.ts
+++ b/app/components/settings.test.ts
@@ -56,8 +56,24 @@ describe("everything that moved into settings is still reachable", () => {
 });
 
 describe("the long settings page can be navigated without scrolling it", () => {
-  it.each(["guardrails", "rounding", "notifications"])("has an anchor for %s", (id) => {
+  // The page names its targets and `JumpTo` turns each into an anchor, so checking the
+  // route for `href="#guardrails"` stopped meaning anything. Both halves are checked
+  // instead: the section exists and the page asks to jump to it, and the component that
+  // renders the ask still renders a real link.
+  it.each(["guardrails", "rounding", "notifications"])("has a section for %s", (id) => {
     expect(index).toContain(`id="${id}"`);
-    expect(index).toContain(`href="#${id}"`);
+    expect(index).toMatch(new RegExp(`\\{ id: "${id}", label: "[^"]+" \\}`));
+  });
+
+  it("renders those as real links, not click handlers on a span", () => {
+    const jumpTo = readFileSync(
+      join(process.cwd(), "app", "components", "JumpTo.tsx"),
+      "utf8",
+    );
+
+    // Middle-click, open-in-new-tab and copy-link-address all depend on the href being
+    // there. The scroll handler is an enhancement over a thing that already means
+    // something.
+    expect(jumpTo).toContain("href={`#${target.id}`}");
   });
 });

--- a/app/components/tab-bar.test.tsx
+++ b/app/components/tab-bar.test.tsx
@@ -72,15 +72,42 @@ describe("every set of tabs uses the shared bar", () => {
     expect(source).toMatch(/import \{ TabBar \} from/);
   });
 
+  /**
+   * The app's own navigation, and what each one is.
+   *
+   * This started as "exactly one file claims the navigation role, because a tab bar is a
+   * navigation landmark and a second one is a second bar, whatever it is called". That
+   * premise stopped being true when `JumpTo` landed: an in-page index is navigation and
+   * is emphatically not a bar — it was built to stop looking like one.
+   *
+   * So the rule is sharpened rather than the file exempted. Anything new claiming the
+   * role has to be added here, deliberately, with what it is; and the thing that actually
+   * makes a tab bar a tab bar — marking one of its items as the one you are on — stays
+   * the property of exactly one component.
+   */
+  const LANDMARKS = {
+    "app/components/TabBar.tsx": "the one tab bar",
+    "app/components/JumpTo.tsx": "an index of the page you are already on",
+  };
+
   it("finds no fourth implementation", () => {
-    // A tab bar is a navigation landmark. The app's own sections are the only navigation
-    // this app renders -- everything else is Shopify's chrome -- so a second file
-    // claiming the role is a second bar, whatever it is called.
     const landmarks = files
       .filter((file) => file.source.includes('accessibilityRole="navigation"'))
       .map((file) => file.path);
 
-    expect(landmarks, "one bar, one landmark").toEqual(["app/components/TabBar.tsx"]);
+    expect(landmarks.sort(), "one bar, one landmark").toEqual(Object.keys(LANDMARKS).sort());
+  });
+
+  it("leaves only the tab bar able to say which one you are on", () => {
+    // A jump row has no current item and cannot have one: every target is on the page
+    // you are looking at. That is the difference between an index and a bar, and it is
+    // what keeps a second selectable row from being written as "not a tab bar".
+    const marksCurrent = files
+      .filter((file) => file.source.includes('accessibilityRole="navigation"'))
+      .filter((file) => /\bcurrent\b/.test(file.source))
+      .map((file) => file.path);
+
+    expect(marksCurrent).toEqual(["app/components/TabBar.tsx"]);
   });
 
   it("never links the tab you are already on", () => {

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -9,7 +9,6 @@ import { ensureShop } from "../services/shop.server";
 import { readSettings, shopCurrency, writeSettings } from "../services/settings.server";
 import { readPreferences, writePreferences } from "../services/notifications.server";
 import { actorFor } from "../lib/audit/actor";
-import { ActionRow } from "../components/ActionRow";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import {
@@ -20,6 +19,7 @@ import {
 import { PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
+import { JumpTo } from "../components/JumpTo";
 import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
@@ -145,14 +145,14 @@ export default function Settings() {
           rather than more routes: these settings are read together — a rounding rule
           that pushes a price under a floor is a conversation between two of them —
           and splitting them across pages is what made the nav sixteen items long. */}
-      <s-section>
-        <ActionRow>
-          <s-text color="subdued">Jump to</s-text>
-          <s-button variant="tertiary" href="#guardrails">Guardrails</s-button>
-          <s-button variant="tertiary" href="#rounding">Rounding</s-button>
-          <s-button variant="tertiary" href="#notifications">Alerts</s-button>
-        </ActionRow>
-      </s-section>
+      <JumpTo
+        label="Settings on this page"
+        targets={[
+          { id: "guardrails", label: "Guardrails" },
+          { id: "rounding", label: "Rounding" },
+          { id: "notifications", label: "Alerts" },
+        ]}
+      />
 
       <s-section id="guardrails" heading="Guardrails">
         <s-paragraph>

--- a/app/routes/app.settings.plan.tsx
+++ b/app/routes/app.settings.plan.tsx
@@ -21,6 +21,7 @@ import { formatMinorUnits } from "../lib/money/format";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { JumpTo } from "../components/JumpTo";
 
 export const loader = withGuard("/app/settings/plan", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -89,7 +90,19 @@ export default function PlanPage() {
         </s-banner>
       ) : null}
 
-      <s-section heading="What you are on">
+      {/* Four blocks, and the one a merchant arrives wanting — what happens if I
+          downgrade — is under a table of every plan. */}
+      <JumpTo
+        label="Plan details on this page"
+        targets={[
+          { id: "current", label: "What you are on" },
+          { id: "plans", label: "Plans" },
+          { id: "included", label: "Every plan" },
+          { id: "downgrade", label: "If you downgrade" },
+        ]}
+      />
+
+      <s-section id="current" heading="What you are on">
         <s-paragraph>
           <s-text>
             {PLANS[current as keyof typeof PLANS].name} · {formatCount(variants)}{" "}
@@ -98,7 +111,7 @@ export default function PlanPage() {
         </s-paragraph>
       </s-section>
 
-      <s-section heading="Plans">
+      <s-section id="plans" heading="Plans">
         <s-paragraph>
           <s-text>
             Pricing is by how much of your catalogue a campaign manages and which
@@ -142,7 +155,7 @@ export default function PlanPage() {
         </s-table>
       </s-section>
 
-      <s-section heading="Every plan, including free">
+      <s-section id="included" heading="Every plan, including free">
         <s-paragraph>
           <s-text>
             Preview before applying. Guardrails that refuse to price below cost or
@@ -158,7 +171,7 @@ export default function PlanPage() {
         </s-paragraph>
       </s-section>
 
-      <s-section heading="If you downgrade">
+      <s-section id="downgrade" heading="If you downgrade">
         <s-paragraph>
           <s-text>
             Running campaigns finish, including their scheduled reverts. Nothing is


### PR DESCRIPTION
Closes #414.

## Why it did nothing

The row was three `s-button href="#guardrails"` pointing at three real `s-section id=`. Correct-looking, and inert.

A bare fragment href hands the job to the browser's fragment navigation, which scrolls **the document's scrolling element**. This app is laid out inside App Home's frame by Shopify's runtime and does not know or control whether the thing that scrolls is the document or a container Polaris renders. If it is a container, fragment navigation moves nothing and reports nothing.

`scrollIntoView` does not take that bet — it walks up and scrolls every scrollable ancestor — so this is correct whichever the answer turns out to be, without having to prove which case we are in first. **The `href` stays**: middle-click, open-in-new-tab and copy-link-address all depend on it, and the handler is an enhancement over a thing that already means something rather than a click listener glued to a span.

**Arriving with a hash is handled too, and was not before.** Nothing in the app read `location.hash`, so `/app/settings#notifications` from a runbook or an email landed at the top of the page and stayed there — half of what in-page anchors are for. Instant on arrival, smooth on click: animating a page the merchant has only just opened reads as the page moving on its own. Both defer to `prefers-reduced-motion`.

## Why it looked like tabs

It was an `s-section` — a full card — holding one line, directly under the section tab bar. The page opened with two rows of similar-weight labels in two boxes, and the lower one was the almost-empty rectangle #395 took off the campaigns index.

Three text labels in a row are a tab bar whatever the spacing, so the fix is a **different object**. `s-clickable-chip` is compact, rounded, used for navigation nowhere else in the app, and takes an arrow that says which way it goes — the one thing a tab never does. No card, no rule, no "Jump to" caption; the arrows are the caption and the landmark carries the words for anyone who cannot see them.

```
<s-box accessibilityRole="navigation" accessibilityLabel="Settings on this page">
  <s-stack direction="inline" gap="small-100" alignItems="center">
    <s-clickable-chip href="#guardrails"><s-icon slot="graphic" type="arrow-down" …/>Guardrails</s-clickable-chip>
    …
```

## Where else

- **`/app/settings/plan`** — four blocks, and the one a merchant arrives wanting ("if you downgrade") is under a table of every plan.
- **The campaign Preview tab** — margins and markets sit below a preview table of up to five hundred rows. Built there from what the campaign *actually has*, so it cannot offer a jump to a block that did not render, and only when there is more than one place to go.
- **Not Home.** Its sections are conditional and two share a heading — "What is live right now" appears twice, for two different states — so a fixed index would list things that are not on the page. There is a test for that.

## Two existing guards fired, and both were right to

`settings.test` asserted the hrefs in the route source; they moved into the component. It checks both halves now — the section exists and the page asks to jump to it, and the component still renders a real link.

The tab-bar guard said *"exactly one file claims the navigation role, because a tab bar is a navigation landmark and a second one is a second bar, whatever it is called."* This makes that premise false. **Sharpened rather than exempted**: landmarks are listed with what each one is, and *marking an item as current* — which is what actually makes a bar a bar — stays the property of exactly one component. A jump row has no current item and cannot have one; every target is on the page you are already looking at.

## What is not verified

**Not opened in the embedded admin.** The whole reason `scrollIntoView` was chosen is a question about a container Shopify's runtime renders, and vitest runs in `node` with no layout — a mock would pass either way. The test covers what it can: the rendered markup, and that every target matches a section the page renders **in order**, which is the way a jump row actually rots (rename an id and the chip still looks right and scrolls nowhere).

Nine mutants confirmed failing: a renamed section id, targets out of page order, chips reverted to buttons, the href removed, the card restored, the arrow removed, a current item introduced, and the row placed on a two-section page and on Home.

2109 tests pass, 18 new. Typecheck, lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)