### PR TITLE
The help popovers open

### DIFF
--- a/app/components/HelpNote.tsx
+++ b/app/components/HelpNote.tsx
@@ -46,6 +46,21 @@ import { PAD, SPACE } from "../lib/ui/spacing";
  * `s-popover` supplies no padding of its own, so the box is not optional decoration —
  * without it the prose sits against the overlay's edge.
  *
+ * ## `command` is required, whatever the documentation shows
+ *
+ * Every example on Shopify's popover page activates it with `commandFor` alone. That
+ * renders a button which does nothing: the first version of this shipped that way,
+ * looked correct in the admin, and silently had no help behind it.
+ *
+ * In `polaris.js` the activator's click handler is built as
+ * `commandFor && command ? {...} : undefined`, and the handler re-checks `command` before
+ * dispatching. With no `command` prop there is no listener at all — no error, no warning,
+ * a button that is focusable and inert. Polaris' own colour field, the one place in the
+ * runtime that opens a popover, passes `command: "--toggle"`.
+ *
+ * So `--toggle` here, matching the runtime rather than the docs. `--show` would open it
+ * and leave no way to close it from the control that opened it.
+ *
  * The prop is `label` and not `title` because what it names is a button's label, and
  * `control-vocabulary.test.ts` exempts exactly that: a bare `{identifier}` inside an
  * `s-button` is a domain value reaching the screen unless its name says a caller wrote the
@@ -60,12 +75,8 @@ export function HelpNote({ label, children }: { label: string; children: ReactNo
           `ActionRow` reserves chrome for things the page wants done, and reading a
           definition is not one of them — but the icon still has to say at a glance that
           the line is help, because a merchant who does not know what "baseline" means is
-          not scanning the page for the word "what".
-
-          No `command`: the default `--auto` is toggle for a popover, which is what a help
-          affordance wants. Naming `--show` would leave the only way to close it a click
-          somewhere else. */}
-      <s-button variant="tertiary" icon="question-circle" commandFor={id}>
+          not scanning the page for the word "what". */}
+      <s-button variant="tertiary" icon="question-circle" commandFor={id} command="--toggle">
         {label}
       </s-button>
 

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -62,6 +62,18 @@ describe("the note itself", () => {
     );
   });
 
+  it("carries a command, without which Polaris attaches no click handler at all", () => {
+    // This shipped once with `commandFor` alone, because that is what every example on
+    // Shopify's popover page shows. The button rendered, looked right, and did nothing.
+    //
+    // `polaris.js` builds the activator as `commandFor && command ? {...} : undefined`
+    // and re-checks `command` inside the handler, so the prop the docs omit is the one
+    // that makes the control exist. Polaris' own colour field passes `--toggle`.
+    expect(html, "a popover activator without a command is an inert button").toMatch(
+      /<s-button[^>]*\scommand="--toggle"/,
+    );
+  });
+
   it("gives the prose an interior, because s-popover supplies none", () => {
     expect(html).toMatch(/<s-popover[^>]*>\s*<s-box padding=/);
   });

--- a/docs/polaris-notes.md
+++ b/docs/polaris-notes.md
@@ -136,3 +136,45 @@ scroller is not a design anybody chose. Cap the rows and page instead.
 pager. Neither is used yet, and the filters slot has a real flaw: it lives inside the
 table, so it unmounts when the table has no rows — which is exactly when a merchant wants
 the search box.
+
+## A popover activator needs `command`, and the documentation says otherwise
+
+`s-popover` opens when a control names it with `commandFor`. Every example on Shopify's
+[popover page](https://shopify.dev/docs/api/app-home/polaris-web-components/overlays/popover)
+does exactly that and nothing more:
+
+```html
+<s-button commandFor="notifications-popover" icon="notification">Notifications</s-button>
+<s-popover id="notifications-popover">…</s-popover>
+```
+
+That button does nothing. It renders, it focuses, it takes a click, and no popover opens —
+no error, no warning, nothing in the console.
+
+In `polaris.js` the activator's props are built as:
+
+```js
+commandForProps: commandFor && command ? { onClick: () => { … } } : undefined
+```
+
+and the handler re-checks `command` before dispatching the `CommandEvent`. **With no
+`command` prop there is no click listener at all.** The `'--auto'` default in the type
+signature is a default for the *attribute*, not for the absent prop, so it never applies.
+
+The one place the runtime opens a popover itself — the colour field's swatch — passes
+`command: "--toggle"`. Follow the runtime, not the docs:
+
+```tsx
+<s-button commandFor={id} command="--toggle">…</s-button>
+<s-popover id={id}>…</s-popover>
+```
+
+`--show` also works and leaves no way to close it from the control that opened it.
+
+This cost a release: the help notes shipped with `commandFor` alone, looked correct on
+screen, and had nothing behind them. `help-note.test.tsx` now pins the `command`.
+
+**The general shape**, which is the reusable part: the Polaris *types* accept a prop, the
+Polaris *docs* omit it, and the Polaris *runtime* requires it. When a Polaris control does
+nothing, read the minified source at `https://cdn.shopify.com/shopifycloud/polaris.js` —
+it is one grep away and it is the only account of the behaviour that is actually true.


### PR DESCRIPTION
Closes #424. Follows #423, which put the notes in the right place with a control that did nothing.

## What was wrong

`s-popover` is activated by a control naming it with `commandFor`. Shopify's docs show exactly that, in all five examples on the page, with no `command`. That renders an inert button.

```js
// polaris.js
commandForProps: commandFor && command ? { onClick: () => { /* dispatch CommandEvent */ } } : undefined
```

The handler re-checks `command` before dispatching too. Without the prop there is **no click listener at all** — no error, no warning. The `'--auto'` default in the type signature is a default for the attribute, not for an absent prop.

Polaris' own colour field, the only place in the runtime that opens a popover, passes `command: "--toggle"`. That is what this uses.

## How it was found

Opened `/app/prices` in the admin on `boltify-apps` after the deploy and clicked the note. Nothing happened, twice, with the click landing on the icon and on the label. The app iframe is cross-origin so it could not be scripted from the page — the answer came from `curl`ing `https://cdn.shopify.com/shopifycloud/polaris.js` and grepping the minified source for `commandFor`.

That last step is the reusable part, and it is now in `docs/polaris-notes.md`: when a Polaris control does nothing, the runtime source is one grep away and is the only account of the behaviour that is actually true.

## Why the tests missed it

They asserted the button and the popover share an id — true, and never the problem. They did not assert the prop that makes the control exist, because the documentation said it was optional. Both are pinned now.

`typecheck`, `lint` and the full suite (2192 tests, 137 files) pass.

Still to confirm after this deploys: that the popover actually opens. The previous round is the reason that sentence is here rather than an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)