### PR TITLE
A campaign list that says what each campaign does (#453)

### DIFF
--- a/app/components/campaign/ApplyConfirmation.tsx
+++ b/app/components/campaign/ApplyConfirmation.tsx
@@ -35,10 +35,15 @@ export const APPLY_MODAL_ID = "apply-confirmation" as const;
 
 export function ApplyConfirmation({
   preview,
+  rule,
+  scope,
   scheduleText,
   children,
 }: {
   preview: CampaignPreview;
+  /** From `describeCampaign`, the same call the campaigns index makes. */
+  rule: string;
+  scope: string;
   /** The schedule sentence the header shows, restated here where the decision is made. */
   scheduleText?: string | null;
   /**
@@ -59,6 +64,13 @@ export function ApplyConfirmation({
             run; lines that do not apply are absent rather than empty, because a row
             reading "Markets: none" is a thing to read and dismiss on every apply. */}
         <s-stack gap={SPACE.item}>
+          {/* The same two sentences the campaigns index shows, through the same
+              formatter. A merchant who read "20% off · In Outerwear" in the list should
+              meet those words again at the moment they commit, not a second description
+              of one campaign. */}
+          <Fact label="Rule">{rule}</Fact>
+          <Fact label="Applies to">{scope}</Fact>
+
           <Fact label="Prices to write">
             {formatCount(counts.planned)} of{" "}
             {formatCount(counts.planned + counts.noop + counts.skipped)} variants in scope

--- a/app/components/campaign/CampaignHeader.tsx
+++ b/app/components/campaign/CampaignHeader.tsx
@@ -40,6 +40,8 @@ export function CampaignHeader({
   rollback,
   practice,
   preview,
+  rule,
+  scope,
   scheduleText,
   lifecycle,
   fetcher,
@@ -157,6 +159,8 @@ export function CampaignHeader({
       {practice ? null : (
       <ApplyConfirmation
         preview={preview}
+        rule={rule}
+        scope={scope}
         scheduleText={scheduleText}
       >
         <fetcher.Form method="post" slot="primary-action">

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -136,6 +136,18 @@ export function CampaignListView({
               <s-table-header-row>
                 <s-table-header listSlot="primary">Campaign</s-table-header>
                 <s-table-header listSlot="inline">Status</s-table-header>
+                {/* What it does, and what to. The list said everything *about* a campaign
+                    — name, status, priority, last run — and nothing about what it is.
+                    Sami renders exactly these two columns; NA writes the row as a
+                    sentence. Either way the index answers "what is this" without opening
+                    anything.
+                    
+                    `inline` for the rule, because collapsed it belongs on the same line
+                    as the name — "Autumn sale · 20% off" is the row. The scope is
+                    `labeled`: it is longer, and a scope stacked under its own label reads
+                    better than one run on after the rule. */}
+                <s-table-header listSlot="inline">Rule</s-table-header>
+                <s-table-header listSlot="labeled">Applies to</s-table-header>
                 {/* Right-aligned in the grid, because it is a number. */}
                 <s-table-header listSlot="labeled" format="numeric">
                   Priority
@@ -152,6 +164,8 @@ export function CampaignListView({
                         {campaign.lifecycle.label}
                       </s-badge>
                     </s-table-cell>
+                    <s-table-cell>{campaign.rule}</s-table-cell>
+                    <s-table-cell>{campaign.scope}</s-table-cell>
                     <s-table-cell>{campaign.priority}</s-table-cell>
                     <s-table-cell>
                       {campaign.lastRun

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -22,6 +22,7 @@ import { describe, expect, it } from "vitest";
 import { CampaignHeader } from "./CampaignHeader";
 import { CampaignOverviewTab } from "./CampaignOverviewTab";
 import { describeState } from "../../lib/lifecycle/transitions";
+import { describeCampaign } from "../../lib/campaigns/describe";
 import { formatWhen } from "../../lib/format/display";
 import type { CampaignDetailProps } from "./props";
 
@@ -61,6 +62,12 @@ const props = (over: Partial<CampaignDetailProps> = {}) =>
     autoEnroll: false,
     enrollPendingAt: null,
     fetcher: { Form: "form", state: "idle" },
+    // Through the real formatter, so this fixture cannot describe a campaign in words
+    // the campaigns index would never produce.
+    ...describeCampaign({
+      rule: { kind: "percent-change", percent: -20 },
+      ast: { groups: [{ conditions: [{ field: "collection", value: "Outerwear" }] }] },
+    }),
     keepers: null,
     keepersPending: false,
     ...over,
@@ -435,5 +442,16 @@ describe("the revert confirmation says what recomputing means", () => {
     const html = render(<CampaignHeader {...withRollback()} keepersPending />);
 
     expect(html).toContain("Working out what the prices would become");
+  });
+});
+
+describe("the confirmation and the index describe a campaign the same way", () => {
+  it("shows the rule and the scope, in the index's own words", () => {
+    // Not "the same words as the index" by coincidence: both call `describeCampaign`,
+    // and `campaign-describe-shared.test.ts` refuses a second formatter.
+    const html = render(<CampaignHeader {...props()} />);
+
+    expect(html).toContain("20% off");
+    expect(html).toContain("In Outerwear");
   });
 });

--- a/app/components/campaign/campaign-list-view.test.tsx
+++ b/app/components/campaign/campaign-list-view.test.tsx
@@ -19,6 +19,7 @@ import { describe, expect, it } from "vitest";
 
 import { CampaignListView } from "./CampaignListView";
 import { describeState } from "../../lib/lifecycle/transitions";
+import { describeRule, describeScope } from "../../lib/campaigns/describe";
 
 type Props = Parameters<typeof CampaignListView>[0];
 
@@ -31,6 +32,10 @@ const campaign = (over: Partial<Props["list"]["campaigns"][number]> = {}) => ({
   lifecycle: describeState("ACTIVE"),
   attention: false,
   priority: 900,
+  // Through the real formatter, for the same reason `lifecycle` is: a fixture that
+  // writes its own sentence stops catching the day the real one changes.
+  rule: describeRule({ kind: "percent-change", percent: -20 }),
+  scope: describeScope({ groups: [{ conditions: [{ field: "tag", value: "sale" }] }] }),
   createdAt: "2026-08-01T00:00:00.000Z",
   lastRun: null,
   ...over,
@@ -69,17 +74,25 @@ describe("the table survives being collapsed into a list", () => {
 
   it("designates every other column too, so none falls back to a default", () => {
     const headers = [...html.matchAll(/<s-table-header(\s[^>]*)?>/g)];
-    expect(headers.length, "five columns, the last one the action").toBe(5);
+    expect(headers.length, "seven columns, the last one the action").toBe(7);
 
     for (const [tag] of headers) {
       expect(tag, `${tag} has no list designation`).toContain("listSlot=");
     }
   });
 
-  it("keeps the status and the way in on the row itself", () => {
-    // Both `inline`, so a collapsed row still answers "what state is this in" and "how do
-    // I open it" without unfolding into a block.
-    expect(html.split('listSlot="inline"').length - 1).toBe(2);
+  it("keeps the status, the rule and the way in on the row itself", () => {
+    // All three `inline`, so a collapsed row reads as one line — "Autumn sale · Active ·
+    // 20% off · Open" — and answers what state this is in, what it does, and how to open
+    // it without unfolding into a block. The scope is `labeled` because it is longer and
+    // reads better stacked under its own word than run on after the rule.
+    expect(html.split('listSlot="inline"').length - 1).toBe(3);
+  });
+
+  it("says what each campaign does and what to", () => {
+    // The gap this table had: everything *about* a campaign and nothing about what it is.
+    expect(html).toContain("20% off");
+    expect(html).toContain("Tagged sale");
   });
 
   it("treats the priority as a number", () => {

--- a/app/lib/campaigns/describe-shared.test.ts
+++ b/app/lib/campaigns/describe-shared.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { describeCampaign } from "./describe";
+
+/** Comments only, so prose about the formatter cannot masquerade as a call to it. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+const LIST = "app/services/campaigns/list.server.ts";
+const DETAIL = "app/routes/app.campaigns.$id.tsx";
+
+/**
+ * The one call, wherever it is made.
+ *
+ * The call is a spread — `...describeCampaign({ ... })` — because both surfaces put the
+ * two sentences straight into a row or a loader payload. Matching the spread is what
+ * makes this a check of the real call and not of a mention in a comment.
+ */
+function describeCall(file: string): string {
+  const source = readFileSync(file, "utf8");
+  const call = /\.\.\.describeCampaign\(\{[^}]*\}\)/.exec(source)?.[0];
+
+  expect(call, `${file} no longer builds its sentences with describeCampaign`).toBeTruthy();
+  return call as string;
+}
+
+describe("the campaigns index and the campaign page describe a campaign the same way", () => {
+  it("passes the same three things, from the same accessors", () => {
+    // The failure this exists for is not "one surface stopped calling the formatter" --
+    // that one is loud, because the column goes blank. It is the quiet one: both call it,
+    // but the index passes `segmentName` and the campaign page forgets to, so a campaign
+    // scoped to a saved segment reads "In Outerwear" in the list and "Tagged sale" on its
+    // own page. Two true sentences about one campaign, and a merchant has no way to know
+    // which is the one that will run.
+    //
+    // So the arguments are compared, not merely the presence of the call. The record
+    // variable is named `c` in the list's `map` and `record` in the loader; normalising it
+    // is the only difference either file is allowed.
+    const normalise = (call: string) => call.replace(/\b(?:c|record)\b/g, "×");
+
+    expect(normalise(describeCall(LIST))).toBe(normalise(describeCall(DETAIL)));
+  });
+
+  it("keeps every surface on the pair, not on one half of it", () => {
+    // Calling `describeRule` alone is how the two sentences drift apart: a surface that
+    // wants only the rule today grows an `Applies to` column tomorrow, writes its own
+    // scope line because the import is already one function short, and now there are two
+    // answers again. Going through `describeCampaign` makes the pair the unit.
+    //
+    // Comments are stripped before the grep. This is the sixth time in this repo a
+    // source-level check has been fooled by its own subject appearing in prose -- the
+    // note in `editor-layout.test.ts` records the last one, and #462 is open to extract
+    // this into something shared.
+    const files = execFileSync("git", ["ls-files", "app"], { encoding: "utf8" })
+      .split("\n")
+      .filter((f) => /\.tsx?$/.test(f))
+      .filter((f) => !f.includes(".test.") && !f.startsWith("app/lib/campaigns/describe"));
+
+    const offenders = files.filter((f) =>
+      /\bdescribe(?:Rule|Scope)\(/.test(withoutComments(readFileSync(f, "utf8"))),
+    );
+
+    expect(offenders, "call describeCampaign, which returns both").toEqual([]);
+  });
+});
+
+describe("describeCampaign", () => {
+  it("names the segment as the scope when there is one", () => {
+    // The argument the two call sites are compared on, exercised for real: a segment
+    // replaces the inline filter rather than narrowing it, so where there is one it is
+    // the whole answer to "applies to".
+    expect(
+      describeCampaign({
+        rule: { kind: "percent-change", percent: -20 },
+        ast: { groups: [{ conditions: [{ field: "tag", value: "sale" }] }] },
+        segmentName: "Winter clearance",
+      }),
+    ).toEqual({ rule: "20% off", scope: "Winter clearance" });
+  });
+
+  it("still answers when a campaign has neither", () => {
+    // A draft in its first second exists with no rule row and no filter, and the index
+    // lists drafts. Blank cells in two columns read as a broken page.
+    expect(describeCampaign({ rule: null, ast: null })).toEqual({
+      rule: "No rule",
+      scope: "All variants",
+    });
+  });
+});

--- a/app/lib/campaigns/describe.test.ts
+++ b/app/lib/campaigns/describe.test.ts
@@ -1,0 +1,116 @@
+/**
+ * What a campaign does, in one sentence, in one place.
+ *
+ * The index listed a name, a status, a priority and a last run — everything *about* a
+ * campaign and nothing about what it is. Sami renders "Price decrease by 10%" beside "All
+ * products"; NA writes the row as "20% off sale on 1 product variant". Either answers
+ * "what is this" without opening anything.
+ *
+ * The sign is the part with a wrong answer available. A rule stored as `-20` is 20% off,
+ * and a formatter that lost the minus would label a discount as a price rise in a column
+ * merchants scan rather than read.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { describeRule, describeScope } from "./describe";
+import { money } from "../money/money";
+
+describe("the rule, as a merchant would say it", () => {
+  it("says off for a discount, not a minus sign", () => {
+    // "-20%" is a worse way to say it: a minus is one character wide in a scanned column.
+    expect(describeRule({ kind: "percent-change", percent: -20 })).toBe("20% off");
+  });
+
+  it("says increase for a rise, so the two cannot be confused", () => {
+    expect(describeRule({ kind: "percent-change", percent: 15 })).toBe("15% increase");
+  });
+
+  it("keeps a fractional percentage without inventing precision", () => {
+    expect(describeRule({ kind: "percent-change", percent: -12.5 })).toBe("12.5% off");
+    expect(describeRule({ kind: "percent-change", percent: -20.0 })).toBe("20% off");
+  });
+
+  it("formats an amount in its own currency", () => {
+    expect(describeRule({ kind: "fixed-change", amount: money(-1000, "USD") })).toContain("off");
+    expect(describeRule({ kind: "fixed-change", amount: money(1000, "USD") })).toContain("more");
+  });
+
+  it("names an exact price as a price, not as a change", () => {
+    expect(describeRule({ kind: "set-exact", amount: money(2999, "USD") })).toContain("Set to");
+  });
+
+  it("says where the prices came from for a file, rather than inventing one rule", () => {
+    // A campaign priced from a spreadsheet has one rule per variant; there is no single
+    // sentence for it, and pretending otherwise would be a lie in a scannable column.
+    expect(describeRule({ kind: "from-import", importId: "imp_1" })).toBe("Prices from a file");
+  });
+
+  it("does not describe a zero as a discount", () => {
+    expect(describeRule({ kind: "percent-change", percent: 0 })).toBe("No change");
+    expect(describeRule({ kind: "fixed-change", amount: money(0, "USD") })).toBe("No change");
+  });
+
+  it("says something for a campaign with no rule at all", () => {
+    expect(describeRule(null)).toBe("No rule");
+    expect(describeRule(undefined)).toBe("No rule");
+  });
+});
+
+describe("what it applies to", () => {
+  it("says the whole catalogue in as many words", () => {
+    // The scope with the largest consequence and the least visible cause. An empty cell
+    // here reads as missing data rather than as "everything".
+    expect(describeScope({ groups: [] })).toBe("All variants");
+    expect(describeScope(null)).toBe("All variants");
+  });
+
+  it("reads a filter as a phrase", () => {
+    expect(
+      describeScope({ groups: [{ conditions: [{ field: "collection", value: "Outerwear" }] }] }),
+    ).toBe("In Outerwear");
+  });
+
+  it("joins several conditions, which combine with AND", () => {
+    expect(
+      describeScope({
+        groups: [
+          {
+            conditions: [
+              { field: "collection", value: "Outerwear" },
+              { field: "tag", value: "sale" },
+            ],
+          },
+        ],
+      }),
+    ).toBe("In Outerwear · Tagged sale");
+  });
+
+  it("counts a pinned variant list rather than listing gids", () => {
+    expect(
+      describeScope({
+        groups: [{ conditions: [{ field: "variantGid", value: ["gid://1", "gid://2"] }] }],
+      }),
+    ).toBe("2 chosen variants");
+  });
+
+  it("prefers the segment, because a segment replaces the filter rather than narrowing it", () => {
+    // Showing the inline filter for a segment-scoped campaign describes a filter the
+    // campaign is ignoring.
+    expect(
+      describeScope({ groups: [{ conditions: [{ field: "tag", value: "sale" }] }] }, "Winter lines"),
+    ).toBe("Winter lines");
+  });
+
+  it("still says something for a field nobody anticipated", () => {
+    // The same argument `describeAction` makes about not being a lookup table: a
+    // plausible phrase for a condition nobody planned beats an empty cell. Cast because
+    // `ConditionField` is a closed union today and the point is what happens when it is
+    // not.
+    expect(
+      describeScope({
+        groups: [{ conditions: [{ field: "colour" as never, value: "red" }] }],
+      }),
+    ).toBe("colour: red");
+  });
+});

--- a/app/lib/campaigns/describe.ts
+++ b/app/lib/campaigns/describe.ts
@@ -1,0 +1,120 @@
+import { format } from "../money/format";
+import type { AdjustmentRule } from "../pricing/types";
+import type { FilterAst } from "../../services/segments.server";
+
+/**
+ * What a campaign does and what it does it to, in words.
+ *
+ * The campaigns index listed a name, a status, a priority and a last run — everything
+ * *about* a campaign and nothing about what it is. Both competitors that have a usable
+ * list solved this: Sami renders an `Editing rules` column reading "Price decrease by
+ * 10%" beside an `Applies to` column reading "All products", and NA writes the whole row
+ * as a sentence — "20% off sale on 1 product variant". Either way the index answers "what
+ * is this" without opening anything, and ours did not.
+ *
+ * One formatter, not one per surface. The index, the apply confirmation and the campaign
+ * header all want this sentence, and three copies of it is three chances to describe the
+ * same rule three ways — which is exactly what happened to the drift page's buttons
+ * before #400. `describe.test.ts` checks the callers go through here.
+ */
+
+/** The rule, as a merchant would say it. */
+export function describeRule(rule: AdjustmentRule | null | undefined): string {
+  if (!rule) return "No rule";
+
+  switch (rule.kind) {
+    case "percent-change":
+      // The sign is the whole meaning, and "-20%" is a worse way to say "20% off": a
+      // merchant scanning a column reads the words, and a minus sign is one character
+      // wide. Zero is neither, and saying "0% off" would imply a sale that is not one.
+      if (rule.percent === 0) return "No change";
+      return rule.percent < 0
+        ? `${strip(-rule.percent)}% off`
+        : `${strip(rule.percent)}% increase`;
+
+    case "fixed-change":
+      if (rule.amount.amount === 0) return "No change";
+      return rule.amount.amount < 0
+        ? `${format({ ...rule.amount, amount: -rule.amount.amount })} off`
+        : `${format(rule.amount)} more`;
+
+    case "set-exact":
+      return `Set to ${format(rule.amount)}`;
+
+    case "from-import":
+      // Deliberately not the file's name: a campaign priced from a spreadsheet has one
+      // rule per variant, and there is no single sentence for it. Saying where the
+      // prices came from is the honest summary.
+      return "Prices from a file";
+
+    default:
+      return "No rule";
+  }
+}
+
+/** Trailing zeros off a percentage: "12.50%" reads as more precision than was meant. */
+function strip(percent: number): string {
+  return Number.isInteger(percent) ? String(percent) : String(Number(percent.toFixed(2)));
+}
+
+/**
+ * What the campaign applies to.
+ *
+ * A segment wins outright, because a segment *replaces* the inline filter rather than
+ * narrowing it — saying "Outerwear · tagged sale" for a campaign scoped by a saved
+ * segment would describe a filter the campaign is ignoring.
+ *
+ * An empty filter is the whole catalogue, and it is worth saying so in as many words: it
+ * is the scope with the largest consequence and the least visible cause.
+ */
+export function describeScope(ast: FilterAst | null | undefined, segmentName?: string | null): string {
+  if (segmentName) return segmentName;
+
+  const conditions = (ast?.groups ?? []).flatMap((group) => group.conditions);
+  if (conditions.length === 0) return "All variants";
+
+  const pinned = conditions.find((condition) => condition.field === "variantGid");
+  if (pinned) {
+    const count = Array.isArray(pinned.value) ? pinned.value.length : 1;
+    return `${count} chosen ${count === 1 ? "variant" : "variants"}`;
+  }
+
+  return conditions.map(describeCondition).join(" · ");
+}
+
+function describeCondition(condition: { field: string; value: unknown }): string {
+  const value = String(condition.value);
+
+  switch (condition.field) {
+    case "collection":
+      return `In ${value}`;
+    case "tag":
+      return `Tagged ${value}`;
+    case "vendor":
+      return `By ${value}`;
+    case "title":
+      return `Title contains “${value}”`;
+    default:
+      // A field nobody anticipated still gets a readable phrase rather than nothing —
+      // the same argument `describeAction` makes about not being a lookup table.
+      return `${condition.field}: ${value}`;
+  }
+}
+
+/**
+ * Both sentences at once, because nothing ever wants one without the other.
+ *
+ * The index and the campaign page each need "what does it do" and "what to", and calling
+ * two functions with two different argument shapes at both call sites is two chances to
+ * pass the segment name to one and forget it for the other.
+ */
+export function describeCampaign(campaign: {
+  rule: AdjustmentRule | null | undefined;
+  ast: FilterAst | null | undefined;
+  segmentName?: string | null;
+}): { rule: string; scope: string } {
+  return {
+    rule: describeRule(campaign.rule),
+    scope: describeScope(campaign.ast, campaign.segmentName),
+  };
+}

--- a/app/lib/ui/table-size.test.ts
+++ b/app/lib/ui/table-size.test.ts
@@ -78,6 +78,9 @@ describe("one number decides how many rows a view holds", () => {
     "app/services/baseline-browser.server.ts: take: 50":
       "the vendor and source dropdowns, and one variant's own baseline history — the " +
       "forensic view, where truncating is the opposite of what it is for",
+    "app/routes/app.campaigns.$id.tsx: take: 1":
+      "the campaign's segment, whose name is the whole \"applies to\" sentence — a " +
+      "campaign has at most one, and the take is the join, not a row limit",
     "app/services/campaigns/list.server.ts: take: 1":
       "each campaign's newest run, joined onto the row it belongs to",
     "app/services/campaigns/rollback-report.server.ts: take: 20":

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -23,6 +23,8 @@ import { RouteBoundary } from "../components/RouteBoundary";
 import { reportError } from "../services/error-report.server";
 import { withGuard } from "../lib/errors/guard.server";
 import { blastRadiusRefusal } from "../services/campaigns/blast-radius.server";
+import { describeCampaign } from "../lib/campaigns/describe";
+import { astOf, ruleOf } from "../services/campaigns/model.server";
 import { actorFor } from "../lib/audit/actor";
 import { isPractice } from "../services/campaigns/model.server";
 import {
@@ -32,7 +34,7 @@ import {
   type CampaignState,
 } from "../lib/lifecycle/transitions";
 import { transitionHistory } from "../services/campaigns/lifecycle.server";
-import { approvalFor, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
+import { approvalFor, approvalSummary, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
 import { PageShell } from "../components/PageShell";
 import { CampaignTabs, currentTab, tabsFor } from "../components/campaign/CampaignTabs";
 import { useKeepers } from "../components/campaign/useKeepers";
@@ -61,6 +63,8 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
         autoEnroll: true,
         enrollPendingAt: true,
         status: true,
+        ruleRows: true,
+        segments: { select: { name: true }, take: 1 },
       },
     }),
   ]);
@@ -115,24 +119,15 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     scheduleText,
     timeZone: shop.timezone,
     warnings,
+    // The same two sentences the index shows, through the same formatter, so a merchant
+    // reading "20% off · In Outerwear" in the list meets those words again here.
+    ...describeCampaign({ rule: ruleOf(record), ast: astOf(record), segmentName: record.segments[0]?.name }),
     autoEnroll: record.autoEnroll,
     enrollPendingAt: record.enrollPendingAt !== null,
     state,
     practice,
     lifecycle,
-    approval: {
-      required: approval.required,
-      state: approval.required ? approval.state : "none",
-      who:
-        approval.required && approval.state === "approved"
-          ? approval.approvedBy
-          : approval.required && approval.state === "declined"
-            ? approval.declinedBy
-            : approval.required && approval.state === "pending"
-              ? approval.requestedBy
-              : null,
-      note: approval.required && approval.state === "declined" ? approval.note : null,
-    },
+    approval: approvalSummary(approval),
     needsAttention: needsAttention(state),
     history,
   };

--- a/app/services/approvals-summary.test.ts
+++ b/app/services/approvals-summary.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { approvalSummary } from "./approvals.server";
+
+/**
+ * The campaign page reads `who` and `note` off one flat object. The union it comes from
+ * makes "declined by nobody" unrepresentable; flattening it is where that guarantee can
+ * be dropped, so each branch is checked for the field it is the only source of.
+ */
+describe("approvalSummary", () => {
+  it("says nobody signed off when approvals are switched off", () => {
+    expect(approvalSummary({ required: false })).toEqual({
+      required: false,
+      state: "none",
+      who: null,
+      note: null,
+    });
+  });
+
+  it("names the person waiting on, the person who approved, and the person who declined", () => {
+    const at = new Date("2026-08-29T10:00:00Z");
+
+    expect(
+      approvalSummary({ required: true, state: "pending", requestedBy: "ada", requestedAt: at, variants: 9 }),
+    ).toMatchObject({ state: "pending", who: "ada", note: null });
+
+    expect(
+      approvalSummary({ required: true, state: "approved", approvedBy: "grace", approvedAt: at }),
+    ).toMatchObject({ state: "approved", who: "grace", note: null });
+
+    expect(
+      approvalSummary({ required: true, state: "declined", declinedBy: "alan", declinedAt: at, note: "too broad" }),
+    ).toMatchObject({ state: "declined", who: "alan", note: "too broad" });
+  });
+
+  it("carries the reason only from the branch that has one", () => {
+    // An approved campaign has no note field at all, and a summary that invented one --
+    // or carried the previous decline's -- would put a rejection reason on the page of a
+    // campaign that was approved.
+    expect(
+      approvalSummary({ required: true, state: "approved", approvedBy: "grace", approvedAt: new Date(0) }).note,
+    ).toBeNull();
+  });
+});

--- a/app/services/approvals.server.ts
+++ b/app/services/approvals.server.ts
@@ -38,6 +38,38 @@ export type ApprovalState =
   | { required: true; state: "declined"; declinedBy: string; declinedAt: Date; note: string | null };
 
 /**
+ * The approval as one flat shape a page can render.
+ *
+ * `ApprovalState` is a discriminated union, which is right for the run path — it makes
+ * "approved but no approver" unrepresentable. It is wrong for a loader payload: a route
+ * narrowing it inline grows a ladder of nested ternaries repeating the same two guards
+ * on every branch, which is what this replaced. Who signed off is a fact about an
+ * approval, and it belongs beside the thing that knows how approvals work.
+ */
+export function approvalSummary(approval: ApprovalState): {
+  required: boolean;
+  state: "none" | "pending" | "approved" | "declined";
+  who: string | null;
+  note: string | null;
+} {
+  if (!approval.required) return { required: false, state: "none", who: null, note: null };
+
+  return {
+    required: true,
+    state: approval.state,
+    who:
+      approval.state === "approved"
+        ? approval.approvedBy
+        : approval.state === "declined"
+          ? approval.declinedBy
+          : approval.state === "pending"
+            ? approval.requestedBy
+            : null,
+    note: approval.state === "declined" ? approval.note : null,
+  };
+}
+
+/**
  * Whether this campaign needs a second person, and whether it has one.
  *
  * The variant count is recomputed rather than read from the request, because a campaign

--- a/app/services/campaigns/list.server.ts
+++ b/app/services/campaigns/list.server.ts
@@ -8,6 +8,8 @@
  */
 
 import prisma from "../../db.server";
+import { describeCampaign } from "../../lib/campaigns/describe";
+import { astOf, ruleOf } from "./model.server";
 import { ROWS_PER_VIEW } from "../../lib/ui/table-budget";
 import {
   describeState,
@@ -60,7 +62,13 @@ export async function listCampaigns(shopId: string, filters: CampaignFilters) {
       orderBy: { createdAt: "desc" },
       skip: (filters.page - 1) * PAGE_SIZE,
       take: PAGE_SIZE,
-      include: { runs: { orderBy: { createdAt: "desc" }, take: 1 } },
+      include: {
+        runs: { orderBy: { createdAt: "desc" }, take: 1 },
+        // Named so the row can say what the campaign applies to. A segment replaces the
+        // inline filter rather than narrowing it, so where there is one it *is* the
+        // scope — see `describeScope`.
+        segments: { select: { name: true }, take: 1 },
+      },
     }),
     prisma.campaign.count({ where }),
     // Counted across the whole shop, not the filtered page. A merchant who has filtered
@@ -78,6 +86,10 @@ export async function listCampaigns(shopId: string, filters: CampaignFilters) {
       lifecycle: describeState(state),
       attention: needsAttention(state),
       priority: c.priority,
+      // What it does and what to, as sentences, through the one formatter every surface
+      // uses. The index used to say everything *about* a campaign and nothing about what
+      // it is.
+      ...describeCampaign({ rule: ruleOf(c), ast: astOf(c), segmentName: c.segments[0]?.name }),
       createdAt: c.createdAt.toISOString(),
       lastRun: c.runs[0]
         ? {

--- a/app/services/campaigns/model.server.ts
+++ b/app/services/campaigns/model.server.ts
@@ -15,7 +15,7 @@ import {
   resolvePolicy,
   type RoundingPolicy,
 } from "../../lib/money/rounding-policy";
-import type {
+import type { AdjustmentRule,
   CompareAtPolicy,
   GuardrailViolationPolicy,
   Guardrails,
@@ -98,6 +98,21 @@ export async function createCampaign(shopId: string, input: CampaignInput) {
  */
 export function roundingFor(raw: unknown): RoundingPolicy {
   return resolvePolicy(parseRoundingPolicy(raw));
+}
+
+/**
+ * A campaign's rule, for anything that wants to describe rather than resolve it.
+ *
+ * `ruleRows` is a list because several rules can match a variant with the last winning
+ * (E16), and nothing in the app creates more than one today. This reads the first, which
+ * is the whole rule for every campaign that exists — and returns null rather than
+ * pretending, so a multi-row campaign is described as having no single rule instead of
+ * being described by an arbitrary one of them.
+ */
+export function ruleOf(campaign: Pick<Campaign, "ruleRows">): AdjustmentRule | null {
+  const rows = (campaign.ruleRows ?? []) as unknown as Array<{ rule?: AdjustmentRule }>;
+  if (rows.length !== 1) return null;
+  return rows[0]?.rule ?? null;
 }
 
 /** The filter that defines a campaign's scope, or an empty AST matching everything. */


### PR DESCRIPTION
The campaigns index listed a name, a status, a priority and a last run — everything *about* a campaign and nothing about what it is. Both competitors with a usable list solved this: Sami runs an `Editing rules` column beside an `Applies to` column, NA writes the whole row as a sentence.

## What changed

- **`describeRule` / `describeScope`**, one formatter in `app/lib/campaigns/describe.ts`. "20% off", not "-20%" — a minus sign is one character wide to someone scanning a column, and the sign is the whole meaning. `describeScope` prefers a segment's name, because a segment replaces the inline filter rather than narrowing it.
- **Two new columns** on the index: `Rule` (inline) and `Applies to` (labeled).
- **The same two lines in the apply confirmation**, so the words read in the list are the words in front of a merchant when they commit.

## The guard that matters

`describeCampaign` returns both sentences, and `describe-shared.test.ts` compares the *arguments* at both call sites rather than the presence of a call. The failure this exists for is the quiet one: both surfaces call the formatter, but one passes `segmentName` and the other forgets — so one campaign reads "In Outerwear" in the list and "Tagged sale" on its own page, both true, with no way to tell which describes the run that will happen. A second assertion refuses any file that reaches for one half of the pair.

## Making room

The route hit its 400-line limit. Two things moved to where they belonged: `ruleOf` joins `astOf`/`scopeOf` in the campaign model, and `approvalSummary` flattens the approval union in the approvals service — the route had a ladder of nested ternaries repeating `approval.required &&` on every branch.

## Verification

typecheck, lint (eslint cache cleared), build, full suite **2526 passed**. Every new assertion mutation-tested: dropping `segmentName` from the detail call fails, dropping it inside `describeCampaign` fails, a surface calling `describeRule` directly fails, removing the scope from the modal fails.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)