### PR TITLE
A definite width, and the Plans table back as a table

### DIFF
--- a/app/components/FieldGrid.tsx
+++ b/app/components/FieldGrid.tsx
@@ -48,7 +48,16 @@ export function Field({
   width: keyof typeof FIELD;
   children: ReactNode;
 }) {
-  return <s-box maxInlineSize={FIELD[width]}>{children}</s-box>;
+  // `inlineSize`, not `maxInlineSize`. A maximum is only a ceiling, and in an inline
+  // stack — which is exactly where Diagnostics needs this — the box shrinks to its
+  // content instead, so an empty text field rendered 68px wide. A definite width with
+  // `maxInlineSize="100%"` gives the field its size and still lets it shrink below that
+  // on a narrow container rather than overflowing.
+  return (
+    <s-box inlineSize={FIELD[width]} maxInlineSize="100%">
+      {children}
+    </s-box>
+  );
 }
 
 /**

--- a/app/components/field-grid.test.ts
+++ b/app/components/field-grid.test.ts
@@ -82,6 +82,19 @@ describe("a single control is sized the same way", () => {
   it("caps the grid too, because two columns of a wide card are still too wide", () => {
     expect(grid).toMatch(/maxInlineSize="\d+px"/);
   });
+
+  it("gives a single field a definite width, not a ceiling", () => {
+    // `maxInlineSize` alone shipped once and was wrong in the one place it mattered most:
+    // inside an inline stack a box with only a maximum shrinks to its content, so
+    // Diagnostics' empty reference field rendered 68px wide next to its button. A width
+    // plus `100%` sizes the field and still lets it shrink on a narrow container.
+    const field = grid.slice(grid.indexOf("export function Field"));
+
+    expect(field).toMatch(/inlineSize=\{FIELD\[width\]\}/);
+    expect(field, "without this it overflows a narrow card instead of shrinking").toContain(
+      'maxInlineSize="100%"',
+    );
+  });
 });
 
 describe("no settings tab leaves a control unbounded", () => {

--- a/app/routes/app.settings.plan.tsx
+++ b/app/routes/app.settings.plan.tsx
@@ -21,7 +21,6 @@ import { formatMinorUnits } from "../lib/money/format";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
-import { SPACE } from "../lib/ui/spacing";
 
 export const loader = withGuard("/app/settings/plan", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -90,22 +89,29 @@ export default function PlanPage() {
         </s-banner>
       ) : null}
 
-      {/* Two cards, and this one answers "what am I on" before "what else is there".
+      {/* Three cards, and this one answers "what am I on" before "what else is there".
 
-          It was four. Three of them held prose alone, and the first held a single line
-          — a card, a heading and a border to carry eight words, with the table it is
-          about in a different box. A card is a container for content; one sentence is
-          not content, it is a lead. */}
+          It was four. The first held a single line — a card, a heading and a border to
+          carry eight words, with the table it is about in a different box. A card is a
+          container for content; one sentence is not content, it is a lead, so it is the
+          lead of the card it was describing.
+
+          It was briefly two: "Every plan, including free" is a footnote to the table and
+          was folded in as a sub-heading. That rendered the table as `s-table`'s stacked
+          list — headers gone, one block per plan — and it is back in its own section
+          because a table that reads correctly beats a card saved. The write-up is in
+          `docs/polaris-notes.md`; **do not re-merge these two without loading the page.** */}
 
       <s-section heading="Plans">
-        <s-stack gap={SPACE.tight}>
+        <s-paragraph>
           <s-text type="strong">
             You are on {PLANS[current as keyof typeof PLANS].name}
           </s-text>
+          {" — "}
           <s-text color="subdued">
             {formatCount(variants)} variants in your catalogue.
           </s-text>
-        </s-stack>
+        </s-paragraph>
 
         <s-paragraph>
           <s-text>
@@ -148,12 +154,9 @@ export default function PlanPage() {
             ))}
           </s-table-body>
         </s-table>
+      </s-section>
 
-        {/* A sub-heading rather than a fourth card. What every plan includes is a
-            footnote to the table above it -- read while looking at the columns, not
-            after leaving them -- and `spacing.ts` keeps a bare `s-heading` for exactly
-            this: a block that needs a name and does not deserve a card. */}
-        <s-heading>Every plan, including free</s-heading>
+      <s-section heading="Every plan, including free">
         <s-paragraph>
           <s-text>
             Preview before applying. Guardrails that refuse to price below cost or

--- a/docs/polaris-notes.md
+++ b/docs/polaris-notes.md
@@ -178,3 +178,32 @@ screen, and had nothing behind them. `help-note.test.tsx` now pins the `command`
 Polaris *docs* omit it, and the Polaris *runtime* requires it. When a Polaris control does
 nothing, read the minified source at `https://cdn.shopify.com/shopifycloud/polaris.js` —
 it is one grep away and it is the only account of the behaviour that is actually true.
+
+## `s-table` can fall back to its stacked list, and a sibling can cause it
+
+The Plans table on `/app/settings/plan` rendered as a normal grid — Plan · Price · Variants
+· Markets · Wholesale · Trial — until its section was rearranged. Afterwards, on the same
+viewport, it rendered as `s-table`'s **stacked list**: one block per row, headers gone,
+values as label/value pairs, and the Trial value orphaned with no label at all.
+
+Nothing about the table changed. What changed around it, in one commit:
+
+- an `s-stack` was added as the section's first child, before the paragraph and table;
+- a bare `s-heading` and two paragraphs were added *after* the table, inside the same
+  section, replacing a separate section.
+
+Reverting both restored the grid. **Which of the two did it is not established** — they
+shipped together and each verification round costs a deploy — so the honest statement is
+the shape, not the mechanism:
+
+> A section that contains an `s-table` should contain the table and prose. Introducing
+> other layout components as its siblings can change how the table measures itself, and
+> the failure is silent: no error, no warning, and a stacked list is a legitimate
+> rendering that looks like a deliberate choice on a narrow screen.
+
+Related, and already known: `s-table` decides grid-versus-list for itself and there is no
+prop to force either. See the cell budget note above.
+
+If this needs pinning down, the cheap experiment is to add back one of the two and look —
+not to reason about it. Layout only runs in the browser, and none of the 2200 tests in this
+repo can see it.


### PR DESCRIPTION
Closes #428. Two things #427 got wrong, both found by opening the pages rather than by any test.

## `maxInlineSize` is only a ceiling

Inside an inline stack a box with no definite width shrinks to its content, so Diagnostics' empty reference field rendered **68px wide** next to its Find button. #427 fixed the row and broke the field in it.

`Field` now sets `inlineSize` with `maxInlineSize="100%"` — a real width that still shrinks on a narrow card instead of overflowing.

## The Plans table fell back to a stacked list

Same viewport, same table: headers gone, one block per plan, the Trial value orphaned with no label. Nothing about the table changed — what changed was its siblings. Reverting both restores the grid.

**Which of the two did it is not established.** They shipped together and each verification round costs a deploy, so `docs/polaris-notes.md` records the shape rather than a mechanism a single observation cannot support: a section holding an `s-table` should hold the table and prose, because a sibling can change how the table measures itself and the failure is silent. A stacked list is a legitimate rendering — on a wide screen it just reads as a different design.

Plan is three cards rather than two as a result. The single-sentence card is still gone, which was the point; a table that reads correctly beats a card saved.

## Tests

The width is pinned (`inlineSize` present, `maxInlineSize="100%"` present, with the 68px story as the reason). The table rendering is **not** pinned and cannot be — layout runs only in the browser, and none of the 2202 tests in this repo can see it. The route carries a comment telling the next person not to re-merge those sections without loading the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)