### PR TITLE
Say "baseline" where the rule is entered

### DIFF
--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -1,4 +1,5 @@
 import { formatCount } from "../lib/format/display";
+import { ActionRow } from "./ActionRow";
 import { EmptyState } from "./AsyncState";
 import { exampleRowFrom, StorefrontExample } from "./StorefrontExample";
 import { OverlapPanel } from "./OverlapPanel";
@@ -128,6 +129,35 @@ export function DraftPreview({
             priced at all. Sync your catalogue to capture them.
           </s-text>
         </s-paragraph>
+      ) : null}
+
+      {/* Said once, above the table, rather than on every row that has one.
+          
+          A `live` figure means the storefront is not at the baseline, and there are two
+          reasons for that: another campaign is pricing the variant, or somebody changed
+          it outside the app. Claiming which on a row would be a guess — the resolver
+          gave this row to *this* draft, so it does not know who priced it last — and
+          `Prices → Drift` is where the app already answers the question properly.
+          
+          Absent when no row has drifted, which is the ordinary case. */}
+      {preview.rows.some((row) => row.live) ? (
+        <s-stack gap={SPACE.tight}>
+          <s-paragraph>
+            <s-text color="subdued">
+              Some of these show a <s-text type="strong">live</s-text> price that is not
+              their baseline: either another campaign is pricing them, or the storefront
+              was changed outside this app.
+            </s-text>
+          </s-paragraph>
+          {/* A tertiary button, not a link. `ActionRow`'s vocabulary reserves blue text
+              for a word *inside* a sentence where colour is doing necessary work; this
+              is a standalone way out of the card, which is what tertiary is for. */}
+          <ActionRow>
+            <s-button variant="tertiary" href="/app/prices/drift">
+              Review drifted prices
+            </s-button>
+          </ActionRow>
+        </s-stack>
       ) : null}
 
       {preview.rows.length > 0 ? (

--- a/app/components/draft-preview.test.tsx
+++ b/app/components/draft-preview.test.tsx
@@ -89,6 +89,25 @@ describe("when the storefront disagrees with the baseline", () => {
     expect(html).toContain("live");
   });
 
+  it("explains what a live price means, once, above the table", () => {
+    const html = render(preview({ rows: [row({ live: "$28.00" }), row()] }));
+
+    expect(html).toContain("either another campaign is pricing them");
+    expect(html).toContain("/app/prices/drift");
+  });
+
+  it("does not claim which of the two reasons it is", () => {
+    // The resolver gave this row to *this* draft, so it does not know who priced the
+    // variant last. Naming a cause per row would be a guess.
+    const html = render(preview({ rows: [row({ live: "$28.00" })] }));
+
+    expect(html).toContain("either");
+  });
+
+  it("says none of that when nothing has drifted", () => {
+    expect(render(preview())).not.toContain("/app/prices/drift");
+  });
+
   it("stays quiet when they agree", () => {
     // The ordinary case. A second identical number in every row teaches a merchant to
     // ignore the column, and then it is not read on the day it matters.

--- a/app/lib/ui/baseline-vocabulary.test.ts
+++ b/app/lib/ui/baseline-vocabulary.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The editor and the help centre define "baseline" the same way.
+ *
+ * The word is the product. `docs/help/concepts/baselines.md` opens with the definition —
+ * *the price a product would be if no campaign were running* — and calls that one
+ * sentence "the whole product". If the editor explains it differently, a merchant who
+ * reads both has been handed two concepts and will trust neither.
+ *
+ * This is the failure the repo has already seen once in a smaller form: drift's buttons
+ * were labelled `adopt`/`reassert`/`ignore` while `docs/help/concepts/drift.md` had
+ * merchant wording for two of them since before the page existed.
+ *
+ * Checked against the document rather than against a copy of it, so the day somebody
+ * improves the help centre's sentence this fails instead of quietly disagreeing.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
+
+/** Source without its own commentary, which discusses the very words being grepped. */
+const code = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+const EDITOR = code(read("app/routes/app.campaigns.new.tsx"));
+const PREVIEW = code(read("app/components/DraftPreview.tsx"));
+const EXAMPLE = code(read("app/components/StorefrontExample.tsx"));
+const OVERLAP = code(read("app/components/OverlapPanel.tsx"));
+const CONCEPT = read("docs/help/concepts/baselines.md");
+const REVERT = read("docs/help/concepts/revert.md");
+
+/** JSX wraps prose across lines; compare on words, not on whitespace. */
+const flat = (text: string) => text.replace(/\s+/g, " ");
+
+describe("the editor defines baseline the way the help centre does", () => {
+  it("uses the help centre's own definition", () => {
+    // "the price a product would be if no campaign were running"
+    expect(flat(CONCEPT)).toContain("the price a product would be if no campaign were running");
+    expect(flat(EDITOR)).toContain("the price it would be if no campaign were running");
+  });
+
+  it("names the baseline where the rule is entered, not only in a note at the foot", () => {
+    const rule = EDITOR.indexOf("<RuleValueField");
+    const advanced = EDITOR.indexOf("Advanced (optional)");
+
+    expect(rule).toBeGreaterThan(-1);
+    expect(
+      EDITOR.indexOf("baseline", rule),
+      "the word appears only after the settings a merchant is told to skip",
+    ).toBeLessThan(advanced);
+  });
+
+  it("states the consequence, which is the part that sells it", () => {
+    // Running it twice is the scenario RUBIX's FAQ has to explain going wrong.
+    expect(flat(EDITOR)).toContain("running this campaign twice gives the same result");
+  });
+});
+
+describe("everything that mentions the baseline agrees", () => {
+  it("calls it a baseline, never an original or a normal price", () => {
+    for (const [name, source] of [
+      ["the editor", EDITOR],
+      ["the preview", PREVIEW],
+      ["the storefront example", EXAMPLE],
+    ] as const) {
+      expect(source, `${name} calls it something else`).toContain("baseline");
+      expect(flat(source), `${name} says "original price"`).not.toMatch(/original price/i);
+    }
+  });
+
+  it("does not describe reverting as restoring, anywhere", () => {
+    // `docs/help/concepts/revert.md`: "Reverting a campaign does not restore the prices
+    // that were there before." Every competitor's revert does exactly that, so the word
+    // is the difference and must not leak into our copy.
+    expect(flat(REVERT)).toContain("does not restore the prices that were there before");
+
+    for (const [name, source] of [
+      ["the preview", PREVIEW],
+      ["the overlap panel", OVERLAP],
+      ["the editor", EDITOR],
+    ] as const) {
+      expect(flat(source), `${name} describes a revert as restoring`).not.toMatch(
+        /revert\w*[^.]{0,40}restor/i,
+      );
+    }
+  });
+
+  it("says recompute where it talks about reverting at all", () => {
+    expect(flat(OVERLAP)).toContain("recomputes");
+  });
+});

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -430,6 +430,23 @@ export default function NewCampaign() {
               </s-select>
             </FieldGrid>
 
+            {/* What "from the baseline" means, next to the field that says it.
+                
+                The words are the help centre's — "the price a product would be if no
+                campaign were running" — because a merchant who reads one definition here
+                and a different one in Help has been given two concepts. The second
+                sentence is the consequence, which is the part that sells it: every
+                competitor computes from the live price, which is why RUBIX's own FAQ has
+                to explain that running two sales leaves a product wrong for ever. */}
+            <s-paragraph>
+              <s-text color="subdued">
+                Changes are computed from each variant&rsquo;s <s-text type="strong">baseline</s-text> —
+                the price it would be if no campaign were running — never from what the
+                storefront shows today. So running this campaign twice gives the same
+                result as running it once.
+              </s-text>
+            </s-paragraph>
+
             {/* What this rule does to prices, from the same resolver the run uses --
                 not an estimate of it. Sits with the rule rather than at the bottom of
                 the page, because it exists to answer "did I mean -20% or x0.20?" while


### PR DESCRIPTION
Closes #448.

The word is the product — `docs/help/concepts/baselines.md` opens with the definition and
calls that sentence "the whole product". The editor said it only in a `HelpNote` at the foot
of the page, which is where a merchant looks *after* they are already confused.

**Beside the rule now**, in the help centre's own words: computed from each variant's
baseline, *the price it would be if no campaign were running*, never from what the storefront
shows today — so running this campaign twice gives the same result as running it once. That
second sentence is the part that sells it: it is exactly the scenario RUBIX's FAQ has to
explain going wrong.

**The preview explains a `live` figure once, above the table** — not per row. The resolver
gave that row to *this* draft, so it does not know who priced the variant last, and there are
two possible reasons (another campaign, or an edit outside the app). Naming one would be a
guess. The way to Drift is a tertiary button, not a blue link — `ActionRow` keeps blue for a
word inside a sentence.

**`baseline-vocabulary.test.ts` reads the help centre**, not a copy of it, so improving that
sentence fails here rather than quietly disagreeing. It also refuses "restore" anywhere near
"revert" in our copy: every competitor's revert restores a saved price and ours recomputes, so
the word is the difference. That is the drift-buttons mistake from #400, caught before it
happens.

### Verification

- `npm test` 152 files / 2442 tests · typecheck · lint **with the cache cleared** · build
- Three mutations, each caught and reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)