### PR TITLE
Three competitors, walked rather than read

### DIFF
--- a/docs/competitors/README.md
+++ b/docs/competitors/README.md
@@ -1,0 +1,28 @@
+# Competitor teardowns
+
+Three direct competitors are installed on `dartmode-labs.myshopify.com` and were walked
+by hand on 29 Aug 2026. One file each, plus the comparison that turns them into work.
+
+| | |
+|---|---|
+| [`na-bulk-price-editor.md`](na-bulk-price-editor.md) | **NA Bulk Price Editor** (Northern Apps) · 4.9★/227 · BFS · the app to beat |
+| [`rubix-bulk-price-editor.md`](rubix-bulk-price-editor.md) | **RUBIX Bulk Price Editor** (Rubix House) · 4.8★/130 · BFS · feature-comparable, trust-incomparable |
+| [`sami-bulk-price-editor.md`](sami-bulk-price-editor.md) | **Sami Bulk Price Editor** (SamiSales) · 4.8★/164 · BFS · newest, free, best craft |
+| [`comparison.md`](comparison.md) | **The comparison and what to do about it** |
+
+## How these were captured
+
+Live, in the Shopify admin, on a store with 3,669 real variants — not from listings or
+marketing copy. Every option list was enumerated by walking the control. Where a claim
+comes from the App Store listing rather than the running app, the file says so.
+
+Nothing destructive was done to the store. One task was created in Sami (`#75577`,
+`Manual` start, never run) to observe its commit flow, and archived immediately. NA's
+"Change market prices" setting was toggled on to reveal its markets step and toggled back
+off. No prices were changed by any of them.
+
+## Keeping them honest
+
+A teardown of last month's UI is still a valid markdown file, so the same rule as
+`docs/help/images/README.md` applies: **a ticket that cites one of these files should
+re-check the claim it cites.** Re-walking one app takes about twenty minutes.

--- a/docs/competitors/comparison.md
+++ b/docs/competitors/comparison.md
@@ -1,0 +1,316 @@
+# Anchor vs the category — what to change, and why
+
+*29 Aug 2026. Written after walking NA Bulk Price Editor, RUBIX Bulk Price Editor and
+Sami Bulk Price Editor live on `dartmode-labs`, then walking our own production build on
+the same store in the same browser session.*
+
+The headline is not a feature gap.
+
+---
+
+## 0. The finding that outranks everything else
+
+**Our embedded app does not scroll. Anything below the first viewport is unreachable.**
+
+Verified back to back, same browser, same tab, same wheel events, within twenty minutes:
+
+| App | Long page | Scrolls? |
+|---|---|---|
+| NA Bulk Price Editor | `/jobs/new` (five steps) | yes |
+| RUBIX Bulk Price Editor | `/CreateTask` (six steps) | yes |
+| Sami Bulk Price Editor | `/tasks/new` (two panes) | yes |
+| **Anchor** | `/app/campaigns/new` | **no** |
+| **Anchor** | `/app/prices` (50-row table) | **no** |
+| **Anchor** | `/app/settings` | **no** |
+
+What that costs, concretely:
+
+- **`/app/campaigns/new` ends after "1 · Scope".** The rule, the amount, compare-at,
+  rounding, markets, the draft preview, the schedule, the advanced block and the
+  **Create button** are all below the fold. Tabbing forward from the last visible field
+  leaves the iframe entirely after three presses. **A merchant cannot create a campaign.**
+- **`/app/prices` shows ten of fifty rows** and no way to reach the eleventh.
+- **`/app/settings` is cut mid-"Rounding"**, so Guardrails cannot be saved.
+
+Prime suspect: `PageWidth` in `app/components/PageShell.tsx` — every page is wrapped in
+`<s-grid justifyItems="center"><s-box inlineSize="80%">…` and App Bridge sizes the frame
+from the document, so a wrapper that does not grow with its content pins the frame to the
+viewport. It is recent (the 80% inset and the aside rebuild both landed 28–29 Aug), which
+matches when this could have appeared. **Reproduce locally before fixing** — this doc
+records a symptom, not a diagnosis.
+
+Why no test and no manual check caught it: `built-for-shopify.test.ts`, `views.test.ts`
+and the rest assert about *markup*, and the markup is fine. The manual checks were run
+against `anchor-perf`, whose production database is empty — so **every page rendered an
+empty state and no page was ever taller than one screen.** The store where verification
+happens has to be the store with data in it.
+
+Everything below this line is worth doing. None of it matters until this is fixed.
+
+---
+
+## 1. The three of them, at a glance
+
+| | NA | RUBIX | Sami | **Anchor** |
+|---|---|---|---|---|
+| Launched | Oct 2020 | Jul 2020 | **Apr 2025** | not launched |
+| Rating | 4.9★ / 227 | 4.8★ / 130 | 4.8★ / 164 | — |
+| Built for Shopify | ✅ | ✅ | ✅ | targeted |
+| Nav items | 2 (Settings, Plans) | 4 (all meta) | **0** | **5** |
+| The noun | "price change job" | task / campaign / job / discount task | "bulk edit task" | "campaign" |
+| Entry point | "how should prices change" (4 radios) | "which campaign type" (modal) | **"which field" (card gallery)** | "1 · Scope" |
+| Live preview | inline, below the rule | **none** | **beside the form** | inline, behind a button |
+| Confirmation | **modal + duration + ack** | none | none | ? (below the fold) |
+| Failure states | **none** | none | **`Partially complete`** | PARTIAL / HELD |
+| Recurrence | none (`Copy to new job`) | Weekly (paid) | **Daily, multi-window** | yes |
+| Baseline model | none | none | none | **yes** |
+| Revert | restore stored value | restore stored value | restore stored value | **recompute** |
+| Metering | changes/month | variants/month | free | variants under management |
+| Free tier | 100 changes/mo | 150 variants/mo | **everything** | 500 variants |
+| Paid | $9.95–$49.95 | $7.95–$14.95 | — | tbc |
+| Languages | 1 | 1 | **18** | 1 |
+
+Two things fall out of that table immediately.
+
+**Sami is the threat, not NA.** It launched sixteen months ago, is free, ships in eighteen
+languages, has the best editor in the category, and is the only competitor that admits a
+run can be partially complete. NA has the reviews; Sami has the trajectory.
+
+**Nobody has a baseline.** All three revert to "whatever the price was when this run
+started". Rubix documents the resulting drift in its own FAQ (§4 below). That is the whole
+product thesis, and it is still true.
+
+---
+
+## 2. What they do better than us — in order of how much it costs us
+
+### 2.1 The preview is next to the control, and it is free
+
+Sami's editor is **two panes**: a narrow form on the left, a wide preview table on the
+right with `Original price · Update price · Original compare at price · Update compare at
+price` over the merchant's real catalogue. Typing `10` turned `$949.95` into `$854.96` on
+every row instantly.
+
+NA does it differently and just as well: a **`STOREFRONT EXAMPLE`** card beside the rule
+showing one real product before → after *as the storefront would render it*, plus the full
+paginated list below.
+
+Ours has `DraftPreview` — which runs the *real planner over real baselines*, so it is
+strictly more truthful than either of theirs — and puts it below the fold behind an
+`Update match count` button the merchant has to press. **We built the harder half and then
+hid it.**
+
+### 2.2 The scope list has pictures and after-prices
+
+Ours renders matches as a bare bullet list: `Alpine Backpack 133 · S · 538.04`. One line,
+no thumbnail, current price only, no "after".
+
+NA and Sami both show a thumbnail, the product name, the old price struck through and the
+new price. A merchant recognises a product by its picture.
+
+### 2.3 CSV is an option, not a destination
+
+NA's "Use CSV upload" is the **fourth radio** in "how should prices change", and choosing
+it makes the product-selection step *disappear*, because the file is the scope.
+
+Ours is `/app/campaigns/import`, reached from a separate "From a spreadsheet" button. We
+already learned this lesson once — #416 dissolved the Imports nav item because "a nav item
+should be a noun" — and the import is still a different door rather than a different
+answer to the same question.
+
+### 2.4 A named "Advanced settings (optional)" bucket
+
+NA's step 5 is four collapsed, off-by-default checkboxes with that exact heading. It is
+the pressure valve that keeps steps 1–4 short.
+
+We have "Advanced (optional)" inside section 2 — the idea is there. What we do not have is
+the discipline it buys: our section 2 still carries name, rule, amount, compare-at,
+rounding, a market checkbox per market, a rounding select per currency, four schedule
+fields, priority, tags, auto-enrol and a revert buffer.
+
+### 2.5 A confirmation that is a sentence, not a form
+
+NA's modal, verbatim in shape:
+
+> **Sale** 20% off
+> **Scheduling** This job is scheduled to start on 30 August 2026. This job is scheduled to revert on 5 September 2026.
+> **Product variants affected** 1
+> **Tags to add** price-change-job-active
+> **Discount codes** All carts that contain any affected product will have all discount codes blocked
+>
+> *A price change job like this usually takes a minute or less to complete.*
+> An email will be sent to `you@example.com` when the job has completed.
+> ☐ I understand that this price change job will block discount codes …
+
+Three things in there we do not do: **a plain-English restatement** of what is about to
+happen, **a duration estimate sized to the job**, and **an acknowledgement checkbox that
+appears only for the dangerous option**. Rubix and Sami have no confirmation at all — Sami
+will change every price in the catalogue on one click of Save.
+
+### 2.6 The commonest job is one field on the landing page
+
+Sami's dashboard has **Quick Discount Campaign Setup**: one number, one unit select, one
+checkbox, `Quick Create`. "20% off everything" never opens the editor.
+
+Our Home offers `Start a practice campaign` and `Create a guided campaign` — both of which
+open the full editor.
+
+### 2.7 A sandbox to learn in
+
+Sami: **"Try a demo run first — We'll create a demo products so you can review the results
+before updating real products"**, one button. Nobody else has this. Our practice mode is
+philosophically better (it prices the merchant's *real* catalogue and refuses to write)
+but it is a mode you must know to ask for, presented as a checklist item on Home.
+
+### 2.8 The list says what each run *did*
+
+Sami's columns: `ID · Name · Recurring · Status · Progress · Applies to · Editing rules ·
+Created at`, where `Editing rules` renders **"Price decrease by 10%"** and `Applies to`
+renders **"All products"**. The index answers "what is this" without opening anything.
+NA does the same in prose: *"20% off sale on 1 product variant"*.
+
+Our campaigns index has status tabs, search and paging — and does not render the rule.
+
+### 2.9 One page template for create and read
+
+NA's `/jobs/:id` is `/jobs/new` with every control disabled, a status banner prepended and
+two labels changed (`Price change preview` → `Price change recap`, `→` → `↺`). One page
+shape to learn.
+
+Ours are two different pages: a two-section editor and a five-tab detail view.
+
+### 2.10 Small things that are cheap and land
+
+- **Timezone stated next to the schedule pickers**, with the current time in it (NA), and
+  **settable** with a plain-English echo — *"The task will run from 06:00 to 18:00 on 29
+  Aug"* (Sami).
+- **A character counter** on the name field (Sami, `8/100`).
+- **A prefilled name** so it is never a blocker (NA, Sami).
+- **`Copy to new job` / `Duplicate`** as a first-class action (all three).
+- **`Note` on a run** and **`Archive` instead of delete** (Sami).
+- **A usage meter with a progress bar on the landing page** (Rubix).
+- **`Exclude products`** beside "apply to products" (Sami).
+- **Rounding helper text that shows the arithmetic on an example number** (Sami).
+- **A `Task ID` field in the support form** (Rubix).
+- **Live chat** (Sami), **per-field video tutorials** (Sami), **18 languages** (Sami).
+
+---
+
+## 3. What we do better — and how much of it is visible
+
+| We have | They have | Is it visible in our UI? |
+|---|---|---|
+| Baseline: relative rules read a captured baseline, never the live price | nothing | Yes — Home, `/app/prices/baselines` |
+| Revert = `resolve(without C)` — recompute, not restore | restore a stored number | **Only in help prose** |
+| Overlapping campaigns resolve by priority | Rubix tells you not to; NA and Sami are silent | **Only in help prose** |
+| Write-ahead ledger, verified-clean runs, PARTIAL/HELD | NA: nothing. Sami: `Partially complete` | Partly — "Needs a decision" tab |
+| Drift detection (storefront changed under us) | nothing | Yes — `/app/prices/drift` |
+| Guardrails: never price at or below cost, min margin, min price | nothing | Yes — Settings |
+| Per-market rounding and per-currency precision (JPY) | NA has global rounding; Rubix has one dropdown | Yes |
+| Market pricing from *each market's own baseline*, not converted | NA converts from base; Rubix sets fixed prices | Yes, but buried |
+| Recurrence | Sami: daily. Rubix: weekly (paid). NA: none | Yes |
+| Segments (saved scopes) | nothing | Settings tab |
+| Practice mode over the real catalogue | Sami's demo product | Home checklist |
+| CSV round-trip with Matrixify-compatible headers | NA: upload only | Separate page |
+| Activity log with actor attribution | nothing | Home aside + `/app/activity` |
+
+**The pattern: our differentiators are real and mostly invisible.** The two that matter
+most — the baseline and recompute-revert — appear in the product as help prose. A merchant
+comparing four apps in a trial week will not read prose.
+
+Rubix's own FAQ is the argument, pre-written by a competitor:
+
+> *when you revert task 2, it will not revert to the original one ($1000), instead it will
+> revert to the initial price of task 2.*
+> **So, please revert the first task BEFORE create the second task if you want to modify
+> the same products**
+
+We should be able to put a merchant in front of that exact scenario and show it not
+happening. Today we cannot, because the editor does not scroll.
+
+---
+
+## 4. Where each of them will lose a merchant
+
+Useful for the beta script in `docs/beta-programme.md` — these are the sentences to open
+with.
+
+**NA** — no failure state exists. `Pending · Queued · In progress · Complete · Reverting ·
+Reverted`. A rate-limited run over 100,000 variants either completes or does not appear.
+Revert restores a stored number, so overlapping jobs drift. No recurrence: a weekly sale
+is `Copy to new job`, by hand, every week.
+
+**RUBIX** — the compounding bug is documented in the FAQ and warned about in the editor
+aside. There is no price preview at all; the Quick Start Guide tells the merchant to check
+the storefront afterwards. There is no confirmation and no submit button in the form.
+Four names for one object.
+
+**Sami** — no baseline, and no warning either, so it compounds silently. Save with
+`Start time: Now` changes every price in the catalogue with no summary and no
+acknowledgement. Markets are two flat fields with no catalogue model behind them.
+
+---
+
+## 5. What to build, in order
+
+Every item below became a GitHub issue under **Epic 15**.
+
+### P0 — the app is unusable in production
+1. **The embedded app does not scroll.** Fix, then add a check that fails when a page
+   taller than the frame cannot be reached. Verify on a store *with data*.
+
+### P1 — the create flow, which is where a trial is won or lost
+2. **Two-pane editor**: form left, live preview right, always visible, no button to press.
+3. **Preview rows get thumbnails and an after-price**, not a bullet list of text.
+4. **One `STOREFRONT EXAMPLE`** — one product, before → after, storefront rendering,
+   beside the rule.
+5. **CSV becomes a rule option**, not a separate door; the scope step disappears when it
+   is chosen.
+6. **A confirmation step**: plain-English summary, variant count, duration estimate, who
+   gets emailed, and an acknowledgement only where the choice is dangerous.
+7. **Name and rule come first**, scope second — the form should open with the decision, not
+   the filter.
+
+### P2 — make the differentiators visible
+8. **Show the baseline in the editor**: every preview row reads baseline → new, and says
+   which campaigns are already in play on those variants.
+9. **An overlap panel**: "3 of these variants are already priced by *Autumn Sale*. This
+   campaign has priority 2, so it wins." Nobody else can render that sentence.
+10. **Revert explained where it is used**, not in help: "Reverting recomputes without this
+    campaign — it does not restore a saved number."
+
+### P3 — the landing page and the list
+11. **Quick create on Home**: one percentage, one button.
+12. **A metric strip on Home** — active · scheduled · needs a decision · reverted — in
+    place of the `Mirror audited` activity feed, which is system jargon.
+13. **The campaigns index renders the rule and the scope** as sentences.
+14. **`Duplicate` on a campaign**, and `Note`, and archive-not-delete.
+
+### P4 — craft, cheap and visible
+15. Timezone beside the schedule, settable, with a plain-English echo.
+16. Prefilled campaign name with a character counter.
+17. Rounding helper text that shows the arithmetic on an example number.
+18. `Exclude products` beside the scope filter.
+19. A usage/plan meter on Home.
+20. Per-page help videos or a "what this does" example on the rule select.
+
+### P5 — reach
+21. Localisation. Sami ships eighteen languages and is free; that is a distribution
+    argument, not a feature.
+22. In-app support: a contact form that captures the run id, at minimum.
+
+---
+
+## 6. What must not be flattened while doing any of this
+
+From `CLAUDE.md`, restated because a UX pass is exactly when these get traded away:
+
+- Campaign math reads the **baseline**, never the live price.
+- **Preview and execution share one code path.** A two-pane preview must still be
+  `resolve()`, not a cheaper estimate written for the sidebar.
+- A run is clean only when every row is **read-back verified**. PARTIAL and HELD belong in
+  the campaign header, not inside a tab.
+- **Revert means recompute.** Do not add a "restore original prices" button because three
+  competitors have one.
+- Money is integer minor units. A live-updating preview that formats on every keystroke is
+  the obvious place for a float to appear.

--- a/docs/competitors/na-bulk-price-editor.md
+++ b/docs/competitors/na-bulk-price-editor.md
@@ -1,0 +1,322 @@
+# NA Bulk Price Editor — teardown
+
+*Captured 29 Aug 2026 by walking the live app on `dartmode-labs.myshopify.com`.*
+
+| | |
+|---|---|
+| Vendor | Northern Apps (Courtenay, BC) |
+| App handle | `price-scheduler-plus` — the handle is older than the name |
+| Host | `price-scheduler.northern-apps.com` |
+| Listing | "Easy bulk price edits, flash sales, and scheduled sales" |
+| Rating | 4.9★ / 227 reviews (93% five-star, 3% one-star) |
+| Built for Shopify | Yes |
+| Launched | 27 Oct 2020 |
+| Categories | Pricing optimization · Bulk editor |
+| Scopes granted | Products (view+edit), Discounts (view+edit), "Other data" |
+| Shopify Functions | Declares a Discounts function (0 active until a job blocks discount codes) |
+
+This is the app to beat. It is the only one of the three that reads as a *designed*
+product rather than a form over an API.
+
+## The shape of the whole app
+
+**Two nav items.** `Settings` and `Plans`. The app root redirects to `/jobs`. Everything
+else — creating, previewing, scheduling, reverting, auditing — happens on two page
+templates: the jobs list and the job page.
+
+**One page template does create *and* read.** `/jobs/new` and `/jobs/:id` are the same
+five-section form. On a finished job every control is rendered disabled, a status banner
+is prepended, and two labels change ("Price change preview" → "Price change recap", `→`
+→ `↺`). A merchant who has created one job can read any job, because it is the same
+page.
+
+**Contextual save bar.** App Bridge's "Unsaved changes · Discard · Save" owns the top of
+the admin chrome while a job is dirty. Navigating away is intercepted by the browser's
+own "Leave site?" dialog.
+
+## Page 1 — `/jobs` (the landing page)
+
+Three summary cards across the top, then a filtered list:
+
+- **Scheduled jobs** — "No scheduled jobs upcoming"
+- **Draft jobs** — "No jobs saved as drafts"
+- **Need help?** — "Read docs on common questions" + `Read FAQs`
+
+Then a search box, an `Add filter +` control, and the job list. Each row is four columns:
+title · a plain-English sentence ("This job ran on 27 August 2026. This job was reverted
+on 29 August 2026.") · a status badge · a one-line description of the change ("20% off
+sale on 1 product variant").
+
+`Add filter +` offers exactly **one** dimension: **Job status**, with values
+`Pending · Queued · In progress · Complete · Reverting · Reverted`.
+
+> **Note what is missing from that list: there is no failed, partial or errored state.**
+> A job either completes or it does not exist. This is the single biggest structural
+> difference from us and it is not a small one — see the comparison doc.
+
+Primary action, top right: **`Add new price change job`**.
+
+## Page 2 — `/jobs/new` (create) and `/jobs/:id` (read)
+
+Five numbered sections on **one scrolling page**. Not a wizard — no back/next, no step
+indicator, everything visible at once. One `Continue` button at the foot.
+
+### Step 1. "Optionally give your price change job a title (eg "March 30% off sale on boots")"
+
+A single text field, **pre-filled** with `29 Aug 2026, 03:46:58 Price change job`.
+Helper text: *"This title is just for internal use, customers won't see it"*.
+
+Two decisions worth stealing: the field is pre-filled so it is never a blocker, and the
+helper answers the question a merchant actually has (will my customers see this?).
+
+### Step 2. "Select how the prices should change"
+
+Four radios — **and CSV is one of them, not a separate route**:
+
+1. **Create sale** (default)
+2. **Use bulk price change rules**
+3. **Set product prices individually**
+4. **Use CSV upload**
+
+Selecting a radio swaps the panel *below* it. To the right of the panel sits a
+**`STOREFRONT EXAMPLE`** card: one real product from the shop, before → after, rendered
+as the storefront would render it (`$759.96` `~~$949.95~~`). It updates as you type.
+
+#### 2a. Create sale
+- `Sale discount percentage` — one number field with a `%` suffix
+- `Show rounding options` — collapsed checkbox
+- `How are sale prices calculated?` link
+
+Expanding rounding reveals two radio groups:
+
+| Rounding | Rounding direction |
+|---|---|
+| Round to nearest .01 *(default)* | Round up or down (whatever is closest) *(default)* |
+| Round to nearest whole number | Always round up |
+| End prices in .99 | Always round down |
+| End prices in a certain number | |
+| Round prices to a certain multiple | |
+
+#### 2b. Use bulk price change rules
+Two stacked cards, **Price** and **Compare at price**, each a `Change type` dropdown with
+an ⓘ. The price card adds a value field and the same rounding checkbox.
+
+**Price change types (8):**
+1. Increase the price by an amount
+2. Increase the price by a percentage
+3. Decrease the price by an amount
+4. Decrease the price by a percentage *(default)*
+5. Set the price to a fixed amount
+6. Set the price to a percentage of the compare at price
+7. **Set the price to a certain margin** ← cost/margin pricing lives here
+8. Don't change the price
+
+**Compare-at change types (6+):**
+1. Change the compare at price to the current price (sale) *(default)*
+2. Increase the compare at price by a percentage
+3. Increase the compare at price by an amount
+4. Decrease the compare at price by a percentage
+5. Decrease the compare at price by an amount
+6. Remove the compare at price
+7. Don't change the compare at price
+
+Choosing "Don't change the price" **removes** the value field and the rounding checkbox
+from the card. The form shrinks to fit the choice.
+
+#### 2c. Set product prices individually
+Step 2 renders **no panel at all**. Instead the preview list further down becomes
+editable: each "after" card grows a `Price` and `Compare at price` money input, two icon
+buttons, and an `Unedited` badge. The preview *is* the editor.
+
+#### 2d. Use CSV upload
+A drop zone with `Add files`, then `Get CSV template` and a `CSV upload FAQ` link.
+**Step 3 (product selection) disappears entirely** and the remaining steps renumber —
+the file defines the scope, so asking for a scope would be a contradiction.
+
+### Step 3. "Select which products should change in price"
+
+Sub-label: *"Select all products, use filters, or select products variants individually"*
+
+1. **All products** (default)
+2. **Filter by product, collection, tag, vendor, product type, variant title, or inventory**
+3. **Select product variants individually**
+
+Option 2 opens a condition builder: `Products must match: ( ) all conditions (•) any
+condition`, then rows of `[The product ▾] [Is equal to ▾] [value]` with `Add another
+condition`.
+
+Below the radios, always: **`Price change preview`** with an ⓘ.
+
+> `Over 250 product variants would be affected by this price change:`
+> — or, once filtered — `1 product variant would be affected by this price change:`
+
+A paginated two-column list of before → after cards with thumbnails, a sort toggle, and a
+**`Full Preview`** button. It recomputes live as the rule or the scope changes. On a
+completed job the same block is titled **`Price change recap`** and reads
+`1 product variant was affected by this price change:`.
+
+### Step 4. "Select when the prices should change"
+
+Left: `Change prices now` / `Change prices later`.
+Right, independent: `☐ Revert to original prices later?`
+
+Choosing "later" or ticking "revert" reveals **two side-by-side date+time pickers with
+inline month calendars**, defaulted to tomorrow and a week after that. Under them:
+
+> *Dates and times shown above use **Asia/Calcutta** as the timezone, where the current
+> time is **03:50***
+
+**There is no recurrence.** No "every Friday", no repeat, no campaign that runs again.
+One start, one optional revert.
+
+### Step 5. "Advanced settings (optional)"
+
+Four checkboxes, all **off by default, all collapsed**. This is the pressure valve that
+keeps the other four steps short.
+
+| Checkbox | What it reveals |
+|---|---|
+| Add tags while price change job is active | A tag input, pre-seeded with a `price-change-job-active` chip, + *"How does tagging work?"* |
+| Remove tags while price change is active | A tag input |
+| Block discount codes on carts that contain any affected product | *"How does discount code blocking work?"* — this is what the Shopify Function is for |
+| Show advanced sale price calculation options | `If an item is already on sale`: **Replace the current discount with the selected percent off** *(default)* / **Apply the selected percent off on top of the current sale price** |
+
+The last one only appears in "Create sale" mode. In "Set prices individually" mode it is
+absent — it would be meaningless.
+
+### Validation
+
+`Continue` with problems produces a red banner at the top of the page —
+*"There are 2 errors with this price change job"* — listing every problem as a bullet
+("A price change job must change at least 1 product variant", "Remove tags checkbox is
+checked but no tags have been selected"), **and** an inline error under the offending
+field (*"Enter at least 1 tag"*). Summary and inline, both.
+
+### The confirmation modal
+
+`Continue` on a valid job opens **"Price change job confirmation"** — a definition list
+in plain English:
+
+| | |
+|---|---|
+| Sale | 20% off |
+| Scheduling | This job is scheduled to start on 30 August 2026. This job is scheduled to revert on 5 September 2026. |
+| Product variants affected | 1 |
+| Tags to add | price-change-job-active |
+| Discount codes | All carts that contain any affected product will have all discount codes blocked |
+
+Then, below the rule:
+
+- **"A price change job like this usually takes a minute or less to complete."** ← a
+  duration estimate, sized to the job
+- **Important** — "An email will be sent to `rishu605@gmail.com` when the job has
+  completed." / "You can update your confirmation email address from your Settings."
+- A **required acknowledgement checkbox** gating `Confirm`: *"I understand that this
+  price change job will block discount codes for all items in the cart when the carts
+  contains any affected item"* — it appears only because discount blocking is on.
+
+## Page 3 — a finished job
+
+Header: title · status badge (`Reverted`) · `Copy to new job` · `Export Recap CSV` ·
+`Delete job`.
+
+Banner: green ✓ **"Prices reverted successfully"**, then *"The prices have been reverted
+to their original values."* and, in italics, *"This job cannot be edited because it has
+already completed."*
+
+Below that, the whole five-step form again, disabled, with the recap in place of the
+preview. `Copy to new job` is how you repeat a sale — **their substitute for
+recurrence**.
+
+## Page 4 — `/settings`
+
+The entire settings surface is one short page:
+
+- A card: `Member since 17 Aug 2026` · `Current plan: Free` + `See plans` ·
+  `August usage 1/100 (1%)`
+- **Notification details** → a single `Email` field. *"This information will be used to
+  send you updates on your price change jobs."*
+- **Advanced settings** → one checkbox:
+  > ☐ **Change market prices in price change jobs**
+  > When enabled, you can pick which Shopify markets to apply price changes to.
+  > *Only needed for stores that require regional, B2B, or POS specific pricing*
+  > Learn about the *Shopify markets feature*
+
+**This is the most important single design decision in the app.** The entire
+markets/B2B/POS surface — the thing that makes multi-market pricing hard — is behind one
+off-by-default checkbox, with a sentence telling you whether it is for you. A
+single-market merchant never sees the word "market" anywhere in the product.
+
+Turning it on inserts a new **Step 4. Shopify markets** into the job form:
+
+> ☑ Select Shopify markets to apply price changes to
+> Apply price changes to:
+> **Regions**
+> ☐ Anchor EU test ☐ Anchor JP test ☐ Canada ☐ United States
+> ☑ **Also change base prices** *What does this mean?*
+> Learn about *Shopify market prices*
+
+Steps renumber from five to six. B2B and POS catalogues appear as further groups on plans
+that include them.
+
+## Page 5 — `/plans`
+
+> Whether you sell thousands of products or just a few - we have a plan that will help
+> your business grow 🚀
+> As a first time customer, you qualify for a 14 day FREE trial on all upgraded plans 🎉
+
+| Plan | Price | Limit |
+|---|---|---|
+| **Free** (active) | $0 | Change the price of up to **100** product variants per month |
+| Basic | $9.95/mo | up to **1,000** per month |
+| Standard | $14.95/mo | up to **10,000** per month |
+| Unlimited | $19.95/mo | **Unlimited** price changes |
+| Unlimited Pro | $49.95/mo | Unlimited + **Change B2B market prices** + **Change POS market prices** |
+
+`Pay Monthly ▾` toggle, *"Switch to yearly to save 16%"*. Footer:
+*"Learn more about how our usage limits work"* and *"Don't see a plan that works for
+you? Email us directly at chris@northern-apps.com and ask about special pricing for new
+businesses"*.
+
+**The meter is price changes per month** — the model D3 in `docs/decisions.md`
+deliberately rejected. Markets are free; **B2B and POS pricing is the $49.95 gate**.
+
+## What they do that we should copy
+
+1. **CSV is a radio option, not a destination.** It sits fourth in "how should prices
+   change", alongside percentage and rules. We made it a route (and then a section, and
+   then dissolved the section).
+2. **A named "Advanced settings (optional)" bucket.** Everything rare, collapsed,
+   off by default, in one place at the end. Our rare options became nav items because we
+   never built this.
+3. **`STOREFRONT EXAMPLE` beside the control.** One product, before → after, in
+   storefront rendering, updating as you type — *plus* the full list below. We have the
+   list; we do not have the one-product example next to the input.
+4. **Steps that renumber.** Pick CSV and the scope step vanishes. Pick "don't change the
+   price" and the amount field vanishes. The form is only ever as long as the choice
+   requires.
+5. **The confirmation modal.** Plain-English summary, a duration estimate, who gets
+   emailed, and an acknowledgement checkbox that appears only for the dangerous option.
+6. **One page template for create and read.** A completed job is the same page, disabled.
+7. **The markets kill-switch in settings.** One checkbox hides an entire feature domain
+   from the merchants who do not need it.
+8. **Timezone stated in the form**, next to the pickers, with the current time in it.
+9. **`Copy to new job`** as a first-class header action.
+10. **Errors twice: banner summary + inline field.**
+
+## What they cannot do, structurally
+
+- **No failure states.** `Pending · Queued · In progress · Complete · Reverting ·
+  Reverted`. Nothing represents "wrote 4,200 of 5,000 and stopped", which is the state a
+  rate-limited bulk price write actually ends in.
+- **Revert restores a stored number.** It does not recompute. Two overlapping jobs on the
+  same variant, reverted out of order, drift — and a 1★ review on their listing describes
+  exactly that.
+- **No recurrence.** `Copy to new job` is manual repetition; a weekly sale is a weekly
+  chore.
+- **No baseline concept.** Relative rules read the live price, so running "-10%" twice
+  compounds.
+- **No read-back verification.** "Complete" means the mutations were sent.
+- **One filter dimension on the job list**, no search across what a job *did*, and no
+  store-wide view of "which campaigns touch this variant".
+- **Change-count metering** taxes exactly the behaviour a campaign manager encourages.

--- a/docs/competitors/rubix-bulk-price-editor.md
+++ b/docs/competitors/rubix-bulk-price-editor.md
@@ -1,0 +1,278 @@
+# RUBIX Bulk Price Editor — teardown
+
+*Captured 29 Aug 2026 by walking the live app on `dartmode-labs.myshopify.com` (installed
+on the free plan, so paid surfaces are visible but gated).*
+
+| | |
+|---|---|
+| Vendor | Rubix House |
+| App handle | `rubix-bulk-price-editor` (listing: `rubix-bulk-price-editor-1`) |
+| Listing tagline | "Automate bulk price changes, discount market prices, schedule discount, & schedule flash sale easily" |
+| In-app tagline | "Automate Bulk Edit Prices, Market Discounts, & Scheduled Sales" |
+| Rating | 4.8★ / 130 reviews (88% five-star, 5% three-star, 2% one-star) |
+| Built for Shopify | Yes |
+| Launched | 27 Jul 2020 |
+| Categories | Bulk editor · Discounts |
+| Scopes granted | Products (view+edit), Discounts (view+edit), "Other data" |
+| Shopify Functions | Declares a Discounts function |
+
+Rubix is the *feature-comparable, trust-incomparable* competitor. It matches the checklist
+— markets, cost, compare-at, scheduling, rollback, tags, discount codes — and then
+documents its own compounding bug in the FAQ and warns you about it in the campaign editor.
+
+## Vocabulary problem, stated first because it runs through everything
+
+The same object is called four things: **task** (nav, list, most headings), **campaign**
+("Select Campaign Type" modal), **job** ("Step 6: set job scheduling"), and **discount
+task** (usage meter). The app's own Quick Start Guide uses "task" and "campaign" in
+adjacent sentences. There is no consistent noun for the thing a merchant creates.
+
+## The shape of the whole app
+
+Nav: **Subscription Plans · FAQ & Support · Feature Request · Settings** — four items, and
+they are all *meta*. Nothing in the nav is about prices. The product itself is one page
+(`Home`) plus one editor (`CreateTask`).
+
+Observed inconsistency: at one point the nav rendered as **Subscription Plans · Settings ·
+Feature Request · Support · Recommended Apps** instead. The nav is not stable.
+
+Content uses the **full admin width** (~1180px on a 1470px viewport), unlike NA's centred
+~1010px column.
+
+## Page 1 — Home
+
+Four stacked blocks:
+
+1. **"We need your feedback 😄"** — a dismissible banner asking for a rating, with five
+   emoji buttons (🤢 😟 😐 😊 😍). It sits *above* the product, on first load, before the
+   merchant has done anything.
+2. **Quick Start Guide** (dismissible) — numbered instructions for the two task types.
+   Notable lines, verbatim:
+   - *"Before saving the task, check all the settings and ensure they are correct. You can
+     check them in the **Task Summary** section."*
+   - *"If the task has already been marked as **ACTIVE**, check whether the price shows
+     correctly for the selected products."* ← **the merchant is asked to verify the write**
+   - *"If you want to restore the original price, go to "Revert Task Setting" then click
+     "Revert Now" button. **Deleting the task will not restore the original price**."*
+   - *"To remove a discount, delete the corresponding discount task from the task list. DO
+     NOT delete the discount directly from the Discounts section."*
+3. **Usage Limits** — `Current Plan: FREE`; *Price Editor & Discount Manager* — "Free Plan
+   Quota: 150 variants/month", "Tasks this month (August): 0/150 variants" with a progress
+   bar; *Automatic & Discount Code (Shopify allows a maximum of 25 ACTIVE discounts at the
+   same time)* — "Total Discount Limit: 2", "Discounts created: 0/2".
+4. **Task list** — tabs `All | Active | Scheduled | Inactive`, with search, filter and sort
+   icons. Empty state: "No tasks found" + `Create Task`.
+
+## Page 2 — Create Task
+
+`Create Task` opens a modal, **"Select Campaign Type"**, with two cards:
+
+| Type | Copy |
+|---|---|
+| **Price Editor & Discount Manager** | "Modify product variant base prices and market-specific prices for your store. Also, you can show the **strike-through** price with this campaign type." |
+| **Automatic & Discount Code** `New` | "Create discount codes or automatically applied in the cart and at checkout when eligibility conditions are met." + a worked use case + `0/2 total discounts used` |
+
+The second type creates real Shopify automatic discounts / discount codes rather than
+writing prices — a genuinely different mechanism, chosen at the top of the funnel.
+
+### The editor: six steps, plus a live summary aside
+
+Left column: six numbered cards. Right column: a sticky **Task Summary** that mirrors the
+form as an eight-item numbered list (Task name · Selected markets · Selected products ·
+Selected variants · Add Product Tags · Remove Product Tags · Price update method · Job
+Scheduling), filling in as you go.
+
+**The first thing in that aside is a warning, not a summary:**
+
+> ⚠ Do not create a 2nd task that target the same products **without reverting** the 1st
+> task, because it will mess up the price. Unless, you know what you are doing. Please read
+> the **FAQ** to learn more.
+
+#### Step 1: add task name
+One empty text field. No prefill, no explanation of whether customers see it.
+
+#### Step 2: choose the implementation method
+- **Apply to the variant base price** ⓘ *(default)*
+- **Apply fixed price to Markets (choosing by Catalogs)** ⓘ
+- **Apply fixed price to Markets (choosing by Markets)** ⓘ
+
+Choosing a markets method reveals a repeater: `Market Name [Anchor EU test ▾]`
+`Revert Options ⓘ [Revert to fixed price (FIXED) ▾]` `[Add Market]`, with
+*"Associated catalog: Anchor EU catalog"* underneath, and a paywall line:
+
+> \*Please upgrade your plan to **SUPER DUPER COOL** to use this feature *here*
+
+**Revert Options** is the one place Rubix acknowledges that reverting is a choice:
+`Revert to fixed price (FIXED)` / `Revert to percentage-based price (RELATIVE)`.
+
+#### Step 3: choose the products
+`Specific Products` / `Specific Variants` / `Collections` / `Based on conditions or All
+products`, followed by a **Product Preview** table with columns
+`Product · Inventory · Product Type · Vendor`.
+
+Note what that table shows: **inventory, type and vendor — not price.** There is no
+before → after anywhere in the editor.
+
+#### Step 3.1: choose the variants
+"Variants must match:" a chip list seeded with `all_variants`, plus a select to add more.
+
+#### Step 4: add/remove product tags (optional)
+`Add Product Tags` ⓘ [input] `Add Tag` · `Remove Product Tags` ⓘ [input] `Add Tag`.
+
+#### Step 5: set price or compare-at-price
+Two radios:
+
+**Price Editor (modify price and/or compare-at-price in general)**
+
+| `Field to edit` | `Operation` |
+|---|---|
+| price | update to |
+| compare-at-price | adjust by amount |
+| price & compare-at-price | adjust by percentage |
+| | adjust based on compare-at-price (by percentage) |
+| | **set to specific gross margin** |
+
+Then a value field labelled in prose — "update price to [ USD ]" — and an **EXAMPLE**
+block:
+
+> **Before updating the price to $30** · price: $10
+> **After updating the price to $30** · price: $30
+
+A generic illustration with invented numbers, not the merchant's data.
+
+**Discount Manager (create sales campaign w/ strike-through pricing)**
+
+- `Discount Value` [Discount Percentage ▾] [ __ % ]
+- *What is compare-at-price?* link
+- ☑ compare-at-price gets replaced by the original price (showing that your product is on **SALE**)
+- ☑ **Do not modify products that are on SALE** ⓘ
+- An **EXAMPLE** that renders a *mock storefront card* — "T-Shirt · 100.00" → "T-Shirt ·
+  80.00 ~~100.00~~ `SALE`" — again with invented numbers
+- **Rounding Options** [Default rounding ▾] with `Examples: Before: 15.638 || After: 15.64`
+
+Rounding exists only in Discount Manager mode; the Price Editor path has none.
+
+#### Step 6: set job scheduling
+`Schedule Options: [--choose schedule option-- ▾]`. On the free plan the only value is
+**One time schedule** — weekly scheduling is a SUPER COOL feature. Choosing it reveals:
+
+| Set Start Date | Set Revert Date |
+|---|---|
+| I want to run the task right now *(default)* | I don't want to set the revert date *(default)* — *"you can still revert the task manually later"* |
+| I want to run the task later | I want to set the revert date |
+
+No timezone is stated anywhere.
+
+#### There is no submit button
+The page ends at Step 6 and the support footer. The only way to create the task is App
+Bridge's contextual **Save**, 600px above at the top of the admin chrome. There is no
+confirmation step, no summary modal, no "this will change N variants", no acknowledgement.
+
+## Page 3 — Subscription Plans
+
+A promo-code field, a `Monthly | Yearly ✨SAVE 25%✨` toggle, and four cards with joke
+names:
+
+| Plan | Price | Features |
+|---|---|---|
+| **FOREVER FREE PLAN** (current) | $0 | 150 product variants/month · 2 automatic discount tasks creation · Advance filters · Schedule start and revert |
+| **COOL** | $7.95/mo | Unlimited Price Editing tasks · 10 automatic discount tasks · Advance filters · Schedule start and revert |
+| **SUPER COOL** | $10.95/mo | + 20 automatic discount tasks · **Weekly Scheduling** · **Synchronize newly added products** |
+| **SUPER DUPER COOL** | $14.95/mo | + Unlimited automatic discount tasks · **Market price editor** · **Cost editor** |
+
+All paid plans: 3-day free trial. Yearly saves 25%.
+
+Two features worth naming because we do not have them:
+- **Weekly Scheduling** — the only recurrence any of the three apps offers.
+- **Synchronize newly added products** — a product added *after* a campaign starts is
+  picked up by it. Our resolver makes this natural; we do not expose it.
+
+## Page 4 — Settings
+
+One field: `Email Address` — *"This email will be used to send an update once the task has
+been done"*. That is the whole settings surface.
+
+## Page 5 — FAQ & Support
+
+A seven-item accordion, then a **Contact us** form (Subject · Name · Email · **Task ID** ·
+Message). The Task ID field tells you how often support needs to look up a specific run.
+
+The questions are the most useful artefact in the whole teardown, because a FAQ is a list
+of the things that go wrong often enough to pre-empt:
+
+1. How the app works?
+2. **How to avoid messing up the price?**
+3. How to show the SALE price and strike-through the original price side by side?
+4. **Why does the discount still appear although I've reverted the task?**
+5. **Why do some products get discounted and some products don't?**
+6. **Why do discounts suddenly disappear? Although I don't revert the discount through the app**
+7. **Why does the compare-at-price (strike-through price) not appear in the Euro markets?**
+
+### Question 2, in full — this is the competitive centre of gravity
+
+> Do not create a 2nd task that target the same products **without reverting** the 1st
+> task. Unless, you know what you are doing. Here is the simulation:
+>
+> - Create the first task (task 1): 30% discount campaign for "Nike Air Jordan"
+>   - initial price: 1000 USD · initial compare-at-price: 0
+>   - `===Apply 30% discount===` current price: 700 USD · current compare-at-price: 1000 USD
+> - Create the second task (task 2): 50% discount campaign for "Nike Air Jordan" **without
+>   reverting task 1**
+>   - initial price: 700 USD · initial current compare-at-price: 1000 USD
+>   - *this is the initial price for this product if you don't revert task 1*
+>   - `===Apply 50% discount===` current price: 350 USD · current compare-at-price: 700 USD
+>   - `===Revert task 2===` initial price: 700 USD · initial current compare-at-price: 1000 USD
+>   - **when you revert task 2, it will not revert to the original one ($1000), instead it
+>     will revert to the initial price of task 2.**
+>
+> **So, please revert the first task BEFORE create the second task if you want to modify
+> the same products**
+
+This is `CLAUDE.md` rule 1 and rule 6 written out as a support article by the vendor who
+violates them. Their model has no baseline: "initial price" means "whatever the price
+happened to be when this task started". A 30% sale followed by a 50% sale leaves the
+product at $350 for ever unless the merchant reverts in exactly the reverse order.
+
+Q6 — "Why do discounts suddenly disappear? Although I don't revert the discount through the
+app" — is the same fault from the other end.
+
+## Page 6 — Feature Request
+
+A form: `Type of Feature` + `Description` ("please describe your need as clear as
+possible"). A feedback inbox, not a roadmap.
+
+## What they do that is worth copying
+
+1. **The live summary aside.** A sticky "Task Summary" that fills in as the form is
+   completed, so the merchant can read back what they built without scrolling. Better than
+   NA's end-of-flow modal in one respect: it is visible *while* you are deciding.
+2. **Campaign type chosen up front, in a modal.** "Price change" and "Shopify discount"
+   are genuinely different mechanisms, and picking between them first keeps each form
+   honest.
+3. **Explicit revert semantics as a control** — FIXED vs RELATIVE — even though the
+   implementation is weaker than ours.
+4. **"Do not modify products that are on SALE"** as a first-class checkbox.
+5. **"Synchronize newly added products"** — campaigns that stay true as the catalogue
+   changes.
+6. **Weekly scheduling** — the only recurrence in the category.
+7. **A usage meter with a progress bar on the landing page**, so the plan limit is never a
+   surprise at commit time.
+8. **A Task ID field in the support form.** Cheap, and it makes every support thread
+   start with the run.
+
+## What is broken or weak
+
+- **No preview of prices, anywhere.** The only preview is a table of matched products
+  showing inventory, type and vendor. The merchant learns the new price by looking at the
+  storefront afterwards — which the Quick Start Guide explicitly instructs them to do.
+- **No confirmation step and no submit button in the form.** The commit is a Save button
+  at the top of the window, far from the last thing you touched.
+- **Compounding is documented, not fixed.** See Q2 above.
+- **Vocabulary drift** — task / campaign / job / discount task.
+- **A feedback-rating banner above the product on first run**, before the merchant has
+  used anything.
+- **No timezone shown** next to the schedule pickers.
+- **Paywall messaging inside the form** ("upgrade your plan to SUPER DUPER COOL") rather
+  than a state the form can be in.
+- **A 500 error** on a mistyped in-app route, rendered as bare `Internal Server Error`
+  monospace text with no navigation back.

--- a/docs/competitors/sami-bulk-price-editor.md
+++ b/docs/competitors/sami-bulk-price-editor.md
@@ -1,0 +1,238 @@
+# Sami Bulk Price Editor — teardown
+
+*Captured 29 Aug 2026 by walking the live app on `dartmode-labs.myshopify.com`. One task
+was created (`#75577`, Manual start, never run) to observe the commit flow, then archived;
+no prices were changed.*
+
+| | |
+|---|---|
+| Vendor | SamiSales by Samita (Hanoi, VN) |
+| App handle | `bulk-price-editor-sami` |
+| Tagline | "Bulk product editor & auto-revert prices for sales campaigns" |
+| Rating | 4.8★ / 164 reviews (91% five-star, 3% one-star) |
+| Built for Shopify | Yes |
+| Launched | **17 Apr 2025** — by far the newest of the three |
+| Categories | Bulk editor (Store Management) |
+| Languages | **18** — English, French, Italian, Chinese (Trad & Simp), Japanese, German, Spanish, Turkish, Swedish, Polish, Norwegian, Korean, Finnish, Dutch, Danish, Czech, Portuguese (BR) |
+| Pricing | **Free.** No paid tier on the listing, no pricing page in the app |
+| Scopes granted | Products (view+edit), "Other data" — **no Discounts scope** |
+
+Sami is the newest, the most polished, and the only one that is free. It is also the only
+one of the three whose *information architecture* is genuinely different: it is a **bulk
+product editor** that happens to be excellent at prices, entered by picking a field rather
+than by picking a price rule.
+
+## The shape of the whole app
+
+**No nav sub-items at all.** The Shopify sidebar shows only "Bulk Price Editor Sami". The
+whole app is: Dashboard → Bulk Edit Tasks → Create task. Settings and plans do not exist as
+pages (there is nothing to configure and nothing to buy).
+
+A **live-chat bubble** floats bottom-right on every page. A **language selector** sits in
+the dashboard header.
+
+## Page 1 — Dashboard
+
+- `Hello ,` (the name interpolation is empty — a small bug) and `🌍 English ▾`
+- `👋 Welcome to: Bulk Price Editor - Sami by Samita`
+- **A four-metric strip**: `Total tasks` · `Tasks completed` · `Tasks reverted` ·
+  `Tasks scheduled`. *Tasks reverted* being a headline metric is a statement of what the
+  product thinks it is for.
+- **Bulk edit products with Sami** — "Quickly update multiple products at once in just a
+  few clicks with an efficient bulk editing workflow" + `New bulk edit` · `View task history`
+- **Quick Discount Campaign Setup** — *"Quickly create a discount campaign task—just enter
+  your target price and click **Quick Create**"*
+  - `Discount` [ number ] [ Percentage ▾ ]
+  - ☐ **Update compare-at price only** — *"Keep the current price unchanged and set a
+    higher compare-at price to display a discount"*
+  - `Quick Create` · `Learn more`
+- **Need any help?** — three tiles: `Get email support` / `Start live chat` / `Help docs`
+
+**The Quick Create pattern is worth stealing outright.** The single most common job — "run
+a X% sale on everything" — is one number and one button on the landing page. Everything
+else is behind "New bulk edit".
+
+## Page 2 — "Choose a Field to Edit"
+
+`New bulk edit` does not open a form. It opens a **gallery of field cards**, filtered by
+`All fields | Product fields | Variant fields`.
+
+Each card shows a **worked before → after example rendered with a real product image**
+(e.g. *Long Sleeve Tee · ~~$250.00~~ → $300.00*), the field name, a `Most popular` badge
+where applicable, whether it is a Product or Variant field, `+ Select`, and — notably —
+**`▷ Video tutorial`** per field.
+
+The eleven fields:
+
+| Field | Scope | Badge |
+|---|---|---|
+| Price | Variant | Most popular |
+| Compare at price | Variant | Most popular |
+| Price by market | Variant | |
+| Compare at price by market | Variant | |
+| Cost price | Variant | |
+| SKU | Variant | |
+| Barcode | Variant | |
+| Title | Product | |
+| Status | Product | |
+| Description | Product | |
+| Tags | Product | |
+
+Footer: *"Learn more about Bulk Edit Tasks"*.
+
+**This is the cleanest answer to "how do I start?" of the three apps.** NA asks "how should
+prices change"; Rubix asks "what campaign type"; Sami asks "what do you want to edit",
+shows you a picture of the answer, and offers a video.
+
+## Page 3 — Create task (the editor)
+
+**A two-pane layout: a narrow form column on the left, a wide live preview on the right.**
+This is the single biggest structural difference from NA (preview inline, below the
+control) and Rubix (no preview at all).
+
+### Left column — stacked cards
+
+**Task name** — prefilled `New task`, with a `8/100` character counter.
+
+**Field to edit**
+- `Field` [ Price ▾ ]
+- `Edit method` [ Decrease by percentage ▾ ] — ten options for the price field:
+  1. Increase by percentage
+  2. Increase by amount
+  3. Increase by percentage of cost price
+  4. Decrease by percentage *(default)*
+  5. Decrease by amount
+  6. Decrease by percentage of cost price
+  7. Set as percentage of price
+  8. Set as percentage of compare at price
+  9. Set the price to the current compare-at price
+  10. Set the price to the current cost price
+- `Value` [ __ % ]
+- `Rounding` [ Round to nearest .01 ▾ ] with helper text that *shows the arithmetic*:
+  *"Round to two decimal places. For example, a price of 10.458 would be rounded to 10.46"*
+
+**Compare at price** — `Don't change compare-at price` *(default)* / `Set the compare-at
+price`. A second field edited from within the first field's task.
+
+**Apply to products** — `All products` / `Collections` / `Specific products` /
+`Match conditions`. Match conditions opens `Products must match: ( ) all conditions
+(•) any condition` then `[ Title ▾ ] [ contains ▾ ] [ value ]` + `Add another condition`.
+
+**Exclude products** — ☐ `Specific products`. *An explicit exclusion list, which neither
+other app has.*
+
+**Apply to variants** — `All variants` / `Match conditions`. Product-level and
+variant-level scoping are separate controls.
+
+**Start time** — four radios:
+- `Now`
+- **`Manual`** — the task exists but only runs when you press "Apply change now"
+- `Schedule the edit`
+- **`Recurring`**
+
+**Revert time** — ☐ `Schedule the revert`
+
+### Recurring, in detail
+
+`Recurring` reveals `[ Daily ▾ ]` plus a repeatable window block:
+
+> `Start date [29/08/2026]` `End date [29/08/2026]`
+> `Start time (hh:mm) [06] [00]` `End time (hh:mm) [18] [00]`
+> *The task will run from 06:00 to 18:00 on 29 Aug*
+> `⊕ Add another condition`
+>
+> Timezone: **(GMT-05:00) Eastern Time (US & Canada)**. *Change timezone*
+
+Three things there that the other two apps do not have: a **plain-English echo of the
+schedule**, **multiple windows per task**, and a **timezone the merchant can change**
+rather than one inferred from the browser.
+
+### Right column — the live preview
+
+- A dismissible banner: **"Try a demo run first — We'll create a demo products so you can
+  review the results before updating real products"** + `Create product`.
+  **A one-click sandbox.** No competitor and no version of our app has this.
+- **Preview** — a real table over the merchant's own catalogue:
+  `Product | Original price | Update price | Original compare at price | Update compare at price`,
+  with thumbnails, variant sub-rows indented under the product, horizontal scroll, and
+  pagination. It recomputes as you type: entering `10` turned `$949.95` into `$854.96`
+  across every row instantly.
+- Empty state when a filter matches nothing: a magnifier illustration, **"No products
+  found"**, *"Try changing the filters or search term"*.
+
+### Commit
+
+There is **no confirmation step**. App Bridge `Save` writes the task and navigates to
+`/admin/tasks/:id`. With `Start time: Now` that is a live price change on the merchant's
+whole catalogue, one click, no summary, no "this affects N variants", no acknowledgement.
+
+The saved task page is the same editable form, with a `Duplicate` action in the header.
+
+## Page 4 — Bulk Edit Tasks (the list)
+
+**The best list view of the three.** Nine status tabs:
+
+`All | Pending | Running | Completed | Scheduled | Partially complete | Revert completed |
+Pause | Archived`
+
+> **"Partially complete" is a first-class, filterable status.** NA has no failure state at
+> all. This is the only competitor that admits a run can stop halfway.
+
+Columns: `ID (#75577) | Name | Recurring | Status | Progress | Applies to | Editing rules |
+Created at | ⋮`
+
+- **`Editing rules`** renders the rule as a sentence — *"Price decrease by 10%"* — so the
+  list answers "what does this task do" without opening it.
+- **`Applies to`** renders the scope — *"All products"*.
+- **`Recurring`** renders *"One-time"* or the recurrence.
+- **`Progress`** is a dedicated column for in-flight runs.
+- Status renders as a badge — *`Manual start`*.
+
+Row menu (⋮): **`Apply change now`** · `Duplicate` · `Archive` · **`Note`**.
+
+Archiving shows a toast: *"Task archived ×"*. There is no destructive delete.
+
+`Note` — attaching free text to a run — is a small idea with a large payoff: it is where
+"why did we do this" lives.
+
+Empty state: a custom illustration plus *"Get started with Bulk Editing — Quickly edit
+product fields at scale with live previews, scheduled changes, and rollbacks — all in one
+place."* with `Learn More` and `New Bulk Edit Task`.
+
+## What they do that we should copy
+
+1. **Quick Create on the dashboard** — the commonest job as one field and one button,
+   with the full editor a separate door.
+2. **"Choose a field to edit" as the entry point**, with a *pictured* before → after per
+   field and a per-field video.
+3. **The two-pane editor: form left, live preview right.** The preview is never below the
+   fold and never a separate step.
+4. **A preview table with `Original` and `Update` columns for both price and compare-at**,
+   recomputing on every keystroke over the merchant's real catalogue.
+5. **"Try a demo run first" — a generated sandbox product.** The safest possible way to
+   learn what a rule does.
+6. **`Partially complete` as a filterable status**, plus `Progress` as a list column.
+7. **`Manual` as a start mode** — build the task now, press the button later. Neither a
+   draft nor a schedule.
+8. **A timezone the merchant sets**, with a plain-English echo of the schedule.
+9. **`Exclude products`** as a control beside `Apply to products`.
+10. **`Note` on a run** and **`Archive` instead of delete**.
+11. **Rounding helper text that shows the arithmetic** on an example number.
+12. **Rules rendered as sentences in the list** (`Price decrease by 10%`), so the index is
+    readable without opening rows.
+13. **Eighteen languages.** Ours is English-only.
+
+## What is weak
+
+- **No confirmation before a live write.** Save with `Start time: Now` changes every price
+  in the catalogue with no summary and no acknowledgement. The safest editor in the
+  category has the least safe commit.
+- **No baseline.** "Original price" in the preview means the current live price, so a
+  second task compounds exactly as Rubix's does — Sami simply does not warn about it.
+- **No markets depth**: `Price by market` and `Compare at price by market` are single
+  fields, with no catalogue/B2B/POS model behind them.
+- **No cost-margin guardrail** — `Decrease by percentage of cost price` exists as a rule,
+  but nothing stops a rule pricing below cost.
+- **`Hello ,`** — an empty interpolation on the first line of the first page.
+- **No usage, plan or settings surface**, which is fine today and a cliff the day they
+  introduce billing.


### PR DESCRIPTION
Four files under `docs/competitors/`: a teardown each for **NA Bulk Price Editor**,
**RUBIX Bulk Price Editor** and **Sami Bulk Price Editor**, plus the comparison that turns
them into work.

All three were walked live on `dartmode-labs` on 29 Aug 2026 — every page, every dropdown
enumerated by keyboard through the control, the pricing pages, the FAQs — and then our own
production build was walked in the same browser session on the same store.

## What the comparison leads with

**Our embedded app does not scroll.** `/app/campaigns/new` ends after "1 · Scope", so the
rule, the amount, the draft preview, the schedule and the **Create button** are all
unreachable; tabbing forward leaves the iframe after three presses. `/app/prices` shows ten
of fifty rows. `/app/settings` is cut mid-card. All three competitors scrolled in the same
tab, with the same synthetic wheel events, minutes earlier.

That is #441, and it blocks the other sixteen issues in Epic 15 (#440).

Why it was never caught: the tests assert about markup, and the markup is fine; the manual
checks ran against `anchor-perf`, whose production database is empty, so **no page was ever
taller than one screen**.

## What else the comparison argues

- **Our differentiators are real and invisible.** Baseline, recompute-revert, overlap
  resolution, verified-clean runs and drift detection are things no competitor has, and in
  the UI they are help prose. RUBIX's own FAQ documents its compounding bug with worked
  numbers — our positioning, written by a competitor.
- **Sami is the threat, not NA.** Launched Apr 2025, free, eighteen languages, the best
  editor in the category, and the only competitor with a `Partially complete` status.
- Seventeen issues filed under #440, ordered P0 → P5.

Nothing destructive was done to the store: one Sami task was created with a `Manual` start
and archived, NA's markets toggle was flipped and flipped back, no prices were changed.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
