### PR TITLE
The amount field is labelled in the currency the rule uses

### DIFF
--- a/app/lib/ui/amount-currency.test.ts
+++ b/app/lib/ui/amount-currency.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The amount a merchant types is labelled in the currency it is built in.
+ *
+ * The editor keeps a sorted list of every currency a campaign could price in, because the
+ * per-currency rounding selects need all of them. It used to hand the **first** of that
+ * list to the field the amount is typed into:
+ *
+ *     <RuleValueField currency={currencies[0] ?? "USD"} />
+ *
+ * That is alphabetical order, not the shop. On a USD shop with CAD, EUR and JPY price
+ * lists the field read "Amount (CAD)" while `ruleFrom` built the amount in USD, and #444's
+ * storefront card inherited it and announced "base price · CAD".
+ *
+ * `s-money-field` exists precisely because it knows how many decimals an amount has, so
+ * this is not only a label: a shop whose first-sorted list is JPY gets a zero-decimal
+ * entry field for a two-decimal rule. Same family as #343 — the form has no currency
+ * field, so a currency gets chosen by something that is not the shop.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const EDITOR = readFileSync(join(process.cwd(), "app/routes/app.campaigns.new.tsx"), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^\s*\/\/.*$/gm, "");
+
+describe("nothing labels an amount from the sorted list", () => {
+  it("passes the shop's own currency to the amount field", () => {
+    expect(EDITOR).toContain("<RuleValueField currency={baseCurrency} />");
+  });
+
+  it("never indexes the sorted currency list", () => {
+    // Sorted for the rounding selects, which want all of them. The first entry means
+    // nothing, and reading it is how this bug is written again.
+    expect(
+      EDITOR,
+      "currencies[0] is whichever code sorts first, not the one the rule is built in",
+    ).not.toContain("currencies[0]");
+  });
+
+  it("takes the base currency from the same place the rule does", () => {
+    // `ruleFrom(read, currency)` in the action, `shopCurrency` in the resource route.
+    // The loader hands the client that same value rather than deriving a second one.
+    expect(EDITOR).toContain("baseCurrency: currency,");
+  });
+
+  it("still builds the full list, because the rounding selects need it", () => {
+    expect(EDITOR).toContain("const currencies = [");
+    expect(EDITOR).toMatch(/currencies\.map/);
+  });
+});

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -106,8 +106,12 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
   // The client asks for it instead, once, on mount. Same work, off the critical path,
   // with somewhere to say it is working.
 
-  // Every currency this campaign could price in. Only these are offered: a list of all
-  // 180 world currencies would bury the two or three that matter.
+  // Every currency this campaign could price in, for the per-currency rounding selects.
+  //
+  // Sorted, and therefore **not** a source of "the" currency: the first entry is whichever
+  // code sorts first across the shop and its price lists. `baseCurrency` below is the one
+  // the rule is actually built in, and anything labelling an amount has to use that
+  // (#473).
   const currencies = [
     ...new Set([currency, ...priceLists.map((list) => list.currency)].filter(Boolean)),
   ].sort();
@@ -129,6 +133,9 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
       b2b: canUseSurface(billing.plan, "b2b"),
     },
     planName: billing.plan.name,
+    // The currency `ruleFrom` builds the amount in, in both the action and the resource
+    // route. Everything that labels or formats an amount reads this, never `currencies[0]`.
+    baseCurrency: currency,
     storeRounding: settings.rounding,
     // What the untouched form describes, built here where it can be built reliably.
     // See the note on the mount effect: reading the form for the *first* request gets a
@@ -255,6 +262,7 @@ export default function NewCampaign() {
     planName,
     defaultName,
     firstPreview,
+    baseCurrency,
   } = useLoaderData<typeof loader>();
 
   // The live price preview. Debounced, because it plans the whole scope on every call
@@ -395,7 +403,7 @@ export default function NewCampaign() {
                   adjustment and its amount — as a fragment, so as bare grid children they
                   land side by side, which is the pair a merchant reads as one decision.
                   Inside a `FullRow` they would both go in one cell and stack. */}
-              <RuleValueField currency={currencies[0] ?? "USD"} />
+              <RuleValueField currency={baseCurrency} />
 
               <s-select name="compareAt" label="Compare-at price">
                 <s-option value="set-to-baseline" defaultSelected>
@@ -707,7 +715,7 @@ export default function NewCampaign() {
           // Named only when there is something to distinguish it from. `previewDraft`
           // prices the base surface; on a shop with catalogues the merchant is reading a
           // card headed "on your storefront" and has more than one.
-          surface={priceLists.length > 0 ? `base price · ${currencies[0]}` : undefined}
+          surface={priceLists.length > 0 ? `base price · ${baseCurrency}` : undefined}
         />
       </s-section>
 


### PR DESCRIPTION
Closes #473. Pre-existing; found by reading #444's storefront card on the deployed app,
which announced **"base price · CAD"** on a USD shop.

The editor keeps a **sorted** list of every currency a campaign could price in — the
per-currency rounding selects need all of them — and handed the *first* of it to the field
the amount is typed into:

```tsx
<RuleValueField currency={currencies[0] ?? "USD"} />
```

That is alphabetical order, not the shop. Meanwhile `ruleFrom(read, shopCurrency)` builds
the amount in the shop's currency, in both the action and the resource route. On
`dartmode-labs` (USD shop; CAD, EUR, JPY price lists) the field read **"Amount (CAD)"**.

**Not only a label.** `s-money-field` is used here because it knows how many decimals an
amount has — a shop whose first-sorted list is JPY gets a zero-decimal entry field for a
two-decimal rule. Same family as #343: the form has no currency field, so a currency gets
picked by something that is not the shop.

`baseCurrency` is the value `ruleFrom` is given, handed to the client rather than derived a
second time. The test refuses `currencies[0]` anywhere in the route, and checks the list
still exists for the rounding selects.

Mutation-tested: putting `currencies[0]` back fails two of four.

`npm test` — 147 files, 2384 tests · typecheck, lint (0 errors), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)