### PR TITLE
One product, the way a customer will see it

### DIFF
--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -1,5 +1,6 @@
 import { formatCount } from "../lib/format/display";
 import { EmptyState } from "./AsyncState";
+import { exampleRowFrom, StorefrontExample } from "./StorefrontExample";
 import { SPACE } from "../lib/ui/spacing";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
@@ -20,10 +21,19 @@ import type { DraftPreview as Preview } from "../services/campaigns/draft-previe
 export function DraftPreview({
   preview,
   pending = false,
+  surface,
 }: {
   preview: Preview | null;
   /** A request is in flight. See the note on the first branch below. */
   pending?: boolean;
+  /**
+   * Which price the panel is showing, when the shop has more than one.
+   *
+   * `previewDraft` prices the base surface. On a single-market shop that needs no
+   * saying; on a shop with catalogues it very much does, because the merchant is looking
+   * at a card headed "on your storefront" and has three storefronts.
+   */
+  surface?: string;
 }) {
   if (!preview) {
     return (
@@ -67,8 +77,15 @@ export function DraftPreview({
     );
   }
 
+  const example = exampleRowFrom(preview.rows);
+
   return (
     <s-stack gap={SPACE.section}>
+      {/* Above the counts, because it answers a question asked before them: a merchant
+          who has typed a percentage wants to know what it looks like, and only then how
+          many products it reaches. */}
+      {example ? <StorefrontExample row={example} surface={surface} /> : null}
+
       <s-paragraph>
         <s-text>
           <strong>{formatCount(preview.changing)}</strong> of {formatCount(preview.matched)}{" "}

--- a/app/components/StorefrontExample.tsx
+++ b/app/components/StorefrontExample.tsx
@@ -1,0 +1,89 @@
+import { SPACE } from "../lib/ui/spacing";
+import type { DraftPreviewRow } from "../services/campaigns/draft-preview.server";
+
+/**
+ * One product, the way a customer will see it.
+ *
+ * The table below this answers "how many, and which?". This answers a different question,
+ * asked earlier and by a different part of the brain: *did I mean −20% or ×0.20, and is
+ * the strike-through going to look right?* Fifty rows set small answer the first badly and
+ * the second not at all.
+ *
+ * NA puts exactly this beside its rule and it is the clearest thing in their app. RUBIX
+ * does a weaker version with invented numbers — a "T-Shirt" at 100.00 that is in nobody's
+ * catalogue — which teaches a merchant the arithmetic and nothing about their own shop.
+ * This uses a real variant, at its real baseline, priced by the same `resolve()` as the
+ * run.
+ *
+ * It is also the only place in this app, or any of the three competitors', where a
+ * merchant sees what the customer sees before committing.
+ */
+export function StorefrontExample({
+  row,
+  /** Named when the shop has more than one, so "which price is this?" has an answer. */
+  surface,
+}: {
+  row: DraftPreviewRow;
+  surface?: string;
+}) {
+  // A compare-at above the price is what a storefront renders as a sale: the old price
+  // struck through and a badge. Below or equal is not a sale and must not be dressed as
+  // one — that is a claim about a discount that is not being given.
+  const onSale = Boolean(row.afterCompareAt) && row.afterCompareAt !== row.after;
+
+  return (
+    <s-box padding={SPACE.item} borderRadius="base" background="subdued">
+      <s-stack gap={SPACE.tight}>
+        <s-text color="subdued" type="strong">
+          On your storefront{surface ? ` · ${surface}` : ""}
+        </s-text>
+
+        <s-stack direction="inline" gap={SPACE.item} alignItems="center">
+          {row.imageUrl ? <s-thumbnail src={row.imageUrl} alt="" size="base" /> : null}
+
+          <s-stack gap={SPACE.tight}>
+            <s-text>{row.title}</s-text>
+
+            <s-stack direction="inline" gap={SPACE.tight} alignItems="center">
+              <s-text type="strong">{row.after ?? "—"}</s-text>
+              {/* `redundant`, not a CSS strike-through. Polaris documents this type for
+                  exactly this case — "no longer accurate… one such use-case is discounted
+                  prices" — and renders it as `<s>`, so a screen reader says so too. A line
+                  drawn with CSS is a line only sighted merchants see. */}
+              {onSale ? (
+                <s-text color="subdued" type="redundant">
+                  {row.afterCompareAt}
+                </s-text>
+              ) : null}
+              {onSale ? <s-badge tone="critical">Sale</s-badge> : null}
+            </s-stack>
+          </s-stack>
+        </s-stack>
+
+        {/* Where the number came from, in one line. The strike-through is the campaign's
+            compare-at policy, not the price it replaced, and a merchant who reads the
+            two as the same thing will expect a revert to restore what is struck out. */}
+        <s-text color="subdued">
+          Priced from a baseline of {row.before ?? "—"}
+          {row.live ? `, though the storefront currently shows ${row.live}` : ""}.
+        </s-text>
+      </s-stack>
+    </s-box>
+  );
+}
+
+/**
+ * The row to show, or nothing.
+ *
+ * Deterministic, and that is the whole requirement: `previewDraft` returns rows ordered
+ * changing, then already-correct, then skipped, so the first changing row is stable
+ * across keystrokes. Picking at random — or picking "the most interesting" — would make
+ * the card flicker between products while a merchant types a percentage, which is the
+ * one thing an example must not do.
+ *
+ * Nothing when no row is changing: an example of a price that is not moving teaches the
+ * opposite of what it is there to teach.
+ */
+export function exampleRowFrom(rows: DraftPreviewRow[]): DraftPreviewRow | null {
+  return rows.find((row) => !row.unchanged && !row.skippedReason) ?? null;
+}

--- a/app/components/storefront-example.test.tsx
+++ b/app/components/storefront-example.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * What the customer will see, before anything is written.
+ *
+ * The table beside this answers "how many, and which?". This answers the question asked
+ * first: *did I mean −20% or ×0.20, and is the strike-through going to look right?* NA
+ * puts the same card beside its rule and it is the clearest thing in their app; RUBIX
+ * does a version of it with invented numbers, which teaches the arithmetic and nothing
+ * about the merchant's own shop.
+ *
+ * Two things here are correctness rather than presentation, and both are asserted:
+ *
+ * - **A sale badge is a claim.** Rendering one when the compare-at does not exceed the
+ *   price tells a merchant their storefront will show a discount that it will not.
+ * - **The example must not move while a merchant types.** A card that changes product
+ *   between keystrokes cannot be compared against itself, which is the only thing an
+ *   example is for.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { exampleRowFrom, StorefrontExample } from "./StorefrontExample";
+import type { DraftPreviewRow } from "../services/campaigns/draft-preview.server";
+
+const row = (over: Partial<DraftPreviewRow> = {}): DraftPreviewRow => ({
+  variantGid: "gid://shopify/ProductVariant/1",
+  title: "Cotton tee · M",
+  imageUrl: "https://cdn.example/tee.png",
+  before: "$40.00",
+  live: null,
+  after: "$32.00",
+  beforeCompareAt: null,
+  afterCompareAt: "$40.00",
+  unchanged: false,
+  skippedReason: null,
+  ...over,
+});
+
+const render = (value: DraftPreviewRow, surface?: string) =>
+  renderToStaticMarkup(<StorefrontExample row={value} surface={surface} />);
+
+describe("the card a customer would see", () => {
+  it("leads with the price they will pay", () => {
+    expect(render(row())).toContain("$32.00");
+  });
+
+  it("strikes the compare-at through semantically, not with a line only sighted merchants see", () => {
+    // Polaris documents `redundant` for exactly this — "no longer accurate… one such
+    // use-case is discounted prices" — and renders `<s>`.
+    expect(render(row())).toContain('type="redundant"');
+  });
+
+  it("says which baseline the price came from", () => {
+    expect(render(row())).toContain("baseline of $40.00");
+  });
+
+  it("mentions the storefront's own price when it has drifted from the baseline", () => {
+    expect(render(row({ live: "$28.00" }))).toContain("storefront currently shows $28.00");
+  });
+
+  it("names the surface when the shop has more than one", () => {
+    expect(render(row(), "base price · USD")).toContain("base price · USD");
+  });
+
+  it("says nothing about surfaces on a shop with one", () => {
+    // Narrow, because the variant title has its own separator in it — "Cotton tee · M".
+    expect(render(row())).toContain("On your storefront<");
+    expect(render(row())).not.toContain("On your storefront ·");
+  });
+});
+
+describe("a sale badge is a claim about the storefront", () => {
+  it("shows one when the compare-at is above the price", () => {
+    expect(render(row())).toContain("Sale");
+  });
+
+  it("shows none when the campaign leaves the compare-at alone", () => {
+    expect(render(row({ afterCompareAt: null }))).not.toContain("Sale");
+  });
+
+  it("shows none when the compare-at equals the price", () => {
+    // Equal is not a discount. A badge here promises a saving of nothing.
+    expect(render(row({ after: "$40.00", afterCompareAt: "$40.00" }))).not.toContain("Sale");
+  });
+});
+
+describe("choosing the example", () => {
+  const changing = row({ variantGid: "changing" });
+  const noop = row({ variantGid: "noop", unchanged: true });
+  const skipped = row({ variantGid: "skipped", skippedReason: "Below your cost floor" });
+
+  it("picks the first row whose price actually moves", () => {
+    expect(exampleRowFrom([noop, skipped, changing])?.variantGid).toBe("changing");
+  });
+
+  it("is stable, so the card does not flicker between products while typing", () => {
+    const rows = [noop, skipped, changing, row({ variantGid: "second" })];
+
+    expect(exampleRowFrom(rows)).toBe(exampleRowFrom(rows));
+    expect(exampleRowFrom(rows)?.variantGid).toBe("changing");
+  });
+
+  it("shows nothing when no price moves", () => {
+    // An example of a price that is not changing teaches the opposite of the lesson.
+    expect(exampleRowFrom([noop, skipped])).toBeNull();
+    expect(exampleRowFrom([])).toBeNull();
+  });
+});

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -704,6 +704,10 @@ export default function NewCampaign() {
         <DraftPreview
           preview={previewFetcher.data ?? null}
           pending={previewFetcher.state !== "idle"}
+          // Named only when there is something to distinguish it from. `previewDraft`
+          // prices the base surface; on a shop with catalogues the merchant is reading a
+          // card headed "on your storefront" and has more than one.
+          surface={priceLists.length > 0 ? `base price · ${currencies[0]}` : undefined}
         />
       </s-section>
 


### PR DESCRIPTION
Closes #444.

The preview table answers *how many, and which?*. It does not answer the question asked
first: **did I mean −20% or ×0.20, and is the strike-through going to look right?** Fifty
rows set small answer the first badly and the second not at all.

One card at the top of the panel: a real variant from the campaign's scope, at its real
baseline, priced by the same `resolve()` as the run. NA puts exactly this beside its rule;
RUBIX does a version with invented numbers that teaches the arithmetic and nothing about
the merchant's shop.

### Two things here are correctness, not presentation

- **A sale badge is a claim.** It renders only when the compare-at is *above* the price.
  Equal or below is not a discount, and a badge there promises a saving the storefront will
  not show.
- **The example must not move while a merchant types.** Rows come back ordered changing →
  already-correct → skipped, so the first changing row is stable across keystrokes.

The strike-through is `type="redundant"` — Polaris documents it for discounted prices and
renders `<s>`, so a screen reader says so too. The card names its surface only when the
shop has more than one.

### Verification

- `npm test` — 146 files, 2380 tests · typecheck, lint (0 errors), build
- Three mutations, each caught and reverted: a badge when compare-at equals price; an
  example picked from a non-changing row; the strike-through losing its semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)