### PR TITLE
The prose that explains a page, folded away until it is asked for

### DIFF
--- a/app/components/HelpNote.tsx
+++ b/app/components/HelpNote.tsx
@@ -1,0 +1,93 @@
+import { useState, type ReactNode } from "react";
+
+import { ActionRow } from "./ActionRow";
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * The prose that explains a page, folded away until it is asked for.
+ *
+ * Ten pages carried an explanation of themselves — what a baseline is, how two campaigns
+ * resolve, why a floor is checked after rounding — and every one of them was an
+ * `s-section slot="aside"`. That put roughly a hundred words in a 22rem column running
+ * the full height of the page, next to the table the merchant actually came for. On the
+ * catalogue the cost was blunt: seven columns of numbers squeezed into two thirds of the
+ * screen so that three paragraphs could sit in the other third, wrapping "Live price"
+ * onto two lines while a quarter of the window stayed white.
+ *
+ * The prose is not the problem — it is some of the best writing in the app, and the
+ * baseline concept genuinely does need teaching. The problem is teaching all of it,
+ * permanently, before anyone has asked. `OnboardingCard` had already reached this
+ * conclusion for the checklist and its "Why?" toggle; this is the same move applied to
+ * the rest of the app.
+ *
+ * So the aside column is now reserved for **facts about this shop** — the store card,
+ * recent activity, cost coverage, errors by kind — and prose explaining how the app works
+ * becomes a note: one quiet line at the foot of the page, holding everything that used to
+ * occupy the column.
+ *
+ * ## Why the foot of the page and not the top
+ *
+ * A note is a footnote. Put above the content it delays the thing the merchant came for
+ * on every visit, forever, to answer a question they have on the first visit only. Pages
+ * here are sized to fit a screen (`ROWS_PER_VIEW`), so the foot is on screen rather than
+ * somewhere to scroll to — which is what makes a footnote findable rather than hidden.
+ *
+ * The divider is the part that does that work. Without it the toggle reads as one more
+ * action belonging to the last card; with it, it reads as the page's own annotation.
+ *
+ * ## Two columns when it opens
+ *
+ * The panel spans the page, and a paragraph set across 1500px is not readable. Opening it
+ * into two columns keeps the measure sane *and* keeps the panel short — three paragraphs
+ * that were a tall thin column are now two short rows, so the content below is barely
+ * pushed and the page does not jump.
+ *
+ * One comma in the responsive value, as everywhere else: Polaris splits on the comma to
+ * separate "when the query matches" from "otherwise", and a second one anywhere in the
+ * string stops the whole value parsing.
+ *
+ * The prop is `label` and not `title` because what it names is a button's label, and
+ * `control-vocabulary.test.ts` exempts exactly that: a bare `{identifier}` inside an
+ * `s-button` is a domain value reaching the screen unless its name says a caller wrote
+ * the words. Calling this what it is keeps that exemption a distinction rather than a
+ * hole.
+ */
+export function HelpNote({ label, children }: { label: string; children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <s-stack gap={SPACE.section}>
+      <s-divider />
+
+      <ActionRow>
+        {/* Tertiary, and a question mark rather than a chevron. The vocabulary in
+            `ActionRow` reserves chrome for things the page wants done, and this is not
+            one of them — but the icon still has to say at a glance that the line is help
+            rather than a filter or a link away, because a merchant who does not know what
+            "baseline" means is not scanning the bottom of the page for the word "what".
+
+            The label does not change when it opens; the panel appearing underneath is the
+            feedback. Assistive technology gets the state through `accessibilityLabel`,
+            which is where a state change belongs when the visible text is a heading. */}
+        <s-button
+          variant="tertiary"
+          icon="question-circle"
+          accessibilityLabel={open ? `Hide: ${label}` : `Show: ${label}`}
+          onClick={() => setOpen((shown) => !shown)}
+        >
+          {label}
+        </s-button>
+      </ActionRow>
+
+      {open ? (
+        <s-grid
+          gridTemplateColumns="@container (inline-size <= 700px) 1fr, 1fr 1fr"
+          gap={SPACE.section}
+          alignItems="start"
+        >
+          {children}
+        </s-grid>
+      ) : null}
+    </s-stack>
+  );
+}

--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -2,9 +2,11 @@
  * The page shell, and the aside it has to rebuild.
  *
  * Polaris renders `s-page`'s `aside` slot **only** at `inlineSize="base"`. Going full
- * width therefore deletes every aside — silently, with no error and no empty box.
- * Nineteen sections across thirteen routes are in that slot, and four of them are on
- * the campaign page, including the one holding apply, revert, resume and cancel.
+ * width therefore deletes every aside — silently, with no error and no empty box. That
+ * was nineteen sections when this landed, including the one on the campaign page holding
+ * apply, revert, resume and cancel. It is four now — the column is reserved for facts
+ * about the shop, and the prose that used to fill it is in `HelpNote` — which changes the
+ * arithmetic and none of the reasoning.
  *
  * So these assertions are about a merchant losing a button, not about layout taste.
  *
@@ -101,7 +103,7 @@ describe("pages without an aside", () => {
 });
 
 describe("asides that a page renders conditionally", () => {
-  // Three of the nineteen sit inside a ternary — `{count > 0 ? <s-section slot="aside">`
+  // Some sit inside a ternary — `{count > 0 ? <s-section slot="aside">`
   // — so they arrive as a direct child only when the condition holds. A partition that
   // missed them would drop an aside on exactly the pages that had something to say.
   it("are found when the condition holds", () => {

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -53,17 +53,30 @@ export function PageWidth({ children }: { children: ReactNode }) {
  * content leaves the title hanging off the left edge, aligned to nothing.
  *
  * The catch that makes this more than one attribute: Polaris renders the `aside` slot
- * **only** when `inlineSize` is `"base"`. Nineteen sections across thirteen routes use
- * it, and four of them are on the campaign page — including the one holding apply,
- * revert, resume and cancel. Setting `inlineSize="large"` and nothing else would have
- * deleted the apply button with no error and no empty box, which is the kind of
- * failure nobody finds until a merchant reports it.
+ * **only** when `inlineSize` is `"base"`. Nineteen sections were in that slot when this
+ * was written, including the one on the campaign page holding apply, revert, resume and
+ * cancel. Setting `inlineSize="large"` and nothing else would have deleted the apply
+ * button with no error and no empty box, which is the kind of failure nobody finds until
+ * a merchant reports it.
  *
  * So the aside is rebuilt here rather than abandoned. Children marked `slot="aside"`
  * are partitioned out and rendered in a second column, and the routes keep writing
  * exactly what they wrote before. The alternative — hand-editing nineteen JSX blocks
  * out of their pages and into a prop — is the same change with far more opportunity to
  * drop one.
+ *
+ * ## What is allowed in the column
+ *
+ * Four sections across three routes, now: the store card, recent activity, cost coverage
+ * and errors by kind. All four are **facts about this shop**.
+ *
+ * That is the rule, and it is worth stating because the column had drifted the other way.
+ * Ten of the nineteen were prose explaining how the app works — what a baseline is, how
+ * two campaigns resolve — and prose does not vary, so those pages spent a permanent 22rem
+ * column, full height, on a paragraph a merchant reads once. On the catalogue that meant
+ * seven columns of prices compressed into two thirds of the screen so three paragraphs
+ * could have the other third. Those are `HelpNote`s at the foot of their pages now; the
+ * reasoning is in that file.
  *
  * The column collapses under 900px so the aside falls below the content rather than
  * being squeezed into something unreadable. It is a container query, not a media

--- a/app/components/campaign/views.test.ts
+++ b/app/components/campaign/views.test.ts
@@ -77,9 +77,11 @@ describe("the page header is a header, not a card", () => {
     expect(header).not.toContain("<s-section");
   });
 
-  it("leaves the list card as the only card above the fold", () => {
-    // One `s-section` in the route itself -- the aside. The list and the calendar bring
-    // their own.
-    expect(route.split("<s-section").length - 1).toBe(1);
+  it("draws no card of its own at all", () => {
+    // It used to draw one: the "How campaigns resolve" aside. That was prose explaining
+    // the resolver rather than anything about this shop, so it is a `HelpNote` at the
+    // foot of the page now and the route is down to a banner, a header and a view. The
+    // list and the calendar bring their own cards.
+    expect(route.split("<s-section").length - 1).toBe(0);
   });
 });

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * The explanations survived being folded away.
+ *
+ * Ten pages had their teaching prose in an `s-section slot="aside"` — a permanent 22rem
+ * column, full height, next to the table the merchant came for. Moving it into a
+ * disclosure at the foot of the page has one obvious failure and one quiet one:
+ *
+ * - obvious: the panel never opens, so the prose is gone from the product;
+ * - quiet: a paragraph is dropped during the move. Nothing errors, nothing looks wrong,
+ *   and the page simply stops explaining what a baseline is. `sections.test.ts` guards
+ *   the same failure for the campaign tabs, and for the same reason.
+ *
+ * So the render assertions cover the mechanism and a source scan covers the content: each
+ * page still names the thing it used to explain, wherever that prose now lives.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { HelpNote } from "./HelpNote";
+
+const ROUTES = join(process.cwd(), "app", "routes");
+const route = (name: string) => readFileSync(join(ROUTES, name), "utf8");
+/** Every route module, so a new explanatory sidebar is caught wherever it is added. */
+const ALL_ROUTES = readdirSync(ROUTES).filter((f) => f.endsWith(".tsx"));
+
+const render = (node: React.ReactElement) => renderToStaticMarkup(node);
+
+describe("closed, which is how a page starts", () => {
+  const html = render(
+    <HelpNote label="What these mean">
+      <s-paragraph>Baseline is the reference price.</s-paragraph>
+    </HelpNote>,
+  );
+
+  it("costs the page one line and no column", () => {
+    expect(html).toContain("What these mean");
+    expect(html, "the prose is the whole reason this collapses").not.toContain(
+      "Baseline is the reference price.",
+    );
+  });
+
+  it("says it is help rather than a filter or a link away", () => {
+    // A merchant who does not know what "baseline" means is not scanning the foot of the
+    // page for the word "what". The icon is what makes the line findable.
+    expect(html).toContain('icon="question-circle"');
+  });
+
+  it("names the state for assistive technology, since the label does not change", () => {
+    expect(html).toContain('accessibilityLabel="Show: What these mean"');
+  });
+
+  it("is quiet enough not to compete with the page's actual actions", () => {
+    // `ActionRow`'s vocabulary: chrome is for things the page wants done, and reading a
+    // definition is not one of them.
+    expect(html).toContain('variant="tertiary"');
+  });
+
+  it("rules itself off, so it reads as the page's annotation and not the last card's", () => {
+    expect(html).toContain("<s-divider");
+  });
+});
+
+describe("the page it sits at the foot of", () => {
+  it("does not take a column back to say so", () => {
+    // The whole point. A note that reappeared as an aside would be the original bug with
+    // an extra component in front of it.
+    const html = render(
+      <HelpNote label="How campaigns resolve">
+        <s-paragraph>Exactly one wins.</s-paragraph>
+      </HelpNote>,
+    );
+
+    expect(html).not.toContain('slot="aside"');
+  });
+});
+
+describe("the prose each page used to keep in a column", () => {
+  /** The ten notes, and a phrase from each that only that explanation would contain. */
+  const MOVED: Array<[route: string, title: string, phrase: string]> = [
+    ["app.prices._index.tsx", "What these mean", "reference price every campaign computes"],
+    ["app.prices.baselines._index.tsx", "Reading this page", "rather than against a previous discount"],
+    ["app.prices.drift.tsx", "What the three choices do", "makes the new price the baseline"],
+    ["app.prices.baselines.recapture.tsx", "If you get this wrong", "Baselines are append-only"],
+    ["app.campaigns._index.tsx", "How campaigns resolve", "They never stack"],
+    ["app.campaigns.new.tsx", "Nothing is written yet", "only records the rule"],
+    ["app.campaigns.import.tsx", "Only price files are listed", "do not record a file yet"],
+    ["app.activity.tsx", "What is kept", "Retention is not a paid tier"],
+    ["app.settings._index.tsx", "Why floors are checked last", "Rounding down can push"],
+    ["app.settings.segments.tsx", "Dynamic or frozen", "re-checks its filter every time"],
+  ];
+
+  it.each(MOVED)("%s still explains itself", (name, title, phrase) => {
+    const source = route(name);
+
+    expect(source, `${name} lost the note titled "${title}"`).toContain(
+      `<HelpNote label="${title}">`,
+    );
+    expect(source, `${name} kept the note but dropped a paragraph out of it`).toContain(phrase);
+  });
+
+  it("leaves none of them still holding a column", () => {
+    const stuck = MOVED.filter(([name, title]) =>
+      route(name).includes(`<s-section slot="aside" heading="${title}">`),
+    );
+
+    expect(stuck.map(([name]) => name)).toEqual([]);
+  });
+});
+
+describe("what stays in the aside", () => {
+  /**
+   * The rule the column now follows: an aside carries facts about *this shop*, which
+   * change per merchant and per visit and are therefore worth a permanent column. Prose
+   * about how the app works does not change, so it is a note.
+   *
+   * Checked rather than written down, because the next explanatory sidebar will be added
+   * by someone who has not read `PageShell`.
+   */
+  const FACTS = [
+    ["app._index.tsx", "Store"],
+    ["app._index.tsx", "Recent activity"],
+    ["app.settings._index.tsx", "Cost data"],
+    ["app.settings.diagnostics.tsx", "By kind"],
+  ] as const;
+
+  it.each(FACTS)("%s keeps its %s card beside the content", (name, heading) => {
+    expect(route(name)).toContain(`<s-section slot="aside" heading="${heading}">`);
+  });
+
+  it("and nothing else does", () => {
+    const asides = ALL_ROUTES.flatMap((name) => {
+      const headings = [...route(name).matchAll(/<s-section slot="aside" heading="([^"]+)">/g)];
+      return headings.map((match) => [name, match[1]] as const);
+    });
+
+    const unexpected = asides.filter(
+      ([name, heading]) => !FACTS.some(([file, kept]) => file === name && kept === heading),
+    );
+
+    expect(
+      unexpected,
+      "an aside holding an explanation is a column spent on a paragraph — use HelpNote",
+    ).toEqual([]);
+  });
+});

--- a/app/lib/ui/page-width.test.ts
+++ b/app/lib/ui/page-width.test.ts
@@ -62,9 +62,16 @@ describe("routes that use the aside slot", () => {
   it("still have somewhere for it to land", () => {
     const withAside = renderingRoutes().filter(({ source }) => source.includes('slot="aside"'));
 
-    // Not a nice-to-have: four of these are on the campaign page, one of them holding
-    // apply, revert, resume and cancel.
-    expect(withAside.length, "the asides this guards should still exist").toBeGreaterThan(5);
+    // Not a nice-to-have: an aside that stops rendering does so silently, and the ones
+    // left are the store card, recent activity, cost coverage and errors by kind — the
+    // only things on their pages that say what state this shop is actually in.
+    //
+    // Three routes, not the thirteen this started with. The other ten were prose
+    // explaining the app rather than facts about the shop, and prose does not need a
+    // column of its own — see `HelpNote`. The floor moves down with them rather than
+    // being deleted: it is here so that "the partition quietly stopped matching anything"
+    // fails, and a floor of zero cannot do that.
+    expect(withAside.length, "the asides this guards should still exist").toBeGreaterThan(2);
 
     for (const { name, source } of withAside) {
       expect(source, `${name} uses slot="aside" but does not render inside PageShell`).toContain(

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -26,6 +26,7 @@ import { describeAction } from "../lib/audit/action";
 import { describeActor } from "../lib/audit/actor";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { HelpNote } from "../components/HelpNote";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { SPACE } from "../lib/ui/spacing";
 
@@ -144,7 +145,7 @@ export default function Activity() {
         )}
       </s-section>
 
-      <s-section slot="aside" heading="What is kept">
+      <HelpNote label="What is kept">
         <s-paragraph>
           <s-text>
             Everything, for as long as you have the app. Retention is not a paid tier
@@ -158,7 +159,7 @@ export default function Activity() {
             the staff account that did it.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -11,6 +11,7 @@ import { PageShell } from "../components/PageShell";
 import { TabBar } from "../components/TabBar";
 import { CampaignCalendar } from "../components/campaign/CampaignCalendar";
 import { CampaignListView } from "../components/campaign/CampaignListView";
+import { HelpNote } from "../components/HelpNote";
 import { filtersFrom, listCampaigns } from "../services/campaigns/list.server";
 import { calendarFor, todayIn } from "../services/calendar.server";
 import { addDays } from "../lib/scheduling/calendar";
@@ -162,7 +163,7 @@ export default function Campaigns() {
         <CampaignListView list={list} filters={filters} linkTo={linkTo} />
       )}
 
-      <s-section slot="aside" heading="How campaigns resolve">
+      <HelpNote label="How campaigns resolve">
         <s-paragraph>
           When two campaigns cover the same variant, exactly one wins — the higher
           priority, then the more recent. They never stack, so a variant cannot end
@@ -172,7 +173,7 @@ export default function Campaigns() {
           Reverting recomputes rather than restoring saved numbers. If another
           campaign still covers a variant, that campaign&rsquo;s price stays in place.
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }

--- a/app/routes/app.campaigns.import.tsx
+++ b/app/routes/app.campaigns.import.tsx
@@ -42,6 +42,7 @@ import { PageShell } from "../components/PageShell";
 import { formatCount, formatWhen } from "../lib/format/display";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { EmptyState } from "../components/AsyncState";
+import { HelpNote } from "../components/HelpNote";
 import { isCommit } from "../lib/imports/intent";
 import {
   ImportForm,
@@ -237,12 +238,12 @@ export default function ImportPrices() {
         )}
       </s-section>
 
-      <s-section slot="aside" heading="Only price files are listed">
+      <HelpNote label="Only price files are listed">
         <s-paragraph>
           Baseline and cost imports do not record a file yet, so they do not appear here.
           Their results are shown when you run them, on the pages they belong to.
         </s-paragraph>
-      </s-section>
+      </HelpNote>
 
       {result ? (
         <ImportReport

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -30,6 +30,7 @@ import { UnsavedChanges } from "../components/UnsavedChanges";
 import { DraftPreview } from "../components/DraftPreview";
 import { RuleValueField } from "../components/RuleValueField";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
+import { HelpNote } from "../components/HelpNote";
 import { SPACE } from "../lib/ui/spacing";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
@@ -641,7 +642,7 @@ export default function NewCampaign() {
         </Form>
       </s-section>
 
-      <s-section slot="aside" heading="Nothing is written yet">
+      <HelpNote label="Nothing is written yet">
         <s-paragraph>
           Creating a campaign only records the rule. The next screen shows exactly
           which prices would change, before anything touches your storefront.
@@ -651,7 +652,7 @@ export default function NewCampaign() {
           not its current price — so applying twice gives the same result rather than
           discounting the discount.
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -13,6 +13,7 @@ import { Pagination } from "../components/Pagination";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { HelpNote } from "../components/HelpNote";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 
 const PAGE_SIZE = ROWS_PER_VIEW;
@@ -156,7 +157,7 @@ export default function Catalog() {
         )}
       </s-section>
 
-      <s-section slot="aside" heading="What these mean">
+      <HelpNote label="What these mean">
         <s-paragraph>
           <strong>Live price</strong> is what your storefront shows right now.
         </s-paragraph>
@@ -171,7 +172,7 @@ export default function Catalog() {
             Outside one, it means something changed the price elsewhere.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }

--- a/app/routes/app.prices.baselines._index.tsx
+++ b/app/routes/app.prices.baselines._index.tsx
@@ -43,6 +43,7 @@ import { downloadCsv } from "../lib/reporting/csv";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { HelpNote } from "../components/HelpNote";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { SPACE } from "../lib/ui/spacing";
 
@@ -352,7 +353,7 @@ export default function Baselines() {
         </ActionRow>
       </s-section>
 
-      <s-section slot="aside" heading="Reading this page">
+      <HelpNote label="Reading this page">
         <s-paragraph>
           <s-text>
             <strong>Baseline</strong> is the reference price every campaign computes from.
@@ -366,7 +367,7 @@ export default function Baselines() {
             running. Outside one, it means something changed the price elsewhere.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }

--- a/app/routes/app.prices.baselines.recapture.tsx
+++ b/app/routes/app.prices.baselines.recapture.tsx
@@ -31,6 +31,7 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { reportError } from "../services/error-report.server";
 import { PageShell } from "../components/PageShell";
+import { HelpNote } from "../components/HelpNote";
 import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/prices/baselines/recapture", async ({ request }: LoaderFunctionArgs) => {
@@ -202,7 +203,7 @@ export default function Recapture() {
         </fetcher.Form>
       </s-section>
 
-      <s-section slot="aside" heading="If you get this wrong">
+      <HelpNote label="If you get this wrong">
         <s-paragraph>
           <s-text>
             Baselines are append-only: the previous one is kept, marked superseded, with
@@ -214,7 +215,7 @@ export default function Recapture() {
         <s-paragraph>
           <s-text>The Baselines page shows every version of every variant.</s-text>
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }

--- a/app/routes/app.prices.drift.tsx
+++ b/app/routes/app.prices.drift.tsx
@@ -23,6 +23,7 @@ import { PageShell } from "../components/PageShell";
 import { EmptyState } from "../components/AsyncState";
 import { ActionRow } from "../components/ActionRow";
 import { ShowingSome } from "../components/Pagination";
+import { HelpNote } from "../components/HelpNote";
 import prisma from "../db.server";
 
 export const loader = withGuard("/app/prices/drift", async ({ request }: LoaderFunctionArgs) => {
@@ -114,7 +115,7 @@ export default function DriftQueue() {
         )}
       </s-section>
 
-      <s-section slot="aside" heading="What the three choices do">
+      <HelpNote label="What the three choices do">
         <s-paragraph>
           <strong>Keep the change</strong> makes the new price the baseline. Use it when
           the edit was a permanent repricing — every future campaign will compute from it.
@@ -133,7 +134,7 @@ export default function DriftQueue() {
             why it is the one marked as consequential.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -19,6 +19,7 @@ import {
 import { PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
+import { HelpNote } from "../components/HelpNote";
 import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
@@ -351,7 +352,7 @@ export default function Settings() {
 
       <SettingsSaveBar form={formRef} saving={busy} />
 
-      <s-section slot="aside" heading="Why floors are checked last">
+      <HelpNote label="Why floors are checked last">
         <s-paragraph>
           A campaign computes a price from the baseline, rounds it, and only then
           checks the floor. Rounding down can push an otherwise-legal price under the
@@ -363,7 +364,7 @@ export default function Settings() {
             floor is always on.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </HelpNote>
 
       <s-section slot="aside" heading="Cost data">
         <s-paragraph>

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -32,6 +32,7 @@ import { FieldGrid, FullRow } from "../components/FieldGrid";
 import { SPACE } from "../lib/ui/spacing";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { ShowingSome } from "../components/Pagination";
+import { HelpNote } from "../components/HelpNote";
 
 export const loader = withGuard("/app/settings/segments", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -224,7 +225,7 @@ export default function Segments() {
 
       <NewSegment available={available} fetcher={fetcher} busy={busy} />
 
-      <s-section slot="aside" heading="Dynamic or frozen">
+      <HelpNote label="Dynamic or frozen">
         <s-paragraph>
           <s-text>
             <s-badge tone="info">Dynamic</s-badge> re-checks its filter every time a
@@ -247,7 +248,7 @@ export default function Segments() {
             one instead.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </HelpNote>
     </PageShell>
   );
 }


### PR DESCRIPTION
Closes #420.

Ten routes explained themselves in a 22rem aside running the full height of the page. The prose is good — it is some of the best writing in the app — but it does not change, so a permanent column was the wrong container for it. On the catalogue that column cost seven columns of prices a third of the screen.

## The rule

**An aside carries facts about this shop. Prose explaining how the app works is a note.**

Four sections stay in the column and all four are shop state: Store, Recent activity, Cost data, By kind. The other ten become `HelpNote`s — one quiet tertiary line with a `question-circle` icon at the foot of the page, under a divider, opening into two columns across the full width so the panel stays short and the measure stays readable.

This is not a new pattern. `OnboardingCard` already argued it for the checklist — *"the mistake was teaching all of it before being asked"*, and *"progressive disclosure, not a link away"* — and this applies the same move rather than inventing a second one or sending merchants to `/help`.

Foot of the page rather than top: pages are already sized to fit a screen (`ROWS_PER_VIEW`), so the note is visible without scrolling and does not delay the content on every visit to answer a first-visit question. The divider is what makes it read as the page's annotation rather than the last card's action.

## Moved

Catalogue · Baselines · Drift · Recapture · Campaigns · New campaign · Import prices · Activity · Settings · Segments — every word preserved verbatim.

## Two things the existing tests caught

- **`control-vocabulary.test.ts`** rejected the first version: the button label was `{title}`, which its rule reads as a domain value reaching the screen. It exempts names ending in "label". The prop is `label` now rather than the exemption being widened — it *is* the button's label, so that keeps the guard a distinction rather than a hole.
- **`views.test.ts`** asserted the campaigns route holds exactly one `s-section` — the aside. It is zero now; the route is a banner, a header and a view, and the list and calendar bring their own cards.

`page-width.test.ts`'s aside floor moved from 6 to 3 rather than being deleted: it exists so that "the partition quietly stopped matching anything" fails, and a floor of zero cannot do that.

## Verification

`typecheck`, `lint` and the full suite (2188 tests, 137 files) pass. The new tests were proved able to fail: forcing the panel open, dropping a paragraph, and reverting a note to an aside each fail the assertion meant to catch them.

**Not verified in the running admin.** This repo has a documented history of layout that serialises fine and breaks only in the browser. The rendered markup puts the note as a sibling of the sections — the same shape `s-banner` and `TabBar` already ship as on the campaigns page — but the pages that lost their only aside also switch `PageShell` branches, and that branch is the one that has blanked before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
