### PR TITLE
A help centre, rather than a folder rendered as markdown

### DIFF
--- a/app/lib/compliance/help-contrast.test.ts
+++ b/app/lib/compliance/help-contrast.test.ts
@@ -7,57 +7,82 @@
  * thing to fail. That makes these colours ours to get right, in both palettes.
  *
  * Computed from the stylesheet as shipped rather than from a list kept beside it — a list
- * agrees with itself no matter what the page actually renders.
+ * agrees with itself no matter what the page actually renders. The sheet declares every
+ * colour as a custom property in exactly two places, so what is read here is what the
+ * browser resolves; a hard-coded hex anywhere else would be invisible to this file, which
+ * is why `every colour is a token` below refuses one.
  */
-
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { HELP_STYLES } from "../help/styles";
+
 import { AA_LARGE, AA_NORMAL, contrastRatio } from "./contrast";
 
-const source = readFileSync(join(process.cwd(), "app/routes/help.$.tsx"), "utf8");
-
-/** The declaration blocks, split at the dark-mode media query. */
-const [lightCss, darkCss] = (() => {
-  const at = source.indexOf("@media (prefers-color-scheme: dark)");
+/** The palette blocks, split at the dark-mode media query. */
+const [light, dark] = (() => {
+  const at = HELP_STYLES.indexOf("@media (prefers-color-scheme: dark)");
   expect(at, "the stylesheet no longer has a dark palette").toBeGreaterThan(-1);
-  return [source.slice(0, at), source.slice(at)];
+
+  return [tokensIn(HELP_STYLES.slice(0, at)), tokensIn(HELP_STYLES.slice(at))];
 })();
 
-/** The value of a property inside a given selector, as the stylesheet declares it. */
-function declared(css: string, selector: string, property: string): string {
-  const block = new RegExp(`${selector.replace(/[.[\]"]/g, "\\$&")}[^{]*\\{([^}]*)\\}`).exec(css);
-  expect(block, `${selector} is not in the stylesheet`).not.toBeNull();
+/** Every `--name: #hex` in a stretch of CSS. */
+function tokensIn(css: string): Record<string, string> {
+  const found: Record<string, string> = {};
 
-  const value = new RegExp(`${property}:\\s*([^;]+)`).exec(block![1]);
-  expect(value, `${selector} does not set ${property}`).not.toBeNull();
+  for (const [, name, value] of css.matchAll(/(--[a-z0-9-]+):\s*(#[0-9a-f]{3,8})\s*;/gi)) {
+    found[name] = value;
+  }
 
-  const hex = /#[0-9a-f]{3,6}/i.exec(value![1]);
-  expect(hex, `${selector}'s ${property} is not a hex colour`).not.toBeNull();
-  return hex![0];
+  return found;
 }
 
-describe("light palette meets AA", () => {
-  const page = "#ffffff";
+function colour(palette: Record<string, string>, token: string): string {
+  const value = palette[token];
+  expect(value, `${token} is not declared in the stylesheet`).toBeDefined();
+  return value!;
+}
+
+/**
+ * Every ratio a reader depends on, against one palette.
+ *
+ * Two named `describe` blocks call this rather than one `describe.each`, because the
+ * pre-audit sheet in `docs/built-for-shopify.md` cites these suites by name as the
+ * evidence for WCAG 1.4.3 and 1.4.11, and a citation has to name something that exists.
+ */
+function assertPaletteMeetsAA(palette: Record<string, string>) {
+  const on = (token: string, background: string) =>
+    contrastRatio(colour(palette, token), colour(palette, background));
 
   it.each([
-    [".help", "color", AA_NORMAL, "body text"],
-    [".help a", "color", AA_NORMAL, "links"],
-  ])("%s %s", (selector, property, threshold, what) => {
-    const ratio = contrastRatio(declared(lightCss, selector, property), page);
+    ["--ink", "--paper", AA_NORMAL, "body text"],
+    ["--ink", "--surface", AA_NORMAL, "body text on a card"],
+    ["--muted", "--paper", AA_NORMAL, "the muted text a lede and every blurb is set in"],
+    ["--muted", "--surface", AA_NORMAL, "muted text on a card, where a dark palette usually fails"],
+    ["--accent", "--paper", AA_NORMAL, "links"],
+    ["--accent", "--surface", AA_NORMAL, "links on a card"],
+  ])("%s on %s", (token, background, threshold, what) => {
+    const ratio = on(token, background);
 
-    expect(ratio, `${what} is ${ratio.toFixed(2)}:1 against the page`).toBeGreaterThanOrEqual(
-      threshold,
-    );
+    expect(ratio, `${what} is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(threshold);
+  });
+
+  /**
+   * The three section accents. They are not decoration: they colour the eyebrow above a
+   * heading, the current entry in the sidebar and the title of a hovered card, all of
+   * which are text a reader has to be able to read.
+   */
+  it.each(["--tone-0", "--tone-1", "--tone-2"])("%s, which is text and not just a stripe", (token) => {
+    const ratio = on(token, "--surface");
+
+    expect(ratio, `${token} is ${ratio.toFixed(2)}:1 on a card`).toBeGreaterThanOrEqual(AA_NORMAL);
   });
 
   it("gives form controls a boundary people can see", () => {
     // WCAG 1.4.11. This started at 1.66:1 — visible to most people, invisible to some,
     // and the sort of thing that is only ever found by computing it.
-    const border = declared(lightCss, '.help input[type="search"], .help button', "border");
-    const ratio = contrastRatio(border, page);
+    const ratio = on("--control-border", "--paper");
 
     expect(ratio, `the search field's border is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(
       AA_LARGE,
@@ -67,43 +92,43 @@ describe("light palette meets AA", () => {
   it("keeps highlighted text readable inside the highlight", () => {
     // A search result's `<mark>` is the one place text sits on a colour chosen for
     // attention rather than for contrast.
-    const ratio = contrastRatio(declared(lightCss, ".help mark", "background"), "#1a1a1a");
+    const ratio = contrastRatio(colour(palette, "--mark"), colour(palette, "--mark-ink"));
 
-    expect(ratio).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect(ratio, `a marked term is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_NORMAL);
   });
-});
+}
 
-describe("dark palette meets AA", () => {
-  const page = "#1a1a1a";
+describe("light palette meets AA", () => assertPaletteMeetsAA(light));
 
-  it("body text", () => {
-    expect(contrastRatio(declared(darkCss, ".help", "color"), page)).toBeGreaterThanOrEqual(
-      AA_NORMAL,
-    );
-  });
+// The dark block redeclares only what changes, so anything it leaves alone is inherited
+// from the light one — which is also how the browser resolves it.
+describe("dark palette meets AA", () => assertPaletteMeetsAA({ ...light, ...dark }));
 
-  it("links", () => {
-    expect(contrastRatio(declared(darkCss, ".help a", "color"), page)).toBeGreaterThanOrEqual(
-      AA_NORMAL,
-    );
-  });
+/**
+ * The property that makes everything above true.
+ *
+ * These ratios are computed from the two token blocks. A colour written inline further
+ * down the sheet would render on a merchant's screen without ever being measured here, so
+ * the sheet is not allowed to contain one.
+ */
+describe("every colour is a token", () => {
+  it("declares no hex outside the two palette blocks", () => {
+    const elsewhere = HELP_STYLES.replace(/:root\s*\{[^}]*\}/g, "");
+    const stray = [...elsewhere.matchAll(/#[0-9a-f]{3,8}\b/gi)].map((m) => m[0]);
 
-  it("muted text, which is where a dark palette usually fails", () => {
-    const ratio = contrastRatio(declared(darkCss, ".help ol.hits p", "color"), page);
-
-    expect(ratio, `muted text is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_NORMAL);
-  });
-
-  it("form control boundaries", () => {
-    const border = declared(darkCss, '.help input[type="search"], .help button', "border-color");
-
-    expect(contrastRatio(border, page)).toBeGreaterThanOrEqual(AA_LARGE);
+    expect(stray, "a colour the contrast test cannot see").toEqual([]);
   });
 
-  it("highlighted text inside the highlight", () => {
-    const mark = /\.help mark \{ background: (#[0-9a-f]{6}); color: (#[0-9a-f]{6})/i.exec(darkCss);
-    expect(mark, "the dark palette no longer sets both mark colours").not.toBeNull();
+  it("would notice one — the assertion above is worthless if it cannot fail", () => {
+    const tampered = `${HELP_STYLES}\n.help .card { color: #ff0000; }`;
+    const elsewhere = tampered.replace(/:root\s*\{[^}]*\}/g, "");
 
-    expect(contrastRatio(mark![1]!, mark![2]!)).toBeGreaterThanOrEqual(AA_NORMAL);
+    expect([...elsewhere.matchAll(/#[0-9a-f]{3,8}\b/gi)].map((m) => m[0])).toEqual(["#ff0000"]);
+  });
+
+  it("names a colour by token in the places a reader looks", () => {
+    for (const token of ["--ink", "--muted", "--accent", "--tone-0", "--mark"]) {
+      expect(HELP_STYLES, `${token} is declared but never used`).toContain(`var(${token})`);
+    }
   });
 });

--- a/app/lib/help/nav.server.test.ts
+++ b/app/lib/help/nav.server.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The index is the help centre's navigation, and four surfaces are built from it.
+ *
+ * The landing page's sections, the sidebar on every page, each page's breadcrumb and its
+ * next/previous links all come from `docs/help/index.md`. That is the point — one file a
+ * writer already maintains rather than a second list in TypeScript that goes stale
+ * silently. The risk it buys is that the parser and the prose can disagree, so these tests
+ * are about the two staying in step.
+ *
+ * The one that matters most is the orphan check. A page absent from the index is a page no
+ * merchant can reach by browsing: it exists, it is served, it answers a question, and
+ * nothing anywhere links to it.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { placeInNav, sectionTitleOf, startingPoints } from "./nav";
+import { helpNav, parseNav } from "./nav.server";
+import { INDEX_SLUG, readHelpPage, resolveHelpFile } from "./pages.server";
+
+const HELP_ROOT = join(process.cwd(), "docs", "help");
+
+/** Pages that exist but are not merchant-facing, and so are not expected in the index. */
+const NOT_HELP = new Set([INDEX_SLUG, "images/README"]);
+
+function publishedSlugs(): string[] {
+  const slugs: string[] = [];
+
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) walk(join(dir, entry.name), `${prefix}${entry.name}/`);
+      else if (entry.name.endsWith(".md")) slugs.push(prefix + entry.name.replace(/\.md$/, ""));
+    }
+  };
+
+  walk(HELP_ROOT, "");
+  return slugs.filter((slug) => !NOT_HELP.has(slug)).sort();
+}
+
+const listed = () => helpNav().sections.flatMap((section) => section.items.map((item) => item.slug));
+
+describe("the index and the pages agree", () => {
+  it("has no page nothing links to", () => {
+    const reachable = new Set(listed());
+    const orphans = publishedSlugs().filter((slug) => !reachable.has(slug));
+
+    expect(orphans, "published but absent from docs/help/index.md").toEqual([]);
+  });
+
+  it("has no entry pointing at a page we do not publish", () => {
+    for (const slug of listed()) {
+      expect(resolveHelpFile(slug), `the index lists ${slug}, which is not a page`).not.toBeNull();
+    }
+  });
+
+  it("loses nothing from the file it is built from", () => {
+    // Every markdown link in the index has to survive parsing. Without this, a mistyped
+    // list marker silently deletes a page from the navigation and nothing else notices.
+    const source = readFileSync(join(HELP_ROOT, `${INDEX_SLUG}.md`), "utf8");
+    const links = [...source.matchAll(/\]\((\.[^)]+)\)/g)].length;
+
+    expect(listed()).toHaveLength(links);
+  });
+
+  it("gives every section something to introduce it with", () => {
+    for (const section of helpNav().sections) {
+      expect(section.blurb, `${section.title} has no description`).toBeTruthy();
+      expect(section.items.length, `${section.title} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("has a lede, which is the first thing on the landing page", () => {
+    expect(helpNav().lede).toBeTruthy();
+    expect(helpNav().title).toBe("Anchor help");
+  });
+});
+
+describe("where a page sits", () => {
+  it("names the section a breadcrumb shows", () => {
+    expect(sectionTitleOf(helpNav(), "concepts/baselines")).toBe("Concepts");
+    expect(sectionTitleOf(helpNav(), "failures/stuck-runs")).toBe("When something goes wrong");
+    expect(sectionTitleOf(helpNav(), "images/README")).toBeNull();
+  });
+
+  it("walks a section in the order the index puts it in", () => {
+    const place = placeInNav(helpNav(), "concepts/revert")!;
+
+    expect(place.previous?.slug).toBe("concepts/resolver");
+    expect(place.next?.slug).toBe("concepts/drift");
+  });
+
+  it("has no previous at the start of a section, and no next at the end", () => {
+    expect(placeInNav(helpNav(), "concepts/baselines")!.previous).toBeNull();
+    expect(placeInNav(helpNav(), "failures/unexpected")!.next).toBeNull();
+  });
+
+  /**
+   * Guardrails are listed twice — as a concept, and as a thing that stops a run. The
+   * sidebar marks one entry and the breadcrumb names one section, so the tie is broken by
+   * order rather than left to whichever the loop reached last.
+   */
+  it("puts a page listed twice in the first section that claims it", () => {
+    expect(sectionTitleOf(helpNav(), "failures/guardrail-blocks")).toBe("Concepts");
+  });
+
+  it("offers the first page of each section as a starting point", async () => {
+    const starts = startingPoints(helpNav());
+
+    expect(starts.map((item) => item.slug)).toEqual([
+      "concepts/baselines",
+      "how-to/first-campaign",
+      "failures/partial-runs",
+    ]);
+
+    // These are rendered as a sentence — "start with what a baseline is" — so the label
+    // has to read as a phrase rather than as a headline.
+    for (const item of starts) {
+      expect((await readHelpPage(item.slug))!.title).toBeTruthy();
+    }
+  });
+});
+
+describe("parsing prose that is not today's index", () => {
+  it("reads a heading, its description and its entries", () => {
+    const nav = parseNav(
+      [
+        "# A title",
+        "",
+        "A lede that runs",
+        "over two lines.",
+        "",
+        "## First",
+        "",
+        "What this section is for.",
+        "",
+        "- [One](./a/one.md) — the first one",
+        "- [Two](./a/two.md)",
+      ].join("\n"),
+    );
+
+    expect(nav.title).toBe("A title");
+    // A wrapped paragraph is one sentence, not two fragments.
+    expect(nav.lede).toBe("A lede that runs over two lines.");
+    expect(nav.sections).toHaveLength(1);
+    expect(nav.sections[0]).toMatchObject({ id: "first", title: "First", blurb: "What this section is for." });
+    expect(nav.sections[0].items).toEqual([
+      { slug: "a/one", title: "One", blurb: "the first one" },
+      { slug: "a/two", title: "Two", blurb: null },
+    ]);
+  });
+
+  it("leaves out an entry that points somewhere we do not serve", () => {
+    // A sidebar entry that navigates off the help centre is not navigation, and one
+    // pointing at a page that does not exist is worse than none at all.
+    const nav = parseNav(
+      [
+        "## Elsewhere",
+        "",
+        "- [Shopify](https://shopify.dev/docs)",
+        "- [The RFC](../../rfc-001-architecture.md)",
+        "- [A real page](./concepts/baselines.md)",
+      ].join("\n"),
+    );
+
+    expect(nav.sections[0].items.map((item) => item.slug)).toEqual(["concepts/baselines"]);
+  });
+
+  it("does not mistake prose after the first entry for the description", () => {
+    const nav = parseNav(["## S", "", "The description.", "", "- [A](./a.md)", "", "A footnote."].join("\n"));
+
+    expect(nav.sections[0].blurb).toBe("The description.");
+  });
+});

--- a/app/lib/help/nav.server.ts
+++ b/app/lib/help/nav.server.ts
@@ -1,0 +1,92 @@
+/**
+ * The help centre's navigation, read from the index page.
+ *
+ * `docs/help/index.md` is a curated list — somebody decided the order, the grouping and
+ * the half-sentence that says why each page is worth opening. Rendering it as markdown
+ * threw all of that away and produced a wall of underlined blue text, which is the
+ * opposite of what a curated list is for.
+ *
+ * So the index is parsed rather than rendered. The same file that reads correctly on
+ * GitHub becomes the landing page's sections, every page's sidebar, its breadcrumb, and
+ * its next/previous links. One source, four surfaces, and no second list to forget to
+ * update — the failure mode of every hand-maintained navigation ever written.
+ *
+ * A page missing from the index is therefore unreachable by browsing. That is asserted
+ * rather than hoped for; see the orphan test in `nav.server.test.ts`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { HELP_ROUTE } from "../errors/help-links";
+
+import { slugify, type HelpNav } from "./nav";
+import { INDEX_SLUG, rewriteHelpHref } from "./pages.server";
+
+const INDEX_FILE = join(process.cwd(), "docs", "help", `${INDEX_SLUG}.md`);
+
+/** `- [Title](./somewhere.md) — why it is worth opening` */
+const ITEM = /^[-*]\s+\[([^\]]+)\]\(([^)]+)\)\s*(?:[—–-]\s*(.+))?$/;
+
+let cached: HelpNav | null = null;
+
+/**
+ * Read once and keep, exactly as the search index does: the file ships inside the
+ * container image and cannot change under a running process.
+ */
+export function helpNav(): HelpNav {
+  return (cached ??= parseNav(readFileSync(INDEX_FILE, "utf8")));
+}
+
+/**
+ * Exported so the parser can be tested against prose that is not today's index — a
+ * guarantee that only holds for the current file is not a guarantee.
+ */
+export function parseNav(markdown: string): HelpNav {
+  const nav: HelpNav = { title: "Help", lede: null, sections: [] };
+
+  for (const raw of markdown.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    const heading = /^(#{1,2})\s+(.+)$/.exec(line);
+    if (heading) {
+      const title = heading[2].trim();
+      if (heading[1] === "#") nav.title = title;
+      else nav.sections.push({ id: slugify(title), title, blurb: null, items: [] });
+      continue;
+    }
+
+    const section = nav.sections.at(-1);
+
+    const item = ITEM.exec(line);
+    if (item) {
+      const slug = slugFromHref(item[2]);
+      // A list entry pointing somewhere we do not publish is a link, not a page, and has
+      // no place in a sidebar. Leaving it out is what makes every nav entry navigable.
+      if (section && slug) {
+        section.items.push({ title: item[1].trim(), slug, blurb: item[3]?.trim() || null });
+      }
+      continue;
+    }
+
+    // Prose. Before the first heading it is the lede; under one it introduces the section.
+    // Wrapped paragraphs join back into a sentence rather than arriving as fragments.
+    if (!section) nav.lede = appendLine(nav.lede, line);
+    else if (section.items.length === 0) section.blurb = appendLine(section.blurb, line);
+  }
+
+  return nav;
+}
+
+function appendLine(existing: string | null, line: string): string {
+  return existing ? `${existing} ${line}` : line;
+}
+
+/** The route a relative markdown link resolves to, as a slug — or null if we do not serve it. */
+function slugFromHref(href: string): string | null {
+  const resolved = rewriteHelpHref(href, INDEX_SLUG);
+  const prefix = `${HELP_ROUTE}/`;
+
+  return resolved.startsWith(prefix) ? resolved.slice(prefix.length) : null;
+}

--- a/app/lib/help/nav.ts
+++ b/app/lib/help/nav.ts
@@ -1,0 +1,92 @@
+/**
+ * The shape of the help centre, and the questions a page asks of it.
+ *
+ * Split from `nav.server.ts` deliberately. Reading `docs/help/index.md` off disk is a
+ * server-only act, but "which section is this page in" and "what comes next" are asked by
+ * the sidebar, the breadcrumb and the pager — components that render in the browser. Kept
+ * in one module, the whole navigation dragged `node:fs` into the client bundle and the
+ * build refused it, which is the correct refusal.
+ */
+
+export interface HelpNavItem {
+  slug: string;
+  title: string;
+  /** The half-sentence after the em dash, or null where the title says enough. */
+  blurb: string | null;
+}
+
+export interface HelpNavSection {
+  /** Slugified heading, so a section can be linked to from a breadcrumb. */
+  id: string;
+  title: string;
+  blurb: string | null;
+  items: HelpNavItem[];
+}
+
+export interface HelpNav {
+  /** The index's `#` heading. */
+  title: string;
+  /** The paragraph under it, before the first section. */
+  lede: string | null;
+  sections: HelpNavSection[];
+}
+
+/** Where a page sits, which is what a breadcrumb and a next/previous link are made of. */
+export interface HelpPlace {
+  section: HelpNavSection;
+  previous: HelpNavItem | null;
+  next: HelpNavItem | null;
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Where a page sits in the index, or null if it is not listed.
+ *
+ * The first section wins. One page is deliberately listed twice — guardrails are both a
+ * concept and a thing that stops a run — and a breadcrumb has to pick one.
+ */
+export function placeInNav(nav: HelpNav, slug: string): HelpPlace | null {
+  for (const section of nav.sections) {
+    const at = section.items.findIndex((item) => item.slug === slug);
+    if (at === -1) continue;
+
+    return {
+      section,
+      previous: section.items[at - 1] ?? null,
+      next: section.items[at + 1] ?? null,
+    };
+  }
+
+  return null;
+}
+
+/** The section a page belongs to, for labelling it in a list of search results. */
+export function sectionTitleOf(nav: HelpNav, slug: string): string | null {
+  return placeInNav(nav, slug)?.section.title ?? null;
+}
+
+/**
+ * The first page of each section — what somebody who has just arrived should read.
+ *
+ * Derived rather than chosen, because a hand-picked list of "popular" pages is a second
+ * thing to maintain and it is wrong the first time the index is reordered.
+ */
+export function startingPoints(nav: HelpNav): HelpNavItem[] {
+  return nav.sections
+    .map((section) => section.items[0])
+    .filter((item): item is HelpNavItem => !!item);
+}
+
+/** How many accents the stylesheet defines, cycled across the index's sections. */
+export const TONES = 3;
+
+/** A section's accent, by its position in the index rather than by its name. */
+export function toneOf(nav: HelpNav, section: HelpNavSection): number {
+  return Math.max(0, nav.sections.indexOf(section)) % TONES;
+}

--- a/app/lib/help/pages.server.test.ts
+++ b/app/lib/help/pages.server.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   escapesRoot,
+  headingId,
   INDEX_SLUG,
   readHelpImage,
   readHelpPage,
@@ -117,7 +118,75 @@ describe("every page renders", () => {
     // A page whose title fell back to the slug has no `#` heading, which means the browser
     // tab and the on-page heading disagree.
     expect(page!.title, `${slug} has no heading`).not.toBe(slug);
-    expect(page!.html).toContain("<h1>");
+    expect(page!.html).toContain(`<h1 id="${headingId(page!.title)}">`);
+  });
+});
+
+/**
+ * The route renders a contents rail beside the prose and a card row under it, and both are
+ * built from what this function returns rather than from a second pass over the HTML.
+ * These assert the parts the reader can see are actually there.
+ */
+describe("a page arrives in the pieces the route lays out", () => {
+  it("lists its own headings, each pointing at an anchor the page has", async () => {
+    const page = (await readHelpPage("concepts/baselines"))!;
+
+    expect(page.headings.map((h) => h.text)).toEqual([
+      "Why it matters",
+      "Where baselines come from",
+      "When to recapture",
+    ]);
+
+    for (const heading of page.headings) {
+      expect(page.html, `no anchor for ${heading.text}`).toContain(`id="${heading.id}"`);
+    }
+  });
+
+  it("lifts the Related list out of the prose, with its links already resolved", async () => {
+    const page = (await readHelpPage("concepts/baselines"))!;
+
+    expect(page.related).toEqual([
+      { href: "/help/concepts/revert", label: "Why revert recomputes" },
+      { href: "/help/how-to/import-baselines", label: "Importing your own prices" },
+    ]);
+
+    // Lifted, not copied: leaving it in as well would render the same two links twice,
+    // once as cards and once as the bullets the cards were built to replace.
+    expect(page.html).not.toContain("Related");
+    expect(page.headings.some((h) => h.text === "Related")).toBe(false);
+  });
+
+  it("leaves a page without a Related section whole", async () => {
+    const page = (await readHelpPage("how-to/first-campaign"))!;
+
+    expect(page.related).toEqual([]);
+    expect(page.html).toContain("Reverting");
+  });
+
+  it("every Related link names a page we publish", async () => {
+    for (const slug of allSlugs()) {
+      for (const link of (await readHelpPage(slug))!.related) {
+        const target = link.href.replace("/help/", "");
+        expect(resolveHelpFile(target), `${slug} points at ${link.href}`).not.toBeNull();
+      }
+    }
+  });
+
+  it("finds Related sections to check — otherwise the assertion above proves nothing", async () => {
+    const counts = await Promise.all(allSlugs().map(async (s) => (await readHelpPage(s))!.related.length));
+
+    expect(counts.reduce((a, b) => a + b, 0)).toBeGreaterThan(3);
+  });
+
+  /**
+   * A table is wider than the column the prose is set in. Without its own scroll box the
+   * whole document scrolls sideways, which is the one thing a reader should never have to
+   * do to finish a sentence.
+   */
+  it("gives a table somewhere to scroll that is not the page", async () => {
+    const page = (await readHelpPage("how-to/shopify-flow"))!;
+
+    expect(page.html).toContain('<div class="scroller"><table>');
   });
 });
 

--- a/app/lib/help/pages.server.ts
+++ b/app/lib/help/pages.server.ts
@@ -1,7 +1,7 @@
 /**
  * Reading a help page off disk, safely.
  *
- * The help centre is twenty-one markdown files in `docs/help`, committed alongside the
+ * The help centre is a directory of markdown files in `docs/help`, committed alongside the
  * code that links to them — which is what keeps the two from drifting. Serving them is
  * what makes those links resolve at all: `HELP_BASE` defaulted to a domain nobody had
  * registered, so every merchant-visible error carried a link to nothing.
@@ -16,7 +16,7 @@
 import { readFile } from "node:fs/promises";
 import { join, normalize, posix, sep } from "node:path";
 
-import { marked, type Tokens } from "marked";
+import { Marked, Renderer, type Token, type Tokens } from "marked";
 
 /** Where the markdown lives, relative to the process's working directory. */
 const ROOT = join(process.cwd(), "docs", "help");
@@ -44,9 +44,25 @@ export interface HelpImage {
 }
 
 export interface HelpPage {
+  /** The path it was read from, so a page can tell where it sits without being told. */
+  slug: string;
   /** The `#` heading, used as the document title. */
   title: string;
   html: string;
+  /** The `##` headings, in order, for the contents rail. */
+  headings: HelpHeading[];
+  /** The `## Related` list, lifted out of the prose so it can be rendered as cards. */
+  related: HelpLink[];
+}
+
+export interface HelpHeading {
+  id: string;
+  text: string;
+}
+
+export interface HelpLink {
+  href: string;
+  label: string;
 }
 
 /**
@@ -180,28 +196,125 @@ export async function readHelpPage(slug: string): Promise<HelpPage | null> {
   // because a browser tab reading "Help" for every page is a tab nobody can find again.
   const heading = /^#\s+(.+)$/m.exec(source)?.[1]?.trim();
 
-  const html = marked.parse(source, {
-    // `async: false` keeps the return type a string rather than a union. The markdown is
-    // ours and committed, so there is nothing untrusted to sanitise — but that is a
-    // property of where it comes from, not of this function, and it stops being true the
-    // moment anything here is written by a merchant.
-    async: false,
-    // Mutating the token rather than overriding the renderer: link text, titles and
-    // nested emphasis keep rendering the way marked already renders them.
-    walkTokens: (token) => {
-      if (token.type === "link") {
-        const link = token as Tokens.Link;
-        link.href = rewriteHelpHref(link.href, slug);
-      }
-      // Images the same way. A browser would resolve `../images/x.svg` correctly from
-      // this URL by accident; rewriting it means the answer does not depend on whether
-      // the page was reached with a trailing slash.
-      if (token.type === "image") {
-        const image = token as Tokens.Image;
-        image.href = rewriteHelpHref(image.href, slug);
-      }
-    },
+  const tokens = markdown.lexer(source);
+
+  // The links are rewritten before anything is split off, so the ones lifted out of the
+  // `Related` section are resolved by exactly the code the prose links go through.
+  markdown.walkTokens(tokens, (token: Token) => {
+    if (token.type === "link") {
+      const link = token as Tokens.Link;
+      link.href = rewriteHelpHref(link.href, slug);
+    }
+    // Images the same way. A browser would resolve `../images/x.svg` correctly from
+    // this URL by accident; rewriting it means the answer does not depend on whether
+    // the page was reached with a trailing slash.
+    if (token.type === "image") {
+      const image = token as Tokens.Image;
+      image.href = rewriteHelpHref(image.href, slug);
+    }
   });
 
-  return { title: heading ?? slug, html };
+  const [body, related] = splitRelated(tokens);
+
+  return {
+    slug,
+    title: heading ?? slug,
+    // The markdown is ours and committed, so there is nothing untrusted to sanitise — but
+    // that is a property of where it comes from, not of this function, and it stops being
+    // true the moment anything here is written by a merchant.
+    html: markdown.parser(body),
+    headings: contentsOf(body),
+    related,
+  };
 }
+
+/**
+ * The prose, and the `## Related` list under it.
+ *
+ * Every page ends with two or three links to the pages next to it, and rendered as
+ * markdown they arrive as the same underlined bullets as everything else — the least
+ * likely thing on the page to be noticed, in the position where a reader who has finished
+ * is deciding whether there is anywhere to go. Lifting them out lets the route render
+ * them as something a person can see.
+ *
+ * A page without the section keeps every token, which is the case for most of them.
+ */
+function splitRelated(tokens: Token[]): [Token[], HelpLink[]] {
+  const at = tokens.findIndex(
+    (token) =>
+      token.type === "heading" &&
+      (token as Tokens.Heading).depth === 2 &&
+      /^related$/i.test((token as Tokens.Heading).text.trim()),
+  );
+
+  if (at === -1) return [tokens, []];
+
+  const links: HelpLink[] = [];
+  markdown.walkTokens(tokens.slice(at + 1), (token: Token) => {
+    if (token.type !== "link") return;
+    const link = token as Tokens.Link;
+    links.push({ href: link.href, label: link.text });
+  });
+
+  return [tokens.slice(0, at), links];
+}
+
+/** The `##` headings, which is the grain a reader scans a page at. */
+function contentsOf(tokens: Token[]): HelpHeading[] {
+  return tokens
+    .filter((token) => token.type === "heading" && (token as Tokens.Heading).depth === 2)
+    .map((token) => {
+      const text = (token as Tokens.Heading).text.trim();
+      return { id: headingId(text), text };
+    });
+}
+
+/**
+ * The anchor for a heading, matching what the renderer emits.
+ *
+ * Both sides call this, so a contents entry cannot point at an id the page does not have
+ * — which is the way hand-rolled anchors always break.
+ */
+export function headingId(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * One configured markdown instance rather than the shared `marked` singleton.
+ *
+ * `marked.use()` is global, and a renderer registered on the singleton would apply to
+ * anything else in the process that ever parses markdown. `async: false` keeps the return
+ * type a string rather than a union.
+ */
+const markdown = new Marked({ async: false });
+
+markdown.use({
+  renderer: {
+    /**
+     * Headings carry their own anchor, so a merchant on a support call can be sent to the
+     * paragraph rather than to the page. It is also what the contents rail links to.
+     */
+    heading(token: Tokens.Heading) {
+      const text = this.parser.parseInline(token.tokens);
+      return `<h${token.depth} id="${headingId(token.text)}">${text}</h${token.depth}>\n`;
+    },
+
+    /**
+     * A table scrolls inside its own box rather than widening the page.
+     *
+     * The prose column is sized for reading and a three-column table of Flow triggers is
+     * wider than it. Without the wrapper the whole document scrolls sideways, which is the
+     * one thing a reader should never have to do to finish a sentence.
+     */
+    table(token: Tokens.Table) {
+      const rendered = renderer.table.call(this, token);
+      return `<div class="scroller">${rendered}</div>\n`;
+    },
+  },
+});
+
+/** The stock renderer, kept so the override above can defer the markup to it. */
+const renderer = new Renderer();

--- a/app/lib/help/search.server.ts
+++ b/app/lib/help/search.server.ts
@@ -1,10 +1,10 @@
 /**
  * Search across the help centre.
  *
- * Twenty-one pages is small enough that scanning all of them per query costs less than a
+ * Twenty pages is small enough that scanning all of them per query costs less than a
  * millisecond, so there is no index to build, invalidate or get wrong. If the help centre
  * ever grows past a few hundred pages this should be reconsidered — but building a search
- * index for twenty-one documents would be answering a question nobody asked.
+ * index for twenty documents would be answering a question nobody asked.
  *
  * The ranking is deliberately crude and explained rather than tuned: a merchant searching
  * "drift" wants the page called drift, not the six pages that mention it in passing.
@@ -15,8 +15,15 @@ import { join } from "node:path";
 
 const ROOT = join(process.cwd(), "docs", "help");
 
-/** The index page is the thing you search *from*; returning it as a result is noise. */
-const EXCLUDED = new Set(["index"]);
+/**
+ * Pages that are in `docs/help` but are not help.
+ *
+ * The index is the thing you search *from*; returning it as a result is noise. The note in
+ * `images/` is for whoever next takes a screenshot — it explains the crop that keeps a
+ * competitor's name out of the picture — and a merchant searching "price" should not be
+ * handed our editorial standards as an answer.
+ */
+const EXCLUDED = new Set(["index", "images/README"]);
 
 export interface HelpHit {
   slug: string;
@@ -90,6 +97,11 @@ export function toProse(markdown: string): string {
     .map(tableRowToProse)
     .join("\n")
     .replace(/^#{1,6}\s+/gm, "")
+    // Images before links, because an image is a link with a `!` in front. Dropped whole
+    // rather than reduced to their alt text: several pages open with a screenshot, and its
+    // alt text is a description of a picture — as the first line of a search result it
+    // reads as the page being about the screenshot rather than about the subject.
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
     .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
     .replace(/[*_`>|]/g, "")
     .replace(/\s+/g, " ")

--- a/app/lib/help/styles.test.ts
+++ b/app/lib/help/styles.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The stylesheet survives the trip to the browser.
+ *
+ * This is not a taste assertion. React escapes text inside a `<style>` element, and the
+ * help centre's sheet was rendered as a text child for as long as it existed — so every
+ * declaration containing a quote reached the browser as `&quot;…&quot;` and was dropped
+ * on the floor. The page had no font stack; it rendered in the browser's default serif.
+ * The search field had no border, whose contrast a WCAG test in `compliance/` was
+ * meanwhile computing and passing, because that test reads the source and not the page.
+ *
+ * That is the shape of bug worth a test: one where the thing asserting correctness and
+ * the thing rendering to a merchant were looking at different strings.
+ */
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { HELP_STYLES, HelpStyles } from "./styles";
+
+describe("the sheet the browser receives", () => {
+  it("is the sheet we wrote, character for character", () => {
+    const markup = renderToStaticMarkup(HelpStyles());
+
+    expect(markup).toBe(`<style>${HELP_STYLES}</style>`);
+  });
+
+  it("would not be, rendered the obvious way — which is how this got shipped", () => {
+    // The hazard, demonstrated rather than described. If React ever stops escaping here
+    // this test fails, and the guard above becomes unnecessary rather than wrong.
+    const escaped = renderToStaticMarkup(createElement("style", null, HELP_STYLES));
+
+    expect(escaped).toContain("&quot;");
+    expect(escaped).not.toBe(`<style>${HELP_STYLES}</style>`);
+  });
+
+  it("has no quotes it could lose without anyone noticing", () => {
+    // Belt as well as braces: the declarations that were dropped are named here, so a
+    // future rewrite that reintroduces the escaping fails on something a reader can see
+    // rather than on a diff of two large strings.
+    expect(HELP_STYLES).toContain('"Segoe UI"');
+    expect(HELP_STYLES).toContain('[data-tone="0"]');
+    expect(HELP_STYLES).toContain('a[aria-current="page"]');
+  });
+
+  /**
+   * The sheet is a template literal. A backtick inside it — in a comment explaining a
+   * property, most temptingly — ends the string early, and the failure is a build error
+   * pointing at CSS rather than at the sentence that caused it.
+   */
+  it("contains no backtick, which would end the literal it lives in", () => {
+    expect(HELP_STYLES).not.toContain("`");
+  });
+});

--- a/app/lib/help/styles.tsx
+++ b/app/lib/help/styles.tsx
@@ -1,0 +1,635 @@
+/**
+ * The help centre's stylesheet.
+ *
+ * Inlined into the document by the route rather than linked, and that is the whole reason
+ * it is a string in a module instead of a `.css` file: this is the page a merchant reaches
+ * when something else has already gone wrong, and one fewer asset to fetch is one fewer
+ * thing to fail. It is authored here rather than in the route so that neither file has to
+ * be scrolled past to read the other.
+ *
+ * Every colour is a custom property declared twice — once on `.help`, once under the dark
+ * media query — and nothing anywhere else in the sheet names a colour directly. That is
+ * not tidiness: `help-contrast.test.ts` resolves these two blocks and computes WCAG ratios
+ * from them, so a palette can only be changed in a place the test is looking. A hard-coded
+ * hex further down the sheet would be invisible to it.
+ *
+ * `data-tone` on a section picks one of three accents by position in the index, so adding
+ * a fourth section to `docs/help/index.md` needs no change here.
+ */
+export const HELP_STYLES = `
+:root {
+  --paper: #ffffff;
+  --surface: #f6f7f9;
+  --raised: #ffffff;
+  --ink: #1a1f24;
+  --muted: #5b656f;
+  --hairline: #e4e7ea;
+  --control-border: #7e878f;
+  --accent: #2748c4;
+  --accent-wash: #eef1fd;
+  --mark: #ffe9a8;
+  --mark-ink: #1a1f24;
+  --figure: #f6f7f9;
+  --tone-0: #3a4ea8;
+  --tone-1: #0d6a4f;
+  --tone-2: #8a4a10;
+  --lift: 0 1px 1px rgba(16, 24, 32, 0.04), 0 10px 24px -18px rgba(16, 24, 32, 0.5);
+  --lift-hover: 0 1px 2px rgba(16, 24, 32, 0.06), 0 16px 32px -18px rgba(16, 24, 32, 0.55);
+
+  --measure: 40rem;
+  --gutter: clamp(1.25rem, 4vw, 2.5rem);
+  --radius: 12px;
+}
+body { margin: 0; background: var(--paper); }
+.help {
+  color: var(--ink);
+  background: var(--paper);
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.help *, .help *::before, .help *::after { box-sizing: border-box; }
+.help :focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+.help a { color: var(--accent); }
+.help [data-tone="0"] { --tone: var(--tone-0); }
+.help [data-tone="1"] { --tone: var(--tone-1); }
+.help [data-tone="2"] { --tone: var(--tone-2); }
+
+/* ---- shell ------------------------------------------------------------- */
+
+/* The explicit width is load-bearing. This element is a child of a column flex container,
+   and a flex child with auto side margins is sized by its content rather than stretched —
+   which centred the search results in a column half the width of the landing page. */
+.help .bar {
+  width: 100%;
+  max-width: 76rem;
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+.help .skip {
+  position: absolute;
+  left: -9999px;
+  top: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  background: var(--raised);
+  border: 1px solid var(--control-border);
+  border-radius: 8px;
+  z-index: 2;
+}
+.help .skip:focus { left: 1rem; }
+
+.help .masthead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  backdrop-filter: saturate(1.6) blur(10px);
+  border-bottom: 1px solid var(--hairline);
+}
+.help .masthead .bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 3.5rem;
+}
+.help .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+.help .brand svg { display: block; color: var(--accent); }
+.help .brand-sep { color: var(--hairline); font-weight: 400; }
+.help .brand-kind { color: var(--muted); font-weight: 450; }
+.help .brand:hover .brand-kind { color: var(--ink); }
+
+/* ---- search ------------------------------------------------------------ */
+
+.help .find { display: flex; align-items: center; gap: 0.5rem; }
+.help .field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  padding: 0 0.7rem;
+  background: var(--raised);
+  border: 1px solid var(--control-border);
+  border-radius: 999px;
+  transition: box-shadow 120ms ease, border-color 120ms ease;
+}
+.help .field:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-wash);
+}
+.help .field svg { flex: none; color: var(--muted); }
+.help .find input {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  outline: 0;
+  padding: 0.45rem 0;
+  width: 12rem;
+  min-width: 0;
+}
+.help .find input::placeholder { color: var(--muted); }
+.help .find button {
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0.45rem 1rem;
+  color: var(--paper);
+  background: var(--ink);
+  border: 1px solid var(--ink);
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.help .find button:hover { background: var(--accent); border-color: var(--accent); }
+.help .find-lg { max-width: 34rem; margin-top: 2rem; }
+.help .find-lg input { width: 100%; font-size: 1.0625rem; padding: 0.7rem 0; }
+.help .find-lg .field { padding: 0 1rem; }
+.help .find-lg button { padding: 0.7rem 1.4rem; }
+
+/* ---- landing ----------------------------------------------------------- */
+
+.help main { flex: 1; }
+.help .hero { padding-block: clamp(3rem, 8vw, 5.5rem) clamp(2.5rem, 5vw, 3.5rem); }
+.help .hero-inner { max-width: 46rem; }
+.help .eyebrow {
+  margin: 0 0 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--tone, var(--muted));
+}
+.help .hero h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 5.5vw, 3.25rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+  font-weight: 640;
+}
+.help .lede {
+  margin: 1.25rem 0 0;
+  font-size: clamp(1.0625rem, 1.4vw, 1.1875rem);
+  line-height: 1.6;
+  color: var(--muted);
+}
+.help .jump { margin: 1rem 0 0; font-size: 0.9375rem; color: var(--muted); }
+.help .jump a {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  text-decoration-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.help .jump a:hover { text-decoration-color: currentColor; }
+
+.help .group { padding-bottom: clamp(2.5rem, 5vw, 3.5rem); }
+.help .group + .group { border-top: 1px solid var(--hairline); padding-top: clamp(2.5rem, 5vw, 3.25rem); }
+.help .group-head { max-width: 42rem; margin-bottom: 1.75rem; }
+.help .group-head h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  font-weight: 620;
+  scroll-margin-top: 5rem;
+}
+.help .group-head p { margin: 0.5rem 0 0; color: var(--muted); }
+
+.help .cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.875rem;
+  grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
+}
+.help .card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 0.35rem;
+  padding: 1.125rem 1.25rem;
+  background: var(--raised);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: inherit;
+  box-shadow: var(--lift);
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+}
+.help .card::before {
+  content: "";
+  width: 1.5rem;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--tone, var(--accent));
+  margin-bottom: 0.5rem;
+  opacity: 0.85;
+}
+.help .card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--tone, var(--accent)) 40%, var(--hairline));
+  box-shadow: var(--lift-hover);
+}
+.help .card-title { font-weight: 580; letter-spacing: -0.01em; line-height: 1.35; }
+.help .card:hover .card-title { color: var(--tone, var(--accent)); }
+.help .card-blurb { font-size: 0.9375rem; line-height: 1.5; color: var(--muted); }
+
+/* A section with more entries than a grid of cards can hold without becoming a wall. */
+.help .cards-dense { grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr)); gap: 0; }
+.help .cards-dense li { border-bottom: 1px solid var(--hairline); }
+.help .cards-dense .card {
+  flex-direction: row;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.8rem 0.25rem;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  background: none;
+}
+.help .cards-dense .card:hover { transform: none; box-shadow: none; }
+.help .cards-dense .card::before {
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 50%;
+  margin: 0;
+  flex: none;
+  align-self: center;
+  opacity: 0.5;
+}
+.help .cards-dense .card:hover::before { opacity: 1; }
+
+/* ---- article ----------------------------------------------------------- */
+
+.help .layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(2rem, 5vw, 3.5rem);
+  padding-block: 2.25rem 4rem;
+  align-items: start;
+}
+.help .rail { order: 3; }
+.help .doc { order: 1; min-width: 0; max-width: var(--measure); }
+.help .toc { order: 2; display: none; }
+
+.help .crumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+  font-size: 0.8125rem;
+  color: var(--muted);
+}
+.help .crumbs a { color: var(--muted); text-decoration: none; }
+.help .crumbs a:hover { color: var(--ink); text-decoration: underline; }
+.help .crumbs .sep { opacity: 0.5; }
+.help .crumbs .here { color: var(--tone, var(--muted)); font-weight: 550; }
+
+.help .rail-head, .help .toc-head {
+  margin: 0 0 0.625rem;
+  padding-left: 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.help .rail ul, .help .toc ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+.help .rail nav + nav { margin-top: 1.25rem; }
+/* No negative margin. A box with overflow-y set to auto scrolls on the x axis too, so
+   anything hanging outside it is clipped — which is what hid the current page's marker
+   and put a horizontal scrollbar under the list. */
+.help .rail a {
+  display: block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 7px;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--muted);
+  text-decoration: none;
+}
+.help .rail a:hover { color: var(--ink); background: var(--surface); }
+.help .rail a[aria-current="page"] {
+  color: var(--tone, var(--accent));
+  background: var(--surface);
+  font-weight: 550;
+  box-shadow: inset 2px 0 0 var(--tone, var(--accent));
+}
+
+.help .toc-head { padding-left: calc(0.75rem + 2px); }
+.help .toc a {
+  display: block;
+  padding: 0.2rem 0 0.2rem 0.75rem;
+  border-left: 2px solid var(--hairline);
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--muted);
+  text-decoration: none;
+}
+.help .toc a:hover { color: var(--ink); border-left-color: var(--tone, var(--accent)); }
+
+/* ---- prose ------------------------------------------------------------- */
+
+.help article { font-size: 1.0625rem; }
+.help article > *:first-child { margin-top: 0; }
+.help article a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  text-decoration-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.help article a:hover { text-decoration-color: currentColor; }
+.help h1 {
+  font-size: clamp(1.875rem, 4vw, 2.5rem);
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+  font-weight: 640;
+  margin: 0 0 1.25rem;
+}
+.help article h2 {
+  font-size: 1.375rem;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
+  font-weight: 620;
+  margin: 2.75rem 0 0.75rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--hairline);
+  scroll-margin-top: 5rem;
+}
+.help article h3 {
+  font-size: 1.0625rem;
+  font-weight: 620;
+  margin: 2rem 0 0.5rem;
+  scroll-margin-top: 5rem;
+}
+.help article p { margin: 0 0 1.125rem; }
+.help article ul, .help article ol { padding-left: 1.25rem; margin: 0 0 1.125rem; }
+.help article li { margin: 0.4rem 0; }
+.help article li::marker { color: var(--muted); }
+.help article strong { font-weight: 620; }
+.help article hr { border: 0; border-top: 1px solid var(--hairline); margin: 2.5rem 0; }
+
+.help code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 0.875em;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  padding: 0.05em 0.35em;
+  border-radius: 5px;
+}
+.help pre {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  padding: 1rem 1.125rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+.help pre code { background: none; border: 0; padding: 0; font-size: 1em; }
+
+/* Screenshots are captured at admin width and are far wider than this column. Scaling
+   them down keeps the page from scrolling sideways, which is the one thing a reader
+   should never have to do to finish a sentence. */
+.help article img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 1.75rem 0;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius);
+  /* Screenshots are of a light admin and the one diagram is authored in light colours, so
+     a dark palette gets a pale mat behind them rather than a bright rectangle floating on
+     black. Redrawing every figure for two palettes is the alternative, and it is a
+     standing cost on every future screenshot. */
+  background: var(--figure);
+  padding: 0.25rem;
+}
+
+.help .scroller { overflow-x: auto; margin: 0 0 1.5rem; }
+.help table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.9375rem;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.help thead { background: var(--surface); }
+.help th, .help td {
+  border-bottom: 1px solid var(--hairline);
+  padding: 0.6rem 0.85rem;
+  text-align: left;
+  vertical-align: top;
+}
+.help th { font-weight: 600; }
+.help tbody tr:last-child td { border-bottom: 0; }
+
+.help blockquote {
+  margin: 1.5rem 0;
+  padding: 0.875rem 1.125rem;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-left: 3px solid var(--tone, var(--accent));
+  border-radius: 0 var(--radius) var(--radius) 0;
+  color: var(--ink);
+}
+.help blockquote > *:last-child { margin-bottom: 0; }
+
+/* ---- what to read next ------------------------------------------------- */
+
+.help .onward { margin-top: 3.5rem; padding-top: 1.75rem; border-top: 1px solid var(--hairline); }
+.help .onward h2 {
+  margin: 0 0 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.help .pager {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  margin-top: 1.5rem;
+}
+.help .step {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.9rem 1.125rem;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: inherit;
+  background: var(--raised);
+}
+.help .step:hover { border-color: color-mix(in srgb, var(--tone, var(--accent)) 40%, var(--hairline)); }
+.help .step-kind { font-size: 0.75rem; color: var(--muted); }
+.help .step-title { font-weight: 550; line-height: 1.35; }
+.help .step:hover .step-title { color: var(--tone, var(--accent)); }
+.help .step-next { text-align: right; }
+
+/* ---- search results ---------------------------------------------------- */
+
+.help .results { padding-block: 2.5rem 4rem; }
+.help .results h1 { margin-bottom: 0.5rem; }
+.help .results .lede { margin-bottom: 2rem; max-width: var(--measure); }
+.help .hits { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.75rem; max-width: 46rem; }
+.help .hit {
+  display: block;
+  padding: 1.125rem 1.25rem;
+  background: var(--raised);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: inherit;
+  box-shadow: var(--lift);
+}
+.help .hit:hover { border-color: color-mix(in srgb, var(--accent) 40%, var(--hairline)); box-shadow: var(--lift-hover); }
+.help .hit-kind {
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.25rem;
+}
+.help .hit-title { font-size: 1.0625rem; font-weight: 580; letter-spacing: -0.01em; }
+.help .hit:hover .hit-title { color: var(--accent); }
+.help .hit-snippet { margin: 0.3rem 0 0; font-size: 0.9375rem; line-height: 1.5; color: var(--muted); }
+.help mark { background: var(--mark); color: var(--mark-ink); border-radius: 3px; padding: 0 0.15em; }
+
+/* ---- footer ------------------------------------------------------------ */
+
+.help .colophon {
+  border-top: 1px solid var(--hairline);
+  background: var(--surface);
+  padding: 2rem 0 2.5rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+.help .colophon .bar { display: flex; flex-wrap: wrap; gap: 0.5rem 1.5rem; justify-content: space-between; }
+.help .colophon p { margin: 0; max-width: 34rem; }
+.help .colophon a { color: var(--muted); }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+/* ---- widths ------------------------------------------------------------ */
+
+@media (min-width: 60rem) {
+  .help .layout { grid-template-columns: 15rem minmax(0, 1fr); }
+  .help .rail {
+    order: 0;
+    position: sticky;
+    top: 4.25rem;
+    max-height: calc(100vh - 5.5rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    padding: 0 0.5rem 1.5rem 0;
+  }
+  .help .doc { order: 1; }
+}
+@media (min-width: 78rem) {
+  .help .layout { grid-template-columns: 15rem minmax(0, 1fr) 12rem; }
+  .help .toc { order: 2; display: block; position: sticky; top: 4.5rem; }
+}
+@media (max-width: 40rem) {
+  .help .masthead .bar { min-height: 3.25rem; }
+  .help .find button { display: none; }
+  .help .find input { width: 100%; }
+  .help .masthead .find { flex: 1; max-width: 13rem; }
+  .help .find-lg button { display: inline-block; }
+  /* The sidebar follows the article on a narrow screen rather than preceding it: a reader
+     who arrived from an error message wants the answer, not a table of contents. */
+  .help .rail { border-top: 1px solid var(--hairline); padding-top: 1.5rem; }
+  .help .rail ul { gap: 0; }
+  .help .rail a { padding: 0.4rem 0.6rem; }
+}
+/* Below this the brand and the search field are fighting for the same row, and the field
+   is the one a person came to use. */
+@media (max-width: 30rem) {
+  .help .brand-sep, .help .brand-kind { display: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .help * { transition: none !important; }
+  .help .card:hover { transform: none; }
+}
+
+/* ---- dark -------------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #101418;
+    --surface: #171c21;
+    --raised: #161b20;
+    --ink: #e6e9ec;
+    --muted: #9aa4ae;
+    --hairline: #262d34;
+    --control-border: #6d7780;
+    --accent: #8fb4ff;
+    --accent-wash: #1b2740;
+    --mark: #5c4a12;
+    --mark-ink: #f2f4f6;
+    --figure: #eef1f4;
+    --tone-0: #a8b8ff;
+    --tone-1: #5ecfa4;
+    --tone-2: #e5a56a;
+    --lift: 0 1px 1px rgba(0, 0, 0, 0.3), 0 10px 24px -18px rgba(0, 0, 0, 0.8);
+    --lift-hover: 0 1px 2px rgba(0, 0, 0, 0.35), 0 16px 32px -18px rgba(0, 0, 0, 0.9);
+  }
+  .help .find button { color: var(--paper); background: var(--ink); border-color: var(--ink); }
+  .help .find button:hover { color: var(--paper); }
+}
+`;
+
+/**
+ * The sheet, as the browser has to receive it.
+ *
+ * dangerouslySetInnerHTML rather than a text child, and it is load-bearing rather than
+ * stylistic: React escapes text inside a style element, so a declaration naming "Segoe UI"
+ * arrived as &quot;Segoe UI&quot; and the browser dropped it — silently, along with every
+ * other declaration containing a quote. The font stack was one. The search field's border,
+ * whose contrast a WCAG test asserts, was another: measured in CI, absent from the page.
+ *
+ * Nothing dangerous goes through here. The argument is a constant in this repo and the
+ * component takes no props, so there is no call site that could pass anything else.
+ */
+export function HelpStyles() {
+  return <style dangerouslySetInnerHTML={{ __html: HELP_STYLES }} />;
+}

--- a/app/routes/help.$.tsx
+++ b/app/routes/help.$.tsx
@@ -13,6 +13,14 @@
  * public and takes a path from the URL, `resolveHelpFile` is the security boundary; the
  * reasoning is in the note there.
  *
+ * **What this route adds to the markdown.** The docs are a curated set, not a folder, and
+ * the first version of this page threw that away: `index.md` was rendered as markdown and
+ * arrived as thirty underlined blue links in three bulleted lists, with no way to tell a
+ * concept from an emergency. So the index is parsed into a structure (`nav.server.ts`)
+ * and rendered — as a landing page, as the sidebar on every page, as the breadcrumb, and
+ * as the next/previous links at the foot of each one. All four come from the one file a
+ * writer already maintains, so none of them can go stale on their own.
+ *
  * The caveat worth stating plainly: `failures/app-unavailable` is served by the app it
  * describes, so it is missing exactly when it is wanted. `HELP_BASE_URL` overrides the
  * base so the docs can move to independent hosting without touching any call site.
@@ -21,17 +29,42 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { data, isRouteErrorResponse, useLoaderData, useRouteError } from "react-router";
 
-import { INDEX_SLUG, readHelpPage } from "../lib/help/pages.server";
+import {
+  placeInNav,
+  sectionTitleOf,
+  startingPoints,
+  toneOf,
+  TONES,
+  type HelpNav,
+  type HelpNavItem,
+  type HelpPlace,
+} from "../lib/help/nav";
+import { helpNav } from "../lib/help/nav.server";
+import { INDEX_SLUG, readHelpPage, type HelpPage } from "../lib/help/pages.server";
 import { searchHelp, type HelpHit } from "../lib/help/search.server";
+import { HelpStyles } from "../lib/help/styles";
+
+/** A result carries the section it came from, so a reader can tell a concept from a crisis. */
+type SearchResult = HelpHit & { section: string | null };
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const slug = params["*"] || INDEX_SLUG;
+  const nav = helpNav();
 
   // Search is a GET with a query string rather than a route of its own, so a merchant can
   // bookmark or share a result list, and so the back button behaves.
   const query = new URL(request.url).searchParams.get("q")?.trim() ?? "";
   if (query) {
-    return { query, hits: searchHelp(query), page: null, isIndex: false };
+    const hits: SearchResult[] = searchHelp(query).map((hit) => ({
+      ...hit,
+      section: sectionTitleOf(nav, hit.slug),
+    }));
+
+    return { view: "search" as const, query, hits, nav, page: null, place: null, tone: null };
+  }
+
+  if (slug === INDEX_SLUG) {
+    return { view: "index" as const, query, hits: null, nav, page: null, place: null, tone: null };
   }
 
   const page = await readHelpPage(slug);
@@ -40,7 +73,17 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   // silently landing them somewhere else hides that a link in the product is wrong.
   if (!page) throw data({ slug }, { status: 404 });
 
-  return { query, hits: null, page, isIndex: slug === INDEX_SLUG };
+  const place = placeInNav(nav, slug);
+
+  return {
+    view: "page" as const,
+    query,
+    hits: null,
+    nav,
+    page,
+    place,
+    tone: place ? toneOf(nav, place.section) : null,
+  };
 }
 
 export function meta({ data: loaded }: { data?: Awaited<ReturnType<typeof loader>> }) {
@@ -53,42 +96,266 @@ export function meta({ data: loaded }: { data?: Awaited<ReturnType<typeof loader
 }
 
 export default function HelpRoute() {
-  const { page, isIndex, query, hits } = useLoaderData<typeof loader>();
+  const loaded = useLoaderData<typeof loader>();
 
-  if (hits) {
+  if (loaded.view === "search") {
     return (
-      <Shell showBack query={query}>
-        <h1>
-          {hits.length === 0 ? "Nothing matched" : `${hits.length} page${hits.length === 1 ? "" : "s"}`}
-          {" for "}
-          {/* Rendered as text, never as markup: this is the only thing on the page that
-              did not come from a file we wrote. */}
-          <em>{query}</em>
-        </h1>
-        {hits.length === 0 ? (
-          <p>
-            Try a single word — the pages are written in plain language, so the word you
-            would say out loud is usually the one that finds them.
-          </p>
-        ) : (
-          <ol className="hits">
-            {hits.map((hit) => (
-              <li key={hit.slug}>
-                <a href={`/help/${hit.slug}`}>{hit.title}</a>
-                <p>{highlight(hit)}</p>
-              </li>
-            ))}
-          </ol>
-        )}
+      <Shell query={loaded.query}>
+        <Results query={loaded.query} hits={loaded.hits} nav={loaded.nav} />
+      </Shell>
+    );
+  }
+
+  if (loaded.view === "index") {
+    return (
+      <Shell query="">
+        <Landing nav={loaded.nav} />
       </Shell>
     );
   }
 
   return (
-    <Shell showBack={!isIndex} query={query}>
-      {/* The markdown is committed alongside this file — it is our prose, not input. */}
-      <article dangerouslySetInnerHTML={{ __html: page!.html }} />
+    <Shell query={loaded.query}>
+      <Document nav={loaded.nav} page={loaded.page} place={loaded.place} tone={loaded.tone} />
     </Shell>
+  );
+}
+
+/* -- the landing page ------------------------------------------------------ */
+
+function Landing({ nav }: { nav: HelpNav }) {
+  return (
+    <main id="content">
+      <div className="hero bar">
+        <div className="hero-inner">
+          <p className="eyebrow">Help centre</p>
+          <h1>{nav.title}</h1>
+          {nav.lede ? <p className="lede">{nav.lede}</p> : null}
+          <SearchForm query="" size="lg" />
+          <StartHere nav={nav} />
+        </div>
+      </div>
+
+      <div className="bar">
+        {nav.sections.map((section, index) => (
+          <section className="group" key={section.id} data-tone={index % TONES}>
+            <div className="group-head">
+              <h2 id={section.id}>{section.title}</h2>
+              {section.blurb ? <p>{section.blurb}</p> : null}
+            </div>
+            <CardList items={section.items} />
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}
+
+/**
+ * The first page of each section, as a sentence.
+ *
+ * Somebody who has just installed the app is not browsing — they have a question and are
+ * deciding whether this page is worth their next thirty seconds. Three named destinations
+ * answer that faster than a heading called "Concepts" does.
+ */
+function StartHere({ nav }: { nav: HelpNav }) {
+  const starts = startingPoints(nav);
+  if (starts.length === 0) return null;
+
+  return (
+    <p className="jump">
+      Start with{" "}
+      {starts.map((item, index) => (
+        <span key={item.slug}>
+          {index > 0 ? (index === starts.length - 1 ? " or " : ", ") : ""}
+          <a href={`/help/${item.slug}`}>{lowerFirst(item.title)}</a>
+        </span>
+      ))}
+      .
+    </p>
+  );
+}
+
+/**
+ * Cards, or a list once there are too many for cards to stay scannable.
+ *
+ * Ten failure pages as ten cards is a wall, and the section a merchant reaches during an
+ * incident is the last one that should need reading twice. The threshold is on the count
+ * rather than on the section's name, so it holds for whatever the index says tomorrow.
+ */
+function CardList({ items }: { items: HelpNavItem[] }) {
+  const dense = items.length > 6;
+
+  return (
+    <ul className={dense ? "cards cards-dense" : "cards"}>
+      {items.map((item) => (
+        <li key={item.slug}>
+          <a className="card" href={`/help/${item.slug}`}>
+            <span className="card-title">{item.title}</span>
+            {item.blurb && !dense ? <span className="card-blurb">{item.blurb}</span> : null}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/* -- a page ---------------------------------------------------------------- */
+
+function Document({
+  nav,
+  page,
+  place,
+  tone,
+}: {
+  nav: HelpNav;
+  page: HelpPage;
+  place: HelpPlace | null;
+  tone: number | null;
+}) {
+  return (
+    <div className="layout bar" data-tone={tone ?? undefined}>
+      <Rail nav={nav} here={place ? { slug: page.slug, section: place.section.id } : null} />
+
+      <main id="content" className="doc">
+        <nav className="crumbs" aria-label="Breadcrumb">
+          <a href="/help">Help centre</a>
+          {place ? (
+            <>
+              <span className="sep" aria-hidden="true">/</span>
+              <a href={`/help#${place.section.id}`}>{place.section.title}</a>
+            </>
+          ) : null}
+        </nav>
+
+        {/* The markdown is committed alongside this file — it is our prose, not input. */}
+        <article dangerouslySetInnerHTML={{ __html: page.html }} />
+
+        {page.related.length > 0 ? (
+          <section className="onward">
+            <h2>Related</h2>
+            <div className="pager">
+              {page.related.map((link) => (
+                <a className="step" key={link.href} href={link.href}>
+                  <span className="step-title">{link.label}</span>
+                </a>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {place && (place.previous || place.next) ? (
+          <section className="onward">
+            <h2>{place.section.title}</h2>
+            <div className="pager">
+              {place.previous ? (
+                <a className="step" href={`/help/${place.previous.slug}`}>
+                  <span className="step-kind">← Previous</span>
+                  <span className="step-title">{place.previous.title}</span>
+                </a>
+              ) : (
+                <span />
+              )}
+              {place.next ? (
+                <a className="step step-next" href={`/help/${place.next.slug}`}>
+                  <span className="step-kind">Next →</span>
+                  <span className="step-title">{place.next.title}</span>
+                </a>
+              ) : null}
+            </div>
+          </section>
+        ) : null}
+      </main>
+
+      <Contents page={page} />
+    </div>
+  );
+}
+
+/**
+ * Every page in the centre, with the current one marked.
+ *
+ * `here` names a section as well as a slug because one page is listed twice — guardrails
+ * are both a concept and a thing that stops a run — and marking both entries would tell a
+ * reader they are in two places at once.
+ */
+function Rail({ nav, here }: { nav: HelpNav; here: { slug: string; section: string } | null }) {
+  return (
+    <div className="rail">
+      {nav.sections.map((section, index) => (
+        <nav key={section.id} aria-label={section.title} data-tone={index % TONES}>
+          <p className="rail-head">{section.title}</p>
+          <ul>
+            {section.items.map((item) => {
+              const current = here?.section === section.id && here.slug === item.slug;
+              return (
+                <li key={item.slug}>
+                  <a href={`/help/${item.slug}`} aria-current={current ? "page" : undefined}>
+                    {item.title}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      ))}
+    </div>
+  );
+}
+
+function Contents({ page }: { page: HelpPage }) {
+  // One heading is not a contents list, it is the page. Two is where it starts to help.
+  if (page.headings.length < 2) return null;
+
+  return (
+    <nav className="toc" aria-label="On this page">
+      <p className="toc-head">On this page</p>
+      <ol>
+        {page.headings.map((heading) => (
+          <li key={heading.id}>
+            <a href={`#${heading.id}`}>{heading.text}</a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+
+/* -- search ---------------------------------------------------------------- */
+
+function Results({ query, hits, nav }: { query: string; hits: SearchResult[]; nav: HelpNav }) {
+  return (
+    <main id="content" className="results bar">
+      <h1>
+        {hits.length === 0 ? "Nothing matched" : `${hits.length} page${hits.length === 1 ? "" : "s"}`}
+        {" for "}
+        {/* Rendered as text, never as markup: this is the only thing on the page that
+            did not come from a file we wrote. */}
+        <em>{query}</em>
+      </h1>
+
+      {hits.length === 0 ? (
+        <>
+          <p className="lede">
+            Try a single word — the pages are written in plain language, so the word you
+            would say out loud is usually the one that finds them.
+          </p>
+          <CardList items={startingPoints(nav)} />
+        </>
+      ) : (
+        <ol className="hits">
+          {hits.map((hit) => (
+            <li key={hit.slug}>
+              <a className="hit" href={`/help/${hit.slug}`}>
+                {hit.section ? <span className="hit-kind">{hit.section}</span> : null}
+                <span className="hit-title">{hit.title}</span>
+                <p className="hit-snippet">{highlight(hit)}</p>
+              </a>
+            </li>
+          ))}
+        </ol>
+      )}
+    </main>
   );
 }
 
@@ -110,138 +377,119 @@ export function ErrorBoundary() {
   const missing = isRouteErrorResponse(error) && error.status === 404;
 
   return (
-    <Shell showBack query="">
-      <h1>{missing ? "No such help page" : "That page could not be loaded"}</h1>
-      <p>
-        {missing
-          ? "The link that brought you here points at a page that does not exist. That is our mistake, not yours — everything we have written is one click away."
-          : "Something went wrong reading this page."}
-      </p>
+    <Shell query="">
+      <main id="content" className="results bar">
+        <p className="eyebrow">{missing ? "404" : "Error"}</p>
+        <h1>{missing ? "No such help page" : "That page could not be loaded"}</h1>
+        <p className="lede">
+          {missing
+            ? "The link that brought you here points at a page that does not exist. That is our mistake, not yours — everything we have written is one click away."
+            : "Something went wrong reading this page. Everything we have written is still one click away."}
+        </p>
+        <p className="jump">
+          <a href="/help">Go to the help centre →</a>
+        </p>
+      </main>
     </Shell>
   );
 }
 
-function Shell({
-  children,
-  showBack,
-  query,
-}: {
-  children: React.ReactNode;
-  showBack: boolean;
-  query: string;
-}) {
+/* -- shell ----------------------------------------------------------------- */
+
+function Shell({ children, query }: { children: React.ReactNode; query: string }) {
   return (
-    <main className="help">
-      <style>{STYLES}</style>
-      <nav>
-        {showBack ? <a href="/help">← Help centre</a> : <span />}
-        {/* A plain GET form: it works before any JavaScript has loaded, which matters on
-            a page a merchant may reach while the rest of the app is misbehaving. */}
-        <form method="get" action="/help" role="search">
-          <label htmlFor="q" className="visually-hidden">
-            Search the help centre
-          </label>
-          <input id="q" type="search" name="q" defaultValue={query} placeholder="Search help" />
-          <button type="submit">Search</button>
-        </form>
-      </nav>
+    <div className="help">
+      <HelpStyles />
+
+      <a className="skip" href="#content">
+        Skip to content
+      </a>
+
+      <header className="masthead">
+        <div className="bar">
+          <a className="brand" href="/help">
+            <AnchorMark />
+            <span>Anchor</span>
+            <span className="brand-sep" aria-hidden="true">
+              /
+            </span>
+            <span className="brand-kind">Help centre</span>
+          </a>
+          <SearchForm query={query} size="sm" />
+        </div>
+      </header>
+
       {children}
-    </main>
+
+      <footer className="colophon">
+        <div className="bar">
+          <p>
+            Anchor manages price campaigns for Shopify stores selling into more than one
+            market. These pages ship with the app, so what they describe is what your store
+            is running.
+          </p>
+          <p>
+            <a href="/help">Help centre</a>
+          </p>
+        </div>
+      </footer>
+    </div>
   );
 }
 
 /**
- * Inline rather than imported: this route is the one a merchant reaches when something
- * else has already gone wrong, and one fewer asset to fetch is one fewer thing to fail.
+ * A plain GET form: it works before any JavaScript has loaded, which matters on a page a
+ * merchant may reach while the rest of the app is misbehaving.
  */
-const STYLES = `
-.help {
-  max-width: 42rem;
-  margin: 0 auto;
-  padding: 2rem 1.25rem 6rem;
-  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  line-height: 1.65;
-  color: #1a1a1a;
+function SearchForm({ query, size }: { query: string; size: "sm" | "lg" }) {
+  const id = `q-${size}`;
+
+  return (
+    <form method="get" action="/help" role="search" className={size === "lg" ? "find find-lg" : "find"}>
+      <label htmlFor={id} className="visually-hidden">
+        Search the help centre
+      </label>
+      <span className="field">
+        <SearchMark />
+        <input
+          id={id}
+          type="search"
+          name="q"
+          defaultValue={query}
+          placeholder={size === "lg" ? "Search every page" : "Search help"}
+        />
+      </span>
+      <button type="submit">Search</button>
+    </form>
+  );
 }
-.help nav {
-  margin-bottom: 2rem;
-  font-size: 0.875rem;
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
+
+function lowerFirst(text: string): string {
+  // "What a baseline is" reads as part of the sentence; "WIP" and "Anchor" must not be
+  // flattened, so only a word that is otherwise lowercase is touched.
+  const [first, rest] = [text.slice(0, 1), text.slice(1)];
+  return rest === rest.toLowerCase() ? first.toLowerCase() + rest : text;
 }
-.help nav form { display: flex; gap: 0.5rem; }
-.help input[type="search"], .help button {
-  font: inherit;
-  padding: 0.35rem 0.6rem;
-  border: 1px solid #8e8e8e;
-  border-radius: 6px;
-  background: transparent;
-  color: inherit;
+
+function AnchorMark() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="5" r="2.4" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M12 7.4V21M7 11h10M21 15a9 9 0 0 1-18 0"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
 }
-.help button { cursor: pointer; }
-.help mark { background: #ffe9a8; color: inherit; }
-.help ol.hits { list-style: none; padding: 0; }
-.help ol.hits li { margin: 0 0 1.5rem; }
-.help ol.hits p { margin: 0.25rem 0 0; color: #4a4a4a; }
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
+
+function SearchMark() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="2" />
+      <path d="m16 16 4.5 4.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
 }
-.help a { color: #005bd3; }
-.help h1 { font-size: 1.75rem; line-height: 1.3; margin: 0 0 1rem; }
-.help h2 { font-size: 1.25rem; margin: 2.5rem 0 0.75rem; }
-.help h3 { font-size: 1.0625rem; margin: 2rem 0 0.5rem; }
-.help ul, .help ol { padding-left: 1.5rem; }
-.help li { margin: 0.35rem 0; }
-.help code {
-  font-size: 0.875em;
-  background: #f1f1f1;
-  padding: 0.1em 0.35em;
-  border-radius: 3px;
-}
-.help pre { background: #f1f1f1; padding: 1rem; border-radius: 6px; overflow-x: auto; }
-/* Screenshots are captured at admin width and are far wider than this column. Scaling
-   them down keeps the page from scrolling sideways, which is the one thing a reader
-   should never have to do to finish a sentence. */
-.help img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-  margin: 1.5rem 0;
-  border: 1px solid #e1e1e1;
-  border-radius: 6px;
-}
-.help pre code { background: none; padding: 0; }
-.help table { border-collapse: collapse; width: 100%; display: block; overflow-x: auto; }
-.help th, .help td {
-  border: 1px solid #e1e1e1;
-  padding: 0.5rem 0.75rem;
-  text-align: left;
-  vertical-align: top;
-}
-.help blockquote {
-  margin: 1.25rem 0;
-  padding-left: 1rem;
-  border-left: 3px solid #e1e1e1;
-  color: #4a4a4a;
-}
-@media (prefers-color-scheme: dark) {
-  body { background: #1a1a1a; }
-  .help { color: #e3e3e3; }
-  .help a { color: #6aa9ff; }
-  .help code, .help pre { background: #2a2a2a; }
-  .help th, .help td { border-color: #3a3a3a; }
-  .help img { border-color: #3a3a3a; }
-  .help blockquote { border-left-color: #3a3a3a; color: #b5b5b5; }
-  .help ol.hits p { color: #b5b5b5; }
-  .help mark { background: #6b5510; color: #f5f5f5; }
-  .help input[type="search"], .help button { border-color: #707070; }
-}
-`;

--- a/docs/help/how-to/shopify-flow.md
+++ b/docs/help/how-to/shopify-flow.md
@@ -46,7 +46,7 @@ so it is refused rather than confirmed on your behalf.
 Prices revert, the ledger records it, and Anchor's *Campaign ended* trigger fires — so you
 can chain a Slack message onto the same Flow if you want to be told.
 
-## Another
+## Another worked example
 
 **"Tell the team when a campaign is held because someone edited a price."**
 

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -1,5 +1,10 @@
 # Anchor help
 
+Anchor runs price campaigns against a baseline, so a discount never compounds, overlapping
+campaigns resolve to one winner, and a revert is exact. These pages explain the ideas that
+make that true, walk through the jobs merchants do most, and say what to do when a run
+does not finish cleanly.
+
 ## Concepts
 
 Unfamiliar ideas that the rest of the product rests on. Worth ten minutes before your
@@ -9,18 +14,23 @@ first campaign.
 - [How overlapping campaigns resolve](./concepts/resolver.md) — one winner per product, never stacked
 - [Why revert recomputes](./concepts/revert.md) — rather than restoring old prices
 - [What drift means](./concepts/drift.md) — when somebody changes a price behind the app
-- [How rate limits affect a run](./concepts/rate-limits.md)
+- [How rate limits affect a run](./concepts/rate-limits.md) — why a large catalogue takes the time it takes
 - [How guardrails work](./failures/guardrail-blocks.md) — the floors no campaign may price below
 
 ## How to
 
-- [Your first campaign](./how-to/first-campaign.md)
-- [Scheduling a sale](./how-to/schedule-a-sale.md)
-- [Running a sale across several markets](./how-to/multi-market-sale.md)
-- [Importing your own prices](./how-to/import-baselines.md)
-- [Wiring pricing into Shopify Flow](./how-to/shopify-flow.md)
+The jobs merchants do most, start to finish. Nothing here writes a price until you say so.
+
+- [Your first campaign](./how-to/first-campaign.md) — fifteen minutes, from baselines to a verified run
+- [Scheduling a sale](./how-to/schedule-a-sale.md) — a start, an end, and what happens at each
+- [Running a sale across several markets](./how-to/multi-market-sale.md) — priced from each market's own normal price
+- [Importing your own prices](./how-to/import-baselines.md) — when your storefront prices are already discounted
+- [Wiring pricing into Shopify Flow](./how-to/shopify-flow.md) — three triggers and three actions for the rest of your stack
 
 ## When something goes wrong
+
+Every error in the app links straight to the page that explains it. If you arrived here
+instead, find the symptom.
 
 - [Understanding a partial run](./failures/partial-runs.md)
 - [A run that seems stuck](./failures/stuck-runs.md)


### PR DESCRIPTION
`docs/help/index.md` is a curated list — an order, a grouping, and a half-sentence per page saying why it is worth opening. Rendering it as markdown discarded all of it, and a merchant got thirty underlined blue links in three bulleted lists. Article pages were a bare column with no navigation, no breadcrumb, no contents and no way to the next page.

The index is now parsed instead. One structure drives four surfaces — the landing page's sections, the sidebar, the breadcrumb, and the next/previous links — from the file a writer already maintains. `nav.server.test.ts` fails if a published page is missing from it, or if an entry names a page we do not serve, or if a link in the file is silently lost in parsing.

## Two bugs, both worse than the layout

**Half the stylesheet never reached the browser.** It was a text child of `<style>`, and React escapes those. Every declaration containing a quote arrived as `&quot;…&quot;` and the browser dropped it — the font stack, so the page rendered in the browser's default serif, and the whole `input[type="search"]` rule. `help-contrast.test.ts` was computing that border's contrast and passing, because it reads the source string rather than the page: a test asserting a property of CSS that was never applied. `HelpStyles` now owns the decision, and `styles.test.ts` asserts the emitted markup equals the sheet character for character, then demonstrates the escaping so the guard is shown to be able to fail.

**Search results opened with screenshot alt text.** `toProse` reduced `[text](url)` but left the `!` in front of an image, so searching "drift" returned `!The drift page with nothing to review: a heading reading "No drift detected"…`. Images are dropped whole now. `docs/help/images/README.md` — the note about cropping screenshots so a competitor's name stays out of them — is no longer returnable as a merchant-facing result.

## The rest

- Sticky masthead, a real search field, and a landing page of cards; a section over six entries renders as a compact list instead of a wall, which is what the ten failure pages needed
- An "On this page" rail, built from heading anchors the renderer emits — both sides call `headingId`, so a contents entry cannot point at an id the page lacks
- `## Related` lifted out of the prose and rendered as cards, and tables given their own scroll box so the document never scrolls sideways
- Figures sit on a pale mat in dark mode; the screenshots and the one diagram are authored light, and redrawing every future one for two palettes is a standing cost
- Every colour is a token in one of two blocks. The contrast test resolves them and additionally refuses a hex anywhere else in the sheet, so a colour cannot render without being measured in both palettes

## Content edits

Added a lede and section descriptions to `index.md`, and blurbs to the How-to entries, since the landing page has places for them. Renamed `## Another` to `## Another worked example` in the Flow page — headings are navigation now, and "Another" says nothing in a contents list.

## Verification

2245 tests, typecheck, lint and `npm run build` all pass. Checked in a browser at desktop and 390px, in both palettes: landing, article, search, and the 404.

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
