### PR TITLE
Sections a route nests keep the page rhythm

### DIFF
--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -127,6 +127,28 @@ function BackLink({ backTo }: { backTo?: { href: string; label: string } }) {
   );
 }
 
+/**
+ * Page rhythm for sections a route has to nest inside something of its own.
+ *
+ * `s-page` spaces its **direct** children, which is why the no-aside branch below hands
+ * them over untouched. A route that wraps its sections in anything — and one does: the
+ * settings page puts three of them inside a single `fetcher.Form`, because one Save
+ * button has to submit all three — is no longer handing `s-page` sections. It is handing
+ * it one form, and the sections inside it come out flush against each other with no gap
+ * at all. Two cards touching read as one card with a line through it.
+ *
+ * So the rhythm is available for that case, and only from here: `spacing.test.ts` refuses
+ * `SPACE.page` in any file but this one, so a route cannot decide the distance between
+ * its own sections — it can only ask for the one the shell already uses.
+ *
+ * An `s-stack` and not an `s-grid`. The note in the no-aside branch below records a
+ * single-column grid rendering the page blank; a stack wrapping sections is the shape the
+ * two-column branch has always used, and it renders.
+ */
+export function PageSections({ children }: { children: ReactNode }) {
+  return <s-stack gap={SPACE.page}>{children}</s-stack>;
+}
+
 export function PageShell({
   heading,
   backTo,

--- a/app/lib/ui/spacing.test.ts
+++ b/app/lib/ui/spacing.test.ts
@@ -171,6 +171,56 @@ describe("nothing in the app sets a distance by hand", () => {
   });
 });
 
+/**
+ * Sections a route nests still get the page rhythm.
+ *
+ * `s-page` spaces its **direct** children and nothing deeper. The settings page put three
+ * sections inside one `fetcher.Form` — correctly, because one Save button submits all
+ * three — and `s-page` then saw one form rather than three sections. The cards rendered
+ * flush against each other, which reads as one card with a rule through it rather than as
+ * three things a merchant can change independently.
+ *
+ * Nothing caught it: the markup is valid, the sections are all there, and the spacing
+ * lives in a layout Polaris only runs in the browser. So the check is structural — a form
+ * holding more than one section has to hand them to `PageSections`.
+ */
+describe("sections nested inside a route's own wrapper keep the page rhythm", () => {
+  const ROUTES = CHECKED.filter((file) => file.startsWith("app/routes/"));
+
+  /** Each `<Form>`/`<fetcher.Form>` block in a file, with its contents. */
+  function formBlocks(source: string): string[] {
+    const blocks: string[] = [];
+
+    for (const open of source.matchAll(/<((?:\w+\.)?Form)\b/g)) {
+      const close = source.indexOf(`</${open[1]}>`, open.index);
+      if (close !== -1) blocks.push(source.slice(open.index, close));
+    }
+
+    return blocks;
+  }
+
+  it("is looking at routes, so it cannot pass by checking nothing", () => {
+    const withForms = ROUTES.filter((file) => formBlocks(readFileSync(join(ROOT, file), "utf8")).length > 0);
+
+    expect(withForms.length).toBeGreaterThan(5);
+  });
+
+  it.each(ROUTES)("%s", (file) => {
+    const source = readFileSync(join(ROOT, file), "utf8");
+
+    for (const block of formBlocks(source)) {
+      const sections = [...block.matchAll(/<s-section\b/g)].length;
+      if (sections < 2) continue;
+
+      expect(
+        block.includes("<PageSections>"),
+        `${file} puts ${sections} sections inside one form, so s-page cannot space them — ` +
+          `wrap them in PageSections`,
+      ).toBe(true);
+    }
+  });
+});
+
 describe("the page rhythm is set in exactly one place", () => {
   it("is PageShell's, and no route sets it", () => {
     // "Page rhythm has to be the largest gap on the screen to do its job. If a route can

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -16,7 +16,7 @@ import {
   readRoundingPolicy,
   ROUNDING_LABELS,
 } from "../lib/money/rounding-policy";
-import { PageShell } from "../components/PageShell";
+import { PageSections, PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
 import { Field, FieldGrid, FullRow } from "../components/FieldGrid";
 import { HelpNote } from "../components/HelpNote";
@@ -141,233 +141,235 @@ export default function Settings() {
       ) : null}
 
       <fetcher.Form method="post" ref={formRef}>
-      {/* Three long sections in one page, so a merchant who came here to change one
-          number does not scroll past the other two hunting for it. In-page anchors
-          rather than more routes: these settings are read together — a rounding rule
-          that pushes a price under a floor is a conversation between two of them —
-          and splitting them across pages is what made the nav sixteen items long. */}
+      <PageSections>
+        {/* Three long sections in one page, so a merchant who came here to change one
+            number does not scroll past the other two hunting for it. In-page anchors
+            rather than more routes: these settings are read together — a rounding rule
+            that pushes a price under a floor is a conversation between two of them —
+            and splitting them across pages is what made the nav sixteen items long. */}
 
-      <s-section heading="Guardrails">
-        <s-paragraph>
-          Floors that no campaign may price below. They are checked after rounding,
-          so a rounding rule cannot push a price under them.
-        </s-paragraph>
+        <s-section heading="Guardrails">
+          <s-paragraph>
+            Floors that no campaign may price below. They are checked after rounding,
+            so a rounding rule cannot push a price under them.
+          </s-paragraph>
 
-        {/* Coverage sits with the fields it qualifies, not in a sidebar card of its own.
-            Two of the controls below — "never price at or below cost" and what to do when
-            a cost-based floor meets a variant without one — mean nothing until you know
-            how many variants that second case actually is. */}
-        <s-paragraph>
-          <s-text color="subdued">
-            {formatCount(withCost)} of {formatCount(variants)} variants have a cost
-            ({costCoverage}%). Cost-based floors only constrain those; the last setting
-            in this section decides the rest.
-          </s-text>
-        </s-paragraph>
+          {/* Coverage sits with the fields it qualifies, not in a sidebar card of its own.
+              Two of the controls below — "never price at or below cost" and what to do when
+              a cost-based floor meets a variant without one — mean nothing until you know
+              how many variants that second case actually is. */}
+          <s-paragraph>
+            <s-text color="subdued">
+              {formatCount(withCost)} of {formatCount(variants)} variants have a cost
+              ({costCoverage}%). Cost-based floors only constrain those; the last setting
+              in this section decides the rest.
+            </s-text>
+          </s-paragraph>
 
-        {settings.neverBelowCost && costCoverage < 100 ? (
-          <s-banner tone="warning">
-            <s-paragraph>
-              Only {costCoverage}% of your variants have a cost recorded. With
-              &ldquo;never below cost&rdquo; on, the rest are skipped rather than
-              priced unguarded — they will not be included in any campaign.
-              Variants added since the last catalogue sync have no cost yet, because
-              Shopify&rsquo;s product webhooks do not carry one; a re-sync from the
-              dashboard fills them in.
-            </s-paragraph>
-          </s-banner>
-        ) : null}
+          {settings.neverBelowCost && costCoverage < 100 ? (
+            <s-banner tone="warning">
+              <s-paragraph>
+                Only {costCoverage}% of your variants have a cost recorded. With
+                &ldquo;never below cost&rdquo; on, the rest are skipped rather than
+                priced unguarded — they will not be included in any campaign.
+                Variants added since the last catalogue sync have no cost yet, because
+                Shopify&rsquo;s product webhooks do not carry one; a re-sync from the
+                dashboard fills them in.
+              </s-paragraph>
+            </s-banner>
+          ) : null}
 
-          <FieldGrid>
-            <FullRow>
-            <s-checkbox
-              name="neverBelowCost"
-              label="Never price at or below cost"
-              checked={settings.neverBelowCost || undefined}
-            />
-            </FullRow>
-
-            <s-number-field
-              name="minMarginPercent"
-              label="Minimum margin (%)"
-              value={settings.minMarginPercent?.toString() ?? ""}
-              details="Share of the selling price. 25 means a price of at least cost ÷ 0.75. Leave blank for none."
-            />
-
-            {/* A money field, not a number field. This is a price, and the two differ
-                in how they handle the decimal separator a merchant's locale uses and
-                how many places the currency actually has — a generic number input is
-                where a ¥1,000 floor becomes ¥1,000.00 and then something else. */}
-            <s-money-field
-              name="minPrice"
-              label={`Minimum price (${currency})`}
-              value={settings.minPrice?.toString() ?? ""}
-              details="An absolute floor, whatever the rule computes. Leave blank for none."
-            />
-
-            <s-select name="violationPolicy" label="When a price would breach a floor">
-              <s-option value="clamp" defaultSelected={settings.violationPolicy === "clamp"}>
-                Clamp it to the floor and carry on
-              </s-option>
-              <s-option value="skip" defaultSelected={settings.violationPolicy === "skip"}>
-                Skip that variant, price the rest
-              </s-option>
-              <s-option value="block" defaultSelected={settings.violationPolicy === "block"}>
-                Block the whole campaign
-              </s-option>
-            </s-select>
-
-            <s-select
-              name="missingCostPolicy"
-              label="When a cost-based floor meets a variant with no cost"
-            >
-              <s-option value="skip" defaultSelected={settings.missingCostPolicy === "skip"}>
-                Skip that variant
-              </s-option>
-              <s-option value="error" defaultSelected={settings.missingCostPolicy === "error"}>
-                Fail the campaign
-              </s-option>
-            </s-select>
-          </FieldGrid>
-      </s-section>
-
-      <s-section heading="Rounding">
-        <s-paragraph>
-          <s-text>
-            How campaign prices are tidied up after the discount is calculated. Set
-            once here; each campaign can override it.
-          </s-text>
-        </s-paragraph>
-
-          <s-stack gap={SPACE.section}>
-            {/* A rounding rule is half a dozen words. Unbounded it was a 970px bar, and
-                the per-currency selects below it were five more. */}
-            <Field width="medium">
-              <s-select name="rounding.default" label="Everywhere, unless overridden">
-                {roundingOptions.map((option) => (
-                  <s-option
-                    key={option.value}
-                    value={option.value}
-                    defaultSelected={option.value === settings.rounding.default}
-                  >
-                    {option.label}
-                  </s-option>
-                ))}
-              </s-select>
-            </Field>
-
-            {currencies.length > 1 ? (
-              <>
-                <s-paragraph>
-                  <s-text>
-                    A price ending that looks considered in one currency can look like
-                    a mistake in another, and some currencies have no cents to end in.
-                  </s-text>
-                </s-paragraph>
-
-                {currencies.map((code) => {
-                  // What this currency will actually do, which is not always what the
-                  // default says: a .99 ending has nowhere to go in a currency with no
-                  // decimal places, so it shows as the step rounding it becomes.
-                  const effective = profileNameFor(settings.rounding, code);
-
-                  return (
-                    <Field key={code} width="medium">
-                    <s-select
-                      name={`rounding.${code}`}
-                      label={`${code}${code === currency ? " (your store's currency)" : ""}`}
-                    >
-                      <s-option
-                        value="inherit"
-                        defaultSelected={!settings.rounding.byCurrency[code]}
-                      >
-                        Use the setting above ({ROUNDING_LABELS[effective].toLowerCase()})
-                      </s-option>
-                      {roundingOptions.map((option) => (
-                        <s-option
-                          key={option.value}
-                          value={option.value}
-                          defaultSelected={settings.rounding.byCurrency[code] === option.value}
-                        >
-                          {option.label}
-                        </s-option>
-                      ))}
-                    </s-select>
-                    </Field>
-                  );
-                })}
-              </>
-            ) : null}
-          </s-stack>
-      </s-section>
-
-      <s-section heading="Notifications">
-        <s-paragraph>
-          <s-text>
-            A campaign over a large catalogue runs for a while. These let you close the
-            tab and still find out what happened.
-          </s-text>
-        </s-paragraph>
-
-        {!mailConfigured ? (
-          <s-banner tone="warning">
-            <s-paragraph>
-              Email is not configured on this deployment, so nothing is sent yet. Your
-              preferences are saved and take effect once it is.
-            </s-paragraph>
-          </s-banner>
-        ) : null}
-
-          <s-stack gap={SPACE.section}>
-            <Field width="medium">
-              <s-text-field
-                name="email"
-                label="Send to"
-                placeholder="ops@yourshop.com"
-                value={notifications.email ?? ""}
-                details="Leave blank to turn notifications off entirely."
+            <FieldGrid>
+              <FullRow>
+              <s-checkbox
+                name="neverBelowCost"
+                label="Never price at or below cost"
+                checked={settings.neverBelowCost || undefined}
               />
-            </Field>
+              </FullRow>
 
-            <s-checkbox
-              name="onPartialOrFailure"
-              label="A run did not finish cleanly"
-              details="Something needs you: rows failed, or the run stopped early."
-              checked={notifications.onPartialOrFailure || undefined}
-            />
-            <s-checkbox
-              name="onDrift"
-              label="Someone changed a price outside the app"
-              details="Those edits are held for your decision rather than overwritten."
-              checked={notifications.onDrift || undefined}
-            />
-            <s-checkbox
-              name="onRevert"
-              label="A campaign was reverted"
-              checked={notifications.onRevert || undefined}
-            />
-            <s-checkbox
-              name="onCompletion"
-              label="A run finished cleanly"
-              details="Off by default. Being emailed about every success is how the one email that mattered gets skimmed past."
-              checked={notifications.onCompletion || undefined}
-            />
-            <s-checkbox
-              name="weeklyDigest"
-              label="Weekly summary"
-              checked={notifications.weeklyDigest || undefined}
-            />
-          </s-stack>
+              <s-number-field
+                name="minMarginPercent"
+                label="Minimum margin (%)"
+                value={settings.minMarginPercent?.toString() ?? ""}
+                details="Share of the selling price. 25 means a price of at least cost ÷ 0.75. Leave blank for none."
+              />
 
-        <s-paragraph>
-          <s-text>
-            Emails carry counts only — how many variants changed, failed or were
-            skipped. No prices are ever included, because email is not a place your
-            pricing should end up.
-          </s-text>
-        </s-paragraph>
-      </s-section>
+              {/* A money field, not a number field. This is a price, and the two differ
+                  in how they handle the decimal separator a merchant's locale uses and
+                  how many places the currency actually has — a generic number input is
+                  where a ¥1,000 floor becomes ¥1,000.00 and then something else. */}
+              <s-money-field
+                name="minPrice"
+                label={`Minimum price (${currency})`}
+                value={settings.minPrice?.toString() ?? ""}
+                details="An absolute floor, whatever the rule computes. Leave blank for none."
+              />
 
+              <s-select name="violationPolicy" label="When a price would breach a floor">
+                <s-option value="clamp" defaultSelected={settings.violationPolicy === "clamp"}>
+                  Clamp it to the floor and carry on
+                </s-option>
+                <s-option value="skip" defaultSelected={settings.violationPolicy === "skip"}>
+                  Skip that variant, price the rest
+                </s-option>
+                <s-option value="block" defaultSelected={settings.violationPolicy === "block"}>
+                  Block the whole campaign
+                </s-option>
+              </s-select>
+
+              <s-select
+                name="missingCostPolicy"
+                label="When a cost-based floor meets a variant with no cost"
+              >
+                <s-option value="skip" defaultSelected={settings.missingCostPolicy === "skip"}>
+                  Skip that variant
+                </s-option>
+                <s-option value="error" defaultSelected={settings.missingCostPolicy === "error"}>
+                  Fail the campaign
+                </s-option>
+              </s-select>
+            </FieldGrid>
+        </s-section>
+
+        <s-section heading="Rounding">
+          <s-paragraph>
+            <s-text>
+              How campaign prices are tidied up after the discount is calculated. Set
+              once here; each campaign can override it.
+            </s-text>
+          </s-paragraph>
+
+            <s-stack gap={SPACE.section}>
+              {/* A rounding rule is half a dozen words. Unbounded it was a 970px bar, and
+                  the per-currency selects below it were five more. */}
+              <Field width="medium">
+                <s-select name="rounding.default" label="Everywhere, unless overridden">
+                  {roundingOptions.map((option) => (
+                    <s-option
+                      key={option.value}
+                      value={option.value}
+                      defaultSelected={option.value === settings.rounding.default}
+                    >
+                      {option.label}
+                    </s-option>
+                  ))}
+                </s-select>
+              </Field>
+
+              {currencies.length > 1 ? (
+                <>
+                  <s-paragraph>
+                    <s-text>
+                      A price ending that looks considered in one currency can look like
+                      a mistake in another, and some currencies have no cents to end in.
+                    </s-text>
+                  </s-paragraph>
+
+                  {currencies.map((code) => {
+                    // What this currency will actually do, which is not always what the
+                    // default says: a .99 ending has nowhere to go in a currency with no
+                    // decimal places, so it shows as the step rounding it becomes.
+                    const effective = profileNameFor(settings.rounding, code);
+
+                    return (
+                      <Field key={code} width="medium">
+                      <s-select
+                        name={`rounding.${code}`}
+                        label={`${code}${code === currency ? " (your store's currency)" : ""}`}
+                      >
+                        <s-option
+                          value="inherit"
+                          defaultSelected={!settings.rounding.byCurrency[code]}
+                        >
+                          Use the setting above ({ROUNDING_LABELS[effective].toLowerCase()})
+                        </s-option>
+                        {roundingOptions.map((option) => (
+                          <s-option
+                            key={option.value}
+                            value={option.value}
+                            defaultSelected={settings.rounding.byCurrency[code] === option.value}
+                          >
+                            {option.label}
+                          </s-option>
+                        ))}
+                      </s-select>
+                      </Field>
+                    );
+                  })}
+                </>
+              ) : null}
+            </s-stack>
+        </s-section>
+
+        <s-section heading="Notifications">
+          <s-paragraph>
+            <s-text>
+              A campaign over a large catalogue runs for a while. These let you close the
+              tab and still find out what happened.
+            </s-text>
+          </s-paragraph>
+
+          {!mailConfigured ? (
+            <s-banner tone="warning">
+              <s-paragraph>
+                Email is not configured on this deployment, so nothing is sent yet. Your
+                preferences are saved and take effect once it is.
+              </s-paragraph>
+            </s-banner>
+          ) : null}
+
+            <s-stack gap={SPACE.section}>
+              <Field width="medium">
+                <s-text-field
+                  name="email"
+                  label="Send to"
+                  placeholder="ops@yourshop.com"
+                  value={notifications.email ?? ""}
+                  details="Leave blank to turn notifications off entirely."
+                />
+              </Field>
+
+              <s-checkbox
+                name="onPartialOrFailure"
+                label="A run did not finish cleanly"
+                details="Something needs you: rows failed, or the run stopped early."
+                checked={notifications.onPartialOrFailure || undefined}
+              />
+              <s-checkbox
+                name="onDrift"
+                label="Someone changed a price outside the app"
+                details="Those edits are held for your decision rather than overwritten."
+                checked={notifications.onDrift || undefined}
+              />
+              <s-checkbox
+                name="onRevert"
+                label="A campaign was reverted"
+                checked={notifications.onRevert || undefined}
+              />
+              <s-checkbox
+                name="onCompletion"
+                label="A run finished cleanly"
+                details="Off by default. Being emailed about every success is how the one email that mattered gets skimmed past."
+                checked={notifications.onCompletion || undefined}
+              />
+              <s-checkbox
+                name="weeklyDigest"
+                label="Weekly summary"
+                checked={notifications.weeklyDigest || undefined}
+              />
+            </s-stack>
+
+          <s-paragraph>
+            <s-text>
+              Emails carry counts only — how many variants changed, failed or were
+              skipped. No prices are ever included, because email is not a place your
+              pricing should end up.
+            </s-text>
+          </s-paragraph>
+        </s-section>
+
+      </PageSections>
       </fetcher.Form>
 
       <SettingsSaveBar form={formRef} saving={busy} />


### PR DESCRIPTION
The Guardrails, Rounding and Notifications cards on **Settings → Guardrails, rounding & alerts** render flush against each other — two cards touching read as one card with a rule through it.

## Cause

`s-page` spaces its **direct** children and nothing deeper. `PageShell`'s no-aside branch relies on exactly that and hands the sections over untouched, which is why every other page is spaced correctly.

Settings is the only route that wraps its sections in something of its own:

```jsx
<fetcher.Form method="post" ref={formRef}>
  <s-section heading="Guardrails">…</s-section>
  <s-section heading="Rounding">…</s-section>
  <s-section heading="Notifications">…</s-section>
</fetcher.Form>
```

The form is right — one Save button submits all three. But `s-page` then sees one form rather than three sections, so it spaces the form against its siblings and the sections inside get nothing. Everywhere else the nesting runs the other way, `s-section` outermost with the form inside it, and none of those pages has the symptom.

## Fix

`PageSections`, exported from `PageShell`. The rhythm stays owned by one file: `spacing.test.ts` still refuses `SPACE.page` anywhere but `PageShell.tsx`, so a route can ask for the distance the shell already uses and cannot invent a smaller one.

It is an `s-stack`, which is what the two-column branch has always wrapped sections in. The blank page recorded in the no-aside branch's comment was a single-column `s-grid` placed directly inside `s-page` — a different shape from a stack nested two levels down, which is what this is.

## Why nothing caught it

The markup is valid, every section is present, and the gap is decided by a Polaris layout that only runs in the browser — so typecheck and 2300 tests were all happy while the page was visibly wrong. The new check is structural instead: a form holding more than one section must hand them to `PageSections`. **Confirmed it fails on the code as it was** — removing the wrapper reproduces `app/routes/app.settings._index.tsx puts 3 sections inside one form`.

It also swept the other seven routes that have a form and multiple sections; none of them nests sections inside the form, so Settings was the only page affected.

## Verification

2313 tests, typecheck, lint and `npm run build` pass.

**Worth flagging:** I can't load the embedded admin locally — it needs a live session through the CLI tunnel — so I have not seen the fixed page rendered. The structure is the one `PageShell` already uses for every page with an aside, but the confirming look is yours.

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
