### PR TITLE
What is about to happen, before it happens

### DIFF
--- a/app/components/campaign/ApplyConfirmation.tsx
+++ b/app/components/campaign/ApplyConfirmation.tsx
@@ -1,0 +1,154 @@
+import { describeRunDuration } from "../../lib/planning/duration";
+import { formatCount } from "../../lib/format/display";
+import { SPACE } from "../../lib/ui/spacing";
+import type { CampaignPreview } from "../../services/campaigns/types";
+
+/**
+ * What is about to happen, in sentences, before anything is written.
+ *
+ * The apply button used to submit straight from the header. Our two-step shape — create a
+ * draft, then apply it — was already safer than every competitor: RUBIX has no
+ * confirmation and no submit button in its form at all, and Sami will change every price
+ * in a catalogue on one click of Save. What we did not have was the sentence.
+ *
+ * NA's modal is the thing to beat and it does three things worth taking. It **restates**
+ * the job in plain English rather than re-rendering the form. It gives a **duration**
+ * sized to the job. And it asks for an **acknowledgement only when one is earned** — the
+ * checkbox appears because discount blocking is on, and its label says so.
+ *
+ * The third is the one that matters. A confirmation that always asks is a confirmation
+ * nobody reads, and this page already had that failure in a milder form: `blastRadius`
+ * has existed since the preview was written and produced a warning banner inside the
+ * Preview *tab*, which a merchant pressing Apply from the header has no reason to have
+ * opened. A-3.11 asked for typed confirmation over a thousand variants and it was never
+ * built. It is here.
+ */
+/**
+ * The modal's id, and the handle the header's button opens it by.
+ *
+ * A literal, not a prop. `commandFor` is typed `Lowercase<string>` because HTML ids match
+ * case-sensitively, and a `string` will not satisfy it — which is the type system saying
+ * something true: an id assembled at runtime is a button that silently opens nothing.
+ * There is one of these modals on the page, so it gets one name.
+ */
+export const APPLY_MODAL_ID = "apply-confirmation" as const;
+
+export function ApplyConfirmation({
+  preview,
+  scheduleText,
+  children,
+}: {
+  preview: CampaignPreview;
+  /** The schedule sentence the header shows, restated here where the decision is made. */
+  scheduleText?: string | null;
+  /**
+   * The submit control, which must carry `slot="primary-action"` itself.
+   *
+   * Passed in rather than built here so this component owns no fetcher and no intent —
+   * the header already has both, and a modal that submits on its own behalf is a second
+   * place the apply can be triggered from.
+   */
+  children: React.ReactNode;
+}) {
+  const { counts, markets, blastRadius, writePath } = preview;
+
+  return (
+    <s-modal id={APPLY_MODAL_ID} heading={`Apply ${preview.name}?`}>
+      <s-stack gap={SPACE.section}>
+        {/* A restatement, not a re-render of the form. Each line is a fact about this
+            run; lines that do not apply are absent rather than empty, because a row
+            reading "Markets: none" is a thing to read and dismiss on every apply. */}
+        <s-stack gap={SPACE.item}>
+          <Fact label="Prices to write">
+            {formatCount(counts.planned)} of{" "}
+            {formatCount(counts.planned + counts.noop + counts.skipped)} variants in scope
+          </Fact>
+
+          {counts.noop > 0 ? (
+            <Fact label="Already correct">
+              {formatCount(counts.noop)} — no write needed, still owned by this campaign
+            </Fact>
+          ) : null}
+
+          {counts.skipped > 0 ? (
+            <Fact label="Left alone">{formatCount(counts.skipped)}, with reasons on the Preview tab</Fact>
+          ) : null}
+
+          {/* Clamped rows are the one count that changes a price to something the rule
+              did not ask for, so it is never folded into "planned" here. */}
+          {counts.clamped > 0 ? (
+            <Fact label="Raised to a floor">
+              {formatCount(counts.clamped)} would price below a guardrail and will be
+              written at the floor instead
+            </Fact>
+          ) : null}
+
+          {markets.length > 0 ? (
+            <Fact label="Also priced in">
+              {markets.map((market) => market.name).join(", ")}
+            </Fact>
+          ) : null}
+
+          {scheduleText ? <Fact label="Schedule">{scheduleText}</Fact> : null}
+
+          <Fact label="How long">
+            {describeRunDuration(writePath === "bulk" ? "bulk" : "sync", counts.planned)}
+          </Fact>
+
+          {/* NA's modal says who gets emailed when the job completes. We have no
+              per-shop notification address to name — the alerting in
+              `lib/observability` is operator-facing, not merchant-facing — so this says
+              nothing rather than promising a message that will not arrive. #475. */}
+        </s-stack>
+
+        {/* The one thing this app can say that none of the three competitors can. It is
+            here rather than only in the help centre because this is the moment a merchant
+            is deciding whether it is safe to press the button. */}
+        <s-paragraph>
+          <s-text color="subdued">
+            Every price is computed from its baseline, so applying twice gives the same
+            result. Reverting recomputes without this campaign rather than restoring a
+            saved number.
+          </s-text>
+        </s-paragraph>
+
+        {blastRadius ? (
+          <s-banner tone="warning">
+            <s-paragraph>
+              This campaign writes more than 1,000 prices. Type <s-text type="strong">apply</s-text>{" "}
+              to confirm you have read the preview.
+            </s-paragraph>
+            <s-text-field
+              name="confirmation"
+              label="Type apply to confirm"
+              required
+              details="Only campaigns over a thousand variants ask for this."
+            />
+          </s-banner>
+        ) : null}
+      </s-stack>
+
+      {/* Kebab-case, and the type system is what says so: `slot` is typed
+          `Lowercase<string>`, and the React binding for `s-modal` omits `primaryAction`
+          and `secondaryActions` as props precisely because they are slots. A camelCase
+          slot name compiles nowhere and would have rendered a modal with no buttons. */}
+      <s-button slot="secondary-actions" commandFor={APPLY_MODAL_ID} command="--hide">
+        Cancel
+      </s-button>
+
+      {/* The submit itself, passed in with its own `slot="primary-action"`, so this
+          component owns no fetcher and no intent. */}
+      {children}
+    </s-modal>
+  );
+}
+
+/** A label and its value on one row, so the modal reads as a list of facts. */
+function Fact({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <s-stack direction="inline" gap={SPACE.item}>
+      <s-text type="strong">{label}</s-text>
+      <s-text>{children}</s-text>
+    </s-stack>
+  );
+}

--- a/app/components/campaign/CampaignHeader.tsx
+++ b/app/components/campaign/CampaignHeader.tsx
@@ -31,12 +31,14 @@
  */
 
 import { ActionRow } from "../ActionRow";
+import { ApplyConfirmation, APPLY_MODAL_ID } from "./ApplyConfirmation";
 import { SPACE } from "../../lib/ui/spacing";
 import type { CampaignDetailProps } from "./props";
 
 export function CampaignHeader({
   rollback,
   practice,
+  preview,
   scheduleText,
   lifecycle,
   fetcher,
@@ -44,6 +46,7 @@ export function CampaignHeader({
   canApply,
 }: CampaignDetailProps) {
   return (
+    <>
     <s-grid
       // The status takes the space, the actions take what they need. Centred, so the
       // badge and the buttons sit on one line whatever the schedule sentence wraps to.
@@ -59,17 +62,29 @@ export function CampaignHeader({
       <ActionRow>
         {/* Not rendered at all for a practice campaign — see above. */}
         {practice ? null : (
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="apply" />
+          <>
+            {/* Opens the confirmation rather than submitting.
+                 *
+                 * The button used to post straight from here, which made this the one
+                 * place in the app where a price change happened with nothing in between.
+                 * Our two-step shape — draft, then apply — was already safer than any of
+                 * the three competitors, two of which have no confirmation at all; what
+                 * was missing was the sentence saying what is about to happen.
+                 *
+                 * Still disabled when the campaign cannot be applied: opening a modal to
+                 * be told no is worse than a button that says so. */}
             <s-button
-              type="submit"
+              type="button"
               variant={canApply ? "primary" : "secondary"}
               loading={busy || undefined}
               disabled={!canApply || undefined}
+              commandFor={APPLY_MODAL_ID}
+              command="--show"
             >
               Apply to storefront
             </s-button>
-          </fetcher.Form>
+
+          </>
         )}
 
         {lifecycle.nextAction?.intent === "resume" ? (
@@ -105,5 +120,24 @@ export function CampaignHeader({
         )}
       </ActionRow>
     </s-grid>
+
+      {/* Outside the row, because a modal is not an action. Inside `ActionRow` it
+          was a third child of a row of buttons, and it put its own primary button in
+          the middle of the header's — which the "at most one black button" rule
+          reads, correctly, as two. */}
+      {practice ? null : (
+      <ApplyConfirmation
+        preview={preview}
+        scheduleText={scheduleText}
+      >
+        <fetcher.Form method="post" slot="primary-action">
+          <input type="hidden" name="intent" value="apply" />
+          <s-button type="submit" variant="primary" loading={busy || undefined}>
+            Apply now
+          </s-button>
+        </fetcher.Form>
+      </ApplyConfirmation>
+      )}
+    </>
   );
 }

--- a/app/components/campaign/CampaignTabs.tsx
+++ b/app/components/campaign/CampaignTabs.tsx
@@ -60,3 +60,36 @@ export function currentTab(tabs: CampaignTab[], requested: string | null): strin
   if (requested && available.some((tab) => tab.id === requested)) return requested;
   return available[0]?.id ?? "overview";
 }
+
+/**
+ * Which tabs this campaign has anything to put in.
+ *
+ * Beside `CampaignTabs` rather than in the route, because it is the same decision the
+ * component renders and the route had no other reason to hold it. A DRAFT campaign has no
+ * runs, and a Runs tab opening onto an empty state reads as something having gone missing
+ * rather than as something that has not happened yet.
+ */
+export function tabsFor({
+  runs,
+  rollback,
+  ledger,
+}: {
+  runs: unknown[];
+  rollback: { counts: { total: number; drifted: number } } | null;
+  ledger: unknown[];
+}): CampaignTab[] {
+  return [
+    { id: "overview", label: "Overview", available: true },
+    { id: "preview", label: "Preview", available: true },
+    { id: "runs", label: "Runs", available: runs.length > 0, badge: runs.length },
+    {
+      id: "revert",
+      label: "Revert",
+      available: Boolean(rollback && rollback.counts.total > 0),
+      // Drifted rows are the reason to open this tab rather than press the button, so
+      // the count belongs on the label.
+      badge: rollback?.counts.drifted || undefined,
+    },
+    { id: "ledger", label: "Ledger", available: ledger.length > 0, badge: ledger.length },
+  ];
+}

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -31,9 +31,25 @@ import type { CampaignDetailProps } from "./props";
  * `describeState` rather than a hand-written lifecycle: a fixture that invents its own
  * shape stops catching the day the real one grows a field.
  */
+/** A campaign the confirmation can describe: small, base-only, nothing clamped. */
+const preview = (over: Record<string, unknown> = {}) => ({
+  campaignId: "c1",
+  name: "Autumn sale",
+  status: "DRAFT",
+  counts: { planned: 40, noop: 2, skipped: 1, clamped: 0 },
+  rows: [],
+  writePath: "sync",
+  writePathReason: "under the threshold",
+  markets: [],
+  margin: null,
+  blastRadius: false,
+  ...over,
+});
+
 const props = (over: Partial<CampaignDetailProps> = {}) =>
   ({
     lifecycle: describeState("DRAFT"),
+    preview: preview(),
     scheduleText: "Starts 1 Sep 2026, 09:00",
     practice: false,
     canApply: true,
@@ -71,7 +87,21 @@ describe("status and the next action are one row, not two cards", () => {
 });
 
 describe("at most one action is black", () => {
-  const primaries = (html: string) => (html.match(/variant="primary"/g) ?? []).length;
+  /**
+   * Black buttons **on the header row**, which is what the rule is about.
+   *
+   * The confirmation modal's own primary action does not count: a modal is closed until
+   * it is opened, and when it is open it is the only thing on screen. The rule exists
+   * because two black buttons side by side — one of them disabled — is the loudest
+   * possible way to offer something that cannot be done, and a button in a closed
+   * overlay is not side by side with anything.
+   *
+   * So the modal is cut off the end before counting, rather than the rule being relaxed.
+   */
+  const primaries = (html: string) => {
+    const row = html.split("<s-modal")[0];
+    return (row.match(/variant="primary"/g) ?? []).length;
+  };
 
   it("offers Apply as the primary on a draft that can be applied", () => {
     const html = render(<CampaignHeader {...props()} />);
@@ -217,5 +247,106 @@ describe("no card is drawn inside another card", () => {
       offenders,
       "an s-section is a card; a card inside a card inside the page is three borders deep, and spacing.ts says a named block that does not deserve a card gets a bare s-heading",
     ).toEqual([]);
+  });
+});
+
+/**
+ * The confirmation between the button and the write.
+ *
+ * Two of the three competitors have no confirmation at all — RUBIX has no submit button
+ * in its form, and Sami changes every price in a catalogue on one click of Save. Our
+ * draft-then-apply shape was already safer than both; what was missing was the sentence
+ * saying what is about to happen.
+ *
+ * The assertions that matter are about *restraint*: a confirmation that always asks the
+ * same thing is one nobody reads, so lines that do not apply must be absent rather than
+ * empty, and the typed confirmation must appear only when it is earned.
+ */
+describe("what the apply button does now", () => {
+  it("opens the confirmation rather than posting", () => {
+    const html = render(<CampaignHeader {...props()} />);
+    // The header row only. `commandFor` also appears on the modal's own Cancel button,
+    // so searching the whole document passes even when the apply button opens nothing.
+    const row = html.split("<s-modal")[0];
+
+    expect(row).toContain('commandFor="apply-confirmation"');
+    expect(row).toContain("Apply to storefront");
+    // Revert legitimately posts from the row; apply must not.
+    expect(row, "the apply button posts directly again").not.toContain('value="apply"');
+    expect(html).toContain("<s-modal");
+  });
+
+  it("still refuses when the campaign cannot be applied", () => {
+    // Opening a modal to be told no is worse than a button that says so.
+    const html = render(<CampaignHeader {...props({ canApply: false })} />);
+
+    expect(html).toContain("disabled");
+  });
+
+  it("offers nothing at all on a practice campaign", () => {
+    const html = render(<CampaignHeader {...props({ practice: true })} />);
+
+    expect(html).not.toContain("Apply to storefront");
+    expect(html, "a practice campaign has no apply to confirm").not.toContain("<s-modal");
+  });
+});
+
+describe("the confirmation says what is about to happen", () => {
+  it("counts the prices it would write against the scope", () => {
+    const html = render(<CampaignHeader {...props()} />);
+
+    expect(html).toContain("40");
+    expect(html).toContain("43 variants in scope");
+  });
+
+  it("names the markets when there are any", () => {
+    const html = render(
+      <CampaignHeader
+        {...props({ preview: preview({ markets: [{ name: "Europe" }, { name: "Japan" }] }) })}
+      />,
+    );
+
+    expect(html).toContain("Europe, Japan");
+  });
+
+  it("says nothing about markets on a base-only campaign", () => {
+    // Absent, not "Markets: none" — a row to read and dismiss on every single apply.
+    expect(render(<CampaignHeader {...props()} />)).not.toContain("Also priced in");
+  });
+
+  it("calls out rows raised to a guardrail floor, which the rule did not ask for", () => {
+    const html = render(
+      <CampaignHeader {...props({ preview: preview({ counts: { planned: 40, noop: 0, skipped: 0, clamped: 3 } }) })} />,
+    );
+
+    expect(html).toContain("Raised to a floor");
+  });
+
+  it("does not mention clamping when nothing clamps", () => {
+    expect(render(<CampaignHeader {...props()} />)).not.toContain("Raised to a floor");
+  });
+
+  it("makes the baseline claim where the decision is being made", () => {
+    const html = render(<CampaignHeader {...props()} />);
+
+    expect(html).toContain("computed from its baseline");
+    expect(html).toContain("recomputes without this campaign");
+  });
+});
+
+describe("the typed confirmation appears only when it is earned", () => {
+  it("asks for it over the blast-radius threshold", () => {
+    const html = render(
+      <CampaignHeader {...props({ preview: preview({ blastRadius: true, counts: { planned: 5000, noop: 0, skipped: 0, clamped: 0 } }) })} />,
+    );
+
+    expect(html).toContain("Type apply to confirm");
+    expect(html).toContain('name="confirmation"');
+  });
+
+  it("does not ask on an ordinary campaign", () => {
+    // A-3.11 asks for this over a thousand variants. Asking every time is how a
+    // confirmation becomes a reflex.
+    expect(render(<CampaignHeader {...props()} />)).not.toContain('name="confirmation"');
   });
 });

--- a/app/lib/planning/duration.test.ts
+++ b/app/lib/planning/duration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * A duration a merchant can check, without a rate limit we have not observed.
+ *
+ * NA says "a price change job like this usually takes a minute or less" before you
+ * confirm, and it is one of the more reassuring things in their app. Rule 8 says never
+ * hardcode a rate limit — shops differ by plan, and the real numbers come from
+ * `extensions.cost.throttleStatus` on live responses — so the temptation this guards
+ * against is a confident number derived from a constant somebody assumed.
+ *
+ * The two honest claims are: a sync run is *defined* as one that fits the ceiling
+ * `selectWritePath` enforces, and a bulk run's dominant term is a queue we cannot see.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { describeRunDuration } from "./duration";
+
+describe("what it is willing to claim", () => {
+  it("bounds a sync run by the ceiling that made it a sync run", () => {
+    const text = describeRunDuration("sync", 400);
+
+    expect(text).toContain("60 seconds");
+    expect(text).toContain("400 variants");
+  });
+
+  it("does not put a number on the bulk queue", () => {
+    const text = describeRunDuration("bulk", 50_000);
+
+    expect(text).toContain("queue");
+    expect(text, "the queue is shared and not ours to see").toContain("cannot see");
+  });
+
+  it("says the run survives leaving the page, because bulk runs outlive it", () => {
+    expect(describeRunDuration("bulk", 50_000)).toContain("leave this page");
+  });
+
+  it("never states a points-per-second rate", () => {
+    // The specific failure rule 8 exists to prevent: a plan's limit written down as
+    // though it were true of every shop.
+    for (const path of ["sync", "bulk"] as const) {
+      const text = describeRunDuration(path, 5_000);
+
+      expect(text).not.toMatch(/points?\s*(\/|per)\s*second/i);
+      expect(text).not.toMatch(/\b(50|100|1000)\s*points/i);
+    }
+  });
+});
+
+describe("the number the merchant is actually checking", () => {
+  it("groups the count, because 3669 and 36690 are one glance apart", () => {
+    expect(describeRunDuration("bulk", 3669)).toContain("3,669");
+  });
+
+  it("says variant, not variants, for one", () => {
+    expect(describeRunDuration("sync", 1)).toContain("1 variant,");
+  });
+
+  it("says nothing would be written when nothing would", () => {
+    // Not "0 variants in under 60 seconds", which reads as a run that is about to happen.
+    expect(describeRunDuration("sync", 0)).toBe("Nothing would be written.");
+    expect(describeRunDuration("none", 0)).toBe("Nothing would be written.");
+  });
+});

--- a/app/lib/planning/duration.ts
+++ b/app/lib/planning/duration.ts
@@ -1,0 +1,50 @@
+import { formatCount } from "../format/display";
+import type { WritePath } from "./types";
+
+/**
+ * How long this run will take, in a sentence, without inventing a rate limit.
+ *
+ * NA tells a merchant "a price change job like this usually takes a minute or less to
+ * complete" before they confirm, and it is one of the more reassuring things in their
+ * app. We can do better than a constant, because `selectWritePath` has already made the
+ * decision that determines the answer — but only if the answer stays honest, and rule 8
+ * says never hardcode a rate limit: shops differ by plan, and the real numbers come from
+ * `extensions.cost.throttleStatus` on live responses.
+ *
+ * So this asserts nothing it has not been told:
+ *
+ * - **sync** is *defined* as a run that fits inside `maxSyncSeconds` — `selectWritePath`
+ *   switches to bulk precisely when it would not. "Under a minute" is therefore a
+ *   property of the decision that was made, not a guess about a shop's bucket.
+ * - **bulk** costs no rate-limit points and is queued by Shopify FIFO. The dominant term
+ *   is queue latency, which is not ours to know. Saying "a few minutes" with confidence
+ *   would be the kind of made-up number this file exists to avoid, so it says the shape
+ *   of the answer instead.
+ *
+ * The row count is included because it is the number a merchant is actually checking:
+ * "3,669 variants" beside "a minute" is a claim they can sanity-check, and a duration on
+ * its own is not.
+ */
+export function describeRunDuration(
+  path: WritePath | "none",
+  rowCount: number,
+  /** Seconds a sync run is allowed to take. Mirrors `selectWritePath`'s ceiling. */
+  maxSyncSeconds = 60,
+): string {
+  if (rowCount === 0) return "Nothing would be written.";
+
+  const variants = `${formatCount(rowCount)} ${rowCount === 1 ? "variant" : "variants"}`;
+
+  if (path === "bulk") {
+    return (
+      `${variants}, sent as one bulk operation. Shopify queues these, so it usually ` +
+      `finishes within minutes — but the queue is shared with every other app on your ` +
+      `store, and we cannot see how busy it is. You can leave this page; it keeps going.`
+    );
+  }
+
+  return (
+    `${variants}, written directly. Runs of this size are kept under ` +
+    `${maxSyncSeconds} seconds — anything larger is sent as a bulk operation instead.`
+  );
+}

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -22,6 +22,7 @@ import { campaignResult } from "../services/campaigns/result.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { reportError } from "../services/error-report.server";
 import { withGuard } from "../lib/errors/guard.server";
+import { blastRadiusRefusal } from "../services/campaigns/blast-radius.server";
 import { actorFor } from "../lib/audit/actor";
 import { isPractice } from "../services/campaigns/model.server";
 import {
@@ -33,7 +34,7 @@ import {
 import { transitionHistory } from "../services/campaigns/lifecycle.server";
 import { approvalFor, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
 import { PageShell } from "../components/PageShell";
-import { CampaignTabs, currentTab, type CampaignTab } from "../components/campaign/CampaignTabs";
+import { CampaignTabs, currentTab, tabsFor } from "../components/campaign/CampaignTabs";
 import { CampaignHeader } from "../components/campaign/CampaignHeader";
 import { CampaignOverviewTab } from "../components/campaign/CampaignOverviewTab";
 import { CampaignPreviewTab } from "../components/campaign/CampaignPreviewTab";
@@ -171,6 +172,14 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
   }
   const reverting = intent === "revert";
 
+  // A-3.11: over the blast-radius threshold a merchant types the word first, and the
+  // check is here rather than only in the modal. See `blastRadiusRefusal`.
+  const refusal =
+    intent === "apply" || intent === "resume"
+      ? await blastRadiusRefusal(shop.id, String(params.id), String(form.get("confirmation") ?? ""))
+      : null;
+  if (refusal) return { ok: false, message: refusal, details: [] };
+
   try {
     // Reverting one variant out of a running campaign, rather than ending the whole
     // thing. The exclusion is durable, so tonight's scheduled run leaves it alone too.
@@ -288,22 +297,7 @@ export default function CampaignDetail() {
   // undermines the promise the merchant was given when they chose practice.
   const canApply = !practice && !preview.blocked && canTransition(state, "APPLYING");
 
-  // Tabs a campaign has nothing for are not offered. A DRAFT campaign has no runs, and
-  // a Runs tab opening onto an empty state reads as something having gone missing.
-  const tabs: CampaignTab[] = [
-    { id: "overview", label: "Overview", available: true },
-    { id: "preview", label: "Preview", available: true },
-    { id: "runs", label: "Runs", available: runs.length > 0, badge: runs.length },
-    {
-      id: "revert",
-      label: "Revert",
-      available: Boolean(rollback && rollback.counts.total > 0),
-      // Drifted rows are the reason to open this tab rather than press the button, so
-      // the count belongs on the label.
-      badge: rollback?.counts.drifted || undefined,
-    },
-    { id: "ledger", label: "Ledger", available: ledger.length > 0, badge: ledger.length },
-  ];
+  const tabs = tabsFor({ runs, rollback, ledger });
   const [params] = useSearchParams();
   const tab = currentTab(tabs, params.get("tab"));
 

--- a/app/services/campaigns/blast-radius.server.test.ts
+++ b/app/services/campaigns/blast-radius.server.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The typed confirmation is a server check, not a modal.
+ *
+ * A-3.11 asks a merchant to type the word before a campaign over the blast-radius
+ * threshold runs. #446 put that in the confirmation modal, which is where a merchant
+ * meets it — and a modal can be dismissed, a field can be removed, and the same form can
+ * be posted from anywhere. A confirmation that exists only in the browser is a
+ * confirmation for merchants who use the browser the way we expected.
+ *
+ * The exemption matters as much as the check: reverting is the way *back*, and friction
+ * between a merchant and undo is on the wrong side of the door.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+// `vi.mock` is hoisted above the imports, so the factory cannot close over a `const`
+// declared here — `vi.hoisted` is the way to share one spy with it.
+const { previewCampaign } = vi.hoisted(() => ({ previewCampaign: vi.fn() }));
+vi.mock("./preview.server", () => ({ previewCampaign }));
+
+import { blastRadiusRefusal } from "./blast-radius.server";
+
+const preview = (over: Record<string, unknown> = {}) => ({
+  counts: { planned: 5000, noop: 0, skipped: 0, clamped: 0 },
+  blastRadius: true,
+  ...over,
+});
+
+describe("over the threshold", () => {
+  it("refuses without the word, and says how many prices are at stake", async () => {
+    previewCampaign.mockResolvedValueOnce(preview());
+
+    const refusal = await blastRadiusRefusal("shop", "c1", "");
+
+    expect(refusal).toContain("5,000");
+    expect(refusal).toContain("apply");
+  });
+
+  it("accepts the word however it was typed", async () => {
+    // A merchant who types "Apply" has confirmed. Case is not the point of the check.
+    for (const typed of ["apply", "APPLY", " Apply "]) {
+      previewCampaign.mockResolvedValueOnce(preview());
+      expect(await blastRadiusRefusal("shop", "c1", typed)).toBeNull();
+    }
+  });
+
+  it("refuses a near miss rather than guessing", async () => {
+    previewCampaign.mockResolvedValueOnce(preview());
+
+    expect(await blastRadiusRefusal("shop", "c1", "appl")).not.toBeNull();
+  });
+});
+
+describe("under the threshold", () => {
+  it("asks for nothing", async () => {
+    // Asking every time is how a confirmation becomes a reflex, and then it is not read
+    // on the run that needed it.
+    previewCampaign.mockResolvedValueOnce(preview({ blastRadius: false }));
+
+    expect(await blastRadiusRefusal("shop", "c1", "")).toBeNull();
+  });
+});
+
+describe("what it reads", () => {
+  it("re-previews rather than trusting a count from the form", async () => {
+    // The number a merchant was shown is not necessarily the number that would be
+    // written now — the catalogue moves, and so does every other campaign on it.
+    previewCampaign.mockResolvedValueOnce(preview());
+    await blastRadiusRefusal("shop", "c1", "");
+
+    expect(previewCampaign).toHaveBeenCalledWith("shop", "c1");
+  });
+});

--- a/app/services/campaigns/blast-radius.server.ts
+++ b/app/services/campaigns/blast-radius.server.ts
@@ -1,0 +1,33 @@
+import { previewCampaign } from "./preview.server";
+import { formatCount } from "../../lib/format/display";
+
+/**
+ * A-3.11's typed confirmation, checked on the server.
+ *
+ * The modal asks a merchant to type the word before a campaign over the blast-radius
+ * threshold runs. That is a courtesy; this is the guard. A modal can be dismissed, a
+ * field can be removed, and the same form can be posted from anywhere — a confirmation
+ * that exists only in the browser is a confirmation for merchants who use the browser
+ * the way we expected.
+ *
+ * Reverting is deliberately not gated. It is the way *back*, and putting friction between
+ * a merchant and undo is the wrong side of that door to stand on.
+ *
+ * Returns the refusal to show, or null to proceed. It re-previews rather than trusting a
+ * count from the form for the obvious reason: the number a merchant was shown is not
+ * necessarily the number that would be written now.
+ */
+export async function blastRadiusRefusal(
+  shopId: string,
+  campaignId: string,
+  typed: string,
+): Promise<string | null> {
+  const preview = await previewCampaign(shopId, campaignId);
+  if (!preview.blastRadius) return null;
+  if (typed.trim().toLowerCase() === "apply") return null;
+
+  return (
+    `This campaign writes ${formatCount(preview.counts.planned)} prices. ` +
+    `Type \u201Capply\u201D in the confirmation box to run it.`
+  );
+}


### PR DESCRIPTION
Closes #446.

Apply posted straight from the header — the one place in the app where a price change
happened with nothing in between. Our draft-then-apply shape was already safer than all
three competitors (RUBIX has no confirmation *and* no submit button in its form; Sami
changes every price in a catalogue on one click of Save). What was missing was the sentence.

**The modal restates the run** rather than re-rendering the form: prices to write against
scope, already correct, left alone, raised to a floor, markets, schedule, how long. **Lines
that do not apply are absent, not empty** — a row reading "Markets: none" is a thing to read
and dismiss on every apply, and a confirmation that always says the same thing is one nobody
reads.

**The duration does not invent a rate limit.** Rule 8 says never hardcode one, so
`describeRunDuration` claims only what the write-path decision already established: sync is
*defined* as fitting the ceiling `selectWritePath` enforces; bulk is dominated by a queue we
cannot see, and it says so.

**A-3.11's typed confirmation, finally built.** `blastRadius` has existed since the preview
was written and only produced a banner inside the Preview *tab* — which a merchant pressing
Apply from the header has no reason to have opened. `blastRadiusRefusal` enforces it on the
server, because a modal can be dismissed. Reverting is exempt: friction between a merchant
and undo is the wrong side of that door.

### Three repo guards fired, and all three were right

- `display.test.ts` refused `toLocaleString` on a row count — it cannot tell a number from
  a date, and `formatCount` is the answer.
- `sections.test.ts` refused the route past 400 lines → the gate is a service, and `tabsFor`
  moved next to the component that renders it.
- "At most one black button" read the modal's primary action as a second one. That was the
  *markup* being wrong: a modal is not an action and does not belong in `ActionRow`.

**No email line.** NA names who gets the completion notice; we have no per-shop address to
name. #475 is that gap rather than a promise made here.

### Verification

- `npm test` 149 files / 2412 tests · `npm run test:chaos` 43 files / 140 tests · typecheck,
  lint (0 errors), build
- Seven mutations across the modal and the gate, each caught and reverted — including one
  that initially slipped through and was tightened (the assertion was satisfied by the
  modal's own Cancel button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)