### PR TITLE
The editor paints before it prices

### DIFF
--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -17,11 +17,25 @@ import type { DraftPreview as Preview } from "../services/campaigns/draft-previe
  * written — a preview that showed only the happy rows would be the estimate it claims
  * not to be.
  */
-export function DraftPreview({ preview }: { preview: Preview | null }) {
+export function DraftPreview({
+  preview,
+  pending = false,
+}: {
+  preview: Preview | null;
+  /** A request is in flight. See the note on the first branch below. */
+  pending?: boolean;
+}) {
   if (!preview) {
     return (
       <s-paragraph>
-        <s-text color="subdued">Set a rule to see what it would do.</s-text>
+        <s-text color="subdued">
+          {/* "Set a rule" is wrong while one is being priced — and on first load a rule
+              is already set, so it would be wrong immediately. The panel used to be
+              primed by the loader, which is what made that sentence unreachable; asking
+              from the client instead (#468) makes this the first thing a merchant reads,
+              for about a second. */}
+          {pending ? "Working out what this would do…" : "Set a rule to see what it would do."}
+        </s-text>
       </s-paragraph>
     );
   }
@@ -60,6 +74,12 @@ export function DraftPreview({ preview }: { preview: Preview | null }) {
           <strong>{formatCount(preview.changing)}</strong> of {formatCount(preview.matched)}{" "}
           variants would change price.
         </s-text>
+        {/* The previous answer stays while a new one is computed, marked as stale rather
+            than replaced by a placeholder. Blanking the panel on every keystroke would
+            make the numbers flicker and give a merchant nothing to compare against. */}
+        {pending ? (
+          <s-text color="subdued"> · updating…</s-text>
+        ) : null}
       </s-paragraph>
 
       {/* Every row that will not move, and why. A merchant who expected 400 and sees 380

--- a/app/components/draft-preview.test.tsx
+++ b/app/components/draft-preview.test.tsx
@@ -44,8 +44,8 @@ const preview = (over: Partial<Preview> = {}): Preview => ({
   ...over,
 });
 
-const render = (value: Preview | null) =>
-  renderToStaticMarkup(<DraftPreview preview={value} />);
+const render = (value: Preview | null, pending = false) =>
+  renderToStaticMarkup(<DraftPreview preview={value} pending={pending} />);
 
 describe("the before column is the baseline", () => {
   it("heads the column with the number the arithmetic starts from", () => {
@@ -98,6 +98,25 @@ describe("when the storefront disagrees with the baseline", () => {
 describe("the states that are not a table", () => {
   it("asks for a rule before there is one", () => {
     expect(render(null)).toContain("Set a rule");
+  });
+
+  it("says it is working rather than asking for a rule that is already set", () => {
+    // The first thing a merchant reads, for about a second: the panel is asked for on
+    // mount, and the form already has a rule in it. "Set a rule" would be wrong on
+    // arrival and wrong again on every scope change.
+    const html = render(null, true);
+
+    expect(html).toContain("Working out");
+    expect(html).not.toContain("Set a rule");
+  });
+
+  it("keeps the last answer on screen while a new one is computed", () => {
+    // Blanking on every keystroke makes the numbers flicker and leaves nothing to
+    // compare the new answer against.
+    const html = render(preview(), true);
+
+    expect(html).toContain("$32.00");
+    expect(html).toContain("updating");
   });
 
   it("names the scope as the thing that matched nothing", () => {

--- a/app/lib/campaigns/draft-defaults.test.ts
+++ b/app/lib/campaigns/draft-defaults.test.ts
@@ -14,7 +14,7 @@
  * So: the values live in one object, and this refuses a literal of them anywhere else.
  */
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -28,6 +28,10 @@ const sourceOf = (path: string) =>
     .replace(/^\s*\/\/.*$/gm, "");
 
 const EDITOR = sourceOf("app/routes/app.campaigns.new.tsx");
+
+const ROUTES = readdirSync(join(process.cwd(), "app", "routes"))
+  .filter((name) => name.endsWith(".tsx") && !name.includes(".test."))
+  .map((name) => ({ name, source: sourceOf(join("app", "routes", name)) }));
 const RULE_FIELD = sourceOf("app/components/RuleValueField.tsx");
 
 describe("the defaults are a value, not a literal in two files", () => {
@@ -43,17 +47,33 @@ describe("the defaults are a value, not a literal in two files", () => {
     }
   });
 
-  it("primes the loader's preview from the same object", () => {
-    expect(EDITOR).toContain("draftDefaultParams()");
-    expect(EDITOR).toContain("previewDraft(");
+  it("asks for the preview from the client, once, on mount", () => {
+    // Not from the loader. `previewDraft` loads every candidate in scope and plans all
+    // of them, because the counts are exact — in front of first paint that is a minute
+    // of blank page on a catalogue of any size (#468), and blank has nowhere to put a
+    // spinner.
+    expect(EDITOR).toContain("submitPreview()");
+    expect(EDITOR).toContain("previewFetcher.state");
+  });
+});
+
+describe("no loader prices a draft before the page paints", () => {
+  it("finds routes to check, so this cannot pass by checking nothing", () => {
+    expect(ROUTES.length).toBeGreaterThan(15);
   });
 
-  it("seeds the shop's own rounding rather than letting it fall back to none", () => {
-    // `readRoundingPolicy` returns "none" when the field is absent, and the select
-    // renders the store setting as its chosen option. Seeding nothing means a preview
-    // that rounds differently from the form beside it.
-    expect(EDITOR).toContain('seeded.set("rounding.default", settings.rounding.default)');
-    expect(EDITOR).toMatch(/rounding\.\$\{code\}/);
+  it("leaves previewDraft to the resource route the client posts to", () => {
+    // Read from the routes directory rather than a list: the temptation to prime the
+    // panel server-side will come back, and it will come back on a store small enough
+    // for the author not to notice.
+    const offenders = ROUTES.filter(
+      ({ name, source }) => name !== "app.preview-draft.tsx" && source.includes("previewDraft("),
+    ).map(({ name }) => name);
+
+    expect(
+      offenders,
+      "a loader that prices the whole scope puts that work in front of first paint",
+    ).toEqual([]);
   });
 });
 

--- a/app/lib/campaigns/draft-defaults.ts
+++ b/app/lib/campaigns/draft-defaults.ts
@@ -1,15 +1,15 @@
 /**
  * What the campaign editor's form says before a merchant touches it.
  *
- * These used to live only in the JSX, which was fine while the only thing that read the
- * form was the form's own submit. It stopped being fine when the loader started pricing
- * the draft server-side so the preview is populated on first paint: the loader has no
- * form to read, so it has to know what the unedited form would have said, and a second
- * copy of "-20" is a preview that disagrees with the editor it previews.
+ * These used to live only in the JSX, spelled out as literals next to the fields that
+ * rendered them. That is fine while one thing reads the form — its own submit — and it
+ * stops being fine the moment anything has to know what an untouched form would say
+ * without a form in front of it.
  *
- * One object, imported by the fields that render the defaults and by the loader that
- * prices them. `draft-defaults.test.ts` checks the editor still renders these rather
- * than literals of its own.
+ * One object, imported by the fields that render the defaults. `draft-defaults.test.ts`
+ * checks the editor still renders these rather than literals of its own, which is the
+ * property worth keeping: a "-20" written out beside the field is a value that can drift
+ * from every other statement of what this form does.
  */
 export const DRAFT_DEFAULTS = {
   /** Percent change, which is what nearly every campaign is. */
@@ -25,10 +25,15 @@ export const DRAFT_DEFAULTS = {
 } as const;
 
 /**
- * The defaults as form fields, for the loader's first-paint preview.
+ * The defaults as form fields — what the editor posts if a merchant submits it untouched.
  *
- * Rounding is deliberately absent: it comes from the shop's own setting, and seeding a
- * default here would preview a rounding rule the merchant never chose.
+ * Nothing in the app builds this: the preview is asked for by the client, which posts the
+ * real form. It exists so the tests that matter can be written against a value rather
+ * than against a hand-typed copy of one — that both readings of the fields agree, and
+ * that the unedited form prices as a percent discount off the baseline.
+ *
+ * Rounding is deliberately absent: it comes from the shop's own setting, and a default
+ * here would describe a rounding rule the merchant never chose.
  */
 export function draftDefaultParams(): URLSearchParams {
   return new URLSearchParams({

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -24,9 +24,6 @@ import { billingFrom } from "../services/billing.server";
 import { canUseSurface } from "../lib/billing/plans";
 import prisma from "../db.server";
 import { astFrom, compareAtFrom, readerFor, ruleFrom } from "../lib/campaigns/draft-form";
-import { draftDefaultParams } from "../lib/campaigns/draft-defaults";
-import { draftCampaignFrom } from "../services/campaigns/draft-input.server";
-import { previewDraft } from "../services/campaigns/draft-preview.server";
 import { PageSections, PageShell } from "../components/PageShell";
 import { UnsavedChanges } from "../components/UnsavedChanges";
 import { DraftPreview } from "../components/DraftPreview";
@@ -95,25 +92,18 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
 
   const billing = billingFrom(shopRecord);
 
-  // The preview the merchant would get if they changed nothing, computed here so the
-  // panel arrives populated rather than saying "set a rule" next to a rule that is
-  // already set. The scope comes from the URL — a merchant who arrived from a segment or
-  // from the calendar has already made that choice — and the rule from the same defaults
-  // the fields render, so this and the first keystroke agree.
-  const seeded = draftDefaultParams();
-  // Rounding is the shop's, not a default of its own: the select renders the store
-  // setting as its chosen option, so a preview built without it would round differently
-  // from the form sitting next to it. `readRoundingPolicy` falls back to "none" when the
-  // field is absent, which is precisely the disagreement to avoid.
-  seeded.set("rounding.default", settings.rounding.default);
-  for (const [code, profile] of Object.entries(settings.rounding.byCurrency)) {
-    seeded.set(`rounding.${code}`, profile);
-  }
-  for (const [key, value] of url.searchParams) if (value) seeded.set(key, value);
-  const preview = await previewDraft(
-    shop.id,
-    await draftCampaignFrom(shop.id, seeded, currency),
-  );
+  // No preview here, deliberately, and this is load-bearing enough to be worth a
+  // paragraph.
+  //
+  // #442 primed the panel from the loader so it arrived populated. `previewDraft` has to
+  // load *every* candidate in scope and plan all of them — the counts are exact, so it
+  // cannot sample — and only then keeps 25 rows to show. In front of first paint that is
+  // a minute of blank page on a 3,669-variant store and worse on a hundred thousand
+  // (#468). Blank is the bad part: nothing has rendered, so there is nothing to put a
+  // spinner in, and the page is indistinguishable from the app being broken.
+  //
+  // The client asks for it instead, once, on mount. Same work, off the critical path,
+  // with somewhere to say it is working.
 
   // Every currency this campaign could price in. Only these are offered: a list of all
   // 180 world currencies would bury the two or three that matter.
@@ -141,7 +131,6 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
     storeRounding: settings.rounding,
     roundingOptions: Object.entries(ROUNDING_LABELS).map(([value, label]) => ({ value, label })),
     facets: available,
-    preview,
     segments,
     usingSegment: segment ? { id: segment.id, name: segment.name, kind: segment.kind } : null,
     practice,
@@ -245,7 +234,6 @@ export const action = withGuard("/app/campaigns/new", async ({ request }: Action
 export default function NewCampaign() {
   const {
     facets: available,
-    preview,
     selected,
     segments,
     usingSegment,
@@ -268,21 +256,33 @@ export default function NewCampaign() {
   const formRef = useRef<HTMLFormElement>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const submitPreview = useCallback(() => {
+    const form = formRef.current;
+    if (!form) return;
+    previewFetcher.submit(new FormData(form), {
+      method: "post",
+      action: "/app/preview-draft",
+    });
+  }, [previewFetcher]);
+
   const requestPreview = useCallback(() => {
     if (timer.current) clearTimeout(timer.current);
-    timer.current = setTimeout(() => {
-      const form = formRef.current;
-      if (!form) return;
-      previewFetcher.submit(new FormData(form), {
-        method: "post",
-        action: "/app/preview-draft",
-      });
-    }, 400);
-  }, [previewFetcher]);
+    timer.current = setTimeout(submitPreview, 400);
+  }, [submitPreview]);
 
   // Clear the pending call on unmount, so navigating away mid-type does not fire a
   // request against a page that is gone.
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+  // Once, on mount, undebounced. The loader used to do this so the panel arrived
+  // populated, which put a minute of blank page in front of first paint on a catalogue
+  // of any size (#468). Asking from here is the same work with the page already drawn
+  // around it, so there is somewhere to say it is being worked out.
+  //
+  // Empty dependencies deliberately: this is "when the page appears", not "whenever the
+  // submit function changes identity". Every later request comes from `onChange`.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { submitPreview(); }, []);
 
 
   // Numbered from what is actually rendered. Both sections apply today; #445 makes the
@@ -678,7 +678,10 @@ export default function NewCampaign() {
           primes it so the panel arrives populated, and the fetcher replaces it from the
           first keystroke onward. */}
       <s-section slot="aside" heading="What this would do">
-        <DraftPreview preview={previewFetcher.data ?? preview} />
+        <DraftPreview
+          preview={previewFetcher.data ?? null}
+          pending={previewFetcher.state !== "idle"}
+        />
       </s-section>
 
       <HelpNote label="Nothing is written yet">


### PR DESCRIPTION
Closes #468. Regression from #442, caught verifying it in production.

#442 primed the preview from the loader so it arrived populated. `previewDraft` loads
**every** candidate in scope and plans all of them — the counts are exact, so it cannot
sample. In front of first paint that was upwards of a minute on `dartmode-labs` (3,669
variants), and the page rendered **blank** while it waited: nothing has rendered, so there
is nowhere to put a spinner, and it is indistinguishable from the app being broken.

**The client asks for it now** — once, on mount, undebounced. Same work, off the critical
path, with the page drawn around it. The panel says "Working out what this would do…"
instead of "Set a rule" (which was wrong on arrival, since a rule is already set), and
later requests leave the previous answer up marked `· updating…` rather than blanking on
every keystroke.

#442's acceptance still holds: populated, no button to press.

**A guard, not just a fix.** `draft-defaults.test.ts` reads the routes directory and
refuses `previewDraft` in any route but the resource one. That temptation will return, and
on a store small enough for whoever tries it not to notice.

### Verification

- `npm test` — 144 files, 2355 tests · typecheck, lint (0 errors), build
- Four mutations, each caught and reverted: mount effect removed; a loader pricing a draft
  again; the pending sentence dropped; a stale answer left unmarked.
- To confirm on `dartmode-labs` after deploy: first paint in seconds, panel fills shortly
  after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)