### PR TITLE
Help under the title, in an overlay that moves nothing

### DIFF
--- a/app/components/HelpNote.tsx
+++ b/app/components/HelpNote.tsx
@@ -1,93 +1,94 @@
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { ActionRow } from "./ActionRow";
-import { SPACE } from "../lib/ui/spacing";
+import { PAD, SPACE } from "../lib/ui/spacing";
 
 /**
- * The prose that explains a page, folded away until it is asked for.
+ * The prose that explains a page, in an overlay under its title.
  *
  * Ten pages carried an explanation of themselves — what a baseline is, how two campaigns
  * resolve, why a floor is checked after rounding — and every one of them was an
- * `s-section slot="aside"`. That put roughly a hundred words in a 22rem column running
- * the full height of the page, next to the table the merchant actually came for. On the
+ * `s-section slot="aside"`. That put roughly a hundred words in a 22rem column running the
+ * full height of the page, next to the table the merchant actually came for. On the
  * catalogue the cost was blunt: seven columns of numbers squeezed into two thirds of the
- * screen so that three paragraphs could sit in the other third, wrapping "Live price"
- * onto two lines while a quarter of the window stayed white.
+ * screen so that three paragraphs could sit in the other third.
  *
  * The prose is not the problem — it is some of the best writing in the app, and the
  * baseline concept genuinely does need teaching. The problem is teaching all of it,
- * permanently, before anyone has asked. `OnboardingCard` had already reached this
+ * permanently, before anyone has asked. `OnboardingCard` had already reached that
  * conclusion for the checklist and its "Why?" toggle; this is the same move applied to
  * the rest of the app.
  *
- * So the aside column is now reserved for **facts about this shop** — the store card,
- * recent activity, cost coverage, errors by kind — and prose explaining how the app works
- * becomes a note: one quiet line at the foot of the page, holding everything that used to
- * occupy the column.
+ * So the aside column is reserved for **facts about this shop** — the store card and the
+ * recent activity feed on the dashboard — and prose explaining how the app works is a
+ * note: one line under the page title, opening into an overlay.
  *
- * ## Why the foot of the page and not the top
+ * ## Two things this got wrong first, both worth keeping written down
  *
- * A note is a footnote. Put above the content it delays the thing the merchant came for
- * on every visit, forever, to answer a question they have on the first visit only. Pages
- * here are sized to fit a screen (`ROWS_PER_VIEW`), so the foot is on screen rather than
- * somewhere to scroll to — which is what makes a footnote findable rather than hidden.
+ * **It was at the foot of the page.** The reasoning was that a note is a footnote and
+ * pages are sized to fit a screen, so the foot is on screen. That is true of a full table
+ * and false of every page that is shorter or longer than the estimate — and it puts the
+ * answer to "what does this column mean?" below the thing the merchant is asking about,
+ * so they have to leave the question to reach the answer. Help goes where the confusion
+ * is, which is the top.
  *
- * The divider is the part that does that work. Without it the toggle reads as one more
- * action belonging to the last card; with it, it reads as the page's own annotation.
+ * **It expanded in place.** A disclosure that pushes the page down moves the table the
+ * merchant is reading, at the exact moment they are trying to read it. `s-popover` is an
+ * overlay: the panel is not in the page's flow at any point, so opening it moves nothing.
+ * That is also why this holds no React state — `commandFor` makes the button the
+ * popover's activator in the platform, and there is no open/closed for us to track, get
+ * wrong, or re-render on.
  *
- * ## Two columns when it opens
+ * A popover rather than `s-tooltip`, which is hover-only and accepts text and paragraphs
+ * only. Half of these notes carry a `<strong>` or an `s-badge`, and a definition a
+ * merchant cannot pin open long enough to read is not a definition.
  *
- * The panel spans the page, and a paragraph set across 1500px is not readable. Opening it
- * into two columns keeps the measure sane *and* keeps the panel short — three paragraphs
- * that were a tall thin column are now two short rows, so the content below is barely
- * pushed and the page does not jump.
- *
- * One comma in the responsive value, as everywhere else: Polaris splits on the comma to
- * separate "when the query matches" from "otherwise", and a second one anywhere in the
- * string stops the whole value parsing.
+ * `s-popover` supplies no padding of its own, so the box is not optional decoration —
+ * without it the prose sits against the overlay's edge.
  *
  * The prop is `label` and not `title` because what it names is a button's label, and
  * `control-vocabulary.test.ts` exempts exactly that: a bare `{identifier}` inside an
- * `s-button` is a domain value reaching the screen unless its name says a caller wrote
- * the words. Calling this what it is keeps that exemption a distinction rather than a
- * hole.
+ * `s-button` is a domain value reaching the screen unless its name says a caller wrote the
+ * words. Calling this what it is keeps that exemption a distinction rather than a hole.
  */
 export function HelpNote({ label, children }: { label: string; children: ReactNode }) {
-  const [open, setOpen] = useState(false);
+  const id = idFor(label);
 
   return (
-    <s-stack gap={SPACE.section}>
-      <s-divider />
+    <ActionRow>
+      {/* Tertiary, and a question mark rather than a chevron. The vocabulary in
+          `ActionRow` reserves chrome for things the page wants done, and reading a
+          definition is not one of them — but the icon still has to say at a glance that
+          the line is help, because a merchant who does not know what "baseline" means is
+          not scanning the page for the word "what".
 
-      <ActionRow>
-        {/* Tertiary, and a question mark rather than a chevron. The vocabulary in
-            `ActionRow` reserves chrome for things the page wants done, and this is not
-            one of them — but the icon still has to say at a glance that the line is help
-            rather than a filter or a link away, because a merchant who does not know what
-            "baseline" means is not scanning the bottom of the page for the word "what".
+          No `command`: the default `--auto` is toggle for a popover, which is what a help
+          affordance wants. Naming `--show` would leave the only way to close it a click
+          somewhere else. */}
+      <s-button variant="tertiary" icon="question-circle" commandFor={id}>
+        {label}
+      </s-button>
 
-            The label does not change when it opens; the panel appearing underneath is the
-            feedback. Assistive technology gets the state through `accessibilityLabel`,
-            which is where a state change belongs when the visible text is a heading. */}
-        <s-button
-          variant="tertiary"
-          icon="question-circle"
-          accessibilityLabel={open ? `Hide: ${label}` : `Show: ${label}`}
-          onClick={() => setOpen((shown) => !shown)}
-        >
-          {label}
-        </s-button>
-      </ActionRow>
-
-      {open ? (
-        <s-grid
-          gridTemplateColumns="@container (inline-size <= 700px) 1fr, 1fr 1fr"
-          gap={SPACE.section}
-          alignItems="start"
-        >
-          {children}
-        </s-grid>
-      ) : null}
-    </s-stack>
+      {/* Pixels, not rem: Polaris types `maxInlineSize` as px, % or 0 only.
+          360 is a readable measure for prose — much wider and the overlay stops being a
+          note and starts being the page again. */}
+      <s-popover id={id} maxInlineSize="360px">
+        <s-box padding={PAD.card}>
+          <s-stack gap={SPACE.section}>{children}</s-stack>
+        </s-box>
+      </s-popover>
+    </ActionRow>
   );
+}
+
+/**
+ * The id linking the button to the overlay it opens.
+ *
+ * Derived from the label rather than `useId`, for two reasons. It is stable across a
+ * server render and its hydration, which an id counter is only accidentally; and it is
+ * legible in the DOM, so an overlay that does not open can be traced to the button that
+ * should have opened it. One note per page, so the label is unique by construction.
+ */
+function idFor(label: string) {
+  return `help-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")}`;
 }

--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -21,6 +21,7 @@ import { join } from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { HelpNote } from "./HelpNote";
 import { PageShell } from "./PageShell";
 
 const render = (node: React.ReactElement) => renderToStaticMarkup(node);
@@ -73,6 +74,56 @@ describe("the aside survives going full width", () => {
 
   it("keeps main content ahead of the aside, so narrow screens read in order", () => {
     expect(html.indexOf("main content")).toBeLessThan(html.indexOf("Apply"));
+  });
+});
+
+describe("the help note, wherever the route wrote it", () => {
+  /**
+   * Position is the shell's decision, not the route's. It shipped at the foot of the page
+   * for one release — which puts the answer to "what does this column mean?" below the
+   * column being asked about, so a merchant has to leave the question to reach it.
+   *
+   * Both branches are checked because they build the main column differently, and a fix
+   * applied to one of them is exactly the kind of thing that looks done.
+   */
+  it("renders under the title, above the content, on a page with no aside", () => {
+    const html = render(
+      <PageShell heading="Catalogue">
+        <s-section>the table</s-section>
+        <HelpNote label="What these mean">
+          <s-paragraph>a definition</s-paragraph>
+        </HelpNote>
+      </PageShell>,
+    );
+
+    expect(html.indexOf("What these mean")).toBeLessThan(html.indexOf("the table"));
+  });
+
+  it("renders under the title on a page that has one", () => {
+    const html = render(
+      <PageShell heading="Home">
+        <s-section>the table</s-section>
+        <HelpNote label="What these mean">
+          <s-paragraph>a definition</s-paragraph>
+        </HelpNote>
+        <s-section slot="aside">store</s-section>
+      </PageShell>,
+    );
+
+    expect(html.indexOf("What these mean")).toBeLessThan(html.indexOf("the table"));
+  });
+
+  it("is taken out of the main flow rather than rendered twice", () => {
+    const html = render(
+      <PageShell heading="Catalogue">
+        <s-section>the table</s-section>
+        <HelpNote label="What these mean">
+          <s-paragraph>a definition</s-paragraph>
+        </HelpNote>
+      </PageShell>,
+    );
+
+    expect(html.split("What these mean").length - 1, "the note is rendered twice").toBe(1);
   });
 });
 

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -1,6 +1,7 @@
 import { Children, cloneElement, isValidElement, type ReactNode } from "react";
 
 import { ActionRow } from "./ActionRow";
+import { HelpNote } from "./HelpNote";
 import { PAGE_INSET, SPACE } from "../lib/ui/spacing";
 
 /**
@@ -67,16 +68,24 @@ export function PageWidth({ children }: { children: ReactNode }) {
  *
  * ## What is allowed in the column
  *
- * Four sections across three routes, now: the store card, recent activity, cost coverage
- * and errors by kind. All four are **facts about this shop**.
+ * Two sections on one route, now: the dashboard's store card and its recent activity
+ * feed. Both are **facts about this shop**, both change every time it is loaded, and a
+ * dashboard is the one page in the app whose job is showing several of those at once.
  *
- * That is the rule, and it is worth stating because the column had drifted the other way.
- * Ten of the nineteen were prose explaining how the app works — what a baseline is, how
- * two campaigns resolve — and prose does not vary, so those pages spent a permanent 22rem
- * column, full height, on a paragraph a merchant reads once. On the catalogue that meant
- * seven columns of prices compressed into two thirds of the screen so three paragraphs
- * could have the other third. Those are `HelpNote`s at the foot of their pages now; the
- * reasoning is in that file.
+ * That is the rule, and it is worth stating because the column had drifted a long way
+ * from it. Ten of the nineteen sections were prose explaining how the app works — what a
+ * baseline is, how two campaigns resolve — and prose does not vary, so those pages spent
+ * a permanent 22rem column, full height, on a paragraph a merchant reads once. On the
+ * catalogue that meant seven columns of prices compressed into two thirds of the screen
+ * so three paragraphs could have the other third. Those are `HelpNote`s now.
+ *
+ * Two more were facts that had been filed away from the thing they qualify: cost coverage
+ * belongs beside the cost-floor settings it decides the scope of, and the breakdown of
+ * failures by code belongs above the failures it counts. Neither needed a column; both
+ * needed to be next to their subject.
+ *
+ * So a new sidebar has to answer: does this change per shop, and is this page a dashboard?
+ * If not, it is a note or it belongs inline.
  *
  * The column collapses under 900px so the aside falls below the content rather than
  * being squeezed into something unreadable. It is a container query, not a media
@@ -143,8 +152,21 @@ export function PageShell({
   const isAside = (child: ReactNode) =>
     isValidElement(child) && (child.props as { slot?: string }).slot === "aside";
 
+  /**
+   * The page's help note, wherever the route happened to write it.
+   *
+   * Matched on the component rather than on a slot, because unlike the aside this is not
+   * a position a route gets to choose. Help belongs directly under the title on every
+   * page — a route that writes its note last, next to the prose it explains, still gets
+   * it rendered first. That is the whole reason the placement lives here: it was at the
+   * foot of the page for one release, which put the answer below the thing being asked
+   * about, and one component is the only way that is fixed once.
+   */
+  const isHelp = (child: ReactNode) => isValidElement(child) && child.type === HelpNote;
+
   const aside = all.filter(isAside);
-  const main = all.filter((child) => !isAside(child));
+  const help = all.filter(isHelp);
+  const main = all.filter((child) => !isAside(child) && !isHelp(child));
 
   if (aside.length === 0) {
     // Children go straight into `s-page`, with no wrapper of any kind.
@@ -164,6 +186,7 @@ export function PageShell({
       <PageWidth>
         <BackLink backTo={backTo} />
         <s-page heading={heading} inlineSize="large">
+          {help}
           {main}
         </s-page>
       </PageWidth>
@@ -191,7 +214,10 @@ export function PageShell({
           // a one-line sidebar next to a long table becomes a very tall empty card.
           alignItems="start"
         >
-          <s-stack gap={SPACE.page}>{main}</s-stack>
+          <s-stack gap={SPACE.page}>
+            {help}
+            {main}
+          </s-stack>
           <s-stack gap={SPACE.page}>
             {aside.map((child) =>
               // The slot is meaningless now that these are ordinary grid children, and

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -1,14 +1,18 @@
 /**
- * The explanations survived being folded away.
+ * The explanations survived being folded into an overlay.
  *
  * Ten pages had their teaching prose in an `s-section slot="aside"` — a permanent 22rem
- * column, full height, next to the table the merchant came for. Moving it into a
- * disclosure at the foot of the page has one obvious failure and one quiet one:
+ * column, full height, next to the table the merchant came for. Three things can go
+ * wrong in moving it, and only the first is loud:
  *
- * - obvious: the panel never opens, so the prose is gone from the product;
- * - quiet: a paragraph is dropped during the move. Nothing errors, nothing looks wrong,
- *   and the page simply stops explaining what a baseline is. `sections.test.ts` guards
- *   the same failure for the campaign tabs, and for the same reason.
+ * - the popover has no activator, so the prose is unreachable — the button and the
+ *   overlay are linked by an id, and an id that does not match is silent;
+ * - the note drifts back down the page. It shipped at the foot for one release, which put
+ *   the answer below the thing being asked about; `PageShell` decides the position now,
+ *   and this pins it there;
+ * - a paragraph is dropped during the move. Nothing errors, nothing looks wrong, and the
+ *   page simply stops explaining what a baseline is. `sections.test.ts` guards the same
+ *   failure for the campaign tabs, and for the same reason.
  *
  * So the render assertions cover the mechanism and a source scan covers the content: each
  * page still names the thing it used to explain, wherever that prose now lives.
@@ -29,7 +33,7 @@ const ALL_ROUTES = readdirSync(ROUTES).filter((f) => f.endsWith(".tsx"));
 
 const render = (node: React.ReactElement) => renderToStaticMarkup(node);
 
-describe("closed, which is how a page starts", () => {
+describe("the note itself", () => {
   const html = render(
     <HelpNote label="What these mean">
       <s-paragraph>Baseline is the reference price.</s-paragraph>
@@ -38,43 +42,40 @@ describe("closed, which is how a page starts", () => {
 
   it("costs the page one line and no column", () => {
     expect(html).toContain("What these mean");
-    expect(html, "the prose is the whole reason this collapses").not.toContain(
-      "Baseline is the reference price.",
+    expect(html).not.toContain('slot="aside"');
+  });
+
+  it("opens an overlay, so nothing on the page moves when it is read", () => {
+    // The reason this is a popover and not a disclosure. An expanding panel pushes the
+    // table down at the moment the merchant is trying to read it.
+    expect(html).toContain("<s-popover");
+  });
+
+  it("wires the button to that overlay, which is the only thing that opens it", () => {
+    // `commandFor` is an id lookup. A mismatch renders both elements, throws nothing, and
+    // leaves a button that does not work.
+    const id = /<s-popover[^>]*\sid="([^"]+)"/.exec(html)?.[1];
+
+    expect(id, "the popover has no id, so nothing can address it").toBeTruthy();
+    expect(html, "the button opens some other popover, or none").toContain(
+      `commandFor="${id}"`,
     );
   });
 
-  it("says it is help rather than a filter or a link away", () => {
-    // A merchant who does not know what "baseline" means is not scanning the foot of the
-    // page for the word "what". The icon is what makes the line findable.
-    expect(html).toContain('icon="question-circle"');
+  it("gives the prose an interior, because s-popover supplies none", () => {
+    expect(html).toMatch(/<s-popover[^>]*>\s*<s-box padding=/);
   });
 
-  it("names the state for assistive technology, since the label does not change", () => {
-    expect(html).toContain('accessibilityLabel="Show: What these mean"');
+  it("says it is help rather than a filter or a link away", () => {
+    // A merchant who does not know what "baseline" means is not scanning the page for the
+    // word "what". The icon is what makes the line findable.
+    expect(html).toContain('icon="question-circle"');
   });
 
   it("is quiet enough not to compete with the page's actual actions", () => {
     // `ActionRow`'s vocabulary: chrome is for things the page wants done, and reading a
     // definition is not one of them.
     expect(html).toContain('variant="tertiary"');
-  });
-
-  it("rules itself off, so it reads as the page's annotation and not the last card's", () => {
-    expect(html).toContain("<s-divider");
-  });
-});
-
-describe("the page it sits at the foot of", () => {
-  it("does not take a column back to say so", () => {
-    // The whole point. A note that reappeared as an aside would be the original bug with
-    // an extra component in front of it.
-    const html = render(
-      <HelpNote label="How campaigns resolve">
-        <s-paragraph>Exactly one wins.</s-paragraph>
-      </HelpNote>,
-    );
-
-    expect(html).not.toContain('slot="aside"');
   });
 });
 
@@ -113,9 +114,11 @@ describe("the prose each page used to keep in a column", () => {
 
 describe("what stays in the aside", () => {
   /**
-   * The rule the column now follows: an aside carries facts about *this shop*, which
-   * change per merchant and per visit and are therefore worth a permanent column. Prose
-   * about how the app works does not change, so it is a note.
+   * The rule the column follows now: a sidebar carries facts about *this shop*, on the
+   * one page whose job is showing several of them at once. Everything else lost its
+   * column — prose became a note, and two cards that were facts filed away from their
+   * subject moved next to it (cost coverage to the cost-floor settings, failures by code
+   * to the failures they count).
    *
    * Checked rather than written down, because the next explanatory sidebar will be added
    * by someone who has not read `PageShell`.
@@ -123,12 +126,32 @@ describe("what stays in the aside", () => {
   const FACTS = [
     ["app._index.tsx", "Store"],
     ["app._index.tsx", "Recent activity"],
-    ["app.settings._index.tsx", "Cost data"],
-    ["app.settings.diagnostics.tsx", "By kind"],
   ] as const;
 
   it.each(FACTS)("%s keeps its %s card beside the content", (name, heading) => {
     expect(route(name)).toContain(`<s-section slot="aside" heading="${heading}">`);
+  });
+
+  it("is the dashboard and nowhere else", () => {
+    const routes = ALL_ROUTES.filter((name) => route(name).includes('slot="aside"'));
+
+    expect(routes, "a second page with a sidebar is a rule that has started drifting").toEqual(
+      ["app._index.tsx"],
+    );
+  });
+
+  it("moved the two facts that were filed away from their subject", () => {
+    // Both were sidebar cards. Neither was help, and neither needed a column -- they
+    // needed to be next to the thing they qualify.
+    expect(
+      route("app.settings._index.tsx"),
+      "cost coverage belongs with the cost-floor settings whose scope it describes",
+    ).toMatch(/variants have a cost[\s\S]*?name="missingCostPolicy"/);
+
+    expect(
+      route("app.settings.diagnostics.tsx"),
+      "the breakdown belongs above the failures it counts",
+    ).toMatch(/<CountsRow items=\{byKind\}[\s\S]*?<s-table>/);
   });
 
   it("and nothing else does", () => {

--- a/app/lib/ui/page-width.test.ts
+++ b/app/lib/ui/page-width.test.ts
@@ -62,16 +62,16 @@ describe("routes that use the aside slot", () => {
   it("still have somewhere for it to land", () => {
     const withAside = renderingRoutes().filter(({ source }) => source.includes('slot="aside"'));
 
-    // Not a nice-to-have: an aside that stops rendering does so silently, and the ones
-    // left are the store card, recent activity, cost coverage and errors by kind — the
-    // only things on their pages that say what state this shop is actually in.
+    // Not a nice-to-have: an aside that stops rendering does so silently, and the two
+    // left are the dashboard's store card and its activity feed — the only things on that
+    // page that say what state this shop is actually in.
     //
-    // Three routes, not the thirteen this started with. The other ten were prose
-    // explaining the app rather than facts about the shop, and prose does not need a
-    // column of its own — see `HelpNote`. The floor moves down with them rather than
+    // One route, not the thirteen this started with. Ten were prose explaining the app
+    // rather than facts about the shop and became `HelpNote`s; two were facts filed away
+    // from their subject and moved next to it. The floor moves down with them rather than
     // being deleted: it is here so that "the partition quietly stopped matching anything"
     // fails, and a floor of zero cannot do that.
-    expect(withAside.length, "the asides this guards should still exist").toBeGreaterThan(2);
+    expect(withAside.length, "the asides this guards should still exist").toBeGreaterThan(0);
 
     for (const { name, source } of withAside) {
       expect(source, `${name} uses slot="aside" but does not render inside PageShell`).toContain(

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -20,6 +20,7 @@ import { PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
 import { HelpNote } from "../components/HelpNote";
+import { formatCount } from "../lib/format/display";
 import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
@@ -150,6 +151,18 @@ export default function Settings() {
         <s-paragraph>
           Floors that no campaign may price below. They are checked after rounding,
           so a rounding rule cannot push a price under them.
+        </s-paragraph>
+
+        {/* Coverage sits with the fields it qualifies, not in a sidebar card of its own.
+            Two of the controls below — "never price at or below cost" and what to do when
+            a cost-based floor meets a variant without one — mean nothing until you know
+            how many variants that second case actually is. */}
+        <s-paragraph>
+          <s-text color="subdued">
+            {formatCount(withCost)} of {formatCount(variants)} variants have a cost
+            ({costCoverage}%). Cost-based floors only constrain those; the last setting
+            in this section decides the rest.
+          </s-text>
         </s-paragraph>
 
         {settings.neverBelowCost && costCoverage < 100 ? (
@@ -365,18 +378,6 @@ export default function Settings() {
           </s-text>
         </s-paragraph>
       </HelpNote>
-
-      <s-section slot="aside" heading="Cost data">
-        <s-paragraph>
-          {withCost} of {variants} variants have a cost ({costCoverage}%).
-        </s-paragraph>
-        <s-paragraph>
-          <s-text>
-            Cost-based floors only constrain variants that have one. The policy above
-            decides what happens to the others.
-          </s-text>
-        </s-paragraph>
-      </s-section>
     </PageShell>
   );
 }

--- a/app/routes/app.settings.diagnostics.tsx
+++ b/app/routes/app.settings.diagnostics.tsx
@@ -19,6 +19,8 @@ import { EmptyState } from "../components/AsyncState";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { CountsRow } from "../components/CountsRow";
+import { HelpNote } from "../components/HelpNote";
 import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings/diagnostics", async ({ request }: LoaderFunctionArgs) => {
@@ -57,8 +59,33 @@ export const loader = withGuard("/app/settings/diagnostics", async ({ request }:
   };
 });
 
+/**
+ * The breakdown as tiles, bounded.
+ *
+ * `CountsRow` gives every item an equal column, so ten codes would be ten slivers of a
+ * number. Four plus a remainder keeps the row readable — and the remainder is its own
+ * tile rather than a silent truncation, because a summary that quietly drops codes is
+ * worse than no summary. Every dropped code is still in the table below, on its own rows.
+ */
+const TILES = 4;
+
+function tilesFor(byCode: Array<[string, number]>) {
+  const top = byCode.slice(0, TILES).map(([label, value]) => ({ label, value }));
+  const rest = byCode.slice(TILES);
+  if (rest.length === 0) return top;
+
+  return [
+    ...top,
+    {
+      label: `${rest.length} other codes`,
+      value: rest.reduce((total, [, count]) => total + count, 0),
+    },
+  ];
+}
+
 export default function Debug() {
   const { query, invalidQuery, match, recent, byCode } = useLoaderData<typeof loader>();
+  const byKind = tilesFor(byCode);
 
   return (
     <PageShell heading="Diagnostics">
@@ -142,54 +169,58 @@ export default function Debug() {
             description="Errors appear here as they happen, with the reference the merchant sees."
           />
         ) : (
-          <s-table>
-            <s-table-header-row>
-              <s-table-header listSlot="kicker">When</s-table-header>
-              <s-table-header listSlot="primary">Reference</s-table-header>
-              <s-table-header listSlot="inline">Code</s-table-header>
-              <s-table-header listSlot="secondary">Route</s-table-header>
-            </s-table-header-row>
-            <s-table-body>
-              {recent.map((row) => (
-                <s-table-row key={row.errorId}>
-                  <s-table-cell>{row.createdAt}</s-table-cell>
-                  <s-table-cell>
-                    <s-button
-                      variant="tertiary"
-                      href={`/app/settings/diagnostics?id=${row.errorId}`}
-                    >
-                      {row.errorId}
-                    </s-button>
-                  </s-table-cell>
-                  <s-table-cell>
-                    <s-badge tone={row.retryable ? "warning" : "critical"}>
-                      {row.code}
-                    </s-badge>
-                  </s-table-cell>
-                  <s-table-cell>{row.route ?? "—"}</s-table-cell>
-                </s-table-row>
-              ))}
-            </s-table-body>
-          </s-table>
+          <>
+            {/* The breakdown sits above the rows it counts rather than in a sidebar.
+                It answers the question the table cannot at a glance -- one broken thing
+                or fifty -- and that question is asked while looking at the table, not
+                across the page from it. */}
+            <CountsRow items={byKind} />
+
+            <s-table>
+              <s-table-header-row>
+                <s-table-header listSlot="kicker">When</s-table-header>
+                <s-table-header listSlot="primary">Reference</s-table-header>
+                <s-table-header listSlot="inline">Code</s-table-header>
+                <s-table-header listSlot="secondary">Route</s-table-header>
+              </s-table-header-row>
+              <s-table-body>
+                {recent.map((row) => (
+                  <s-table-row key={row.errorId}>
+                    <s-table-cell>{row.createdAt}</s-table-cell>
+                    <s-table-cell>
+                      <s-button
+                        variant="tertiary"
+                        href={`/app/settings/diagnostics?id=${row.errorId}`}
+                      >
+                        {row.errorId}
+                      </s-button>
+                    </s-table-cell>
+                    <s-table-cell>
+                      <s-badge tone={row.retryable ? "warning" : "critical"}>
+                        {row.code}
+                      </s-badge>
+                    </s-table-cell>
+                    <s-table-cell>{row.route ?? "—"}</s-table-cell>
+                  </s-table-row>
+                ))}
+              </s-table-body>
+            </s-table>
+          </>
         )}
       </s-section>
 
-      {byCode.length > 0 ? (
-        <s-section slot="aside" heading="By kind">
-          <s-paragraph>
-            <s-text>
-              One code dominating usually means one broken thing, not fifty.
-            </s-text>
-          </s-paragraph>
-          {byCode.map(([code, count]) => (
-            <s-paragraph key={code}>
-              <s-text>
-                {code} — {count}
-              </s-text>
-            </s-paragraph>
-          ))}
-        </s-section>
-      ) : null}
+      <HelpNote label="Reading the failures">
+        <s-paragraph>
+          One code dominating usually means one broken thing, not fifty.
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>
+            The breakdown counts the fifty most recent failures, which is also what the
+            table lists — so a code with a large share here is worth opening before the
+            newest row is.
+          </s-text>
+        </s-paragraph>
+      </HelpNote>
     </PageShell>
   );
 }


### PR DESCRIPTION
Closes #422. Follows up #421, which got the column back but put the help in the wrong place and gave it the wrong mechanism.

## Where it is now

Directly under the page title, on every page that has one — and `PageShell` decides that, not the route. A route writes its note wherever the prose belongs in source; the shell partitions it out by component and renders it first. That is the difference between fixing this once and fixing it per page until one is missed.

## What it is now

`s-popover`, activated by `commandFor`. It is an overlay, so it is never in the page's flow and opening it moves nothing — no layout shift at any point. It also removes the open/closed state entirely: the platform links button to overlay by id, so there is no React state to track, get wrong, or re-render on.

Not `s-tooltip`: hover-only, and it accepts text and paragraphs only, while half these notes carry a `<strong>` or an `s-badge`. A definition you cannot pin open long enough to read is not a definition.

`s-popover` supplies no padding of its own, so the `s-box` inside it is structural rather than decoration.

## The last two sidebars

Neither was help, and neither needed a column — both needed to be beside their subject.

| was | is |
|---|---|
| Settings → "Cost data" sidebar | the coverage line inside **Guardrails**, next to the two settings whose scope it describes |
| Diagnostics → "By kind" sidebar | a `CountsRow` **above the failures it counts**, plus a new note carrying the sentence |

The breakdown is capped at four codes with a named `N other codes` tile, so a long tail is bounded without being silently dropped — and every code is still on its own rows in the table below.

**The dashboard keeps its sidebar.** Its two cards are facts about the shop, and a dashboard is the one page whose job is showing several of those at once. That is now the stated rule, and `help-note.test.tsx` fails if a second page grows one.

## Verification

`typecheck`, `lint` and the full suite (2191 tests, 137 files) pass. The new assertions were proved able to fail: breaking the `commandFor` id, rendering the note after the main content in both `PageShell` branches, and reverting a note to an aside each fail the assertion meant to catch them.

**The popover has not been seen in a browser.** `s-popover` and `commandFor` are new to this codebase, and a Polaris overlay that does not open fails silently — the button renders, nothing throws, and the help is unreachable. The markup matches Shopify's documented activator pattern, but that is a claim about docs, not about the admin. Worth opening `/app/prices` after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
