### PR TITLE
The preview's first request is built, not read off the form

### DIFF
--- a/app/lib/campaigns/draft-defaults.test.ts
+++ b/app/lib/campaigns/draft-defaults.test.ts
@@ -52,8 +52,19 @@ describe("the defaults are a value, not a literal in two files", () => {
     // of them, because the counts are exact — in front of first paint that is a minute
     // of blank page on a catalogue of any size (#468), and blank has nowhere to put a
     // spinner.
-    expect(EDITOR).toContain("submitPreview()");
     expect(EDITOR).toContain("previewFetcher.state");
+    expect(EDITOR).toMatch(/useEffect\(\(\) => \{[\s\S]*?previewFetcher\.submit/);
+  });
+
+  it("builds that first request rather than reading a form that is not ready", () => {
+    // Serialising the fields at mount described a scope that matched nothing where an
+    // empty filter matches everything (#470). Only later requests read the form.
+    expect(EDITOR).toContain("firstPreviewParams(");
+    expect(EDITOR).toMatch(/useEffect\(\(\) => \{[\s\S]*?new URLSearchParams\(firstPreview\)/);
+    expect(
+      EDITOR,
+      "the mount request is reading the form again, which is where #470 came from",
+    ).not.toMatch(/useEffect\(\(\) => \{[\s\S]*?submitPreview\(\)[\s\S]*?\}, \[\]\)/);
   });
 });
 

--- a/app/lib/campaigns/first-preview.test.ts
+++ b/app/lib/campaigns/first-preview.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The preview's first request describes the form a merchant is looking at.
+ *
+ * It cannot be read off that form. At mount the editor's fields are Polaris custom
+ * elements, and serialising them at that instant produced a scope matching nothing where
+ * an empty filter matches everything — the panel said "Nothing matches this scope" beside
+ * a catalogue of 3,669 (#470). So this builds the payload instead, and only later
+ * requests read the form.
+ *
+ * Which makes it the one statement of what an untouched editor asks for, and worth
+ * pinning: the failure it prevents is a merchant's first impression of the panel being a
+ * confidently wrong number, which is worse than no number.
+ *
+ * In `lib/` rather than beside the route for two reasons, both learned the hard way: a
+ * `.test.ts` under `app/routes/` becomes a route and breaks the browser build, and
+ * importing the route to reach the function drags in `shopify.server` and Prisma.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { DRAFT_DEFAULTS } from "./draft-defaults";
+import { firstPreviewParams } from "./first-preview";
+
+const ROUNDING = { default: "charm99", byCurrency: { JPY: "whole" } };
+const noUrl = () => new URLSearchParams();
+
+describe("what an untouched editor asks for", () => {
+  it("carries the rule the fields render", () => {
+    const params = firstPreviewParams(ROUNDING, noUrl());
+
+    expect(params.get("ruleKind")).toBe(DRAFT_DEFAULTS.ruleKind);
+    expect(params.get("ruleValue")).toBe(DRAFT_DEFAULTS.percentValue);
+    expect(params.get("compareAt")).toBe(DRAFT_DEFAULTS.compareAt);
+  });
+
+  it("carries no scope, because an empty filter is every variant", () => {
+    // The bug: anything in here that reaches `astFrom` as a condition turns "everything"
+    // into "nothing", and the panel reports that as an empty scope rather than an error.
+    const params = firstPreviewParams(ROUNDING, noUrl());
+
+    for (const field of ["collection", "tag", "vendor", "title", "segment"]) {
+      expect(params.get(field), `${field} narrows a scope nobody narrowed`).toBeNull();
+    }
+  });
+
+  it("carries the shop's rounding, not the fallback of none", () => {
+    // `readRoundingPolicy` falls back to "none" when the field is absent, while the
+    // select renders the store's setting — so omitting it previews a rounding rule the
+    // merchant can see is not the one selected.
+    const params = firstPreviewParams(ROUNDING, noUrl());
+
+    expect(params.get("rounding.default")).toBe("charm99");
+    expect(params.get("rounding.JPY")).toBe("whole");
+  });
+});
+
+describe("choices the merchant has already made", () => {
+  it("takes the scope from the URL, which is what the fields render", () => {
+    const params = firstPreviewParams(ROUNDING, new URLSearchParams("collection=Outerwear&tag=sale"));
+
+    expect(params.get("collection")).toBe("Outerwear");
+    expect(params.get("tag")).toBe("sale");
+  });
+
+  it("lets a segment through, since it replaces the filter entirely", () => {
+    expect(firstPreviewParams(ROUNDING, new URLSearchParams("segment=seg_1")).get("segment")).toBe(
+      "seg_1",
+    );
+  });
+
+  it("ignores an empty parameter rather than treating it as a filter", () => {
+    // `?collection=` is how a cleared select arrives. Setting it would scope the preview
+    // to products whose collection is the empty string, which is none of them — the same
+    // shape as the bug this function exists to fix.
+    expect(
+      firstPreviewParams(ROUNDING, new URLSearchParams("collection=")).get("collection"),
+    ).toBeNull();
+  });
+
+  it("keeps the shop's rounding when the URL carries unrelated parameters", () => {
+    const params = firstPreviewParams(ROUNDING, new URLSearchParams("startAt=2026-09-01&guided=1"));
+
+    expect(params.get("rounding.default")).toBe("charm99");
+    expect(params.get("startAt")).toBe("2026-09-01");
+  });
+});

--- a/app/lib/campaigns/first-preview.ts
+++ b/app/lib/campaigns/first-preview.ts
@@ -1,0 +1,32 @@
+import { draftDefaultParams } from "./draft-defaults";
+
+/**
+ * The request that populates the preview before the merchant has touched anything.
+ *
+ * Built rather than read off the form, because at mount the form does not yet describe
+ * what is on screen: the fields are Polaris custom elements, and serialising them at
+ * that instant produced a scope that matched nothing where an empty filter should match
+ * everything (#470). Every request after this one reads the form, by which time it is
+ * trustworthy.
+ *
+ * Rounding comes from the shop. `readRoundingPolicy` falls back to `"none"` when the
+ * field is absent while the select renders the store's setting, so leaving it out is a
+ * preview that rounds differently from the form beside it.
+ *
+ * The URL wins last: a merchant who arrived from a segment, a collection or the calendar
+ * has already made those choices, and the fields render them.
+ */
+export function firstPreviewParams(
+  rounding: { default: string; byCurrency: Record<string, string> },
+  from: URLSearchParams,
+): URLSearchParams {
+  const params = draftDefaultParams();
+
+  params.set("rounding.default", rounding.default);
+  for (const [code, profile] of Object.entries(rounding.byCurrency)) {
+    params.set(`rounding.${code}`, profile);
+  }
+  for (const [key, value] of from) if (value) params.set(key, value);
+
+  return params;
+}

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -30,6 +30,7 @@ import { DraftPreview } from "../components/DraftPreview";
 import { RuleValueField } from "../components/RuleValueField";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
 import { HelpNote } from "../components/HelpNote";
+import { firstPreviewParams } from "../lib/campaigns/first-preview";
 import { numberSections } from "../lib/ui/sections";
 import { SPACE } from "../lib/ui/spacing";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
@@ -129,6 +130,10 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
     },
     planName: billing.plan.name,
     storeRounding: settings.rounding,
+    // What the untouched form describes, built here where it can be built reliably.
+    // See the note on the mount effect: reading the form for the *first* request gets a
+    // scope that matches nothing (#470).
+    firstPreview: firstPreviewParams(settings.rounding, url.searchParams).toString(),
     roundingOptions: Object.entries(ROUNDING_LABELS).map(([value, label]) => ({ value, label })),
     facets: available,
     segments,
@@ -154,6 +159,7 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
  * other cannot silently stop being filterable.
  */
 export const SCOPE_FIELDS = ["collection", "tag", "vendor", "title", "segment"] as const;
+
 
 /** Builds an AST from the simple scope form: all provided conditions ANDed. */
 
@@ -248,6 +254,7 @@ export default function NewCampaign() {
     gates,
     planName,
     defaultName,
+    firstPreview,
   } = useLoaderData<typeof loader>();
 
   // The live price preview. Debounced, because it plans the whole scope on every call
@@ -255,6 +262,7 @@ export default function NewCampaign() {
   const previewFetcher = useFetcher<Preview>();
   const formRef = useRef<HTMLFormElement>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const askedForPreview = useRef(false);
 
   const submitPreview = useCallback(() => {
     const form = formRef.current;
@@ -274,15 +282,30 @@ export default function NewCampaign() {
   // request against a page that is gone.
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
-  // Once, on mount, undebounced. The loader used to do this so the panel arrived
-  // populated, which put a minute of blank page in front of first paint on a catalogue
-  // of any size (#468). Asking from here is the same work with the page already drawn
-  // around it, so there is somewhere to say it is being worked out.
+  // Once, on mount, undebounced, from a payload the loader built rather than from the
+  // form.
   //
-  // Empty dependencies deliberately: this is "when the page appears", not "whenever the
-  // submit function changes identity". Every later request comes from `onChange`.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { submitPreview(); }, []);
+  // The loader used to price this itself, which put a minute of blank page in front of
+  // first paint (#468). Asking from here is the same work with the page already drawn
+  // around it — but reading `new FormData(form)` at mount describes something other than
+  // what is on screen: an empty filter came back matching nothing (#470). The fields are
+  // custom elements, and this is not a thing to bet a preview on. Every later request
+  // reads the form, by which point it is trustworthy.
+  //
+  // A ref rather than an empty dependency array, so the dependencies can be honest. The
+  // fetcher changes identity as it moves through its states, so listing it and firing
+  // every time would loop; an empty array would mean lying about that in a comment. This
+  // says what is meant — ask once — and survives StrictMode's double mount into the
+  // bargain.
+  useEffect(() => {
+    if (askedForPreview.current) return;
+    askedForPreview.current = true;
+
+    previewFetcher.submit(new URLSearchParams(firstPreview), {
+      method: "post",
+      action: "/app/preview-draft",
+    });
+  }, [firstPreview, previewFetcher]);
 
 
   // Numbered from what is actually rendered. Both sections apply today; #445 makes the


### PR DESCRIPTION
Closes #470. Regression from #468, caught verifying it in production.

With an empty scope the panel came back **"Nothing matches this scope"** beside a catalogue
of 3,669 — where an empty filter means every variant.

The resolver was not wrong; the request was. #442 built the same request server-side and
the panel read "3,669 of 3,669", so the only thing that changed is where the payload came
from: `new FormData(form)` at mount, over fields that are Polaris custom elements. An empty
filter reaching `astFrom` as a *condition* is the only way `matched` gets to zero — and the
panel reports that as an empty scope rather than an error, which is a confidently wrong
number and worse than no number.

`firstPreviewParams` builds it: rendered defaults, the shop's rounding, then the URL's own
scope. Later requests still read the form, where it is trustworthy.

Two traps avoided on the way: the helper lives in `lib/` because importing the route to
test it drags in `shopify.server` and Prisma, and because a `.test.ts` under `app/routes/`
becomes a route and breaks the browser build. The mount effect uses a ref rather than an
empty dependency array, so the deps are honest and it survives StrictMode's double mount.

### Verification

- `npm test` — 145 files, 2363 tests · typecheck, lint (0 errors), build
- Three mutations, each caught and reverted: an empty URL parameter treated as a filter;
  the shop's rounding omitted; the mount request reading the form again.
- To confirm after deploy: empty scope reads 3,669 of 3,669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)