### PR TITLE
The preview sits beside the rule, from one form

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -385,3 +385,41 @@ describe("pages that can lose typed work", () => {
     expect(missing, "these can discard a filled-in form on any navigation").toEqual([]);
   });
 });
+
+describe("how wide the second column is", () => {
+  // `<=` arrives HTML-escaped from `renderToStaticMarkup`, which is correct output and
+  // noise here — the assertions are about the track list, not about entity encoding.
+  const columnsOf = (html: string) =>
+    (/gridtemplatecolumns="([^"]*)"/i.exec(html)?.[1] ?? "").replaceAll("&lt;", "<");
+
+  const page = (asideWidth?: "base" | "wide") =>
+    render(
+      <PageShell heading="Campaign" {...(asideWidth ? { asideWidth } : {})}>
+        <s-section heading="Rule">main content</s-section>
+        <s-section slot="aside" heading="Preview">rows</s-section>
+      </PageShell>,
+    );
+
+  it("defaults to the narrow strip every other page wants", () => {
+    expect(columnsOf(page())).toBe("@container (inline-size <= 900px) 1fr, 1fr 22rem");
+  });
+
+  it("gives the campaign editor's price table half the page", () => {
+    // A preview of prices at 22rem wraps every row onto three lines, and a preview a
+    // merchant has to decode is not a preview.
+    expect(columnsOf(page("wide"))).toBe("@container (inline-size <= 900px) 1fr, 1fr 1fr");
+  });
+
+  it("never puts a second comma in the value", () => {
+    // Polaris splits a responsive grid value on the comma to separate "when the query
+    // matches" from "otherwise". The obvious `minmax(0, 1fr)` brings its own comma, the
+    // whole value stops parsing, and the aside silently stacks underneath — which looks
+    // exactly like a layout choice rather than a broken string.
+    for (const width of ["base", "wide"] as const) {
+      expect(
+        columnsOf(page(width)).split(",").length - 1,
+        `the ${width} column value has a comma inside a track, so it will not parse`,
+      ).toBe(1);
+    }
+  });
+});

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -149,12 +149,42 @@ export function PageSections({ children }: { children: ReactNode }) {
   return <s-stack gap={SPACE.page}>{children}</s-stack>;
 }
 
+/**
+ * How wide the second column is.
+ *
+ * `"base"` is the 22rem strip the column was built for: a store card, an activity feed,
+ * a set of actions — things whose content is a few short lines and whose job is to sit
+ * out of the way.
+ *
+ * `"wide"` exists for one thing, and it should stay that way: the campaign editor's live
+ * preview, which is a table of prices. A price table at 22rem wraps every row onto three
+ * lines, and a preview a merchant has to decode is not a preview. Half the page is the
+ * proportion Sami uses for the same panel and it is the right one — the form is a dozen
+ * short controls and the preview is the answer the merchant came for.
+ */
+export type AsideWidth = "base" | "wide";
+
+/**
+ * No value in here may contain a comma. The note on `gridTemplateColumns` below is not
+ * decoration: Polaris splits a responsive value on the comma to separate "when the query
+ * matches" from "otherwise", so the obvious `minmax(0, 1fr)` takes its own comma as that
+ * separator, the whole value stops parsing, and the aside silently stacks underneath —
+ * looking exactly like a layout choice. `PageShell.test.tsx` refuses one.
+ */
+const ASIDE_TRACK: Record<AsideWidth, string> = {
+  base: "22rem",
+  wide: "1fr",
+};
+
 export function PageShell({
   heading,
   backTo,
+  asideWidth = "base",
   children,
 }: {
   heading: string;
+  /** See `AsideWidth`. Defaults to the narrow strip every other page wants. */
+  asideWidth?: AsideWidth;
   /**
    * Where this page came from, for pages the nav menu cannot reach.
    *
@@ -231,7 +261,7 @@ export function PageShell({
           // takes its own comma as that separator and the whole value stops parsing --
           // which silently falls back to `none` and stacks the aside underneath, looking
           // exactly like a layout choice rather than a broken string.
-          gridTemplateColumns="@container (inline-size <= 900px) 1fr, 1fr 22rem"
+          gridTemplateColumns={`@container (inline-size <= 900px) 1fr, 1fr ${ASIDE_TRACK[asideWidth]}`}
           // Without this the aside column stretches to the height of the main content, so
           // a one-line sidebar next to a long table becomes a very tall empty card.
           alignItems="start"

--- a/app/components/RuleValueField.tsx
+++ b/app/components/RuleValueField.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import { DRAFT_DEFAULTS } from "../lib/campaigns/draft-defaults";
+
 /**
  * The rule's amount, which is a percentage or a price depending on the rule.
  *
@@ -25,7 +27,7 @@ export function RuleValueField({
   name?: string;
   selectName?: string;
 }) {
-  const [kind, setKind] = useState("percent-change");
+  const [kind, setKind] = useState<string>(DRAFT_DEFAULTS.ruleKind);
   const money = kind === "fixed-change" || kind === "set-exact";
 
   return (
@@ -35,7 +37,7 @@ export function RuleValueField({
         label="Adjustment"
         onChange={(event) => setKind(String(event.currentTarget.value))}
       >
-        <s-option value="percent-change" defaultSelected>
+        <s-option value={DRAFT_DEFAULTS.ruleKind} defaultSelected>
           Percent change from baseline
         </s-option>
         <s-option value="fixed-change">Fixed change from baseline</s-option>
@@ -46,19 +48,19 @@ export function RuleValueField({
         <s-money-field
           name={name}
           label={kind === "set-exact" ? `Price (${currency})` : `Amount (${currency})`}
-          value={kind === "set-exact" ? "" : "-10"}
+          value={kind === "set-exact" ? "" : DRAFT_DEFAULTS.fixedValue}
           details={
             kind === "set-exact"
               ? "Every variant in scope gets this exact price."
-              : `Negative reduces. -10 takes ${currency} 10 off the baseline.`
+              : `Negative reduces. ${DRAFT_DEFAULTS.fixedValue} takes ${currency} ${DRAFT_DEFAULTS.fixedValue.replace('-', '')} off the baseline.`
           }
         />
       ) : (
         <s-number-field
           name={name}
           label="Percentage"
-          value="-20"
-          details="Negative discounts. -20 means 20% off the baseline."
+          value={DRAFT_DEFAULTS.percentValue}
+          details={`Negative discounts. ${DRAFT_DEFAULTS.percentValue} means ${DRAFT_DEFAULTS.percentValue.replace("-", "")}% off the baseline.`}
         />
       )}
     </>

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -158,11 +158,15 @@ describe("the prose each page used to keep in a column", () => {
 
 describe("what stays in the aside", () => {
   /**
-   * The rule the column follows now: a sidebar carries facts about *this shop*, on the
-   * one page whose job is showing several of them at once. Everything else lost its
-   * column — prose became a note, and two cards that were facts filed away from their
-   * subject moved next to it (cost coverage to the cost-floor settings, failures by code
-   * to the failures they count).
+   * The rule the column follows: a sidebar carries **facts about this shop**. Everything
+   * else lost its column — prose became a note, and two cards that were facts filed away
+   * from their subject moved next to it (cost coverage to the cost-floor settings,
+   * failures by code to the failures they count).
+   *
+   * The campaign editor's preview is the second page to earn one, and it earns it on the
+   * same rule rather than by exception: it is this shop's own variants, priced by the
+   * rule being typed, recomputed on every keystroke. It is not an explanation of how the
+   * app works — it is the answer.
    *
    * Checked rather than written down, because the next explanatory sidebar will be added
    * by someone who has not read `PageShell`.
@@ -170,18 +174,21 @@ describe("what stays in the aside", () => {
   const FACTS = [
     ["app._index.tsx", "Store"],
     ["app._index.tsx", "Recent activity"],
+    ["app.campaigns.new.tsx", "What this would do"],
   ] as const;
 
   it.each(FACTS)("%s keeps its %s card beside the content", (name, heading) => {
     expect(route(name)).toContain(`<s-section slot="aside" heading="${heading}">`);
   });
 
-  it("is the dashboard and nowhere else", () => {
+  it("is those two pages and nowhere else", () => {
     const routes = ALL_ROUTES.filter((name) => route(name).includes('slot="aside"'));
 
-    expect(routes, "a second page with a sidebar is a rule that has started drifting").toEqual(
-      ["app._index.tsx"],
-    );
+    expect(
+      routes,
+      "a third page with a sidebar is a rule that has started drifting — the column is " +
+        "for facts about this shop, and there are two pages whose job is showing them",
+    ).toEqual(["app._index.tsx", "app.campaigns.new.tsx"]);
   });
 
   it("moved the two facts that were filed away from their subject", () => {

--- a/app/lib/campaigns/draft-defaults.test.ts
+++ b/app/lib/campaigns/draft-defaults.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The unedited form and the preview of it say the same thing.
+ *
+ * The campaign editor's preview is now primed by the loader, so the panel arrives
+ * populated instead of saying "set a rule" next to a rule that is already set. That
+ * means two things read the same defaults: the fields, which render them, and the
+ * loader, which prices them without a form to read.
+ *
+ * A merchant cannot see this drift the way a broken layout is visible. They see a
+ * sidebar predicting −20% beside a field that says −25%, or a preview computed with no
+ * rounding beside a select that says `.99` — a preview that is wrong in exactly the way
+ * rule 4 exists to prevent, and wrong quietly.
+ *
+ * So: the values live in one object, and this refuses a literal of them anywhere else.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { DRAFT_DEFAULTS, draftDefaultParams } from "./draft-defaults";
+
+/** Source with comments removed — they discuss the very literals being grepped for. */
+const sourceOf = (path: string) =>
+  readFileSync(join(process.cwd(), path), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
+const EDITOR = sourceOf("app/routes/app.campaigns.new.tsx");
+const RULE_FIELD = sourceOf("app/components/RuleValueField.tsx");
+
+describe("the defaults are a value, not a literal in two files", () => {
+  it("renders the rule fields from the shared object", () => {
+    expect(RULE_FIELD).toContain("DRAFT_DEFAULTS");
+
+    for (const literal of ['"percent-change"', '"-20"', '"-10"']) {
+      expect(
+        RULE_FIELD,
+        `${literal} is written out in the field as well as in DRAFT_DEFAULTS, so the ` +
+          "loader's preview and the form can now disagree",
+      ).not.toContain(literal);
+    }
+  });
+
+  it("primes the loader's preview from the same object", () => {
+    expect(EDITOR).toContain("draftDefaultParams()");
+    expect(EDITOR).toContain("previewDraft(");
+  });
+
+  it("seeds the shop's own rounding rather than letting it fall back to none", () => {
+    // `readRoundingPolicy` returns "none" when the field is absent, and the select
+    // renders the store setting as its chosen option. Seeding nothing means a preview
+    // that rounds differently from the form beside it.
+    expect(EDITOR).toContain('seeded.set("rounding.default", settings.rounding.default)');
+    expect(EDITOR).toMatch(/rounding\.\$\{code\}/);
+  });
+});
+
+describe("the seeded params are what the form would have sent", () => {
+  const params = draftDefaultParams();
+
+  it("carries the rule, its amount, the compare-at policy and the priority", () => {
+    expect(params.get("ruleKind")).toBe(DRAFT_DEFAULTS.ruleKind);
+    expect(params.get("ruleValue")).toBe(DRAFT_DEFAULTS.percentValue);
+    expect(params.get("compareAt")).toBe(DRAFT_DEFAULTS.compareAt);
+    expect(params.get("priority")).toBe(DRAFT_DEFAULTS.priority);
+  });
+
+  it("carries no rounding of its own", () => {
+    // Rounding is the shop's setting, not a default of this module's — a value here
+    // would be a rounding rule the merchant never chose, previewed as though they had.
+    expect([...params.keys()].filter((key) => key.startsWith("rounding."))).toEqual([]);
+  });
+
+  it("defaults the amount to a discount, because that is what a campaign is", () => {
+    expect(Number(DRAFT_DEFAULTS.percentValue)).toBeLessThan(0);
+    expect(Number(DRAFT_DEFAULTS.fixedValue)).toBeLessThan(0);
+  });
+});

--- a/app/lib/campaigns/draft-defaults.ts
+++ b/app/lib/campaigns/draft-defaults.ts
@@ -1,0 +1,40 @@
+/**
+ * What the campaign editor's form says before a merchant touches it.
+ *
+ * These used to live only in the JSX, which was fine while the only thing that read the
+ * form was the form's own submit. It stopped being fine when the loader started pricing
+ * the draft server-side so the preview is populated on first paint: the loader has no
+ * form to read, so it has to know what the unedited form would have said, and a second
+ * copy of "-20" is a preview that disagrees with the editor it previews.
+ *
+ * One object, imported by the fields that render the defaults and by the loader that
+ * prices them. `draft-defaults.test.ts` checks the editor still renders these rather
+ * than literals of its own.
+ */
+export const DRAFT_DEFAULTS = {
+  /** Percent change, which is what nearly every campaign is. */
+  ruleKind: "percent-change",
+  /** Negative discounts: -20 is 20% off the baseline. */
+  percentValue: "-20",
+  /** The money equivalent, used by the two rules that take an amount. */
+  fixedValue: "-10",
+  /** A strike-through by default: a sale that does not look like one converts worse. */
+  compareAt: "set-to-baseline",
+  /** Only matters once two campaigns overlap. */
+  priority: "100",
+} as const;
+
+/**
+ * The defaults as form fields, for the loader's first-paint preview.
+ *
+ * Rounding is deliberately absent: it comes from the shop's own setting, and seeding a
+ * default here would preview a rounding rule the merchant never chose.
+ */
+export function draftDefaultParams(): URLSearchParams {
+  return new URLSearchParams({
+    ruleKind: DRAFT_DEFAULTS.ruleKind,
+    ruleValue: DRAFT_DEFAULTS.percentValue,
+    compareAt: DRAFT_DEFAULTS.compareAt,
+    priority: DRAFT_DEFAULTS.priority,
+  });
+}

--- a/app/lib/ui/editor-layout.test.ts
+++ b/app/lib/ui/editor-layout.test.ts
@@ -23,7 +23,18 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const EDITOR = readFileSync(join(process.cwd(), "app/routes/app.campaigns.new.tsx"), "utf8");
+/**
+ * The editor's source with its comments removed.
+ *
+ * Every assertion here is a grep, and the comments in that file talk about the very
+ * things being grepped for — the removed "Update match count" button is named in the
+ * comment explaining why it went. A grep that reads its own explanation is the trap this
+ * repo has now hit five times. The same two lines appear in `table-size.test.ts` and
+ * `imports.test.ts`; extracting them is #462.
+ */
+const EDITOR = readFileSync(join(process.cwd(), "app/routes/app.campaigns.new.tsx"), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^\s*\/\/.*$/gm, "");
 
 /** Where a name first appears in the file, or -1. Source order is render order here. */
 const at = (needle: string) => EDITOR.indexOf(needle);
@@ -59,9 +70,16 @@ describe("step 2 lays its fields out in columns", () => {
 });
 
 describe("the rule is what a merchant meets first", () => {
-  it("previews the rule directly under the rule", () => {
-    expect(at("<RuleValueField")).toBeLessThan(at("What this would do"));
-    expect(at("What this would do")).toBeLessThan(at("Markets and catalogues"));
+  it("previews the rule beside it, in the aside, rather than under it", () => {
+    // It was directly under the rule, which on a form this long meant off screen while
+    // the rule was being typed. The column is where it goes; what has to stay true is
+    // that there is exactly one of it and it is not back inside the form.
+    expect(EDITOR).toContain('<s-section slot="aside" heading="What this would do">');
+    expect((EDITOR.match(/<DraftPreview/g) ?? []).length).toBe(1);
+    expect(
+      at("<DraftPreview"),
+      "the preview is inside the form again, which is where it was off screen",
+    ).toBeGreaterThan(at("</Form>"));
   });
 
   it("puts the four rarely-touched settings after the schedule, not before it", () => {
@@ -78,9 +96,30 @@ describe("the rule is what a merchant meets first", () => {
     expect(EDITOR).toMatch(/Skip them\s*\n?\s*unless you have a reason/);
   });
 
-  it("still submits after everything, exactly once", () => {
-    expect((EDITOR.match(/type="submit"/g) ?? []).length).toBe(2); // scope's, and the create
+  it("submits once, after everything", () => {
+    // Two, once: the scope had its own GET form with an "Update match count" button, so
+    // reading the count meant a navigation that reset every field in the rule form. One
+    // form has one submit, and a second appearing here means the scope has been split
+    // back out.
+    expect((EDITOR.match(/type="submit"/g) ?? []).length).toBe(1);
+    expect(EDITOR).not.toContain("Update match count");
     expect(at("Create and preview")).toBeGreaterThan(at("Advanced (optional)"));
+  });
+
+  it("scopes and prices from one form, so a filter change reprices", () => {
+    // The fetcher posts `new FormData(form)`. With the scope outside that form a filter
+    // change could not move the preview, and the scope had to be mirrored in as six
+    // hidden inputs that a new field could silently miss.
+    expect((EDITOR.match(/<Form /g) ?? []).length).toBe(1);
+    expect(
+      EDITOR,
+      "a hidden mirror of a scope field means there are two forms again",
+    ).not.toMatch(/<input type="hidden" name="(collection|tag|vendor|title|segment)"/);
+
+    for (const field of ['name="segment"', 'name="collection"', 'name="tag"', 'name="vendor"', 'name="title"']) {
+      expect(at(field), `${field} is outside the form that prices it`).toBeGreaterThan(at("<Form "));
+      expect(at(field), `${field} is outside the form that submits it`).toBeLessThan(at("</Form>"));
+    }
   });
 });
 

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -5,7 +5,7 @@ import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
-import { facets, previewMatches } from "../services/segments.server";
+import { facets } from "../services/segments.server";
 import { createCampaign } from "../services/campaigns/index.server";
 import { joinDateAndTime, localInputToUtc, type Schedule } from "../lib/scheduling/window";
 import { presetStartFor } from "../lib/scheduling/calendar";
@@ -16,16 +16,17 @@ import {
   ROUNDING_LABELS,
 } from "../lib/money/rounding-policy";
 import { ActionRow } from "../components/ActionRow";
-import { FilterForm } from "../components/FilterForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { readSettings, shopCurrency } from "../services/settings.server";
 import { billingFrom } from "../services/billing.server";
 import { canUseSurface } from "../lib/billing/plans";
 import prisma from "../db.server";
-import { segmentToAst } from "../services/segments.server";
 import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/draft-form";
-import { PageShell } from "../components/PageShell";
+import { draftDefaultParams } from "../lib/campaigns/draft-defaults";
+import { draftCampaignFrom } from "../services/campaigns/draft-input.server";
+import { previewDraft } from "../services/campaigns/draft-preview.server";
+import { PageSections, PageShell } from "../components/PageShell";
 import { UnsavedChanges } from "../components/UnsavedChanges";
 import { DraftPreview } from "../components/DraftPreview";
 import { RuleValueField } from "../components/RuleValueField";
@@ -53,18 +54,9 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
       })
     : null;
 
-  const ast = segment
-    ? segmentToAst({
-        kind: segment.kind as "DYNAMIC" | "FROZEN",
-        filterAst: segment.filterAst,
-        frozenVariantGids: segment.frozenVariantGids,
-      })
-    : astFrom(readerFor(url.searchParams));
-
-  const [available, preview, segments, priceLists, settings, currency, shopRecord] =
+  const [available, segments, priceLists, settings, currency, shopRecord] =
     await Promise.all([
     facets(shop.id),
-    previewMatches(shop.id, ast),
     prisma.segment.findMany({
       where: { shopId: shop.id },
       select: { id: true, name: true, kind: true },
@@ -100,6 +92,26 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
   ]);
 
   const billing = billingFrom(shopRecord);
+
+  // The preview the merchant would get if they changed nothing, computed here so the
+  // panel arrives populated rather than saying "set a rule" next to a rule that is
+  // already set. The scope comes from the URL — a merchant who arrived from a segment or
+  // from the calendar has already made that choice — and the rule from the same defaults
+  // the fields render, so this and the first keystroke agree.
+  const seeded = draftDefaultParams();
+  // Rounding is the shop's, not a default of its own: the select renders the store
+  // setting as its chosen option, so a preview built without it would round differently
+  // from the form sitting next to it. `readRoundingPolicy` falls back to "none" when the
+  // field is absent, which is precisely the disagreement to avoid.
+  seeded.set("rounding.default", settings.rounding.default);
+  for (const [code, profile] of Object.entries(settings.rounding.byCurrency)) {
+    seeded.set(`rounding.${code}`, profile);
+  }
+  for (const [key, value] of url.searchParams) if (value) seeded.set(key, value);
+  const preview = await previewDraft(
+    shop.id,
+    await draftCampaignFrom(shop.id, seeded, currency),
+  );
 
   // Every currency this campaign could price in. Only these are offered: a list of all
   // 180 world currencies would bury the two or three that matter.
@@ -269,6 +281,7 @@ export default function NewCampaign() {
     <PageShell
       heading={practice ? "Practice campaign" : guided ? "Your first campaign" : "New campaign"}
       backTo={{ href: "/app/campaigns", label: "Campaigns" }}
+      asideWidth="wide"
     >
       {/* Before anything else on the page, because it is the answer to a click that has
           already happened. Nothing here is persisted until the campaign is created, so
@@ -294,14 +307,33 @@ export default function NewCampaign() {
         </s-banner>
       ) : null}
 
+      {/* One form, not two.
+
+          The scope used to be its own GET form with an "Update match count" submit, so
+          reading the count meant a navigation — which reset every uncontrolled field in
+          the rule form below it. Two forms also meant the scope had to be mirrored into
+          the create form as six hidden inputs, and a field added to one and forgotten in
+          the other would silently stop scoping the campaign.
+
+          One form removes both. It is also what makes the preview live: the fetcher
+          already posts `new FormData(form)`, so with the scope inside that form a change
+          to a filter reprices exactly as a change to the rule does. */}
+      <Form method="post" ref={formRef} onChange={requestPreview}>
+        <input type="hidden" name="practice" value={practice ? "1" : ""} />
+
+        {/* `s-page` spaces its direct children, and these are no longer direct children
+            — they are inside a form. `PageSections` is the page rhythm, available for
+            exactly this case. Without it two cards touch and read as one card with a
+            line through it. */}
+        <PageSections>
       <s-section heading="1 · Scope">
         <s-paragraph>
           Leave everything blank to target the whole catalogue. Conditions combine
           with AND.
         </s-paragraph>
-        <FilterForm fields={SCOPE_FIELDS}>
-          <FieldGrid>
-            <FullRow>
+
+        <FieldGrid>
+          <FullRow>
             <s-select name="segment" label="Saved segment">
               <s-option value="" defaultSelected={!selected.segment}>
                 Build a filter below instead
@@ -316,9 +348,10 @@ export default function NewCampaign() {
                 </s-option>
               ))}
             </s-select>
-            </FullRow>
+          </FullRow>
 
-            {usingSegment ? (
+          {usingSegment ? (
+            <FullRow>
               <s-banner tone="info">
                 <s-paragraph>
                   Targeting the segment <s-text>{usingSegment.name}</s-text>. The filter
@@ -328,74 +361,44 @@ export default function NewCampaign() {
                     : "Its product list is pinned, so this campaign hits exactly those products and nothing added later."}
                 </s-paragraph>
               </s-banner>
-            ) : null}
+            </FullRow>
+          ) : null}
 
-            <s-select name="collection" label="Collection">
-              <s-option value="" defaultSelected={!selected.collection}>
-                Any collection
+          <s-select name="collection" label="Collection">
+            <s-option value="" defaultSelected={!selected.collection}>
+              Any collection
+            </s-option>
+            {available.collections.map((c) => (
+              <s-option key={c} value={c} defaultSelected={selected.collection === c}>
+                {c}
               </s-option>
-              {available.collections.map((c) => (
-                <s-option key={c} value={c} defaultSelected={selected.collection === c}>
-                  {c}
-                </s-option>
-              ))}
-            </s-select>
-            <s-select name="vendor" label="Vendor">
-              <s-option value="" defaultSelected={!selected.vendor}>
-                Any vendor
-              </s-option>
-              {available.vendors.map((v) => (
-                <s-option key={v} value={v} defaultSelected={selected.vendor === v}>
-                  {v}
-                </s-option>
-              ))}
-            </s-select>
-            <s-select name="tag" label="Tag">
-              <s-option value="" defaultSelected={!selected.tag}>
-                Any tag
-              </s-option>
-              {available.tags.map((t) => (
-                <s-option key={t} value={t} defaultSelected={selected.tag === t}>
-                  {t}
-                </s-option>
-              ))}
-            </s-select>
-            <s-text-field name="title" label="Title contains" value={selected.title} />
-          </FieldGrid>
-
-          {/* Was an inline stack around exactly one button. A stack with one child lays
-              nothing out; ActionRow is what a row of actions is, and this is a row of
-              one. */}
-          <ActionRow>
-            <s-button type="submit">Update match count</s-button>
-          </ActionRow>
-        </FilterForm>
-
-        <s-paragraph>
-          <strong>{preview.count}</strong> variants match.
-        </s-paragraph>
-        {preview.sample.length > 0 ? (
-          <s-unordered-list>
-            {preview.sample.slice(0, 5).map((v) => (
-              <s-list-item key={v.variantGid}>
-                {v.title} {v.price ? `· ${v.price}` : ""}
-              </s-list-item>
             ))}
-          </s-unordered-list>
-        ) : null}
+          </s-select>
+          <s-select name="vendor" label="Vendor">
+            <s-option value="" defaultSelected={!selected.vendor}>
+              Any vendor
+            </s-option>
+            {available.vendors.map((v) => (
+              <s-option key={v} value={v} defaultSelected={selected.vendor === v}>
+                {v}
+              </s-option>
+            ))}
+          </s-select>
+          <s-select name="tag" label="Tag">
+            <s-option value="" defaultSelected={!selected.tag}>
+              Any tag
+            </s-option>
+            {available.tags.map((t) => (
+              <s-option key={t} value={t} defaultSelected={selected.tag === t}>
+                {t}
+              </s-option>
+            ))}
+          </s-select>
+          <s-text-field name="title" label="Title contains" value={selected.title} />
+        </FieldGrid>
       </s-section>
 
       <s-section heading="2 · Rule">
-        <Form method="post" ref={formRef} onChange={requestPreview}>
-          {/* The scope form and the create form are separate elements, so the chosen
-              segment has to travel with the submission that actually creates. */}
-          <input type="hidden" name="segment" value={selected.segment} />
-          <input type="hidden" name="practice" value={practice ? "1" : ""} />
-          <input type="hidden" name="collection" value={selected.collection} />
-          <input type="hidden" name="tag" value={selected.tag} />
-          <input type="hidden" name="vendor" value={selected.vendor} />
-          <input type="hidden" name="title" value={selected.title} />
-
           <s-stack gap={SPACE.section}>
             {/* The rule, and nothing else, first.
 
@@ -450,9 +453,6 @@ export default function NewCampaign() {
                 the page, because it exists to answer "did I mean -20% or x0.20?" while
                 the merchant is still deciding. With the rarely-touched settings moved to
                 the end, it now lands directly under the rule it is previewing. */}
-            <s-divider />
-            <s-heading>What this would do</s-heading>
-            <DraftPreview preview={previewFetcher.data ?? null} />
 
             {priceLists.length > 0 ? (
               <>
@@ -639,7 +639,23 @@ export default function NewCampaign() {
               </s-button>
             </ActionRow>
           </s-stack>
-        </Form>
+      </s-section>
+        </PageSections>
+      </Form>
+
+      {/* Beside the rule, not below it.
+
+          This is the panel a merchant came to read, and it lived at the foot of the rule
+          section behind a `What this would do` heading — so on a form of this length it
+          was reliably off screen while the rule was being typed. Competitors that compute
+          a far weaker preview than this one all put it next to the control.
+
+          It is `resolve()`, not an estimate of it: the same planner, the same baselines,
+          the draft resolved alongside the shop's other ACTIVE campaigns. The loader
+          primes it so the panel arrives populated, and the fetcher replaces it from the
+          first keystroke onward. */}
+      <s-section slot="aside" heading="What this would do">
+        <DraftPreview preview={previewFetcher.data ?? preview} />
       </s-section>
 
       <HelpNote label="Nothing is written yet">

--- a/app/routes/app.preview-draft.tsx
+++ b/app/routes/app.preview-draft.tsx
@@ -13,43 +13,17 @@ import type { ActionFunctionArgs } from "react-router";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
-import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/draft-form";
+import { draftCampaignFrom } from "../services/campaigns/draft-input.server";
 import { previewDraft } from "../services/campaigns/draft-preview.server";
-import { readRoundingPolicy } from "../lib/money/rounding-policy";
 import { shopCurrency } from "../services/settings.server";
-import { segmentToAst } from "../services/segments.server";
-import prisma from "../db.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { session } = await authenticate.admin(request);
   const shop = await ensureShop(session.shop);
 
   const form = await request.formData();
-  const read = readerFor(form);
 
-  // A chosen segment replaces the inline filter, exactly as it does on submit -- a
-  // preview scoped differently from the campaign it previews is worse than no preview.
-  const segmentId = (read("segment") ?? "").trim();
-  const segment = segmentId
-    ? await prisma.segment.findFirst({
-        where: { id: segmentId, shopId: shop.id },
-        select: { kind: true, filterAst: true, frozenVariantGids: true },
-      })
-    : null;
-
-  const preview = await previewDraft(shop.id, {
-    ast: segment
-      ? segmentToAst({
-          kind: segment.kind as "DYNAMIC" | "FROZEN",
-          filterAst: segment.filterAst,
-          frozenVariantGids: segment.frozenVariantGids,
-        })
-      : astFrom(read),
-    rule: ruleFrom(read, await shopCurrency(shop.id)),
-    compareAtPolicy: compareAtFrom(read),
-    rounding: readRoundingPolicy(form.entries()),
-    priority: Number(read("priority") ?? 100) || 100,
-  });
-
-  return preview;
+  // The same reading of the fields the editor's loader uses for its first paint, so the
+  // preview does not change the moment a merchant touches an unrelated control.
+  return previewDraft(shop.id, await draftCampaignFrom(shop.id, form, await shopCurrency(shop.id)));
 };

--- a/app/services/campaigns/draft-input.server.ts
+++ b/app/services/campaigns/draft-input.server.ts
@@ -1,0 +1,54 @@
+/**
+ * One reading of the editor's fields, for everything that has to price a draft.
+ *
+ * Two callers exist and a third is coming: the resource route the live preview posts to,
+ * the loader that prices the unedited form so the preview is populated on first paint,
+ * and eventually the confirmation step. Each of them was going to repeat the same six
+ * lines — segment lookup, AST, rule, compare-at, rounding, priority — and rule 4 says
+ * preview and execution share one code path. Six lines copied twice is where that stops
+ * being true, quietly, in a way no test notices until a merchant sees one number in the
+ * sidebar and a different one in the run.
+ */
+
+import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../../lib/campaigns/draft-form";
+import { readRoundingPolicy } from "../../lib/money/rounding-policy";
+import { segmentToAst } from "../segments.server";
+import type { DraftCampaign } from "./draft-preview.server";
+import prisma from "../../db.server";
+
+/**
+ * The draft a set of fields describes.
+ *
+ * A chosen segment replaces the inline filter rather than narrowing it, exactly as it
+ * does on submit — a preview scoped differently from the campaign it previews is worse
+ * than no preview.
+ */
+export async function draftCampaignFrom(
+  shopId: string,
+  source: FormData | URLSearchParams,
+  currency: string,
+): Promise<DraftCampaign> {
+  const read = readerFor(source);
+
+  const segmentId = (read("segment") ?? "").trim();
+  const segment = segmentId
+    ? await prisma.segment.findFirst({
+        where: { id: segmentId, shopId },
+        select: { kind: true, filterAst: true, frozenVariantGids: true },
+      })
+    : null;
+
+  return {
+    ast: segment
+      ? segmentToAst({
+          kind: segment.kind as "DYNAMIC" | "FROZEN",
+          filterAst: segment.filterAst,
+          frozenVariantGids: segment.frozenVariantGids,
+        })
+      : astFrom(read),
+    rule: ruleFrom(read, currency),
+    compareAtPolicy: compareAtFrom(read),
+    rounding: readRoundingPolicy(source.entries()),
+    priority: Number(read("priority") ?? 100) || 100,
+  };
+}


### PR DESCRIPTION
Closes #442.

The editor had two forms: the scope was a GET form with an **Update match count** submit,
so reading the count meant a navigation that reset every uncontrolled field in the rule
form below it — and the scope had to be mirrored into the create form as six hidden
inputs, where a field added to one and forgotten in the other silently stops scoping the
campaign.

**One form now.** The fetcher already posts `new FormData(form)`, so with the scope inside
it a filter change reprices exactly as a rule change does, and "how many match" stops
being a separate question from "what would they cost".

**`DraftPreview` moves to the aside.** It sat at the foot of the rule section, which on a
form this long meant off screen while the rule was being typed. `PageShell` grows an
`asideWidth`; the editor is the only page that asks for `wide`, because a price table in
a 22rem strip wraps every row onto three lines.

**The loader primes it**, so the panel arrives populated instead of saying "set a rule"
next to a rule that is already set. That created a second reader of the form's defaults,
so they are now one object (`DRAFT_DEFAULTS`) and `draftCampaignFrom` is one reading of
the fields shared by the loader and the resource route — rule 4, kept honest.

### Verification

- `npm test` — 140 files, 2324 tests
- `npm run test:chaos` — 43 files, 140 tests
- `npm run typecheck`, `npm run lint` (0 errors), `npm run build`
- Four mutations, each caught by the intended test and reverted: a comma inside the aside
  track; `-20` written back into the field as a literal; the rounding seed removed; a
  scope field mirrored back into a hidden input.

### Noted while here

`editor-layout.test.ts` failed on a comment naming the button whose removal it asserts —
the fifth time that trap has fired in this repo. Stripped comments here; #462 extracts the
idiom its four copies share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)