### PR TITLE
The editor opens on the rule

### DIFF
--- a/app/lib/ui/editor-layout.test.ts
+++ b/app/lib/ui/editor-layout.test.ts
@@ -70,6 +70,37 @@ describe("step 2 lays its fields out in columns", () => {
 });
 
 describe("the rule is what a merchant meets first", () => {
+  it("opens on the rule and asks for the scope after it", () => {
+    // A merchant arrives having decided "20% off boots". The form used to open on boots.
+    // Every competitor asks for the change first — NA and RUBIX by name-then-method,
+    // Sami by picking the field to edit — because it is the decision that was already
+    // made before the page loaded.
+    expect(at('headings.rule')).toBeLessThan(at('headings.scope'));
+    expect(at('name="name"'), "the campaign's name is below the scope again").toBeLessThan(
+      at('name="collection"'),
+    );
+    expect(at("<RuleValueField")).toBeLessThan(at('name="collection"'));
+  });
+
+  it("numbers the headings from what it renders, rather than writing them out", () => {
+    // #445 makes the scope conditional — a campaign priced from a file has no scope to
+    // choose — and a form that jumps from "1 · Rule" to "3 · Schedule" reads as a step
+    // gone missing.
+    expect(EDITOR).toContain("numberSections(");
+    expect(EDITOR).not.toMatch(/heading="\d+ · /);
+  });
+
+  it("prefills the name and says who sees it", () => {
+    // Empty and required is a blocker in front of a decision. RUBIX leaves it empty and
+    // it is the first thing on their page; NA prefills a timestamp and adds a line
+    // saying customers will not see it, which is the question a merchant actually has.
+    expect(EDITOR).toContain("value={defaultName}");
+    expect(EDITOR).toMatch(/Customers never see it/);
+    expect(EDITOR, "a name built during render is a hydration mismatch").toContain(
+      "defaultName: `",
+    );
+  });
+
   it("previews the rule beside it, in the aside, rather than under it", () => {
     // It was directly under the rule, which on a form this long meant off screen while
     // the rule was being typed. The column is where it goes; what has to stay true is

--- a/app/lib/ui/sections.test.ts
+++ b/app/lib/ui/sections.test.ts
@@ -1,0 +1,51 @@
+/**
+ * A numbered form that is not always the same length still counts from one.
+ *
+ * The failure this prevents is small and unmistakable: a merchant reads "1 · Rule" and
+ * then "3 · Schedule", and spends a moment looking for the step they skipped. It arrives
+ * the day a section becomes conditional, which is #445 — a campaign priced from a file
+ * has no scope to choose.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { numberSections } from "./sections";
+
+const RULE = { key: "rule", title: "Rule" };
+const SCOPE = { key: "scope", title: "Scope" };
+
+describe("numbering the sections that apply", () => {
+  it("numbers from one, in order", () => {
+    expect(numberSections([RULE, SCOPE])).toEqual({
+      rule: "1 · Rule",
+      scope: "2 · Scope",
+    });
+  });
+
+  it("closes the numbering up when one does not apply", () => {
+    expect(numberSections([RULE, { ...SCOPE, when: false }, { key: "when", title: "When" }])).toEqual(
+      { rule: "1 · Rule", when: "2 · When" },
+    );
+  });
+
+  it("gives an absent section no heading at all, rather than an empty one", () => {
+    // A heading of `""` renders a titled card with no title, which looks like a bug in
+    // the card rather than a section that was deliberately left out.
+    expect(numberSections([{ ...RULE, when: false }])).toEqual({});
+  });
+
+  it("treats an omitted `when` as present", () => {
+    expect(numberSections([RULE, { ...SCOPE, when: true }])).toEqual({
+      rule: "1 · Rule",
+      scope: "2 · Scope",
+    });
+  });
+
+  it("keys by name so the caller never counts", () => {
+    const headings = numberSections([SCOPE, RULE]);
+
+    expect(headings.rule, "reordering must not hand a section its neighbour's number").toBe(
+      "2 · Rule",
+    );
+  });
+});

--- a/app/lib/ui/sections.ts
+++ b/app/lib/ui/sections.ts
@@ -1,0 +1,43 @@
+/**
+ * Numbering a form's sections, when the form is not always the same length.
+ *
+ * The campaign editor is a numbered sequence — "1 · Rule", "2 · Scope" — and it is about
+ * to stop having a fixed number of steps: a campaign priced from a file has no scope to
+ * choose, because the file is the scope, so that section will not be rendered at all
+ * (#445). NA does exactly this and it reads as the form being only as long as the choice
+ * requires.
+ *
+ * Hardcoding the numbers means the day a section is dropped the merchant reads "1 · Rule"
+ * followed by "3 · Schedule" and wonders what they missed. Numbering what is present is
+ * one line and cannot do that.
+ */
+
+/** A section that may or may not be part of this form. */
+export interface SectionSpec {
+  /** Stable name, so a caller can look its heading up without counting. */
+  key: string;
+  title: string;
+  /** Absent or true renders it; false leaves it out and closes the numbering up. */
+  when?: boolean;
+}
+
+/**
+ * Headings for the sections that apply, numbered from one in order.
+ *
+ * Returns a lookup rather than an array because the caller renders each section in its
+ * own place in the JSX: asking for `headings.rule` reads better at the call site than
+ * indexing a list, and it cannot silently pick up the wrong heading when the order
+ * changes.
+ */
+export function numberSections(sections: SectionSpec[]): Record<string, string> {
+  const headings: Record<string, string> = {};
+  let n = 0;
+
+  for (const section of sections) {
+    if (section.when === false) continue;
+    n += 1;
+    headings[section.key] = `${n} · ${section.title}`;
+  }
+
+  return headings;
+}

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -9,6 +9,7 @@ import { facets } from "../services/segments.server";
 import { createCampaign } from "../services/campaigns/index.server";
 import { joinDateAndTime, localInputToUtc, type Schedule } from "../lib/scheduling/window";
 import { presetStartFor } from "../lib/scheduling/calendar";
+import { formatDay } from "../lib/format/display";
 import { describeAdjustment } from "../lib/markets/describe";
 import {
   profileNameFor,
@@ -32,6 +33,7 @@ import { DraftPreview } from "../components/DraftPreview";
 import { RuleValueField } from "../components/RuleValueField";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
 import { HelpNote } from "../components/HelpNote";
+import { numberSections } from "../lib/ui/sections";
 import { SPACE } from "../lib/ui/spacing";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
@@ -120,6 +122,11 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
   ].sort();
 
   return {
+    // Prefilled, so naming a campaign is never the thing standing between a merchant and
+    // a rule. Built here rather than in the component: a name containing today's date
+    // computed during render is two different strings on the server and in the browser,
+    // which is the hydration mismatch `formatAgo` carries a paragraph about avoiding.
+    defaultName: `${practice ? "Practice" : "Sale"} · ${formatDay(new Date(), shop.timezone)}`,
     timeZone: shop.timezone,
     priceLists,
     currencies,
@@ -252,6 +259,7 @@ export default function NewCampaign() {
     presetStart,
     gates,
     planName,
+    defaultName,
   } = useLoaderData<typeof loader>();
 
   // The live price preview. Debounced, because it plans the whole scope on every call
@@ -277,6 +285,14 @@ export default function NewCampaign() {
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
 
+  // Numbered from what is actually rendered. Both sections apply today; #445 makes the
+  // scope conditional, because a campaign priced from a file has no scope to choose, and
+  // a form that jumps from "1 · Rule" to "3 · Schedule" reads as a step gone missing.
+  const headings = numberSections([
+    { key: "rule", title: "Rule" },
+    { key: "scope", title: "Scope" },
+  ]);
+
   return (
     <PageShell
       heading={practice ? "Practice campaign" : guided ? "Your first campaign" : "New campaign"}
@@ -300,9 +316,10 @@ export default function NewCampaign() {
       {guided ? (
         <s-banner tone="info">
           <s-paragraph>
-            Start small. Narrow the scope below to a handful of products — five is
-            plenty — so your first run is quick and easy to check. You will see every
-            price that would change before anything is applied.
+            Start small. Set your rule, then narrow the scope to a handful of
+            products — five is plenty — so your first run is quick and easy to check.
+            The panel beside it shows every price that would change, before anything is
+            applied.
           </s-paragraph>
         </s-banner>
       ) : null}
@@ -326,79 +343,7 @@ export default function NewCampaign() {
             exactly this case. Without it two cards touch and read as one card with a
             line through it. */}
         <PageSections>
-      <s-section heading="1 · Scope">
-        <s-paragraph>
-          Leave everything blank to target the whole catalogue. Conditions combine
-          with AND.
-        </s-paragraph>
-
-        <FieldGrid>
-          <FullRow>
-            <s-select name="segment" label="Saved segment">
-              <s-option value="" defaultSelected={!selected.segment}>
-                Build a filter below instead
-              </s-option>
-              {segments.map((segment) => (
-                <s-option
-                  key={segment.id}
-                  value={segment.id}
-                  defaultSelected={selected.segment === segment.id}
-                >
-                  {segment.name} ({segment.kind === "DYNAMIC" ? "dynamic" : "frozen"})
-                </s-option>
-              ))}
-            </s-select>
-          </FullRow>
-
-          {usingSegment ? (
-            <FullRow>
-              <s-banner tone="info">
-                <s-paragraph>
-                  Targeting the segment <s-text>{usingSegment.name}</s-text>. The filter
-                  below is ignored.{" "}
-                  {usingSegment.kind === "DYNAMIC"
-                    ? "It re-checks its filter on every run, so products added later join this campaign."
-                    : "Its product list is pinned, so this campaign hits exactly those products and nothing added later."}
-                </s-paragraph>
-              </s-banner>
-            </FullRow>
-          ) : null}
-
-          <s-select name="collection" label="Collection">
-            <s-option value="" defaultSelected={!selected.collection}>
-              Any collection
-            </s-option>
-            {available.collections.map((c) => (
-              <s-option key={c} value={c} defaultSelected={selected.collection === c}>
-                {c}
-              </s-option>
-            ))}
-          </s-select>
-          <s-select name="vendor" label="Vendor">
-            <s-option value="" defaultSelected={!selected.vendor}>
-              Any vendor
-            </s-option>
-            {available.vendors.map((v) => (
-              <s-option key={v} value={v} defaultSelected={selected.vendor === v}>
-                {v}
-              </s-option>
-            ))}
-          </s-select>
-          <s-select name="tag" label="Tag">
-            <s-option value="" defaultSelected={!selected.tag}>
-              Any tag
-            </s-option>
-            {available.tags.map((t) => (
-              <s-option key={t} value={t} defaultSelected={selected.tag === t}>
-                {t}
-              </s-option>
-            ))}
-          </s-select>
-          <s-text-field name="title" label="Title contains" value={selected.title} />
-        </FieldGrid>
-      </s-section>
-
-      <s-section heading="2 · Rule">
+      <s-section heading={headings.rule}>
           <s-stack gap={SPACE.section}>
             {/* The rule, and nothing else, first.
 
@@ -414,7 +359,13 @@ export default function NewCampaign() {
                   and a title above the settings that describe it is the shape every form
                   of this kind takes. */}
               <FullRow>
-                <s-text-field name="name" label="Campaign name" value="Sale" required />
+                <s-text-field
+                  name="name"
+                  label="Campaign name"
+                  value={defaultName}
+                  details="For you and your team. Customers never see it — use the storefront tags below if you want your theme to badge the sale."
+                  required
+                />
               </FullRow>
 
               {/* Not wrapped in a `FullRow`, deliberately. This renders *two* fields — the
@@ -640,6 +591,78 @@ export default function NewCampaign() {
             </ActionRow>
           </s-stack>
       </s-section>
+      <s-section heading={headings.scope}>
+        <s-paragraph>
+          Which variants the rule above applies to. Leave everything blank to target the
+          whole catalogue; conditions combine with AND.
+        </s-paragraph>
+
+        <FieldGrid>
+          <FullRow>
+            <s-select name="segment" label="Saved segment">
+              <s-option value="" defaultSelected={!selected.segment}>
+                Build a filter below instead
+              </s-option>
+              {segments.map((segment) => (
+                <s-option
+                  key={segment.id}
+                  value={segment.id}
+                  defaultSelected={selected.segment === segment.id}
+                >
+                  {segment.name} ({segment.kind === "DYNAMIC" ? "dynamic" : "frozen"})
+                </s-option>
+              ))}
+            </s-select>
+          </FullRow>
+
+          {usingSegment ? (
+            <FullRow>
+              <s-banner tone="info">
+                <s-paragraph>
+                  Targeting the segment <s-text>{usingSegment.name}</s-text>. The filter
+                  below is ignored.{" "}
+                  {usingSegment.kind === "DYNAMIC"
+                    ? "It re-checks its filter on every run, so products added later join this campaign."
+                    : "Its product list is pinned, so this campaign hits exactly those products and nothing added later."}
+                </s-paragraph>
+              </s-banner>
+            </FullRow>
+          ) : null}
+
+          <s-select name="collection" label="Collection">
+            <s-option value="" defaultSelected={!selected.collection}>
+              Any collection
+            </s-option>
+            {available.collections.map((c) => (
+              <s-option key={c} value={c} defaultSelected={selected.collection === c}>
+                {c}
+              </s-option>
+            ))}
+          </s-select>
+          <s-select name="vendor" label="Vendor">
+            <s-option value="" defaultSelected={!selected.vendor}>
+              Any vendor
+            </s-option>
+            {available.vendors.map((v) => (
+              <s-option key={v} value={v} defaultSelected={selected.vendor === v}>
+                {v}
+              </s-option>
+            ))}
+          </s-select>
+          <s-select name="tag" label="Tag">
+            <s-option value="" defaultSelected={!selected.tag}>
+              Any tag
+            </s-option>
+            {available.tags.map((t) => (
+              <s-option key={t} value={t} defaultSelected={selected.tag === t}>
+                {t}
+              </s-option>
+            ))}
+          </s-select>
+          <s-text-field name="title" label="Title contains" value={selected.title} />
+        </FieldGrid>
+      </s-section>
+
         </PageSections>
       </Form>
 


### PR DESCRIPTION
Closes #447.

A merchant arrives having already decided "20% off boots". The form opened on boots — five
filter controls and a match count, with the name and rule below them. Every competitor asks
for the change first, because it is the decision that was already made before the page
loaded.

**Rule first, then scope.** The scope's lead-in now says what it is for ("which variants the
rule above applies to"), and the guided banner points at the preview beside the form rather
than "below".

**The headings are numbered from what is rendered.** No visible change today — it is
groundwork for #445, where a campaign priced from a file has no scope to choose and a form
that jumps from "1 · Rule" to "3 · Schedule" reads as a step gone missing.

**The name is prefilled and says who sees it.** Empty-and-required is a blocker in front of
a decision. Built in the loader, not during render: a name containing today's date computed
in both places is two different strings.

### Verification

- `npm test` — 142 files, 2337 tests · typecheck, lint (0 errors), build
- Four mutations, each caught and reverted: the two headings swapped; a heading written out
  as `"1 · Rule"`; the name back to a fixed `"Sale"`; `numberSections` not closing up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)