### PR TITLE
Reverting recomputes, said where the button is

### DIFF
--- a/app/components/campaign/CampaignHeader.tsx
+++ b/app/components/campaign/CampaignHeader.tsx
@@ -32,6 +32,7 @@
 
 import { ActionRow } from "../ActionRow";
 import { ApplyConfirmation, APPLY_MODAL_ID } from "./ApplyConfirmation";
+import { RevertConfirmation, REVERT_MODAL_ID } from "./RevertConfirmation";
 import { SPACE } from "../../lib/ui/spacing";
 import type { CampaignDetailProps } from "./props";
 
@@ -44,6 +45,8 @@ export function CampaignHeader({
   fetcher,
   busy,
   canApply,
+  keepers,
+  keepersPending,
 }: CampaignDetailProps) {
   return (
     <>
@@ -111,15 +114,41 @@ export function CampaignHeader({
             Review {rollback.counts.drifted} edited before reverting
           </s-button>
         ) : (
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="revert" />
-            <s-button type="submit" tone="critical" loading={busy || undefined}>
-              Revert
-            </s-button>
-          </fetcher.Form>
+          // Opens the confirmation. The Revert *tab* already explains the recompute
+          // well, and a merchant who opens it is not the one at risk — this is the
+          // button pressed by somebody who has decided to end a sale and is not
+          // expecting a lesson.
+          <s-button
+            type="button"
+            tone="critical"
+            loading={busy || undefined}
+            commandFor={REVERT_MODAL_ID}
+            command="--show"
+          >
+            Revert
+          </s-button>
         )}
       </ActionRow>
     </s-grid>
+
+      {/* Asked for when the modal opens, not on page load: answering means planning the
+          whole scope again with this campaign excluded, and most visits to a campaign
+          never press Revert. Putting it in the loader would be #468 in a new place. */}
+      {rollback && rollback.straightforward ? (
+        <RevertConfirmation
+          campaignName={preview.name}
+          counts={rollback.counts}
+          keepers={keepers}
+          pending={keepersPending}
+        >
+          <fetcher.Form method="post" slot="primary-action">
+            <input type="hidden" name="intent" value="revert" />
+            <s-button type="submit" tone="critical" loading={busy || undefined}>
+              Revert now
+            </s-button>
+          </fetcher.Form>
+        </RevertConfirmation>
+      ) : null}
 
       {/* Outside the row, because a modal is not an action. Inside `ActionRow` it
           was a third child of a row of buttons, and it put its own primary button in

--- a/app/components/campaign/RevertConfirmation.tsx
+++ b/app/components/campaign/RevertConfirmation.tsx
@@ -1,0 +1,128 @@
+import { formatCount } from "../../lib/format/display";
+import { SPACE } from "../../lib/ui/spacing";
+import type { KeepersAfterRevert } from "../../services/campaigns/keepers.server";
+
+/**
+ * The modal's id, and the handle the header's button opens it by.
+ *
+ * A literal, for the reason `ApplyConfirmation` gives: `commandFor` is typed
+ * `Lowercase<string>` because HTML ids match case-sensitively, and an id assembled at
+ * runtime is a button that silently opens nothing.
+ */
+export const REVERT_MODAL_ID = "revert-confirmation";
+
+/**
+ * What reverting actually does, beside the button that does it.
+ *
+ * The Revert **tab** already explains the recompute well, and a merchant who opens it is
+ * not the one at risk. The header button is — it is the one pressed by somebody who has
+ * decided to end a sale and is not expecting a lesson — and it posted straight through.
+ * Exactly the shape of `blastRadius`, which has existed since the preview was written and
+ * only ever appeared inside a tab.
+ *
+ * The words are `docs/help/concepts/revert.md`'s, because that page makes the argument
+ * properly: a jacket at £100, a summer sale taking it to £80, clearance taking it to £70
+ * — end the summer sale and restoring "what it was before" gives £100, while the right
+ * answer is £70. Every competitor restores. Ours is the only one that can name the
+ * campaign still holding the variant, and it does.
+ */
+export function RevertConfirmation({
+  campaignName,
+  counts,
+  keepers,
+  pending,
+  children,
+}: {
+  campaignName: string;
+  /** From the rollback report the page already has. */
+  counts: { total: number; drifted: number; deleted: number };
+  /** Asked for when the modal opens, because answering means planning the scope again. */
+  keepers: KeepersAfterRevert | null;
+  pending: boolean;
+  /** The submit, carrying `slot="primary-action"` itself. */
+  children: React.ReactNode;
+}) {
+  return (
+    <s-modal id={REVERT_MODAL_ID} heading={`Revert ${campaignName}?`}>
+      <s-stack gap={SPACE.section}>
+        {/* The sentence, first, because it is the thing most likely to be wrong in a
+            merchant's head — every other app in this category restores a saved price. */}
+        <s-paragraph>
+          <s-text>
+            Reverting does not put the old prices back. It works out what each price should
+            be now, with this campaign removed, and writes that.
+          </s-text>
+        </s-paragraph>
+
+        <s-stack gap={SPACE.item}>
+          <s-paragraph>
+            <s-text type="strong">{formatCount(counts.total)}</s-text>{" "}
+            <s-text>
+              {counts.total === 1 ? "variant is" : "variants are"} priced by this campaign.
+            </s-text>
+          </s-paragraph>
+
+          {counts.drifted > 0 ? (
+            <s-paragraph>
+              <s-text tone="caution">
+                {formatCount(counts.drifted)} of them have been changed since this campaign
+                set them. Open the Revert tab to choose which of those to leave alone —
+                reverting from here rewrites all of them.
+              </s-text>
+            </s-paragraph>
+          ) : null}
+
+          {counts.deleted > 0 ? (
+            <s-paragraph>
+              <s-text color="subdued">
+                {formatCount(counts.deleted)}{" "}
+                {counts.deleted === 1 ? "was" : "were"} deleted in Shopify. Nothing is
+                written for {counts.deleted === 1 ? "it" : "them"}.
+              </s-text>
+            </s-paragraph>
+          ) : null}
+        </s-stack>
+
+        {/* The half no competitor can render: not "some prices may not return to normal",
+            but which campaign holds which variants, by name. */}
+        {pending ? (
+          <s-paragraph>
+            <s-text color="subdued">Working out what the prices would become…</s-text>
+          </s-paragraph>
+        ) : null}
+
+        {keepers && keepers.keepers.length > 0 ? (
+          <s-banner tone="info">
+            <s-paragraph>
+              <s-text type="strong">Not everything goes back to its baseline.</s-text>
+            </s-paragraph>
+            {keepers.keepers.map((keeper) => (
+              <s-paragraph key={keeper.campaignId}>
+                <s-text>
+                  {keeper.name} still covers {formatCount(keeper.variants)}{" "}
+                  {keeper.variants === 1 ? "variant" : "variants"}, so{" "}
+                  {keeper.variants === 1 ? "it keeps" : "they keep"} that campaign&rsquo;s
+                  price rather than returning to the baseline.
+                </s-text>
+              </s-paragraph>
+            ))}
+          </s-banner>
+        ) : null}
+
+        {keepers && keepers.keepers.length === 0 && !pending ? (
+          <s-paragraph>
+            <s-text color="subdued">
+              No other campaign covers these variants, so every one of them returns to its
+              baseline.
+            </s-text>
+          </s-paragraph>
+        ) : null}
+      </s-stack>
+
+      <s-button slot="secondary-actions" commandFor={REVERT_MODAL_ID} command="--hide">
+        Cancel
+      </s-button>
+      {children}
+    </s-modal>
+  );
+}

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -61,6 +61,8 @@ const props = (over: Partial<CampaignDetailProps> = {}) =>
     autoEnroll: false,
     enrollPendingAt: null,
     fetcher: { Form: "form", state: "idle" },
+    keepers: null,
+    keepersPending: false,
     ...over,
   }) as unknown as CampaignDetailProps;
 
@@ -348,5 +350,90 @@ describe("the typed confirmation appears only when it is earned", () => {
     // A-3.11 asks for this over a thousand variants. Asking every time is how a
     // confirmation becomes a reflex.
     expect(render(<CampaignHeader {...props()} />)).not.toContain('name="confirmation"');
+  });
+});
+
+/**
+ * The confirmation between Revert and the write.
+ *
+ * The Revert *tab* already explains the recompute, and a merchant who opens it is not the
+ * one at risk. The header button is: it is pressed by somebody who has decided to end a
+ * sale and is not expecting a lesson, and it posted straight through — the same shape as
+ * `blastRadius`, which lived only inside the Preview tab for as long as it existed.
+ *
+ * Reverting is the one operation in this app whose behaviour differs from every
+ * competitor's. All three restore a saved price; ours recomputes. A merchant carrying the
+ * wrong model presses this expecting prices to snap back to full, and the two answers
+ * differ precisely when another campaign is still running — which is when it matters.
+ */
+const withRollback = (over: Record<string, unknown> = {}) =>
+  props({
+    rollback: {
+      campaignId: "c1",
+      campaignName: "Summer sale",
+      rows: [],
+      counts: { total: 812, clean: 812, drifted: 0, deleted: 0 },
+      straightforward: true,
+      ...over,
+    },
+  } as unknown as Partial<CampaignDetailProps>);
+
+describe("what the revert button does now", () => {
+  it("opens the confirmation rather than posting", () => {
+    const html = render(<CampaignHeader {...withRollback()} />);
+    const row = html.split("<s-modal")[0];
+
+    expect(row).toContain('commandFor="revert-confirmation"');
+    expect(row, "the revert button posts directly again").not.toContain('value="revert"');
+  });
+
+  it("still sends drifted campaigns to the tab instead of offering a one-click revert", () => {
+    // There are edits to decide about; a confirmation that skipped them would be a
+    // one-click overwrite wearing a seatbelt.
+    const html = render(
+      <CampaignHeader {...withRollback({ straightforward: false, counts: { total: 812, clean: 800, drifted: 12, deleted: 0 } })} />,
+    );
+
+    expect(html).toContain("Review 12 edited before reverting");
+    expect(html).not.toContain('commandFor="revert-confirmation"');
+  });
+});
+
+describe("the revert confirmation says what recomputing means", () => {
+  it("leads with the thing a merchant is most likely to have wrong", () => {
+    const html = render(<CampaignHeader {...withRollback()} />);
+
+    expect(html).toContain("does not put the old prices back");
+    expect(html).toContain("with this campaign removed");
+  });
+
+  it("counts what this campaign is holding", () => {
+    expect(render(<CampaignHeader {...withRollback()} />)).toContain("812");
+  });
+
+  it("names the campaigns that keep some of them", () => {
+    const html = render(
+      <CampaignHeader
+        {...withRollback()}
+        keepers={{ repriced: 812, keepers: [{ campaignId: "c_clear", name: "Clearance", variants: 40 }] }}
+      />,
+    );
+
+    expect(html).toContain("Not everything goes back to its baseline");
+    expect(html).toContain("Clearance still covers 40 variants");
+  });
+
+  it("says so plainly when nothing else covers them", () => {
+    const html = render(
+      <CampaignHeader {...withRollback()} keepers={{ repriced: 812, keepers: [] }} />,
+    );
+
+    expect(html).toContain("every one of them returns to its baseline");
+  });
+
+  it("says it is working while the answer is on its way", () => {
+    const html = render(<CampaignHeader {...withRollback()} keepersPending />);
+
+    expect(html).toContain("Working out what the prices would become");
   });
 });

--- a/app/components/campaign/props.ts
+++ b/app/components/campaign/props.ts
@@ -1,6 +1,7 @@
 import type { useFetcher } from "react-router";
 
 import type { action, loader } from "../../routes/app.campaigns.$id";
+import type { KeepersAfterRevert } from "../../services/campaigns/keepers.server";
 
 /**
  * Everything the campaign page's tab bodies read.
@@ -19,4 +20,13 @@ export type CampaignDetailProps = Awaited<ReturnType<typeof loader>> & {
   canApply: boolean;
   /** The loader renames this; the components keep the clearer name. */
   attention: boolean;
+  /**
+   * Who would keep these variants if this campaign were reverted, once asked for.
+   *
+   * Null until the answer arrives, and asked for by the route rather than by the header —
+   * see `useKeepers`, and the note there about why a component may not reach for a
+   * fetcher of its own.
+   */
+  keepers: KeepersAfterRevert | null;
+  keepersPending: boolean;
 };

--- a/app/components/campaign/use-keepers.test.ts
+++ b/app/components/campaign/use-keepers.test.ts
@@ -1,0 +1,45 @@
+/**
+ * When the app is willing to plan the whole scope a second time.
+ *
+ * Answering "who would keep these variants if this campaign went away" means running the
+ * planner again with the campaign excluded. That is the same work the campaign page
+ * already does once, and doing it unconditionally would put it in front of every visit to
+ * a campaign for the sake of a modal most visits never open — which is #468 in a new
+ * place.
+ *
+ * The predicate is separate from the hook because `useFetcher` throws outside a data
+ * router and these components are rendered under a `StaticRouter`. The hook cannot be
+ * tested here; the decision inside it can, and the decision is the part with a wrong
+ * answer available.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { shouldAskForKeepers } from "./useKeepers";
+
+const rollback = (over: Partial<Parameters<typeof shouldAskForKeepers>[0] & object> = {}) => ({
+  campaignId: "c1",
+  straightforward: true,
+  counts: { total: 812 },
+  ...over,
+});
+
+describe("asking for the keepers", () => {
+  it("asks when a revert would run straight from the header", () => {
+    expect(shouldAskForKeepers(rollback())).toBe(true);
+  });
+
+  it("does not ask when there is no rollback report at all", () => {
+    // A draft campaign has written nothing, so there is nothing to revert.
+    expect(shouldAskForKeepers(null)).toBe(false);
+  });
+
+  it("does not ask when drifted rows send the merchant to the tab", () => {
+    // The header refuses a one-click revert in that case, so the modal never opens.
+    expect(shouldAskForKeepers(rollback({ straightforward: false }))).toBe(false);
+  });
+
+  it("does not ask when the campaign holds nothing", () => {
+    expect(shouldAskForKeepers(rollback({ counts: { total: 0 } }))).toBe(false);
+  });
+});

--- a/app/components/campaign/useKeepers.ts
+++ b/app/components/campaign/useKeepers.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react";
+import { useFetcher } from "react-router";
+
+import type { KeepersAfterRevert } from "../../services/campaigns/keepers.server";
+
+/**
+ * Who would keep these variants if this campaign were reverted.
+ *
+ * A hook, in the route, for two reasons. The tab bodies take their fetcher as a prop —
+ * `campaign-header.test.tsx` renders them under a `StaticRouter`, where `useFetcher`
+ * throws — so a component that reaches for one of its own stops being testable. And the
+ * route is held under 400 lines by `sections.test.ts`, so the asking has somewhere to
+ * live that is neither the route body nor a component that cannot be rendered.
+ *
+ * Asked once, lazily, and never in the loader: answering means planning the whole scope
+ * again with this campaign excluded, and most visits to a campaign page never press
+ * Revert. Putting it in the loader would be #468 in a new place.
+ *
+ * Not asked at all when there is nothing to revert, or when drifted rows mean the header
+ * sends the merchant to the tab instead — in both cases the modal it feeds never opens.
+ */
+export interface RollbackSummary {
+  campaignId: string;
+  straightforward: boolean;
+  counts: { total: number };
+}
+
+/**
+ * Whether the answer is worth asking for.
+ *
+ * Pure and exported so it can be tested: `useFetcher` throws outside a data router, and
+ * the components on this page are rendered under a `StaticRouter`, so the hook itself
+ * cannot be. The decision is the part with a wrong answer available — asking always is a
+ * plan of the whole scope on every campaign page, for a modal most visits never open.
+ */
+export function shouldAskForKeepers(rollback: RollbackSummary | null): boolean {
+  if (!rollback) return false;
+  // Drifted rows send the merchant to the tab, where the modal never opens.
+  if (!rollback.straightforward) return false;
+  // Nothing to revert means no button, so nothing to explain.
+  return rollback.counts.total > 0;
+}
+
+export function useKeepers(
+  rollback: RollbackSummary | null,
+): { keepers: KeepersAfterRevert | null; pending: boolean } {
+  const fetcher = useFetcher<KeepersAfterRevert>();
+  const asked = useRef(false);
+
+  const wanted = shouldAskForKeepers(rollback);
+  const campaignId = rollback?.campaignId;
+
+  useEffect(() => {
+    if (asked.current || !wanted || !campaignId) return;
+    asked.current = true;
+    fetcher.submit({ campaignId }, { method: "post", action: "/app/revert-preview" });
+  }, [wanted, campaignId, fetcher]);
+
+  return { keepers: fetcher.data ?? null, pending: wanted && fetcher.state !== "idle" };
+}

--- a/app/lib/ui/baseline-vocabulary.test.ts
+++ b/app/lib/ui/baseline-vocabulary.test.ts
@@ -29,6 +29,8 @@ const EDITOR = code(read("app/routes/app.campaigns.new.tsx"));
 const PREVIEW = code(read("app/components/DraftPreview.tsx"));
 const EXAMPLE = code(read("app/components/StorefrontExample.tsx"));
 const OVERLAP = code(read("app/components/OverlapPanel.tsx"));
+const REVERT_MODAL = code(read("app/components/campaign/RevertConfirmation.tsx"));
+const REVERT_TAB = code(read("app/components/campaign/CampaignRevertTab.tsx"));
 const CONCEPT = read("docs/help/concepts/baselines.md");
 const REVERT = read("docs/help/concepts/revert.md");
 
@@ -81,6 +83,10 @@ describe("everything that mentions the baseline agrees", () => {
       ["the preview", PREVIEW],
       ["the overlap panel", OVERLAP],
       ["the editor", EDITOR],
+      // The two most likely to say it, and the reason this list is not a sample: the
+      // revert confirmation and the revert tab are where a merchant meets the word.
+      ["the revert confirmation", REVERT_MODAL],
+      ["the revert tab", REVERT_TAB],
     ] as const) {
       expect(flat(source), `${name} describes a revert as restoring`).not.toMatch(
         /revert\w*[^.]{0,40}restor/i,
@@ -90,5 +96,15 @@ describe("everything that mentions the baseline agrees", () => {
 
   it("says recompute where it talks about reverting at all", () => {
     expect(flat(OVERLAP)).toContain("recomputes");
+    expect(flat(REVERT_TAB)).toContain("recomputes");
+  });
+
+  it("opens the revert confirmation with the help centre's own correction", () => {
+    // `revert.md` leads with it: "Reverting a campaign does not restore the prices that
+    // were there before. It works out what the price *should* be now, with that campaign
+    // removed, and writes that." It is the first thing in the modal for the same reason
+    // it is the first thing on the page — it is the belief a merchant arrives with.
+    expect(flat(REVERT_MODAL)).toContain("does not put the old prices back");
+    expect(flat(REVERT_MODAL)).toContain("with this campaign removed");
   });
 });

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -35,6 +35,7 @@ import { transitionHistory } from "../services/campaigns/lifecycle.server";
 import { approvalFor, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
 import { PageShell } from "../components/PageShell";
 import { CampaignTabs, currentTab, tabsFor } from "../components/campaign/CampaignTabs";
+import { useKeepers } from "../components/campaign/useKeepers";
 import { CampaignHeader } from "../components/campaign/CampaignHeader";
 import { CampaignOverviewTab } from "../components/campaign/CampaignOverviewTab";
 import { CampaignPreviewTab } from "../components/campaign/CampaignPreviewTab";
@@ -298,6 +299,7 @@ export default function CampaignDetail() {
   const canApply = !practice && !preview.blocked && canTransition(state, "APPLYING");
 
   const tabs = tabsFor({ runs, rollback, ledger });
+  const { keepers, pending: keepersPending } = useKeepers(rollback);
   const [params] = useSearchParams();
   const tab = currentTab(tabs, params.get("tab"));
 
@@ -307,6 +309,7 @@ export default function CampaignDetail() {
     rollback, practice, preview, runs, ledger, ledgerTotal, result: runResult, selectedRunId,
     scheduleText, timeZone, warnings, autoEnroll, enrollPendingAt, lifecycle, approval,
     state, needsAttention: attention, history, fetcher, busy, canApply, attention,
+    keepers, keepersPending,
   } as CampaignDetailProps;
 
 

--- a/app/routes/app.revert-preview.tsx
+++ b/app/routes/app.revert-preview.tsx
@@ -1,0 +1,52 @@
+/**
+ * Who keeps each variant once this campaign is taken out.
+ *
+ * A resource route, and asked for only when the revert confirmation is opened, because
+ * answering it means planning the whole scope again with this campaign excluded. The
+ * campaign page already pays for one plan and a rollback report; a third in the loader
+ * would put that cost in front of every page load for a modal most visits never open —
+ * which is #468 in a new place.
+ *
+ * Outside `/app/campaigns/*` for the same reason `app.preview-draft` is: `app.campaigns.$id`
+ * would read the segment as a campaign id.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { previewCampaign } from "../services/campaigns/preview.server";
+import { keepersAfterRevert } from "../services/campaigns/keepers.server";
+import prisma from "../db.server";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+
+  const form = await request.formData();
+  const campaignId = String(form.get("campaignId") ?? "");
+  if (!campaignId) return { keepers: [], repriced: 0 };
+
+  // `revert: true` plans with this campaign excluded, so every row that comes back is
+  // owned by whoever keeps the variant afterwards — the resolver's answer rather than a
+  // guess assembled from priorities.
+  const preview = await previewCampaign(shop.id, campaignId, { revert: true });
+
+  // Names for whatever the plan says still owns rows. Fetched after the plan rather than
+  // before it, so the query asks for the few campaigns that actually keep something
+  // instead of every campaign the shop has.
+  const owners = [
+    ...new Set(preview.rows.map((row) => row.campaignId).filter((id): id is string => Boolean(id))),
+  ].filter((id) => id !== campaignId);
+
+  const named = await prisma.campaign.findMany({
+    where: { shopId: shop.id, id: { in: owners } },
+    select: { id: true, name: true },
+  });
+
+  return keepersAfterRevert(
+    preview,
+    campaignId,
+    new Map(named.map((campaign) => [campaign.id, campaign.name])),
+  );
+};

--- a/app/services/campaigns/keepers.server.ts
+++ b/app/services/campaigns/keepers.server.ts
@@ -1,0 +1,56 @@
+import type { CampaignPreview } from "./types";
+
+/** A campaign that keeps some of the variants this one is giving up. */
+export interface Keeper {
+  campaignId: string;
+  name: string;
+  variants: number;
+}
+
+export interface KeepersAfterRevert {
+  /** Prices that would be rewritten — the whole point of a revert being a recompute. */
+  repriced: number;
+  /** Campaigns still covering some of those variants, biggest first. */
+  keepers: Keeper[];
+}
+
+/**
+ * What a revert leaves behind.
+ *
+ * `docs/help/concepts/revert.md` makes the argument: a jacket at £100, a summer sale
+ * taking it to £80, a clearance campaign taking it to £70 — end the summer sale and
+ * restoring "what it was before" gives £100, while the right answer is £70, because
+ * clearance is still running.
+ *
+ * This is that sentence with the merchant's own campaign names in it. The rows come from
+ * a plan made with the campaign excluded, so a row's owner *is* who keeps the variant;
+ * deriving it from priorities here would be a second implementation of the resolver.
+ *
+ * Rows carry an owner but not a name, so the caller passes the names it has and a keeper
+ * whose name is unknown is reported rather than dropped — a merchant about to revert needs
+ * the count to be right more than they need every name.
+ */
+export function keepersAfterRevert(
+  preview: Pick<CampaignPreview, "counts" | "rows">,
+  revertingCampaignId: string,
+  names: Map<string, string> = new Map(),
+): KeepersAfterRevert {
+  const counts = new Map<string, number>();
+
+  for (const row of preview.rows) {
+    const owner = row.campaignId;
+    if (!owner || owner === revertingCampaignId) continue;
+    counts.set(owner, (counts.get(owner) ?? 0) + 1);
+  }
+
+  return {
+    repriced: preview.counts.planned,
+    keepers: [...counts.entries()]
+      .map(([campaignId, variants]) => ({
+        campaignId,
+        name: names.get(campaignId) ?? "Another campaign",
+        variants,
+      }))
+      .sort((a, b) => b.variants - a.variants),
+  };
+}

--- a/app/services/campaigns/keepers.test.ts
+++ b/app/services/campaigns/keepers.test.ts
@@ -1,0 +1,83 @@
+/**
+ * What a revert leaves behind, named.
+ *
+ * `docs/help/concepts/revert.md` makes the argument with a jacket: £100 normally, £80 in
+ * the summer sale, £70 once clearance starts. End the summer sale and restoring "what it
+ * was before" gives £100 — while the right answer is £70, because clearance is still
+ * running. Every competitor restores.
+ *
+ * This turns that paragraph into the merchant's own campaign names. The rows come from a
+ * plan made with the campaign excluded, so a row's owner *is* whoever keeps the variant;
+ * working it out from priorities here would be a second implementation of the resolver,
+ * free to disagree with the one that will run.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { keepersAfterRevert } from "./keepers.server";
+
+const preview = (owners: Array<string | undefined>, planned = owners.length) => ({
+  counts: { planned, noop: 0, skipped: 0, clamped: 0 },
+  rows: owners.map((campaignId, index) => ({
+    variantGid: `gid://v/${index}`,
+    title: `Variant ${index}`,
+    before: null,
+    after: null,
+    compareAt: null,
+    status: "pending" as const,
+    campaignId,
+  })),
+});
+
+const NAMES = new Map([
+  ["c_clear", "Clearance"],
+  ["c_loyal", "Loyalty pricing"],
+]);
+
+describe("who keeps the variants", () => {
+  it("names the campaign that still covers them", () => {
+    const { keepers } = keepersAfterRevert(preview(["c_clear", "c_clear"]), "c_summer", NAMES);
+
+    expect(keepers).toEqual([{ campaignId: "c_clear", name: "Clearance", variants: 2 }]);
+  });
+
+  it("does not count the campaign being reverted", () => {
+    // Its own rows are the ones being given up, not kept.
+    const { keepers } = keepersAfterRevert(preview(["c_summer", "c_clear"]), "c_summer", NAMES);
+
+    expect(keepers).toEqual([{ campaignId: "c_clear", name: "Clearance", variants: 1 }]);
+  });
+
+  it("reports a keeper whose name we could not find, rather than dropping it", () => {
+    // A dropped keeper is a count that is quietly wrong, and the count is the part a
+    // merchant is deciding on.
+    const { keepers } = keepersAfterRevert(preview(["c_ghost"]), "c_summer", NAMES);
+
+    expect(keepers).toEqual([
+      { campaignId: "c_ghost", name: "Another campaign", variants: 1 },
+    ]);
+  });
+
+  it("puts the biggest keeper first", () => {
+    const { keepers } = keepersAfterRevert(
+      preview(["c_loyal", "c_clear", "c_clear", "c_clear"]),
+      "c_summer",
+      NAMES,
+    );
+
+    expect(keepers.map((keeper) => keeper.campaignId)).toEqual(["c_clear", "c_loyal"]);
+  });
+
+  it("finds none when nothing else covers the scope", () => {
+    // The ordinary case: reverting puts every variant back to its baseline.
+    expect(keepersAfterRevert(preview([undefined, "c_summer"]), "c_summer", NAMES).keepers).toEqual(
+      [],
+    );
+  });
+});
+
+describe("how many prices move", () => {
+  it("reports the planned count, because a revert is a write like any other", () => {
+    expect(keepersAfterRevert(preview(["c_clear"], 812), "c_summer", NAMES).repriced).toBe(812);
+  });
+});

--- a/app/services/campaigns/preview.server.ts
+++ b/app/services/campaigns/preview.server.ts
@@ -143,6 +143,7 @@ export async function previewCampaign(
       compareAt: row.intendedCompareAtSet ? fmt(row.intendedCompareAt) : null,
       status: row.status,
       reason: row.reason,
+      campaignId: row.campaignId,
       ...(marketCells.size > 0
         ? { surfaces: marketCells.get(row.ref.variantGid) ?? {} }
         : {}),

--- a/app/services/campaigns/types.ts
+++ b/app/services/campaigns/types.ts
@@ -71,6 +71,17 @@ export interface CampaignInput {
 export interface PreviewRow {
   variantGid: string;
   title: string;
+  /**
+   * The campaign that owns this row.
+   *
+   * Usually the campaign being previewed, and uninteresting. It matters on a *revert*
+   * preview, which plans with this campaign excluded: every row then belongs to whoever
+   * keeps the variant afterwards, which is the answer to "what happens to my prices if I
+   * end this sale" and the thing `docs/help/concepts/revert.md` argues about.
+   *
+   * The planner has always had it; the preview used to drop it.
+   */
+  campaignId?: string;
   before: string | null;
   after: string | null;
   compareAt: string | null;


### PR DESCRIPTION
Closes #450.

The Revert **tab** already explains this; a merchant who opens it is not the one at risk. The
**header button** is — pressed by somebody who has decided to end a sale and is not expecting
a lesson — and it posted straight through. The same shape as `blastRadius`, which lived only
inside the Preview tab for as long as it existed.

The confirmation opens with the help centre's own correction: *reverting does not put the old
prices back; it works out what each price should be now, with this campaign removed.* That is
the belief a merchant arrives with, because **every other app in this category restores**.

Then the half none of them can render. `revert.md` argues it with a jacket — £100, £80 in the
summer sale, £70 once clearance starts; end the summer sale and "restore" gives £100 while the
right answer is £70. The modal says that with the merchant's **own campaign names**:
*"Clearance still covers 40 variants, so they keep that campaign's price rather than returning
to the baseline."*

**Where the owner comes from.** A plan made with this campaign excluded, so a row's
`campaignId` *is* who keeps the variant. `PreviewRow` was always built from a `PlannedRow`
that carries it and dropped it on the way out; it does not now. Deriving it from priorities
would be a second implementation of the resolver.

**Asked for lazily, never in the loader** — it means planning the whole scope again, and most
visits never press Revert (#468's lesson). Not asked at all when drifted rows send the
merchant to the tab, or when the campaign holds nothing.

### Two mutants survived the first version of the tests

Both taught something, and both now fail: the vocabulary check did not read
`RevertConfirmation.tsx` — the file *most likely* to say "restore" was the one not covered —
and the hook's guard had no test because the hook cannot be rendered under `StaticRouter`. The
predicate is extracted and tested.

`npm test` 154 files / 2470 tests · `npm run test:chaos` 43 / 140 · typecheck · lint (cache
cleared) · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)