### PR TITLE
What this campaign meets, and who keeps it

### DIFF
--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -1,6 +1,7 @@
 import { formatCount } from "../lib/format/display";
 import { EmptyState } from "./AsyncState";
 import { exampleRowFrom, StorefrontExample } from "./StorefrontExample";
+import { OverlapPanel } from "./OverlapPanel";
 import { SPACE } from "../lib/ui/spacing";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 
@@ -85,6 +86,11 @@ export function DraftPreview({
           who has typed a percentage wants to know what it looks like, and only then how
           many products it reaches. */}
       {example ? <StorefrontExample row={example} surface={surface} /> : null}
+
+      {/* Above the counts, because it changes what they mean: "3,669 of 3,669 would
+          change" reads differently once a merchant knows 1,240 of them belong to
+          something else. */}
+      <OverlapPanel overlaps={preview.overlaps} />
 
       <s-paragraph>
         <s-text>

--- a/app/components/OverlapPanel.tsx
+++ b/app/components/OverlapPanel.tsx
@@ -1,0 +1,69 @@
+import { formatCount } from "../lib/format/display";
+import { SPACE } from "../lib/ui/spacing";
+import type { DraftOverlap } from "../services/campaigns/draft-preview.server";
+
+/**
+ * What this campaign meets, and who keeps it.
+ *
+ * The single thing this app can say that none of the three competitors can.
+ *
+ * RUBIX puts this in the aside of its editor, above everything else, as a warning:
+ *
+ * > Do not create a 2nd task that target the same products **without reverting** the 1st
+ * > task, because it will mess up the price.
+ *
+ * and its FAQ works the arithmetic through — 30% off, then 50% off without reverting,
+ * leaves a $1000 product at $350 for ever, because "initial price" means whatever the
+ * price happened to be when the second task started. NA and Sami have the same fault and
+ * say nothing at all.
+ *
+ * We resolve overlap by priority and revert by recomputing, so the honest rendering is
+ * not a warning. It is a statement of what will happen, from the resolver that will do
+ * it — which is why the counts come out of the same `planRun` as the preview beside them
+ * rather than from a second query that could disagree.
+ *
+ * Nothing renders when nothing overlaps. A panel that says "no overlaps" on every draft
+ * is a panel a merchant stops reading before the one that matters.
+ */
+export function OverlapPanel({ overlaps }: { overlaps: DraftOverlap[] }) {
+  if (overlaps.length === 0) return null;
+
+  const total = overlaps.reduce((sum, overlap) => sum + overlap.variants, 0);
+
+  return (
+    <s-banner tone="info">
+      <s-stack gap={SPACE.tight}>
+        <s-paragraph>
+          <s-text type="strong">
+            {formatCount(total)} {total === 1 ? "variant" : "variants"} in this scope{" "}
+            {total === 1 ? "is" : "are"} already priced by another campaign.
+          </s-text>
+        </s-paragraph>
+
+        {overlaps.map((overlap) => (
+          <s-paragraph key={overlap.campaignId}>
+            <s-text>
+              <s-link href={`/app/campaigns/${overlap.campaignId}`}>{overlap.name}</s-link>{" "}
+              {overlap.variants === 1
+                ? "keeps it"
+                : `keeps ${formatCount(overlap.variants)} of them`}{" "}
+              &mdash; it outranks this campaign. Raise this campaign&rsquo;s priority above{" "}
+              {overlap.priority} to take {overlap.variants === 1 ? "it" : "them"}.
+            </s-text>
+          </s-paragraph>
+        ))}
+
+        {/* The half a competitor cannot write. Their revert restores a number, so the
+            order campaigns are reverted in changes the result; ours recomputes without
+            the campaign, so it does not. */}
+        <s-paragraph>
+          <s-text color="subdued">
+            Campaigns never stack. Each variant is priced by exactly one of them, and
+            reverting either recomputes the rest from their baselines rather than
+            restoring a saved price — so the order you revert in does not matter.
+          </s-text>
+        </s-paragraph>
+      </s-stack>
+    </s-banner>
+  );
+}

--- a/app/components/action-row.test.tsx
+++ b/app/components/action-row.test.tsx
@@ -25,11 +25,16 @@ const APP = join(process.cwd(), "app");
  * a button there renders nothing.
  *
  * A link *inside a sentence* is the other legitimate use, where colour is the only thing
- * marking a word mid-paragraph as clickable. There are none today. Adding one means
- * adding the file here, which is the point: it should be a decision somebody made, not a
- * habit that returned.
+ * marking a word mid-paragraph as clickable. Adding one means adding the file here, which
+ * is the point: it should be a decision somebody made, not a habit that returned.
+ *
+ * `OverlapPanel` is the first, and it is the case the paragraph above describes. It reads
+ * "**Autumn sale** keeps 1,240 of them — it outranks this campaign", and the campaign's
+ * name is the subject of that sentence. A button in the middle of it would break the
+ * sentence into three pieces to make one word clickable, and the sentence is the whole
+ * point: it is the statement about overlap that no competitor can make.
  */
-const MAY_USE_LINKS = ["routes/app.tsx"];
+const MAY_USE_LINKS = ["routes/app.tsx", "components/OverlapPanel.tsx"];
 
 function sources(dir: string): Array<{ path: string; text: string }> {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {

--- a/app/components/draft-preview.test.tsx
+++ b/app/components/draft-preview.test.tsx
@@ -40,6 +40,7 @@ const preview = (over: Partial<Preview> = {}): Preview => ({
   skipped: 0,
   withoutBaseline: 0,
   rows: [row()],
+  overlaps: [],
   blocked: null,
   ...over,
 });

--- a/app/components/overlap-panel.test.tsx
+++ b/app/components/overlap-panel.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * The sentence no competitor can write.
+ *
+ * RUBIX's editor warns merchants not to create a second task over the same products, and
+ * its FAQ works the arithmetic: 30% off, then 50% off without reverting, leaves a $1000
+ * product at $350 for ever — because "initial price" means whatever it happened to be
+ * when the second task started. NA and Sami share the fault and say nothing.
+ *
+ * We resolve by priority and revert by recomputing, so the right rendering is a statement
+ * rather than a warning. Two properties are load-bearing:
+ *
+ * - **Silence when nothing overlaps.** A panel that says "no overlaps" on every draft is
+ *   one a merchant stops reading before the draft where it matters.
+ * - **The claim about reverting.** It is the difference between our model and theirs, and
+ *   it is only true because a revert recomputes.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { StaticRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { OverlapPanel } from "./OverlapPanel";
+import type { DraftOverlap } from "../services/campaigns/draft-preview.server";
+
+const overlap = (over: Partial<DraftOverlap> = {}): DraftOverlap => ({
+  campaignId: "c_autumn",
+  name: "Autumn sale",
+  variants: 1240,
+  keepsThem: true,
+  priority: 200,
+  ...over,
+});
+
+const render = (overlaps: DraftOverlap[]) =>
+  renderToStaticMarkup(
+    <StaticRouter location="/app/campaigns/new">
+      <OverlapPanel overlaps={overlaps} />
+    </StaticRouter>,
+  );
+
+describe("when something overlaps", () => {
+  const html = render([overlap()]);
+
+  it("leads with how much of the scope is already spoken for", () => {
+    expect(html).toContain("1,240");
+    expect(html).toContain("already priced by another campaign");
+  });
+
+  it("names the campaign and links to it", () => {
+    expect(html).toContain("Autumn sale");
+    expect(html).toContain("/app/campaigns/c_autumn");
+  });
+
+  it("says who wins, and what to change to win instead", () => {
+    // A merchant reading "these overlap" and nothing else has been given a problem.
+    expect(html).toContain("outranks this campaign");
+    expect(html).toContain("200");
+  });
+
+  it("makes the claim that separates us from all three of them", () => {
+    expect(html).toContain("never stack");
+    expect(html).toContain("recomputes");
+    expect(html, "their revert restores a saved price; ours does not").toContain(
+      "rather than restoring a saved price",
+    );
+  });
+});
+
+describe("when nothing overlaps", () => {
+  it("renders nothing at all", () => {
+    // Not an empty banner, and not "no overlapping campaigns" — either is a thing to
+    // read and dismiss on every draft.
+    expect(render([])).toBe("");
+  });
+});
+
+describe("more than one", () => {
+  const html = render([overlap(), overlap({ campaignId: "c_clear", name: "Clearance", variants: 12, priority: 150 })]);
+
+  it("counts them together at the top", () => {
+    expect(html).toContain("1,252");
+  });
+
+  it("gives each its own line, so each can be opened", () => {
+    expect(html).toContain("/app/campaigns/c_autumn");
+    expect(html).toContain("/app/campaigns/c_clear");
+  });
+});
+
+describe("one variant", () => {
+  it("does not say 1 variants are", () => {
+    const html = render([overlap({ variants: 1 })]);
+
+    expect(html).toContain("1 variant in this scope is");
+    expect(html).not.toContain("1 variants");
+  });
+
+  it("says keeps it, not keeps 1 of them", () => {
+    expect(render([overlap({ variants: 1 })])).toContain("keeps it");
+  });
+});

--- a/app/services/campaigns/draft-preview.server.ts
+++ b/app/services/campaigns/draft-preview.server.ts
@@ -79,6 +79,28 @@ export interface DraftPreviewRow {
   skippedReason: string | null;
 }
 
+/**
+ * A campaign already running over some of the variants this draft would price.
+ *
+ * The thing no competitor can say. All three compute against the live price and none of
+ * them resolves overlap: RUBIX puts a warning in its editor telling merchants not to
+ * create a second task over the same products, and its FAQ explains with worked numbers
+ * that reverting out of order leaves a product wrong for ever. NA and Sami do the same
+ * thing and say nothing at all.
+ *
+ * We resolve it, by priority, and a revert recomputes rather than restoring — so the
+ * honest thing is not a warning but a statement of what will happen.
+ */
+export interface DraftOverlap {
+  campaignId: string;
+  name: string;
+  /** Variants in this draft's scope that the other campaign currently prices. */
+  variants: number;
+  /** True when the other campaign keeps those variants — it outranks the draft. */
+  keepsThem: boolean;
+  priority: number;
+}
+
 export interface DraftPreview {
   /** Variants the scope matches, whether or not their price moves. */
   matched: number;
@@ -91,6 +113,13 @@ export interface DraftPreview {
   /** Rows with no baseline, which cannot be priced at all. */
   withoutBaseline: number;
   rows: DraftPreviewRow[];
+  /**
+   * Campaigns already pricing variants in this scope, biggest first.
+   *
+   * Empty is the ordinary case and renders nothing — a panel saying "overlaps: none" on
+   * every draft is a panel that stops being read before the one that matters.
+   */
+  overlaps: DraftOverlap[];
   /**
    * A guardrail that stops the whole run, surfaced here rather than on submit.
    *
@@ -108,6 +137,7 @@ const EMPTY: DraftPreview = {
   skipped: 0,
   withoutBaseline: 0,
   rows: [],
+  overlaps: [],
   blocked: null,
 };
 
@@ -187,6 +217,14 @@ export async function previewDraft(
   // promise a price the run will not write.
   const ours = outcome.rows.filter((row) => row.campaignId === DRAFT_ID);
 
+  // And the ones it does not control, which are the interesting half.
+  //
+  // These fall out of the same `planRun` that produced the draft's own rows, so they are
+  // the resolver's answer rather than a second opinion assembled from a query. A campaign
+  // in this list is one the merchant is about to write over, or one that is about to
+  // write over them — and which of the two is a fact we can state.
+  const overlaps = overlapsFrom(outcome.rows, others, draft.priority);
+
   const changing = ours.filter((row) => row.status !== "skipped" && !isNoop(row));
   const alreadyCorrect = ours.filter((row) => row.status !== "skipped" && isNoop(row));
   const skipped = ours.filter((row) => row.status === "skipped");
@@ -206,6 +244,7 @@ export async function previewDraft(
 
   return {
     matched,
+    overlaps,
     changing: changing.length,
     alreadyCorrect: alreadyCorrect.length,
     skipped: skipped.length,
@@ -228,6 +267,45 @@ export async function previewDraft(
       };
     }),
   };
+}
+
+/**
+ * Which existing campaigns share variants with this draft, and who keeps them.
+ *
+ * Counted from the planned rows rather than from the scopes: two campaigns whose filters
+ * both say "Outerwear" may still not meet, because a third campaign outranks them both on
+ * some of it. The resolver has already worked that out and the rows say who won.
+ *
+ * Sorted by size, because a merchant reading this wants the one that matters first, and a
+ * campaign that owns four variants of three thousand is a footnote.
+ */
+export function overlapsFrom(
+  rows: Array<{ campaignId?: string }>,
+  others: Array<{ id: string; name: string; priority: number }>,
+  draftPriority: number,
+): DraftOverlap[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.campaignId || row.campaignId === DRAFT_ID) continue;
+    counts.set(row.campaignId, (counts.get(row.campaignId) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([campaignId, variants]) => {
+      const other = others.find((candidate) => candidate.id === campaignId);
+      return {
+        campaignId,
+        name: other?.name ?? "Another campaign",
+        variants,
+        priority: other?.priority ?? 0,
+        // A row the resolver gave to them is a row they keep — that *is* the answer, and
+        // recomputing "who should win" from the priorities here would be a second
+        // implementation free to disagree with the first.
+        keepsThem: true,
+      };
+    })
+    .filter((overlap) => overlap.variants > 0)
+    .sort((a, b) => b.variants - a.variants);
 }
 
 /** A row whose price does not move. */

--- a/app/services/campaigns/overlaps.test.ts
+++ b/app/services/campaigns/overlaps.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Which campaigns this draft meets, counted from the resolver's own answer.
+ *
+ * The count could be assembled from the scopes — two campaigns whose filters both say
+ * "Outerwear" surely meet — and it would be wrong. A third campaign may outrank them both
+ * on part of it, so the variants they actually share is a question only `planRun` has
+ * answered. Rule 4's reasoning applied one level up: a second implementation of "who owns
+ * this variant" is free to disagree with the one that will run.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { overlapsFrom } from "./draft-preview.server";
+
+const OTHERS = [
+  { id: "c_autumn", name: "Autumn sale", priority: 200 },
+  { id: "c_clear", name: "Clearance", priority: 150 },
+];
+
+const rows = (...ids: Array<string | undefined>) => ids.map((campaignId) => ({ campaignId }));
+
+describe("counting from planned rows", () => {
+  it("counts only rows the draft did not win", () => {
+    const found = overlapsFrom(rows("draft", "c_autumn", "c_autumn", "draft"), OTHERS, 100);
+
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ campaignId: "c_autumn", name: "Autumn sale", variants: 2 });
+  });
+
+  it("finds nothing when the draft won everything", () => {
+    // The ordinary case, and the one that must render silence.
+    expect(overlapsFrom(rows("draft", "draft"), OTHERS, 100)).toEqual([]);
+  });
+
+  it("ignores rows with no campaign at all", () => {
+    // A skipped row can carry no owner; counting it as an overlap invents a conflict.
+    expect(overlapsFrom(rows(undefined, "draft"), OTHERS, 100)).toEqual([]);
+  });
+
+  it("puts the biggest overlap first, because that is the one to decide about", () => {
+    const found = overlapsFrom(
+      rows("c_clear", "c_autumn", "c_autumn", "c_autumn"),
+      OTHERS,
+      100,
+    );
+
+    expect(found.map((overlap) => overlap.campaignId)).toEqual(["c_autumn", "c_clear"]);
+  });
+
+  it("carries each campaign's priority, so the panel can say what to change", () => {
+    expect(overlapsFrom(rows("c_clear"), OTHERS, 100)[0].priority).toBe(150);
+  });
+});
+
+describe("a campaign the caller did not hand us", () => {
+  it("is still reported, without inventing a name", () => {
+    // Better a nameless overlap than a silently dropped one: the merchant is about to be
+    // told a count, and a count that quietly omits a campaign is the wrong count.
+    const found = overlapsFrom(rows("c_ghost"), OTHERS, 100);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].name).toBe("Another campaign");
+  });
+});


### PR DESCRIPTION
Closes #449. **The one thing this app can say that none of the three competitors can.**

RUBIX warns, in the aside of its editor, *"Do not create a 2nd task that target the same
products without reverting the 1st task, because it will mess up the price"* — and its FAQ
works the arithmetic: 30% off, then 50% off without reverting, leaves a $1000 product at
$350 for ever. NA and Sami share the fault and say nothing.

We resolve by priority and revert by recomputing, so the honest rendering is a **statement,
not a warning**: how many variants another campaign already prices, which one, that it
outranks this campaign, and what to change to take them. Then the half they cannot write —
campaigns never stack, and reverting either recomputes the rest from their baselines rather
than restoring a saved price, *so the order you revert in does not matter*.

**The counts come from the resolver, not a second query.** They could have been assembled
from the scopes, and that would be wrong: a third campaign may outrank both on part of it,
so what two campaigns actually share is a question only `planRun` has answered. `keepsThem`
is read off the rows for the same reason.

**Silence when nothing overlaps** — a panel saying "no overlaps" on every draft is one a
merchant stops reading before the draft where it matters.

`action-row.test.tsx` refused the campaign-name link, and its own comment describes this
case exactly: *a link inside a sentence, where colour is the only thing marking a word
mid-paragraph as clickable*. Added to the allow-list as a decision, with the reasoning.

### Verification

- `npm test` 151 files / 2432 tests · `npm run test:chaos` 43 / 140 · typecheck, lint, build
- Four mutations, each caught and reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)