### PR TITLE
Put everything on sale, as one number

### DIFF
--- a/app/lib/campaigns/quick-campaign.test.ts
+++ b/app/lib/campaigns/quick-campaign.test.ts
@@ -1,0 +1,67 @@
+/**
+ * One field, and the four ways it can be wrong.
+ *
+ * The field is labelled "% off" and takes a positive number, which is the opposite sign
+ * convention from the editor's own rule field. That is deliberate — asking for "-20" in a
+ * box labelled "% off" is a double negative — and it is exactly the kind of deliberate
+ * inconsistency that gets "tidied up" later, so the reasoning is pinned here.
+ *
+ * The refusals matter more than the acceptances. This control creates a campaign over the
+ * *whole catalogue*, so a misread number is every price in the shop.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { quickCampaignName, readQuickPercent } from "./quick-campaign";
+
+describe("what it accepts", () => {
+  it("reads a plain number as a discount", () => {
+    expect(readQuickPercent("20")).toEqual({ ok: true, percent: 20 });
+  });
+
+  it("forgives a typed percent sign and stray spaces", () => {
+    expect(readQuickPercent("  15 % ")).toEqual({ ok: true, percent: 15 });
+  });
+
+  it("keeps a fractional percentage rather than rounding it", () => {
+    // 12.5% off is a real sale. Rounding here would silently price a different campaign
+    // from the one the merchant asked for.
+    expect(readQuickPercent("12.5")).toEqual({ ok: true, percent: 12.5 });
+  });
+});
+
+describe("what it refuses, and why", () => {
+  it("refuses nothing at all", () => {
+    expect(readQuickPercent("   ")).toMatchObject({ ok: false });
+  });
+
+  it("refuses text, quoting what was typed", () => {
+    const result = readQuickPercent("half");
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok === false && result.message).toContain("half");
+  });
+
+  it("refuses zero and negatives, and says where increases live", () => {
+    // A negative here would mean a *rise* under the editor's convention, which is the
+    // opposite of what the label says. Refusing is better than guessing which one was
+    // meant across the whole catalogue.
+    for (const raw of ["0", "-20"]) {
+      const result = readQuickPercent(raw);
+      expect(result, raw).toMatchObject({ ok: false });
+      expect(result.ok === false && result.message).toContain("full editor");
+    }
+  });
+
+  it("refuses 100 and above rather than making everything free", () => {
+    for (const raw of ["100", "150"]) {
+      expect(readQuickPercent(raw), raw).toMatchObject({ ok: false });
+    }
+  });
+});
+
+describe("the name it gives the campaign", () => {
+  it("says what it is and when it was made", () => {
+    expect(quickCampaignName(20, "29/08/2026")).toBe("20% off · 29/08/2026");
+  });
+});

--- a/app/lib/campaigns/quick-campaign.ts
+++ b/app/lib/campaigns/quick-campaign.ts
@@ -1,0 +1,56 @@
+/**
+ * The commonest job in the category, as one number.
+ *
+ * "20% off everything" is what most merchants open this app to do, and until now it cost
+ * them the whole editor: a name, a rule, a scope, a compare-at policy, rounding, a
+ * schedule. Sami puts it on its dashboard as one field and one button — *"just enter your
+ * target price and click Quick Create"* — and it is the single best idea in their app.
+ *
+ * What we do not copy is where it ends. Sami's Quick Create can write prices; ours makes a
+ * **draft**, which lands on the campaign page with the preview already computed. The
+ * two-step shape is the safety property, and trading it for parity with an app that
+ * changes every price in a catalogue on one click would be trading away the reason to
+ * choose us.
+ */
+
+/** What a merchant typed, and what is wrong with it. */
+export type QuickPercent =
+  | { ok: true; percent: number }
+  | { ok: false; message: string };
+
+/**
+ * Reading the one field.
+ *
+ * A discount is entered as a positive number here — "20" means 20% off — because that is
+ * how a merchant says it out loud, and the field is labelled "% off". The editor's own
+ * rule field takes a signed number because it also does increases; this one does not, and
+ * asking for "-20" in a box labelled "% off" is a double negative.
+ */
+export function readQuickPercent(raw: string): QuickPercent {
+  const trimmed = raw.trim().replace(/%$/, "").trim();
+  if (trimmed === "") return { ok: false, message: "Enter a percentage to discount by." };
+
+  const value = Number(trimmed);
+  if (!Number.isFinite(value)) {
+    return { ok: false, message: `“${raw.trim()}” is not a number.` };
+  }
+  if (value <= 0) {
+    return {
+      ok: false,
+      message: "Enter a positive number — 20 means 20% off. Use the full editor to raise prices.",
+    };
+  }
+  if (value >= 100) {
+    return {
+      ok: false,
+      message: "100% off would make everything free. Use the full editor if you mean that.",
+    };
+  }
+
+  return { ok: true, percent: value };
+}
+
+/** The campaign's name, which a merchant can change but should never have to invent. */
+export function quickCampaignName(percent: number, today: string): string {
+  return `${percent}% off · ${today}`;
+}

--- a/app/lib/dashboard/home.test.ts
+++ b/app/lib/dashboard/home.test.ts
@@ -67,8 +67,27 @@ describe("a shop that finished the checklist and deleted its campaigns", () => {
     expect(sections.emptyState).toBe(true);
   });
 
-  it("gets a black Create campaign, because nothing else is pointing anywhere", () => {
-    expect(sections.createIsPrimary).toBe(true);
+  it("is offered quick create, because there is a catalogue to price", () => {
+    expect(sections.quickCreate).toBe(true);
+  });
+
+  it("does not get a black Create campaign, because quick create is the black one", () => {
+    // Quick create *is* creating a campaign, for the case that covers most of them. With
+    // both on the page it is the one worth pointing at, and two black buttons point at
+    // nothing — which is the same rule that kept Create quiet while the checklist was up.
+    expect(sections.createIsPrimary).toBe(false);
+  });
+});
+
+describe("quick create needs something to price and nothing else asking for attention", () => {
+  it("is not offered before the first sync", () => {
+    expect(shop({ neverSynced: true, onboardingComplete: true }).quickCreate).toBe(false);
+  });
+
+  it("is not offered while the checklist is still telling the merchant what to do", () => {
+    // A merchant three steps into being led somewhere does not need a fourth thing to do
+    // offered beside it.
+    expect(shop({ onboardingComplete: false }).quickCreate).toBe(false);
   });
 });
 

--- a/app/lib/dashboard/home.ts
+++ b/app/lib/dashboard/home.ts
@@ -40,10 +40,21 @@ export interface HomeSections {
   /**
    * Whether "Create campaign" is the black button.
    *
-   * Only once the checklist has gone. While it is up, its own next step is what the page
-   * is pointing at, and two black buttons point at nothing.
+   * Only once the checklist has gone — while it is up, its own next step is what the page
+   * is pointing at, and two black buttons point at nothing — and only when quick create
+   * is not offered. Quick create *is* creating a campaign, for the case that covers most
+   * of them, so when both are on the page it is the one worth pointing at and the full
+   * editor becomes the alternative.
    */
   createIsPrimary: boolean;
+  /**
+   * The one-field card: a percentage, a button, a draft campaign.
+   *
+   * Needs a synced catalogue, because there is nothing to price without one, and needs
+   * the checklist gone: a merchant three steps into being told what to do next does not
+   * need a fourth thing to do offered beside it.
+   */
+  quickCreate: boolean;
   /** The catalogue card, which has nothing to count before a sync. */
   catalogue: boolean;
 }
@@ -53,10 +64,13 @@ export function homeSections(facts: HomeFacts): HomeSections {
   // counters that all read zero.
   const live = facts.campaigns > 0 || facts.hasRun;
 
+  const quickCreate = !facts.neverSynced && facts.onboardingComplete;
+
   return {
     live,
     emptyState: !facts.neverSynced && !live && facts.onboardingComplete,
-    createIsPrimary: facts.onboardingComplete,
+    createIsPrimary: facts.onboardingComplete && !quickCreate,
     catalogue: !facts.neverSynced,
+    quickCreate,
   };
 }

--- a/app/lib/ui/quick-create.test.ts
+++ b/app/lib/ui/quick-create.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The one-field card on Home, and the promise it makes before the button.
+ *
+ * Sami's dashboard has the same idea and it is the best thing in their app. The
+ * difference is where it ends: theirs can write prices — Save with "start now" changes
+ * every price in a catalogue on one click — and ours makes a draft. That is the safety
+ * property this whole product is built on, so the card has to say it *before* the button
+ * rather than leave a merchant to discover it.
+ *
+ * A source check, because what is being defended is what the page promises and what the
+ * action does, not how either looks.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const HOME = readFileSync(join(process.cwd(), "app/routes/app._index.tsx"), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^\s*\/\/.*$/gm, "");
+
+const at = (needle: string) => HOME.indexOf(needle);
+
+describe("what the card promises", () => {
+  it("says it makes a draft, before the button rather than after", () => {
+    const promise = at("Creates a draft");
+    const button = at("Create the draft");
+
+    expect(promise).toBeGreaterThan(-1);
+    expect(promise, "the promise is below the button that makes it").toBeLessThan(button);
+  });
+
+  it("says how many variants it covers, from the real count", () => {
+    expect(HOME).toContain("formatCount(health.variants)");
+  });
+
+  it("offers the full editor as the alternative rather than hiding it", () => {
+    expect(HOME).toContain("/app/campaigns/new");
+  });
+});
+
+describe("what the action does", () => {
+  it("creates a campaign and never runs one", () => {
+    const branch = HOME.slice(at('intent === "quick-campaign"'), at('intent === "sync"'));
+
+    expect(branch).toContain("createCampaign(");
+    expect(branch, "quick create must not apply anything").not.toContain("runCampaign");
+  });
+
+  it("targets every variant, which is what the card says", () => {
+    const branch = HOME.slice(at('intent === "quick-campaign"'), at('intent === "sync"'));
+
+    expect(branch).toContain("ast: { groups: [] }");
+  });
+
+  it("negates the percentage, because the field asks for a discount", () => {
+    // The field is labelled "% off" and takes a positive number; the rule takes a signed
+    // one. Losing the minus sign here raises every price in the shop.
+    const branch = HOME.slice(at('intent === "quick-campaign"'), at('intent === "sync"'));
+
+    expect(branch).toContain("percent: -parsed.percent");
+  });
+
+  it("takes rounding from the shop rather than inventing one", () => {
+    const branch = HOME.slice(at('intent === "quick-campaign"'), at('intent === "sync"'));
+
+    expect(branch).toContain("rounding: settings.rounding");
+  });
+
+  it("refuses before creating anything when the number is wrong", () => {
+    const branch = HOME.slice(at('intent === "quick-campaign"'), at('intent === "sync"'));
+
+    expect(branch.indexOf("if (!parsed.ok)")).toBeLessThan(branch.indexOf("createCampaign("));
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -1,6 +1,9 @@
 import { formatAgo, formatCount, formatDay } from "../lib/format/display";
+import { quickCampaignName, readQuickPercent } from "../lib/campaigns/quick-campaign";
+import { createCampaign } from "../services/campaigns/index.server";
+import { readSettings } from "../services/settings.server";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData } from "react-router";
+import { redirect, useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -164,6 +167,30 @@ export const action = withGuard("/app", async ({ request }: ActionFunctionArgs) 
       resolution === "extended" || resolution === "removed" ? resolution : "ignored",
     );
     return { ok: true, message: "Thanks — that market question is settled." };
+  }
+
+  // One field, one button, one draft. See `quick-campaign.ts` for why the sign
+  // convention here is the opposite of the editor's, and why this stops at a draft.
+  if (intent === "quick-campaign") {
+    const parsed = readQuickPercent(String(form.get("percent") ?? ""));
+    if (!parsed.ok) return { ok: false, message: parsed.message };
+
+    const settings = await readSettings(shop.id);
+
+    const campaign = await createCampaign(shop.id, {
+      name: quickCampaignName(parsed.percent, formatDay(new Date(), shop.timezone)),
+      // The whole catalogue: an empty filter is every variant, which is what "everything"
+      // means and what the card says it will do.
+      ast: { groups: [] },
+      rule: { kind: "percent-change", percent: -parsed.percent },
+      // A sale that does not look like one converts worse, and it is the editor's own
+      // default — a quick campaign that behaved differently from the same campaign made
+      // the long way would be a second set of defaults to keep in step.
+      compareAtPolicy: { kind: "set-to-baseline" },
+      rounding: settings.rounding,
+    });
+
+    return redirect(`/app/campaigns/${campaign.id}`);
   }
 
   if (intent === "sync") {
@@ -428,6 +455,47 @@ export default function Dashboard() {
             <s-button variant="tertiary" href="/app/prices/drift">Drift queue</s-button>
             <s-button variant="tertiary" href="/app/activity">Activity log</s-button>
           </ActionRow>
+        </s-section>
+      ) : null}
+
+      {/* The commonest job in the category, as one number.
+      
+          "20% off everything" is what most merchants open this app to do, and it used to
+          cost them the whole editor. Sami puts this on its dashboard and it is the single
+          best idea in their app.
+      
+          Where ours differs is where it ends: theirs can write prices, and Save with
+          "start now" changes every price in a catalogue on one click. This makes a
+          **draft** and lands on it with the preview already computed. The two-step shape
+          is the safety property; trading it for parity would be trading away the reason to
+          choose us — so the card says so before the button rather than after. */}
+      {sections.quickCreate ? (
+        <s-section heading="Put everything on sale">
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="quick-campaign" />
+            <s-stack gap={SPACE.item}>
+              <s-number-field
+                name="percent"
+                label="% off"
+                placeholder="20"
+                details={`Applies to all ${formatCount(health.variants)} variants, priced from their baselines.`}
+              />
+              <s-paragraph>
+                <s-text color="subdued">
+                  Creates a draft. Nothing is written until you apply it, and the next
+                  screen shows every price that would change.
+                </s-text>
+              </s-paragraph>
+              <ActionRow>
+                <s-button type="submit" variant="primary" loading={busy || undefined}>
+                  Create the draft
+                </s-button>
+                <s-button variant="tertiary" href="/app/campaigns/new">
+                  Or set a scope, a schedule and more
+                </s-button>
+              </ActionRow>
+            </s-stack>
+          </fetcher.Form>
         </s-section>
       ) : null}
 


### PR DESCRIPTION
Closes #451.

"20% off everything" is what most merchants open this app to do, and it cost them the whole
editor. Sami puts it on its dashboard as one field and one button — the single best idea in
their app.

**Where ours differs is where it ends.** Sami's Quick Create can write prices; Save with
"start now" changes every price in a catalogue on one click. This makes a **draft** and lands
on it with the preview computed. The card says so *before* the button: *"Creates a draft.
Nothing is written until you apply it, and the next screen shows every price that would
change."*

**The field is labelled "% off" and takes a positive number** — the opposite convention from
the editor's rule field, deliberately, because "-20" in a box labelled "% off" is a double
negative. `quick-campaign.ts` says why and the test pins it: losing the minus on the way into
the rule **raises every price in the shop**, and that is the mutation that matters most.

It refuses zero, negatives and ≥100 rather than guessing, pointing at the full editor for
what it will not do.

**Quick create takes the black button**; "Create campaign" becomes the alternative. Both
create a campaign and this one covers most of them — two black buttons point at nothing,
which is the rule that already kept Create quiet while the checklist was up. Offered only
once there is a catalogue to price and the checklist has retired itself.

`npm test` 156 files / 2489 tests · typecheck · lint (cache cleared) · build. Five mutations,
each caught and reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)