### PR TITLE
Nothing in the help note has a definite width

### DIFF
--- a/app/components/HelpNote.tsx
+++ b/app/components/HelpNote.tsx
@@ -86,21 +86,27 @@ export function HelpNote({ label, children }: { label: string; children: ReactNo
         {label}
       </s-button>
 
-      {/* The width goes on the box, not on the overlay, and that is not a style choice.
-          `maxInlineSize` on the popover did nothing — a ceiling it never reached, so it
-          sized to its content and three paragraphs of prose opened a metre wide over the
-          table. Setting `inlineSize` on the popover did fix that, and took every
-          `s-table` in the app down with it: the catalogue and the plans table both fell
-          back to `s-table`'s stacked list, on pages whose tables had not been touched.
-          The Polaris bundle was byte-identical across the two deploys, and the one page
-          with a table and no note rendered normally, so the overlay was the difference.
+      {/* `maxInlineSize` on the **box**, and no `inlineSize` anywhere in this subtree.
+          Both halves of that are scars.
 
-          Sizing the content instead gets the same 320px column — the popover shrink-wraps
-          the box — without putting a definite size on the overlay element. Written up in
-          `docs/polaris-notes.md`. Do not move this attribute up onto the `s-popover`
-          without loading a page that has a table on it. */}
+          A maximum on the `s-popover` did nothing: the overlay is sized by its content,
+          so its own ceiling was never the binding constraint and three paragraphs opened
+          a metre wide. Capping the *content* is what bites — the box wraps at 320px and
+          the popover shrink-wraps the box.
+
+          Giving anything here a definite `inlineSize` instead made every `s-table` in the
+          app fall back to its stacked list: the catalogue and the plans table both, on
+          tables nobody had touched, with `polaris.js` byte-identical across the deploys
+          and the one page with a table and no note rendering normally. Moving the
+          `inlineSize` from the overlay onto the box did not help, which is what narrows
+          it to the definite width rather than to where it sat.
+
+          Why a definite width inside a closed overlay reaches a sibling table at all is
+          not established, and nothing here should pretend otherwise. What is established
+          is the shape that renders: `docs/polaris-notes.md`. Do not introduce an
+          `inlineSize` here without loading a page that has a table on it. */}
       <s-popover id={id}>
-        <s-box padding={PAD.card} inlineSize="320px" maxInlineSize="100%">
+        <s-box padding={PAD.card} maxInlineSize="320px">
           <s-stack gap={SPACE.section}>{children}</s-stack>
         </s-box>
       </s-popover>

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -76,21 +76,30 @@ describe("the note itself", () => {
 
   it("gives the prose an interior and a measure, because s-popover supplies neither", () => {
     expect(html).toMatch(/<s-popover[^>]*>\s*<s-box[^>]*padding=/);
-    expect(html).toMatch(/<s-box[^>]*inlineSize="\d+px"/);
+    expect(html).toMatch(/<s-box[^>]*maxInlineSize="\d+px"/);
   });
 
-  it("sizes the box and not the overlay", () => {
-    // Not a preference. `inlineSize` on the `s-popover` itself made every `s-table` in
-    // the app fall back to its stacked list -- the catalogue and the plans table both,
-    // on pages whose tables had not been touched, with the Polaris bundle byte-identical
-    // across the two deploys. The popover shrink-wraps its content, so sizing the box
-    // gets the same column without putting a definite size on the overlay.
+  it("caps the content rather than the overlay, which is what actually binds", () => {
+    // A maximum on the popover is never the binding constraint: the overlay is sized by
+    // its content, so it opened as wide as the prose wanted -- a metre, over the table.
     const popover = /<s-popover([^>]*)>/.exec(html)?.[1] ?? "";
 
+    expect(popover, "a ceiling here does nothing; cap the box").not.toMatch(/InlineSize/);
+  });
+
+  it("gives nothing here a definite width", () => {
+    // Every `s-table` in the app fell back to its stacked list when this subtree carried
+    // an `inlineSize` -- on the overlay, and again when it was moved onto the box. The
+    // catalogue and the plans table both, tables nobody had touched, with `polaris.js`
+    // byte-identical across the deploys and the one page with a table and no note
+    // rendering normally.
+    //
+    // Why a definite width inside a closed overlay reaches a sibling table is not
+    // established. That it does is, twice.
     expect(
-      popover,
-      "a sized overlay breaks table layout app-wide — see docs/polaris-notes.md",
-    ).not.toMatch(/inlineSize/);
+      html,
+      "a definite width here breaks table layout app-wide — see docs/polaris-notes.md",
+    ).not.toMatch(/\sinlineSize="/);
   });
 
   it("says it is help rather than a filter or a link away", () => {

--- a/docs/polaris-notes.md
+++ b/docs/polaris-notes.md
@@ -210,31 +210,44 @@ repo can see it.
 
 ## Correction: what actually broke `s-table`
 
-The note above blamed a section's siblings. That was wrong, and reverting them did not
-bring the tables back — worth leaving on the page, because the wrong answer was reached by
-reasoning about one observation and the right one by taking a second.
+The note above blamed a section's siblings. That was wrong — reverting them did not bring
+the tables back. It is left on the page because the wrong answer was reached by reasoning
+about one observation, and the right one by taking more.
 
-The real cause was `inlineSize` on an **`s-popover`**, added to stop the help notes opening
-a metre wide. Every page carrying a `HelpNote` had its `s-table` fall back to the stacked
-list — the catalogue and the plans table both, on tables nobody had touched. The evidence
-that settles it:
+Every page carrying a `HelpNote` had its `s-table` fall back to the stacked list — the
+catalogue and the plans table both, on tables nobody had touched. What settles the scope:
 
-- `https://cdn.shopify.com/shopifycloud/polaris.js` was **byte-identical** across the two
-  deploys, so it was not Shopify changing under us;
+- `https://cdn.shopify.com/shopifycloud/polaris.js` was **byte-identical** across the
+  deploys either side, so it was not Shopify changing under us;
 - `/app/prices/costs`, the one page with a table and no note, rendered normally;
-- the popover was the only change common to both broken pages.
+- the note was the only change common to both broken pages.
 
-**Size the popover's content, not the popover.** It shrink-wraps its box, so
-`<s-box inlineSize="320px">` inside gives the same column with no definite size on the
-overlay element:
+Inside the note, the trigger is **a definite `inlineSize` anywhere in the subtree**. It was
+first added to the `s-popover`; moving it onto the box inside did not help, and only
+removing it entirely restored the tables. The last shape with working tables had no
+`inlineSize` at all.
+
+**Why a definite width inside a closed overlay reaches a sibling table is not established.**
+Do not let this section imply that it is. What is established, twice over, is that it does.
+
+### The shape that works
 
 ```tsx
 <s-popover id={id}>
-  <s-box padding="base" inlineSize="320px" maxInlineSize="100%">…</s-box>
+  <s-box padding="base" maxInlineSize="320px">…</s-box>
 </s-popover>
 ```
 
-The general lesson is the one this file keeps re-learning: **an overlay is not free of the
-page**. A Polaris overlay participates in its container enough to change what a sibling
-measures, and every symptom of that is a silent, legitimate-looking rendering somewhere
-else entirely.
+Two things that look interchangeable and are not:
+
+- **`maxInlineSize` on the popover does nothing.** The overlay is sized by its content, so
+  its own ceiling is never the binding constraint — prose opened a metre wide with a 360px
+  maximum set on it. Cap the **content**; the popover shrink-wraps the box.
+- **`inlineSize` is not a stricter `maxInlineSize` here.** It works, and it breaks tables
+  elsewhere on the page.
+
+The general lesson this file keeps re-learning: **an overlay is not free of the page**, and
+a layout symptom surfaces somewhere other than the change that caused it — as a rendering
+that is legitimate at some width and therefore reads as a design rather than a bug. Three
+deploys were spent on causes that turned out to be wrong; all three were narrowed by
+looking at one more page, never by reasoning harder.


### PR DESCRIPTION
Closes #432. #431's fix did not work — moving the `inlineSize` from the overlay onto the box left every table a stacked list. The trigger is the definite width itself, not where it sits, so this uses `maxInlineSize` on the box and the subtree carries no `inlineSize` at all.

That is also the correct way to size a popover, and it explains the original symptom: a maximum on the overlay is never the binding constraint, because the overlay is sized by its content. A 360px ceiling on the popover did nothing and the prose opened a metre wide. Capping the content is what bites.

**Why a definite width inside a closed overlay reaches a sibling table is not established**, and neither the comment nor the note claims it is. What is established, twice, is that it does. The test asserts the absence, with that reason attached.

`docs/polaris-notes.md` is rewritten rather than appended to — it had accreted two confident wrong causes, and a trap file that records bad reasoning as fact is worse than no file. The wrong answers stay, marked, because the pattern is the lesson: all three were narrowed by looking at one more page, never by reasoning harder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)