### PR TITLE
Size the popover's content, not the popover

### DIFF
--- a/app/components/HelpNote.tsx
+++ b/app/components/HelpNote.tsx
@@ -86,16 +86,21 @@ export function HelpNote({ label, children }: { label: string; children: ReactNo
         {label}
       </s-button>
 
-      {/* `inlineSize`, not `maxInlineSize`. A maximum is a ceiling the popover never
-          reached: with nothing setting a width it sized to its content, and content that
-          is three paragraphs of prose wants the whole page — so the overlay opened a
-          metre wide, over the table, which is the opposite of a note.
+      {/* The width goes on the box, not on the overlay, and that is not a style choice.
+          `maxInlineSize` on the popover did nothing — a ceiling it never reached, so it
+          sized to its content and three paragraphs of prose opened a metre wide over the
+          table. Setting `inlineSize` on the popover did fix that, and took every
+          `s-table` in the app down with it: the catalogue and the plans table both fell
+          back to `s-table`'s stacked list, on pages whose tables had not been touched.
+          The Polaris bundle was byte-identical across the two deploys, and the one page
+          with a table and no note rendered normally, so the overlay was the difference.
 
-          Pixels because Polaris types these as px, % or 0 only. 320 is a column of prose:
-          wide enough not to hyphenate, narrow enough that the eye reads it as an aside
-          rather than as the page having changed. */}
-      <s-popover id={id} inlineSize="320px">
-        <s-box padding={PAD.card}>
+          Sizing the content instead gets the same 320px column — the popover shrink-wraps
+          the box — without putting a definite size on the overlay element. Written up in
+          `docs/polaris-notes.md`. Do not move this attribute up onto the `s-popover`
+          without loading a page that has a table on it. */}
+      <s-popover id={id}>
+        <s-box padding={PAD.card} inlineSize="320px" maxInlineSize="100%">
           <s-stack gap={SPACE.section}>{children}</s-stack>
         </s-box>
       </s-popover>

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -74,8 +74,23 @@ describe("the note itself", () => {
     );
   });
 
-  it("gives the prose an interior, because s-popover supplies none", () => {
-    expect(html).toMatch(/<s-popover[^>]*>\s*<s-box padding=/);
+  it("gives the prose an interior and a measure, because s-popover supplies neither", () => {
+    expect(html).toMatch(/<s-popover[^>]*>\s*<s-box[^>]*padding=/);
+    expect(html).toMatch(/<s-box[^>]*inlineSize="\d+px"/);
+  });
+
+  it("sizes the box and not the overlay", () => {
+    // Not a preference. `inlineSize` on the `s-popover` itself made every `s-table` in
+    // the app fall back to its stacked list -- the catalogue and the plans table both,
+    // on pages whose tables had not been touched, with the Polaris bundle byte-identical
+    // across the two deploys. The popover shrink-wraps its content, so sizing the box
+    // gets the same column without putting a definite size on the overlay.
+    const popover = /<s-popover([^>]*)>/.exec(html)?.[1] ?? "";
+
+    expect(
+      popover,
+      "a sized overlay breaks table layout app-wide — see docs/polaris-notes.md",
+    ).not.toMatch(/inlineSize/);
   });
 
   it("says it is help rather than a filter or a link away", () => {

--- a/docs/polaris-notes.md
+++ b/docs/polaris-notes.md
@@ -179,7 +179,7 @@ Polaris *docs* omit it, and the Polaris *runtime* requires it. When a Polaris co
 nothing, read the minified source at `https://cdn.shopify.com/shopifycloud/polaris.js` —
 it is one grep away and it is the only account of the behaviour that is actually true.
 
-## `s-table` can fall back to its stacked list, and a sibling can cause it
+## `s-table` can fall back to its stacked list — **see the correction below**
 
 The Plans table on `/app/settings/plan` rendered as a normal grid — Plan · Price · Variants
 · Markets · Wholesale · Trial — until its section was rearranged. Afterwards, on the same
@@ -207,3 +207,34 @@ prop to force either. See the cell budget note above.
 If this needs pinning down, the cheap experiment is to add back one of the two and look —
 not to reason about it. Layout only runs in the browser, and none of the 2200 tests in this
 repo can see it.
+
+## Correction: what actually broke `s-table`
+
+The note above blamed a section's siblings. That was wrong, and reverting them did not
+bring the tables back — worth leaving on the page, because the wrong answer was reached by
+reasoning about one observation and the right one by taking a second.
+
+The real cause was `inlineSize` on an **`s-popover`**, added to stop the help notes opening
+a metre wide. Every page carrying a `HelpNote` had its `s-table` fall back to the stacked
+list — the catalogue and the plans table both, on tables nobody had touched. The evidence
+that settles it:
+
+- `https://cdn.shopify.com/shopifycloud/polaris.js` was **byte-identical** across the two
+  deploys, so it was not Shopify changing under us;
+- `/app/prices/costs`, the one page with a table and no note, rendered normally;
+- the popover was the only change common to both broken pages.
+
+**Size the popover's content, not the popover.** It shrink-wraps its box, so
+`<s-box inlineSize="320px">` inside gives the same column with no definite size on the
+overlay element:
+
+```tsx
+<s-popover id={id}>
+  <s-box padding="base" inlineSize="320px" maxInlineSize="100%">…</s-box>
+</s-popover>
+```
+
+The general lesson is the one this file keeps re-learning: **an overlay is not free of the
+page**. A Polaris overlay participates in its container enough to change what a sibling
+measures, and every symptom of that is a silent, legitimate-looking rendering somewhere
+else entirely.


### PR DESCRIPTION
Closes #430.

Every `s-table` in the app had fallen back to the stacked list — the catalogue and the plans table both, on tables nobody had touched.

## What it was

`inlineSize` on `s-popover`, added in #427 to stop the help notes opening a metre wide.

#429 blamed the Plan section's siblings and reverted them; the tables did not come back. That answer came from reasoning about one observation. This one came from taking a second:

| evidence | rules out |
|---|---|
| `polaris.js` byte-identical across both deploys | Shopify changing under us |
| `/app/prices/costs` — a table, no help note — renders normally | something global to `PageShell` or the width pass |
| the popover is the only change common to both broken pages | everything else in #427 |

**An overlay is not free of the page.** Sizing it changed what a sibling table measured, and the symptom surfaced somewhere else entirely, as a rendering that is legitimate on a narrow screen and therefore looks like a design rather than a bug.

## The fix

The popover shrink-wraps its content, so the width goes on the box inside it. Same 320px column, no definite size on the overlay.

The test asserts the **absence** of a size on the overlay as well as the presence of one on the box, with the reason attached — the presence alone is what let this through.

`docs/polaris-notes.md` carries the correction and keeps the wrong answer above it, marked. It is worth more than a tidy note: it is a worked example of the failure mode, which is reasoning confidently from a single observation about layout that only the browser can see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)