### PR TITLE
An unused parameter the cached lint did not see

### DIFF
--- a/app/services/campaigns/draft-preview.server.ts
+++ b/app/services/campaigns/draft-preview.server.ts
@@ -223,7 +223,7 @@ export async function previewDraft(
   // the resolver's answer rather than a second opinion assembled from a query. A campaign
   // in this list is one the merchant is about to write over, or one that is about to
   // write over them — and which of the two is a fact we can state.
-  const overlaps = overlapsFrom(outcome.rows, others, draft.priority);
+  const overlaps = overlapsFrom(outcome.rows, others);
 
   const changing = ours.filter((row) => row.status !== "skipped" && !isNoop(row));
   const alreadyCorrect = ours.filter((row) => row.status !== "skipped" && isNoop(row));
@@ -282,7 +282,6 @@ export async function previewDraft(
 export function overlapsFrom(
   rows: Array<{ campaignId?: string }>,
   others: Array<{ id: string; name: string; priority: number }>,
-  draftPriority: number,
 ): DraftOverlap[] {
   const counts = new Map<string, number>();
   for (const row of rows) {

--- a/app/services/campaigns/overlaps.test.ts
+++ b/app/services/campaigns/overlaps.test.ts
@@ -20,8 +20,16 @@ const OTHERS = [
 const rows = (...ids: Array<string | undefined>) => ids.map((campaignId) => ({ campaignId }));
 
 describe("counting from planned rows", () => {
+  it("does not take the draft's priority, because it does not decide anything", () => {
+    // `keepsThem` is read off the rows the resolver produced. Recomputing "who should
+    // win" from the priorities here would be a second implementation of the resolver,
+    // free to disagree with the one that will run — and the unused parameter that said
+    // otherwise is what turned main red (#478).
+    expect(overlapsFrom.length).toBe(2);
+  });
+
   it("counts only rows the draft did not win", () => {
-    const found = overlapsFrom(rows("draft", "c_autumn", "c_autumn", "draft"), OTHERS, 100);
+    const found = overlapsFrom(rows("draft", "c_autumn", "c_autumn", "draft"), OTHERS);
 
     expect(found).toHaveLength(1);
     expect(found[0]).toMatchObject({ campaignId: "c_autumn", name: "Autumn sale", variants: 2 });
@@ -29,26 +37,22 @@ describe("counting from planned rows", () => {
 
   it("finds nothing when the draft won everything", () => {
     // The ordinary case, and the one that must render silence.
-    expect(overlapsFrom(rows("draft", "draft"), OTHERS, 100)).toEqual([]);
+    expect(overlapsFrom(rows("draft", "draft"), OTHERS)).toEqual([]);
   });
 
   it("ignores rows with no campaign at all", () => {
     // A skipped row can carry no owner; counting it as an overlap invents a conflict.
-    expect(overlapsFrom(rows(undefined, "draft"), OTHERS, 100)).toEqual([]);
+    expect(overlapsFrom(rows(undefined, "draft"), OTHERS)).toEqual([]);
   });
 
   it("puts the biggest overlap first, because that is the one to decide about", () => {
-    const found = overlapsFrom(
-      rows("c_clear", "c_autumn", "c_autumn", "c_autumn"),
-      OTHERS,
-      100,
-    );
+    const found = overlapsFrom(rows("c_clear", "c_autumn", "c_autumn", "c_autumn"), OTHERS);
 
     expect(found.map((overlap) => overlap.campaignId)).toEqual(["c_autumn", "c_clear"]);
   });
 
   it("carries each campaign's priority, so the panel can say what to change", () => {
-    expect(overlapsFrom(rows("c_clear"), OTHERS, 100)[0].priority).toBe(150);
+    expect(overlapsFrom(rows("c_clear"), OTHERS)[0].priority).toBe(150);
   });
 });
 
@@ -56,7 +60,7 @@ describe("a campaign the caller did not hand us", () => {
   it("is still reported, without inventing a name", () => {
     // Better a nameless overlap than a silently dropped one: the merchant is about to be
     // told a count, and a count that quietly omits a campaign is the wrong count.
-    const found = overlapsFrom(rows("c_ghost"), OTHERS, 100);
+    const found = overlapsFrom(rows("c_ghost"), OTHERS);
 
     expect(found).toHaveLength(1);
     expect(found[0].name).toBe("Another campaign");


### PR DESCRIPTION
Closes #478. **main is red** — this makes it green.

#449 merged with `Typecheck, lint & build` failing on `'draftPriority' is defined but never
used`. Not using it is correct: `keepsThem` is read off the resolver's own rows rather than
recomputed from priorities. The parameter was left over.

### Why it got through

- **`npm run lint` is cached** (`--cache --cache-location ./node_modules/.cache/eslint`), so
  a local run can pass on a file CI rejects — and did. `rm -rf node_modules/.cache/eslint`
  reproduces it immediately. Same shape as the `admin-<version>.schema.json` trap already in
  the notes: cached locally, fetched fresh in CI.
- **`gh pr checks --watch --fail-fast` returns on the first failure**, with the passing
  checks still in the tail of its output. At a glance that reads green. The exit status does
  not.

The test pins the arity so the parameter cannot return as a comment about something the
function does not do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)