### PR TITLE
Home stops saying "Mirror audited", and its figures lead somewhere

### DIFF
--- a/app/components/CountsRow.tsx
+++ b/app/components/CountsRow.tsx
@@ -27,13 +27,33 @@ import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
  * The template is built from the item count rather than hardcoded, so a caller passing
  * three or five gets a full row rather than a gap on the end.
  *
+ * ## Tiles that lead somewhere
+ *
+ * A figure on a dashboard is a question — "three need attention" is only useful if the
+ * next click is the three. Where a caller gives an `href`, the whole tile becomes the
+ * target rather than a link tucked under the number: the number is what a merchant is
+ * aiming at, and a hit area smaller than the thing being read is a hit area people miss.
+ *
+ * Optional, because not every figure has a page behind it. "Variants: 3,669" on the
+ * catalogue card is a fact, not a queue, and giving it a destination invents one.
+ *
+ * `s-clickable` rather than `s-link`: `ActionRow`'s vocabulary reserves blue for a word
+ * inside a sentence, and this is a whole box.
+ *
  * **One comma.** Polaris splits a responsive value on the comma to separate "when the
  * query matches" from "otherwise", so a `repeat(4, 1fr)` on either side of it takes its
  * own comma as that separator and the whole value stops parsing — falling back to `none`,
  * which stacks the tiles into a single column that looks like a deliberate layout rather
  * than a broken string. Spelling out `1fr 1fr 1fr 1fr` is the price of that.
  */
-export function CountsRow({ items }: { items: Array<{ label: string; value: number }> }) {
+export interface CountItem {
+  label: string;
+  value: number;
+  /** Where this figure leads, when it leads anywhere. */
+  href?: string;
+}
+
+export function CountsRow({ items }: { items: CountItem[] }) {
   // `|| "1fr"` for the empty list: an empty template string leaves the responsive value
   // ending in a bare comma, which is the unparseable shape described above.
   const columns = items.map(() => "1fr").join(" ") || "1fr";
@@ -45,21 +65,41 @@ export function CountsRow({ items }: { items: Array<{ label: string; value: numb
       gridTemplateColumns={`@container (inline-size <= 600px) 1fr 1fr, ${columns}`}
       gap={SPACE.item}
     >
-      {items.map((item) => (
-        <s-box
-          key={item.label}
-          padding={PAD.card}
-          borderWidth={HAIRLINE.borderWidth}
-          borderStyle={HAIRLINE.borderStyle}
-          borderColor={HAIRLINE.borderColor}
-          borderRadius="base"
-        >
-          <s-stack gap={SPACE.tight}>
-            <s-text color="subdued">{item.label}</s-text>
-            <s-heading>{formatCount(item.value)}</s-heading>
-          </s-stack>
-        </s-box>
-      ))}
+      {items.map((item) =>
+        // Two shapes rather than one wrapped in a spare element: a `div` around the
+        // non-linking tile would become the grid item, and the box inside it would size
+        // to its content instead of filling the column — which is the unequal-width
+        // failure this grid exists to prevent.
+        item.href ? (
+          <s-clickable
+            key={item.label}
+            href={item.href}
+            accessibilityLabel={`${item.label}: ${formatCount(item.value)}`}
+          >
+            <Tile item={item} />
+          </s-clickable>
+        ) : (
+          <Tile key={item.label} item={item} />
+        ),
+      )}
     </s-grid>
+  );
+}
+
+/** The bounded figure itself, so the linking and non-linking cases cannot drift apart. */
+function Tile({ item }: { item: CountItem }) {
+  return (
+    <s-box
+      padding={PAD.card}
+      borderWidth={HAIRLINE.borderWidth}
+      borderStyle={HAIRLINE.borderStyle}
+      borderColor={HAIRLINE.borderColor}
+      borderRadius="base"
+    >
+      <s-stack gap={SPACE.tight}>
+        <s-text color="subdued">{item.label}</s-text>
+        <s-heading>{formatCount(item.value)}</s-heading>
+      </s-stack>
+    </s-box>
   );
 }

--- a/app/lib/audit/housekeeping.test.ts
+++ b/app/lib/audit/housekeeping.test.ts
@@ -1,0 +1,81 @@
+/**
+ * What the dashboard leads with, and what it leaves to the log.
+ *
+ * Live on `dartmode-labs` the Recent activity card read "Mirror audited / Mirror audit /
+ * Market added ×3", all attributed to Scheduler — two entries a merchant cannot tell
+ * apart, both naming an internal concept, on the first screen after installing.
+ *
+ * The direction of the filter is the decision worth testing. An allow-list would go stale
+ * by silently dropping a new merchant-facing action from Home, which nobody would ever
+ * notice; a deny-list goes stale by leaking a new internal one onto the dashboard, which
+ * is visible immediately. So: deny-list, and this pins that a stranger is shown.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { isHousekeeping, merchantFacing } from "./housekeeping";
+
+describe("what counts as the app talking to itself", () => {
+  it("hides the mirror auditing itself", () => {
+    expect(isHousekeeping("mirror.audit")).toBe(true);
+    expect(isHousekeeping("mirror.audited")).toBe(true);
+  });
+
+  it("keeps everything a merchant did or decided", () => {
+    for (const action of [
+      "campaign.transition",
+      "campaign.applied",
+      "drift.accepted",
+      "baselines.recaptured",
+      "settings.guardrails.update",
+      "cost.imported",
+    ]) {
+      expect(isHousekeeping(action), action).toBe(false);
+    }
+  });
+
+  it("keeps market changes, which are the merchant's business even when we noticed them", () => {
+    // Written by the scheduler, but a new market is a thing to know about: it changes
+    // what a campaign can price.
+    expect(isHousekeeping("market.added")).toBe(false);
+  });
+
+  it("shows an action from a namespace nobody has seen before", () => {
+    // The deny-list's whole point. A new *internal* namespace leaking here is visible and
+    // one line to fix; a new merchant-facing one silently missing is not.
+    expect(isHousekeeping("something.new")).toBe(false);
+  });
+
+  it("does not match a namespace that merely starts with the same letters", () => {
+    expect(isHousekeeping("mirrors.thing")).toBe(false);
+  });
+});
+
+describe("choosing the entries for the dashboard", () => {
+  const entry = (action: string) => ({ action });
+
+  it("drops housekeeping and keeps the order it was given", () => {
+    const shown = merchantFacing(
+      [entry("mirror.audited"), entry("campaign.applied"), entry("mirror.audit"), entry("drift.accepted")],
+      5,
+    );
+
+    expect(shown.map((row) => row.action)).toEqual(["campaign.applied", "drift.accepted"]);
+  });
+
+  it("counts the limit after filtering, not before", () => {
+    // Filtering a page of five and then showing what survives is how a busy scheduler
+    // empties the card: three housekeeping rows left two entries where five were asked
+    // for.
+    const entries = [
+      ...Array.from({ length: 6 }, () => entry("mirror.audit")),
+      ...Array.from({ length: 4 }, (_, i) => entry(`campaign.step${i}`)),
+    ];
+
+    expect(merchantFacing(entries, 3)).toHaveLength(3);
+  });
+
+  it("returns nothing rather than padding when there is nothing to show", () => {
+    expect(merchantFacing([entry("mirror.audit")], 5)).toEqual([]);
+  });
+});

--- a/app/lib/audit/housekeeping.ts
+++ b/app/lib/audit/housekeeping.ts
@@ -1,0 +1,45 @@
+/**
+ * Which audit entries are the app talking to itself.
+ *
+ * The dashboard's Recent activity feed showed whatever the log's last five rows were, and
+ * on a quiet shop that is the scheduler's own housekeeping. Live on `dartmode-labs` it
+ * read:
+ *
+ *     Mirror audited   Scheduler · 17 hours ago
+ *     Mirror audit     Scheduler · 17 hours ago
+ *     Market added ×3  Scheduler · 1 day ago
+ *
+ * Two entries a merchant cannot tell apart, both naming an internal concept, on the first
+ * screen after installing. The activity *log* is a genuine differentiator — no competitor
+ * has one — and this is not the half of it worth leading with.
+ *
+ * ## Why a list of what to hide rather than a list of what to show
+ *
+ * The same argument `describeAction` makes about not being a lookup table, pointed the
+ * other way. An allow-list goes stale silently in the direction that costs most: a new
+ * merchant-facing action would simply never appear on Home, and nobody would notice
+ * because nothing is missing from any page. A deny-list goes stale in the direction that
+ * costs least — a new *internal* namespace leaks onto the dashboard, which is visible the
+ * first time anybody looks and takes one line to fix.
+ *
+ * Nothing is hidden from `/app/activity`, which remains complete. This decides what leads.
+ */
+
+/**
+ * Namespaces written by the app about its own upkeep.
+ *
+ * `mirror` is the catalogue mirror auditing itself against Shopify. A merchant has no
+ * decision to make about it; when it finds something they can act on, that surfaces as
+ * drift, which has its own namespace and its own queue.
+ */
+const HOUSEKEEPING = ["mirror"];
+
+/** True when this entry is the app talking to itself rather than to the merchant. */
+export function isHousekeeping(action: string): boolean {
+  return HOUSEKEEPING.includes(action.split(".")[0]);
+}
+
+/** The entries worth putting on the dashboard, newest first, at most `limit`. */
+export function merchantFacing<T extends { action: string }>(entries: T[], limit: number): T[] {
+  return entries.filter((entry) => !isHousekeeping(entry.action)).slice(0, limit);
+}

--- a/app/lib/ui/home-vocabulary.test.ts
+++ b/app/lib/ui/home-vocabulary.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Home says nothing a merchant has to translate, and its figures lead somewhere.
+ *
+ * The dashboard's activity card read "Mirror audited / Mirror audit / Market added ×3",
+ * all by "Scheduler", on the first screen after installing — two entries nobody can tell
+ * apart, both naming an internal concept. And its figures were numbers with no next
+ * click: "Need attention: 3" is only useful if the three are one press away.
+ *
+ * Checked against the source because both are properties of what the page *is*, not of
+ * how it renders — and because the route cannot be rendered here without a data router.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const HOME = readFileSync(join(process.cwd(), "app/routes/app._index.tsx"), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^\s*\/\/.*$/gm, "");
+
+const ACTIVITY = readFileSync(join(process.cwd(), "app/routes/app.activity.tsx"), "utf8");
+
+describe("the dashboard leaves the app's own upkeep to the log", () => {
+  it("filters the feed through the one place that decides", () => {
+    expect(HOME).toContain("merchantFacing(recent, 5)");
+  });
+
+  it("reads more rows than it shows, because the filter comes after the query", () => {
+    // A quiet shop's last five entries are all scheduler upkeep. Taking five and then
+    // filtering empties the card.
+    expect(HOME).toMatch(/take: (\d+),\s*select: \{ id: true, actor: true, action: true/);
+    const take = Number(/take: (\d+),\s*select: \{ id: true, actor: true, action: true/.exec(HOME)?.[1]);
+    expect(take).toBeGreaterThan(5);
+  });
+
+  it("does not filter the activity log itself, which stays complete", () => {
+    // Hiding entries from the log would make it stop being the record. The dashboard
+    // decides what *leads*; the log decides nothing.
+    expect(ACTIVITY).not.toContain("merchantFacing");
+    expect(ACTIVITY).not.toContain("isHousekeeping");
+  });
+});
+
+describe("every figure on the dashboard is a front door", () => {
+  it("gives each campaign count a filtered list to open", () => {
+    for (const href of [
+      "/app/campaigns?status=ACTIVE",
+      "/app/campaigns?status=SCHEDULED",
+      "/app/campaigns?status=attention",
+      "/app/prices/drift",
+    ]) {
+      expect(HOME, `${href} is not reachable from its tile`).toContain(href);
+    }
+  });
+
+  it("uses the campaigns index's own filter vocabulary, not a second one", () => {
+    // `attention` spans PARTIAL and HELD in `list.server.ts`, which is exactly what the
+    // "Need attention" tile counts. Two queries that merely agree today would drift.
+    const LIST = readFileSync(join(process.cwd(), "app/services/campaigns/list.server.ts"), "utf8");
+
+    expect(LIST).toContain('"attention"');
+    expect(HOME).toContain("status=attention");
+  });
+
+  it("leaves the catalogue figures alone, because they are facts and not queues", () => {
+    // "Variants: 3,669" has no page behind it, and giving it one invents a destination.
+    const catalogue = HOME.slice(HOME.indexOf('heading="Catalogue"'));
+
+    expect(catalogue.slice(0, catalogue.indexOf("</CountsRow>") + 1)).not.toContain("href:");
+  });
+});

--- a/app/lib/ui/table-size.test.ts
+++ b/app/lib/ui/table-size.test.ts
@@ -66,8 +66,10 @@ describe("one number decides how many rows a view holds", () => {
    * not put rows on a screen, and it has to be made deliberately.
    */
   const NOT_A_TABLE: Record<string, string> = {
-    "app/routes/app._index.tsx: take: 5":
-      "the dashboard's activity summary, which links to the full log",
+    "app/routes/app._index.tsx: take: 40":
+      "the dashboard's activity summary, which links to the full log — it reads more " +
+      "than the five it shows because the scheduler's own upkeep is filtered out " +
+      "afterwards, and a quiet shop's last five entries are all upkeep",
     "app/routes/app._index.tsx: take: 8":
       "the dashboard's upcoming campaigns, which links to the calendar",
     "app/services/activity.server.ts: take: 50": "distinct actors, for the Who dropdown",

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -1,5 +1,6 @@
 import { formatAgo, formatCount, formatDay } from "../lib/format/display";
 import { quickCampaignName, readQuickPercent } from "../lib/campaigns/quick-campaign";
+import { merchantFacing } from "../lib/audit/housekeeping";
 import { createCampaign } from "../services/campaigns/index.server";
 import { readSettings } from "../services/settings.server";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
@@ -56,10 +57,14 @@ export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) 
         campaign: { select: { id: true, name: true } },
       },
     }),
+    // More than the five shown, because housekeeping is filtered out afterwards and a
+    // quiet shop's last five rows are all scheduler upkeep. Filtering in SQL would mean
+    // encoding the namespace list in a query as well as in `housekeeping.ts`, which is
+    // two places for one decision.
     prisma.auditLogEntry.findMany({
       where: { shopId: shop.id },
       orderBy: { createdAt: "desc" },
-      take: 5,
+      take: 40,
       select: { id: true, actor: true, action: true, createdAt: true },
     }),
     // Campaigns with a start or an end still ahead of them. Which of the two is next
@@ -144,7 +149,10 @@ export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) 
       })),
       new Date().toISOString(),
     ),
-    recent: recent.map((entry) => ({
+    // What the merchant did or decided. The scheduler's own upkeep stays in the full
+    // log, which `/app/activity` shows unfiltered — see `housekeeping.ts` for why the
+    // filter is a deny-list rather than an allow-list.
+    recent: merchantFacing(recent, 5).map((entry) => ({
       id: entry.id,
       actor: entry.actor,
       action: entry.action,
@@ -421,15 +429,24 @@ export default function Dashboard() {
           action rather than with four zeroes. */}
       {sections.live ? (
         <s-section heading="What is live right now">
+          {/* Each figure is a question, so each tile is the answer's front door. The
+              status values are the campaigns index's own filter vocabulary — `attention`
+              spans PARTIAL and HELD there, which is exactly what "Need attention"
+              counts — so the number a merchant clicks and the list they land on are the
+              same query rather than two that happen to agree today. */}
           <CountsRow
             items={[
-              { label: "Campaigns running", value: live },
-              { label: "Scheduled", value: upcoming },
-              { label: "Need attention", value: needsAttention },
+              { label: "Campaigns running", value: live, href: "/app/campaigns?status=ACTIVE" },
+              { label: "Scheduled", value: upcoming, href: "/app/campaigns?status=SCHEDULED" },
+              {
+                label: "Need attention",
+                value: needsAttention,
+                href: "/app/campaigns?status=attention",
+              },
               // Two words. "Prices changed outside the app" wrapped to three lines in
               // this column and "Changed outside Anchor" to two, either of which makes
               // its tile taller than the three beside it.
-              { label: "Changed elsewhere", value: driftOpen },
+              { label: "Changed elsewhere", value: driftOpen, href: "/app/prices/drift" },
             ]}
           />
 


### PR DESCRIPTION
Closes #452 — and the issue was **half wrong**, which the PR records rather than hides.

**The metric strip already existed** and is good. I wrote that half of the ticket from a
screenshot of a shop with *no campaigns*, where `sections.live` is false and the strip is not
rendered. What was actually missing: the figures went nowhere. Each tile is now the front
door to a filtered list, using the campaigns index's **own** filter vocabulary (`attention`
spans PARTIAL and HELD there — exactly what the tile counts) rather than a second query that
agrees today. The whole tile is the target, not a link under the number. Catalogue figures
keep no href: "Variants: 3,669" is a fact, not a queue.

**The second half was right.** Live on `dartmode-labs` the card read *"Mirror audited / Mirror
audit / Market added ×3"*, all by Scheduler — two entries nobody can tell apart, both naming
an internal concept, on the first screen after installing.

`housekeeping.ts` filters it, and **the direction is the decision**: an allow-list goes stale
by silently dropping a new merchant-facing action from Home, which nobody notices; a deny-list
goes stale by leaking a new internal namespace onto the dashboard, which is visible
immediately. Same argument `describeAction` makes, pointed the other way. Market changes stay
— the scheduler notices them, but a new market changes what a campaign can price.

**`/app/activity` stays complete**, and a test says so. The query reads 40 rows to show 5,
because a quiet shop's last five are all upkeep; `table-size.test.ts`'s exemption records that
reason rather than just the new number.

`npm test` 158 files / 2503 tests · typecheck · lint (cache cleared) · build. Five mutations,
each caught — including a prefix match that would have hidden a `mirrors.*` namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)