### PR TITLE
An app nav item is a route, not a link

### DIFF
--- a/app/components/imports/imports.test.ts
+++ b/app/components/imports/imports.test.ts
@@ -42,14 +42,38 @@ const NAV = read("app/routes/app.tsx");
 const IMPORT_FORM = read("app/components/imports/ImportForm.tsx");
 const DROP_ZONE = read("app/components/imports/CsvDropZone.tsx");
 
-describe("the nav is four items, and none of them is a verb", () => {
+describe("the nav is five items, and none of them is a verb", () => {
   it("no longer offers Imports", () => {
     expect(code(NAV)).not.toContain("/app/imports");
   });
 
-  it("keeps the four nouns", () => {
+  /**
+   * Five, and it was always five on screen.
+   *
+   * This read "four nouns" and passed while a fifth item sat beside them, because Help's
+   * href was an expression — `{helpBase}` — and the pattern below only matches a string
+   * literal. The item this test could not see was the one that was broken: an absolute
+   * URL in an app nav navigates the embedded frame off the app and takes App Bridge with
+   * it, after which every item here is inert. See `docs/polaris-notes.md`.
+   *
+   * So the assertion counts what a merchant sees. An item the pattern cannot match is now
+   * a failure rather than an omission, which is the property that was missing.
+   */
+  it("keeps the five nouns", () => {
     const items = [...code(NAV).matchAll(/<s-link href="(\/app[^"]*)"/g)].map((m) => m[1]);
-    expect(items).toEqual(["/app", "/app/campaigns", "/app/prices", "/app/settings"]);
+    expect(items).toEqual([
+      "/app",
+      "/app/campaigns",
+      "/app/prices",
+      "/app/settings",
+      "/app/help",
+    ]);
+  });
+
+  it("has no nav item the assertion above cannot see", () => {
+    const links = [...code(NAV).matchAll(/<s-link\s/g)].length;
+
+    expect(links, "an s-link whose href is not a literal path is invisible above").toBe(5);
   });
 
   it("stops naming Baselines and Costs twice", () => {

--- a/app/lib/ui/polaris-traps.test.ts
+++ b/app/lib/ui/polaris-traps.test.ts
@@ -80,6 +80,56 @@ describe("s-button is never given name or value", () => {
   });
 });
 
+/**
+ * The nav menu's links are app routes, not links.
+ *
+ * Shopify's documentation for `s-app-nav` is explicit: an item's `href` "must be a
+ * relative path within your app", and clicking one "navigates the app to this route
+ * without a full page reload". Nothing in the contract mentions `target`.
+ *
+ * The Help item was an absolute URL to the help centre, with `target="_blank"` on it in
+ * the belief that a relative path would resolve against admin.shopify.com. App Bridge
+ * navigated the embedded frame to it instead — a full load of a non-embedded page, which
+ * takes `host`, `id_token` and `shop` with it, and App Bridge with them. Every nav item
+ * in the admin went inert from that point on: not an error, not a blank page, just
+ * clicks that did nothing.
+ *
+ * It is the session loss the native-form test above guards, reached through a link. This
+ * catches the link.
+ */
+describe("every app nav item is a path inside the app", () => {
+  const layout = readFileSync(join(ROOT, "app/routes/app.tsx"), "utf8");
+
+  const hrefs = (() => {
+    const nav = /<s-app-nav>([\s\S]*?)<\/s-app-nav>/.exec(layout);
+    expect(nav, "the app nav is no longer in app/routes/app.tsx").not.toBeNull();
+
+    return [...nav![1].matchAll(/<s-link[^>]*\shref=(?:"([^"]*)"|\{([^}]*)\})/g)].map(
+      (match) => match[1] ?? match[2],
+    );
+  })();
+
+  it("finds the nav items, so it cannot pass by checking nothing", () => {
+    expect(hrefs.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(hrefs)("%s is a relative path under /app", (href) => {
+    // An expression rather than a literal is the shape the broken one had: the absolute
+    // base came from a loader, so nothing about the JSX looked wrong.
+    expect(href.startsWith("/app"), `${href} is not a path inside the app`).toBe(true);
+  });
+
+  /**
+   * `target` on a nav item is not honoured, and believing it is was half of the bug: it
+   * reads as "this one opens elsewhere" while the element navigates the frame anyway.
+   */
+  it("asks for no new tabs, which the element does not give", () => {
+    const nav = /<s-app-nav>([\s\S]*?)<\/s-app-nav>/.exec(layout)![1];
+
+    expect(nav).not.toContain("target=");
+  });
+});
+
 describe("no native form on an embedded surface", () => {
   /**
    * A plain `<form>`, GET or POST, does a full navigation that wipes App Bridge's `host`,

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -1,0 +1,109 @@
+/**
+ * Help, inside the admin.
+ *
+ * This page exists because of what the nav item used to be: an `s-app-nav` child whose
+ * href was the absolute `helpBase`, carrying `target="_blank"` in the belief that it would
+ * open a tab. (Written out rather than quoted as JSX because `action-row.test.tsx` greps
+ * the source for that tag, and a comment describing the mistake should not read as one
+ * making it.)
+ *
+ * An app nav link's `href` **must be a relative path within your app** — Shopify's
+ * documentation for the element says so, and says that clicking one "navigates the app to
+ * this route without a full page reload". `helpBase` is absolute, and `target` is not part
+ * of that contract. So App Bridge did what it does with a route it was handed: it pointed
+ * the embedded frame at it. That is a full document load to a page outside the embedded
+ * app, which drops `host`, `id_token` and `shop` — and with them App Bridge itself.
+ *
+ * The merchant sees the help centre, and from then on every nav item in the admin is inert,
+ * because there is no longer anything in the frame listening for the navigation. Nothing
+ * looks broken; clicking simply does nothing. It is the same session loss that
+ * `docs/polaris-notes.md` records for a native form element, reached through a link
+ * instead. (Written out rather than in angle brackets on purpose: `polaris-traps.test.ts`
+ * greps the source for that tag, and a comment describing the trap should not read as one
+ * committing it.)
+ *
+ * So the nav item points here, which is a real route under `app.tsx` and keeps App Bridge
+ * alive, and this page sends a merchant onward in a **new tab** — the pattern `ErrorScreen`
+ * already uses for the same destination, and the only safe way to reach a non-embedded page
+ * from inside the frame.
+ *
+ * The list is `docs/help/index.md`, parsed — the same structure the help centre itself is
+ * built from, so a page added there appears here without anybody remembering to.
+ */
+
+import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ActionRow } from "../components/ActionRow";
+import { PageShell } from "../components/PageShell";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { HELP_ROUTE } from "../lib/errors/help-links";
+import { withGuard } from "../lib/errors/guard.server";
+import { helpNav } from "../lib/help/nav.server";
+import { SPACE } from "../lib/ui/spacing";
+
+export const loader = withGuard("/app/help", async ({ request }: LoaderFunctionArgs) => {
+  // Authenticated like every other embedded route, even though the content is public
+  // prose: an unauthenticated hit here has to go through OAuth rather than render a page
+  // the admin frame cannot host.
+  await authenticate.admin(request);
+
+  return { nav: helpNav() };
+});
+
+export default function HelpIndex() {
+  const { nav } = useLoaderData<typeof loader>();
+
+  return (
+    <PageShell heading="Help">
+      <s-section>
+        <s-stack gap={SPACE.section}>
+          {nav.lede ? <s-paragraph>{nav.lede}</s-paragraph> : null}
+          <s-paragraph>
+            <s-text color="subdued">
+              Each page opens in a new tab, so nothing you have open in here is lost.
+            </s-text>
+          </s-paragraph>
+        </s-stack>
+      </s-section>
+
+      {nav.sections.map((section) => (
+        <s-section key={section.id} heading={section.title}>
+          <s-stack gap={SPACE.section}>
+            {section.blurb ? <s-paragraph>{section.blurb}</s-paragraph> : null}
+
+            <s-stack gap={SPACE.item}>
+              {section.items.map((item) => (
+                <ActionRow key={item.slug}>
+                  {/* Root-relative and a new tab. Relative because the app document is
+                      served from our own origin inside the frame as well as outside it,
+                      and a new tab because the destination is not an embedded page — see
+                      the note at the top of this file for what happens when it is not. */}
+                  <s-button
+                    variant="tertiary"
+                    icon="external"
+                    href={`${HELP_ROUTE}/${item.slug}`}
+                    target="_blank"
+                  >
+                    {item.title}
+                  </s-button>
+                  {item.blurb ? <s-text color="subdued">{item.blurb}</s-text> : null}
+                </ActionRow>
+              ))}
+            </s-stack>
+          </s-stack>
+        </s-section>
+      ))}
+    </PageShell>
+  );
+}
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -4,21 +4,18 @@ import { boundary } from "@shopify/shopify-app-react-router/server";
 import { AppProvider } from "@shopify/shopify-app-react-router/react";
 
 import { authenticate } from "../shopify.server";
-import { HELP_BASE } from "../lib/errors/help-links.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { RouteProgress } from "../components/RouteProgress";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   await authenticate.admin(request);
 
-  // `HELP_BASE` is read from the environment, so it is resolved here rather than in the
-  // component — the loader is stripped from the client bundle, `process.env` is not.
   // eslint-disable-next-line no-undef
-  return { apiKey: process.env.SHOPIFY_API_KEY || "", helpBase: HELP_BASE };
+  return { apiKey: process.env.SHOPIFY_API_KEY || "" };
 };
 
 export default function App() {
-  const { apiKey, helpBase } = useLoaderData<typeof loader>();
+  const { apiKey } = useLoaderData<typeof loader>();
 
   return (
     <AppProvider embedded apiKey={apiKey}>
@@ -28,9 +25,13 @@ export default function App() {
         <s-link href="/app/campaigns">Campaigns</s-link>
         <s-link href="/app/prices">Prices</s-link>
         <s-link href="/app/settings">Settings</s-link>
-        {/* Absolute and a new tab: this renders in an iframe on admin.shopify.com,
-            where a relative href would resolve against Shopify rather than us. */}
-        <s-link href={helpBase} target="_blank">Help</s-link>
+        {/* Relative, like every other item, and pointing at an embedded route rather than
+            at the help centre itself. An `s-app-nav` href must be a path within the app:
+            App Bridge navigates the frame to whatever it is given, so the absolute URL
+            that used to be here loaded a non-embedded page into the frame and took
+            `host`, `id_token` and `shop` with it. Every nav item went inert from then on.
+            `app.help.tsx` has the detail. */}
+        <s-link href="/app/help">Help</s-link>
       </s-app-nav>
       <Outlet />
     </AppProvider>

--- a/docs/polaris-notes.md
+++ b/docs/polaris-notes.md
@@ -99,6 +99,29 @@ A plain `<form>` — GET or POST — does a full navigation that wipes App Bridg
 `id_token` and `shop` parameters. The server then logs `shop: null` and the merchant sees
 a blank page. Use `FilterForm` for GET or React Router's `<Form>` for POST.
 
+## An app nav item is a route, not a link
+
+`s-app-nav`'s children take a **relative path within the app**, and Shopify's docs are
+plain about what happens next: clicking one "navigates the app to this route without a
+full page reload". `target` is not part of that contract.
+
+The Help item was an absolute URL to `/help`, with `target="_blank"` on it, on the
+reasoning that a relative path inside an iframe on admin.shopify.com would resolve
+against Shopify. That reasoning is right for a bare anchor and wrong for this element:
+App Bridge resolves nav hrefs against the app, which is the whole point of it. So the
+frame was navigated to a non-embedded page, losing `host`, `id_token` and `shop` — and
+App Bridge with them.
+
+The symptom is worth knowing because it names nothing: the admin still draws the nav, and
+clicking any item does **nothing at all**. No error, no blank page, no reload. Every page
+after visiting help is dead until the app is reopened from the admin.
+
+Same session loss as the native form above, reached through a link. `/app/help` is a real
+embedded route now, and it sends merchants onward with `s-button target="_blank"` — which
+does work, and is what `ErrorScreen` already used for the same destination.
+`polaris-traps.test.ts` rejects a nav href that is not under `/app`, and rejects `target`
+in the nav at all.
+
 ## `*.server.ts` is stripped from the client bundle
 
 Calling something from one in a component gives `undefined` at click time with no build


### PR DESCRIPTION
After visiting the help centre, every nav item in the admin stopped responding — no error, no blank page, no reload, just clicks that did nothing, on every page, until the app was reopened.

## Cause

```jsx
<s-link href={helpBase} target="_blank">Help</s-link>
```

`helpBase` is absolute. [Shopify's docs for the app nav element](https://shopify.dev/docs/api/app-home/app-bridge-web-components/app-nav) say an item's href "must be a relative path within your app, such as `/products` or `/settings`", and that clicking one "navigates the app to this route without a full page reload". `target` is not part of that contract.

So App Bridge navigated the embedded frame to `/help` — a page deliberately outside the embedded app. A full document load, dropping `host`, `id_token` and `shop`, and App Bridge with them. The admin kept drawing the nav; nothing in the frame was left listening for a navigation.

The comment above the line had it backwards: *"a relative href would resolve against Shopify rather than us"* is true of a bare anchor and false of this element — resolving nav hrefs against the app is what it is for.

This is the session loss `docs/polaris-notes.md` already records for a native form element, reached through a link instead. The href has been wrong for as long as the nav has had five items; #435 just gave people a reason to click Help.

**Established vs. not:** the contract violation is established from the docs, and the symptom matches App Bridge session loss precisely. I could not watch the frame navigate — driving the embedded admin needs a live session through the CLI tunnel. The fix holds either way, since an absolute href there is unsupported regardless of which step fails first.

## Fix

`/app/help` is a real embedded route, so the nav item is a relative in-app path like the other four and App Bridge stays alive. It lists the help centre from the same parsed `docs/help/index.md` the centre itself is built from, so a page added there appears in both. Each entry opens in a new tab via `s-button target="_blank"` — which does work, and is what `ErrorScreen` already used for this destination.

## Two tests that could not see the broken item

Worth calling out, because in both cases the thing they skipped was the thing that was wrong.

- `polaris-traps.test.ts` guarded native forms against this exact session loss but not links. It now rejects a nav href that is not under `/app`, and rejects `target` in the nav at all. Verified it fails on the original line.
- `imports.test.ts` asserted "the nav is four items" while five were on screen — Help's href was `{helpBase}`, an expression, and the pattern only matched string literals. It counts five now, plus a second assertion that fails if an href it cannot read ever appears again.

## Verification

2257 tests, typecheck, lint and `npm run build` pass. `/app/help` resolves through the auth boundary like every other embedded route. The nav guard was confirmed to fail when the original href is restored.

## Not in this PR

Help still *reads* in a separate tab. Rendering the pages themselves inside the admin is the better end state and a bigger change — happy to open it as a follow-up if you want it.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
