### PR TITLE
Duplicate, Note, and archive instead of delete (#454)

### DIFF
--- a/app/components/campaign/CampaignHeader.tsx
+++ b/app/components/campaign/CampaignHeader.tsx
@@ -42,6 +42,7 @@ export function CampaignHeader({
   preview,
   rule,
   scope,
+  archived,
   scheduleText,
   lifecycle,
   fetcher,
@@ -61,6 +62,10 @@ export function CampaignHeader({
     >
       <s-stack direction="inline" gap={SPACE.item} alignItems="center">
         <s-badge tone={lifecycle.tone}>{lifecycle.label}</s-badge>
+        {/* Beside the lifecycle badge and not instead of it. An archived campaign that
+            is still ACTIVE still has prices live on the storefront, and a page that
+            replaced one badge with the other would be hiding the half that matters. */}
+        {archived ? <s-badge tone="neutral">Archived</s-badge> : null}
         {scheduleText ? <s-text color="subdued">{scheduleText}</s-text> : null}
       </s-stack>
 
@@ -130,6 +135,34 @@ export function CampaignHeader({
             Revert
           </s-button>
         )}
+
+        {/* Copy it and file it away. Both tertiary, and last: they are about the campaign
+            as a record rather than about the prices, so they must not compete with the
+            one button that writes to a storefront.
+
+            Duplicate is not recurrence, which this app already has. Recurrence re-arms
+            *this* campaign for its next occurrence and keeps one history; duplicate is
+            how next month's different sale gets built out of last month's sale that
+            worked. NA offers `Copy to new job` in place of recurrence; Sami offers both,
+            and both is right.
+
+            There is no delete anywhere, and that is deliberate rather than missing: the
+            ledger hangs off this campaign's runs, so deleting the row would erase the
+            record of every price we ever wrote for it. Archive keeps all of it and takes
+            the campaign out of the list. `delete-guard.test.ts` holds the line. */}
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="duplicate" />
+          <s-button type="submit" variant="tertiary" icon="duplicate" loading={busy || undefined}>
+            Duplicate
+          </s-button>
+        </fetcher.Form>
+
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value={archived ? "unarchive" : "archive"} />
+          <s-button type="submit" variant="tertiary" icon="archive" loading={busy || undefined}>
+            {archived ? "Restore" : "Archive"}
+          </s-button>
+        </fetcher.Form>
       </ActionRow>
     </s-grid>
 

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -1,3 +1,5 @@
+import type { useFetcher } from "react-router";
+
 import { humanise } from "../../lib/format/label";
 import { ActionRow } from "../ActionRow";
 import { EmptyState, NoMatches } from "../AsyncState";
@@ -55,10 +57,20 @@ export function CampaignListView({
   list,
   filters,
   linkTo,
+  fetcher,
 }: {
   list: List;
   filters: CampaignFilters;
   linkTo: (next: Record<string, string>) => string;
+  /**
+   * The route's fetcher, for the one control here that writes.
+   *
+   * Handed down rather than reached for, the same way the campaign page's sections take
+   * theirs. A component that calls `useFetcher` itself cannot be rendered outside a data
+   * router, which is how every one of these is tested — and the hook would tie a
+   * presentational component to the route that happens to own it today.
+   */
+  fetcher: Pick<ReturnType<typeof useFetcher>, "Form">;
 }) {
   const filtered = Boolean(filters.q || filters.status);
 
@@ -105,12 +117,32 @@ export function CampaignListView({
           </s-grid>
         </FilterForm>
 
+        {/* Not a seventh status tab. Archiving is a filing decision and the tabs are the
+            lifecycle; folding them together would mean giving up the status filter to
+            look in the archive, and "archived" would have to claim to be a state a
+            campaign can be in. A merchant looking for an archived campaign is usually
+            looking for a finished one, so both controls have to work at once. */}
+        <ActionRow>
+          <s-button
+            variant="tertiary"
+            icon="archive"
+            href={linkTo({ archived: filters.archived ? "" : "1" })}
+          >
+            {filters.archived ? "Show active campaigns" : "Show archived"}
+          </s-button>
+        </ActionRow>
+
         {list.campaigns.length === 0 ? (
-          filtered ? (
+          filters.archived ? (
+            <EmptyState
+              title="Nothing archived"
+              description="Archiving takes a campaign out of this list and leaves everything else alone — its runs, its ledger and any prices it has live. Nothing here is ever deleted."
+            />
+          ) : filtered ? (
             <NoMatches
               noun="campaigns"
               description="Nothing here matches the status and search you have set. Clearing them shows every campaign in the shop."
-              clearHref={linkTo({ q: "", status: "" })}
+              clearHref={linkTo({ q: "", status: "", archived: "" })}
             />
           ) : (
             <EmptyState
@@ -158,7 +190,14 @@ export function CampaignListView({
               <s-table-body>
                 {list.campaigns.map((campaign) => (
                   <s-table-row key={campaign.id}>
-                    <s-table-cell>{campaign.name}</s-table-cell>
+                    <s-table-cell>
+                      {campaign.name}
+                      {/* Only in the archive view, where every row has it, and on a
+                          campaign that turns up in a search from the active list —
+                          which is the case that would otherwise be confusing, because
+                          the row looks live and is not in the list. */}
+                      {campaign.archived ? <s-badge tone="neutral">Archived</s-badge> : null}
+                    </s-table-cell>
                     <s-table-cell>
                       <s-badge tone={campaign.lifecycle.tone}>
                         {campaign.lifecycle.label}
@@ -177,9 +216,22 @@ export function CampaignListView({
                         : "—"}
                     </s-table-cell>
                     <s-table-cell>
-                      <s-button variant="tertiary" href={`/app/campaigns/${campaign.id}`}>
-                        Open
-                      </s-button>
+                      <ActionRow>
+                        {/* Duplicate is not recurrence, which we already have. It is how
+                            next month's different sale gets built out of last month's
+                            sale that worked, and the row is where a merchant is when
+                            they recognise the one that worked. */}
+                        <fetcher.Form method="post">
+                          <input type="hidden" name="intent" value="duplicate" />
+                          <input type="hidden" name="campaignId" value={campaign.id} />
+                          <s-button type="submit" variant="tertiary" icon="duplicate">
+                            Duplicate
+                          </s-button>
+                        </fetcher.Form>
+                        <s-button variant="tertiary" href={`/app/campaigns/${campaign.id}`}>
+                          Open
+                        </s-button>
+                      </ActionRow>
                     </s-table-cell>
                   </s-table-row>
                 ))}

--- a/app/components/campaign/CampaignNote.tsx
+++ b/app/components/campaign/CampaignNote.tsx
@@ -1,0 +1,54 @@
+/**
+ * Why this campaign exists, in the merchant's own words.
+ *
+ * The cheapest possible answer to the question every audit asks, and the one thing on
+ * this page nothing else can reconstruct. The ledger says exactly what was written and
+ * the activity log says who asked for it; neither says why, and six weeks later "why"
+ * is the only part anybody has forgotten.
+ *
+ * Sami has this and neither of the other two does, which is the shape of most of what
+ * they get right: not a pricing feature, a record-keeping one.
+ *
+ * ## Why it is always an open field
+ *
+ * No view mode with an Edit button. A note that has to be unlocked before it can be
+ * corrected is a note that stays wrong — and there is nothing to protect here, since the
+ * previous text is kept in the audit log either way. The empty state is a placeholder
+ * asking the question rather than a heading announcing there is no note, because an
+ * empty text field already says that.
+ */
+
+import { SPACE } from "../../lib/ui/spacing";
+import type { CampaignDetailProps } from "./props";
+
+export function CampaignNote({ note, fetcher, busy }: CampaignDetailProps) {
+  return (
+    <s-section heading="Why this campaign exists">
+      <fetcher.Form method="post">
+        <input type="hidden" name="intent" value="note" />
+        <s-stack direction="block" gap={SPACE.item}>
+          <s-text-area
+            name="note"
+            label="Note"
+            labelAccessibilityVisibility="exclusive"
+            rows={3}
+            // `value`, not `defaultValue`: a Polaris web component ignores the React
+            // default and renders an empty box, which here would look exactly like a
+            // campaign that has no note. `polaris-traps.test.ts` catches it.
+            value={note ?? ""}
+            placeholder="Matching a competitor on outerwear until the end of the season. Agreed with Priya."
+            details="Searchable from the campaigns list, and kept when this campaign is archived."
+          />
+          {/* Right where the field ends, not in the page header. This is a note about a
+              campaign, not an action on it, and putting Save beside Apply would be two
+              very different consequences on one row. */}
+          <s-stack direction="inline" gap={SPACE.item} justifyContent="end">
+            <s-button type="submit" variant="secondary" loading={busy || undefined}>
+              Save note
+            </s-button>
+          </s-stack>
+        </s-stack>
+      </fetcher.Form>
+    </s-section>
+  );
+}

--- a/app/components/campaign/CampaignOverviewTab.tsx
+++ b/app/components/campaign/CampaignOverviewTab.tsx
@@ -9,17 +9,20 @@ import { formatWhen } from "../../lib/format/display";
 import { describeActor } from "../../lib/audit/actor";
 import { ALL_STATES, describeState } from "../../lib/lifecycle/transitions";
 import { humanise } from "../../lib/format/label";
+import { CampaignNote } from "./CampaignNote";
 import type { CampaignDetailProps } from "./props";
 
-export function CampaignOverviewTab({
-  scheduleText,
-  warnings,
-  autoEnroll,
-  enrollPendingAt,
-  lifecycle,
-  history,
-  timeZone,
-}: CampaignDetailProps) {
+export function CampaignOverviewTab(props: CampaignDetailProps) {
+  const {
+    scheduleText,
+    warnings,
+    autoEnroll,
+    enrollPendingAt,
+    lifecycle,
+    history,
+    timeZone,
+  } = props;
+
   return (
     <>
       <s-section heading="Status">
@@ -30,6 +33,9 @@ export function CampaignOverviewTab({
           <s-text>{lifecycle.explanation}</s-text>
         </s-paragraph>
       </s-section>
+
+      {/* Above the history, because the note is why the history happened. */}
+      <CampaignNote {...props} />
 
       {history.length > 0 ? (
         // Its own section rather than a run of paragraphs under a bare `s-paragraph`

--- a/app/components/campaign/campaign-list-view.test.tsx
+++ b/app/components/campaign/campaign-list-view.test.tsx
@@ -36,6 +36,8 @@ const campaign = (over: Partial<Props["list"]["campaigns"][number]> = {}) => ({
   // writes its own sentence stops catching the day the real one changes.
   rule: describeRule({ kind: "percent-change", percent: -20 }),
   scope: describeScope({ groups: [{ conditions: [{ field: "tag", value: "sale" }] }] }),
+  note: null,
+  archived: false,
   createdAt: "2026-08-01T00:00:00.000Z",
   lastRun: null,
   ...over,
@@ -55,8 +57,12 @@ const render = (over: Partial<Props> = {}) =>
     <StaticRouter location="/app/campaigns">
       <CampaignListView
         list={over.list ?? list()}
-        filters={over.filters ?? { q: "", status: "", page: 1 }}
+        filters={over.filters ?? { q: "", status: "", archived: false, page: 1 }}
         linkTo={(next) => `?${new URLSearchParams(next)}`}
+        // A plain element in place of the router's Form, the same stand-in the campaign
+        // header's tests use: this renders to static markup, and a real fetcher needs a
+        // data router the assertions here have no use for.
+        fetcher={{ Form: "form" } as never}
       />
     </StaticRouter>,
   );
@@ -116,7 +122,7 @@ describe("when there is nothing to list", () => {
     // control to do it.
     const html = render({
       list: list({ campaigns: [], total: 0 }),
-      filters: { q: "nothing", status: "DRAFT", page: 1 },
+      filters: { q: "nothing", status: "DRAFT", archived: false, page: 1 },
     });
 
     expect(html).toContain("No campaigns match those filters");

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -83,8 +83,12 @@ describe("the campaigns index picks the right one of the two", () => {
       <StaticRouter location="/app/campaigns">
         <CampaignListView
           list={list([])}
-          filters={{ ...filters, page: 1 }}
+          filters={{ ...filters, archived: false, page: 1 }}
           linkTo={(next) => `?${new URLSearchParams(next)}`}
+          // A plain element in place of the router's Form, the same stand-in the campaign
+          // header's tests use: this renders to static markup, and a real fetcher needs a
+          // data router the assertions here have no use for.
+          fetcher={{ Form: "form" } as never}
         />
       </StaticRouter>,
     );
@@ -152,10 +156,13 @@ describe("no page answers 'where are my rows' with a loose paragraph", () => {
    * early return a table component takes before it renders a header row.
    */
   const BRANCHES = [
-    // `(?:\w+\s*\?\s*\(\s*)*` steps over the inner ternary that picks between the two
-    // states. Without it a page that got this *right* — filtered one way, empty the other
-    // — is the one the check cannot see.
-    /(\w+)(?:\.length)? === 0\s*\?\s*\(\s*(?:\w+\s*\?\s*\(\s*)*(<[A-Za-z][\w.-]*)/g,
+    // `(?:[\w.]+\s*\?\s*\(\s*)*` steps over the inner ternaries that pick between the
+    // states. Without it a page that got this *right* — one state when a filter emptied
+    // it, another when there was never anything — is the one the check cannot see. The
+    // dot is in the class because the condition is as likely to be `filters.archived` as
+    // a bare name, and a check that stops seeing a branch the moment its condition lives
+    // on an object is a check that rewards the wrong refactor.
+    /(\w+)(?:\.length)? === 0\s*\?\s*\(\s*(?:[\w.]+\s*\?\s*\(\s*)*(<[A-Za-z][\w.-]*)/g,
     /(\w+)(?:\.length)? === 0\)\s*\{\s*return\s*\(\s*(<[A-Za-z][\w.-]*)/g,
   ];
 

--- a/app/lib/campaigns/copy-name.test.ts
+++ b/app/lib/campaigns/copy-name.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { copyName } from "./copy-name";
+
+describe("copyName", () => {
+  it("says where the copy came from", () => {
+    expect(copyName("Summer sale", [])).toBe("Summer sale (copy)");
+  });
+
+  it("keeps four copies of one campaign distinguishable", () => {
+    // The failure this prevents is not a collision -- names are not unique in the
+    // database. It is a list of four rows with identical names, which is exactly the
+    // thing the merchant duplicated the campaign to avoid.
+    const taken = ["Summer sale", "Summer sale (copy)", "Summer sale (copy 2)"];
+
+    expect(copyName("Summer sale", taken)).toBe("Summer sale (copy 3)");
+  });
+
+  it("numbers from two, because the first copy is the unnumbered one", () => {
+    expect(copyName("Sale", ["Sale (copy)"])).toBe("Sale (copy 2)");
+  });
+
+  it("does not stack a suffix per generation", () => {
+    // Duplicating a duplicate: "(copy) (copy)" grows a word per generation and says
+    // less with each one.
+    expect(copyName("Sale (copy)", ["Sale (copy)"])).toBe("Sale (copy 2)");
+    expect(copyName("Sale (copy 2)", ["Sale (copy)", "Sale (copy 2)"])).toBe("Sale (copy 3)");
+  });
+
+  it("leaves a name that merely mentions copies alone", () => {
+    // Only a trailing suffix is ours. "Copy deck pricing" is a campaign name.
+    expect(copyName("Copy deck pricing", [])).toBe("Copy deck pricing (copy)");
+  });
+});

--- a/app/lib/campaigns/copy-name.ts
+++ b/app/lib/campaigns/copy-name.ts
@@ -1,0 +1,40 @@
+/**
+ * What a duplicate is called.
+ *
+ * Duplicate is not recurrence. Recurrence re-arms the same campaign for its next
+ * occurrence and keeps one history; duplicate is how a merchant builds *next month's
+ * different sale* out of *last month's sale that worked*. So the name has to say where
+ * this one came from, and it has to stay distinguishable when it happens four times —
+ * a list of four rows all called "Summer sale (copy)" is the same problem the copy was
+ * meant to solve.
+ *
+ * Numbering starts at 2 rather than 1, because the first copy is "(copy)" and the one
+ * after it is the second copy. "(copy 1)" would imply an earlier "(copy 0)".
+ */
+export function copyName(name: string, taken: readonly string[]): string {
+  const used = new Set(taken);
+  const base = stripCopySuffix(name);
+
+  const first = `${base} (copy)`;
+  if (!used.has(first)) return first;
+
+  // No upper bound to stop at: the loop terminates because `used` is finite, and
+  // refusing to duplicate at some arbitrary count would be a worse answer than a long
+  // name. `n` is the count of copies, so it starts at the second one.
+  for (let n = 2; ; n += 1) {
+    const candidate = `${base} (copy ${n})`;
+    if (!used.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * A copy of a copy is still a copy of the original.
+ *
+ * Without this, duplicating twice down a chain produces "Summer sale (copy) (copy)" and
+ * then "(copy) (copy) (copy)" — the name grows a suffix per generation while saying less
+ * with each one. Stripping it means the second generation is "(copy 2)", which is both
+ * shorter and true.
+ */
+function stripCopySuffix(name: string): string {
+  return name.replace(/ \(copy(?: \d+)?\)$/, "");
+}

--- a/app/lib/campaigns/describe-shared.test.ts
+++ b/app/lib/campaigns/describe-shared.test.ts
@@ -54,7 +54,13 @@ describe("the campaigns index and the campaign page describe a campaign the same
     // source-level check has been fooled by its own subject appearing in prose -- the
     // note in `editor-layout.test.ts` records the last one, and #462 is open to extract
     // this into something shared.
-    const files = execFileSync("git", ["ls-files", "app"], { encoding: "utf8" })
+    // Tracked and untracked-but-not-ignored: a new file is the likeliest place for a
+    // second formatter, and `git ls-files` alone cannot see one until it is committed.
+    const files = execFileSync(
+      "git",
+      ["ls-files", "--cached", "--others", "--exclude-standard", "--", "app"],
+      { encoding: "utf8" },
+    )
       .split("\n")
       .filter((f) => /\.tsx?$/.test(f))
       .filter((f) => !f.includes(".test.") && !f.startsWith("app/lib/campaigns/describe"));

--- a/app/lib/ui/polaris-traps.test.ts
+++ b/app/lib/ui/polaris-traps.test.ts
@@ -46,11 +46,27 @@ function owningTag(source: string, at: number): string {
   return /^<\s*([A-Za-z][\w.-]*)/.exec(source.slice(open, at))?.[1] ?? "";
 }
 
+/**
+ * Whole-line `//` comments removed before matching.
+ *
+ * The seventh time a source-level check in this repo has been fooled by its own subject
+ * appearing in prose, and the first where the offending comment was the one explaining
+ * *why the field does not use the banned attribute*. A rule that fires on the note
+ * documenting compliance with it teaches people to stop writing the note. Only lines that
+ * are nothing but a comment go, so a `//` inside an href is left alone. #462 is open to
+ * extract this — it now exists in four files.
+ */
+const scannable = (source: string) =>
+  source
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("//"))
+    .join("\n");
+
 describe("defaultValue and defaultChecked never reach a Polaris element", () => {
   // React intercepts both on form elements and never forwards them to the custom element,
   // so the field renders empty. It compiles, and it is in the TypeScript types.
   it.each(FILES)("%s", (file) => {
-    const source = readFileSync(join(ROOT, file), "utf8");
+    const source = scannable(readFileSync(join(ROOT, file), "utf8"));
 
     for (const match of source.matchAll(/\b(defaultValue|defaultChecked)\b/g)) {
       const tag = owningTag(source, match.index!);

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -1,5 +1,5 @@
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useFetcher, useLoaderData, useSearchParams } from "react-router";
+import { redirect, useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -13,12 +13,11 @@ import {
   revertVariant,
   rollbackReport,
   runCampaign,
-  runLedger,
 } from "../services/campaigns/index.server";
 import { describeSchedule, parseSchedule, scheduleWarnings } from "../lib/scheduling/window";
 import { RunHistoryTable } from "../components/RunHistoryTable";
 import { RunResultSection } from "../components/RunResultSection";
-import { campaignResult } from "../services/campaigns/result.server";
+import { runEvidence } from "../services/campaigns/run-evidence.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { reportError } from "../services/error-report.server";
 import { withGuard } from "../lib/errors/guard.server";
@@ -34,6 +33,7 @@ import {
   type CampaignState,
 } from "../lib/lifecycle/transitions";
 import { transitionHistory } from "../services/campaigns/lifecycle.server";
+import { housekeepingAction } from "../services/campaigns/housekeeping.server";
 import { approvalFor, approvalSummary, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
 import { PageShell } from "../components/PageShell";
 import { CampaignTabs, currentTab, tabsFor } from "../components/campaign/CampaignTabs";
@@ -64,6 +64,8 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
         enrollPendingAt: true,
         status: true,
         ruleRows: true,
+        note: true,
+        archivedAt: true,
         segments: { select: { name: true }, take: 1 },
       },
     }),
@@ -84,20 +86,8 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
   // the people who most need the answer.
   const requested = new URL(request.url).searchParams.get("run");
   const selectedRunId = requested ?? runs[0]?.id ?? null;
-  const ledger = selectedRunId ? await runLedger(shop.id, selectedRunId) : [];
-
-  // How many rows that run wrote in total, so the table can say what it is not showing.
-  // The ledger is capped — `s-table` blanks the page past a few hundred cells — and a
-  // capped table that says nothing reads as the whole record, on the one screen whose
-  // entire job is being the record.
-  const ledgerTotal = selectedRunId
-    ? await prisma.variantChange.count({ where: { shopId: shop.id, runId: selectedRunId } })
-    : 0;
-
-  // What that run actually did, as opposed to what the preview said it would. The ledger
-  // is the evidence; the preview is the intention, and a partial run is exactly where the
-  // two stop agreeing.
-  const result = selectedRunId ? await campaignResult(shop.id, selectedRunId) : null;
+  // What that run actually did, as opposed to what the preview said it would.
+  const { ledger, ledgerTotal, result } = await runEvidence(shop.id, selectedRunId);
 
   // Only for a campaign that has actually written something and could still be
   // reverted. It costs a full plan, and on a draft it would be a report about
@@ -122,6 +112,8 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     // The same two sentences the index shows, through the same formatter, so a merchant
     // reading "20% off · In Outerwear" in the list meets those words again here.
     ...describeCampaign({ rule: ruleOf(record), ast: astOf(record), segmentName: record.segments[0]?.name }),
+    note: record.note,
+    archived: record.archivedAt !== null,
     autoEnroll: record.autoEnroll,
     enrollPendingAt: record.enrollPendingAt !== null,
     state,
@@ -140,6 +132,13 @@ export const action = withGuard("/app/campaigns/$id", async ({ request, params }
   const form = await request.formData();
   const intent = String(form.get("intent") ?? "");
   const campaignId = String(params.id);
+
+  // Copy it, note it, file it away. None of the three touches a price, so they are
+  // answered before any of the machinery that does — see `housekeepingAction`.
+  const housekeeping = await housekeepingAction(shop.id, campaignId, actor, form);
+  if (housekeeping) {
+    return housekeeping.redirectTo ? redirect(housekeeping.redirectTo) : housekeeping;
+  }
 
   if (intent === "request-approval") {
     await requestApproval(shop.id, campaignId, actor);

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -1,5 +1,5 @@
-import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { useLoaderData, useSearchParams } from "react-router";
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { redirect, useFetcher, useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
@@ -13,6 +13,7 @@ import { CampaignCalendar } from "../components/campaign/CampaignCalendar";
 import { CampaignListView } from "../components/campaign/CampaignListView";
 import { HelpNote } from "../components/HelpNote";
 import { filtersFrom, listCampaigns } from "../services/campaigns/list.server";
+import { duplicateCampaign } from "../services/campaigns/housekeeping.server";
 import { calendarFor, todayIn } from "../services/calendar.server";
 import { addDays } from "../lib/scheduling/calendar";
 
@@ -58,6 +59,30 @@ export const loader = withGuard("/app/campaigns", async ({ request }: LoaderFunc
   } as const;
 });
 
+/**
+ * Duplicating from the row.
+ *
+ * The redirect is the feature, not a detail of it: a merchant duplicates a campaign in
+ * order to change something about it, so landing them back on the list — with a new row
+ * they now have to find and open — would be most of the work and none of the point.
+ *
+ * The web process may not write prices, and this does not: a duplicate is a draft, and a
+ * draft has written nothing to a storefront.
+ */
+export const action = withGuard("/app/campaigns", async ({ request }: ActionFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  if (String(form.get("intent")) !== "duplicate") {
+    return { ok: false, message: "That action is not available from the campaigns list." };
+  }
+
+  const copy = await duplicateCampaign(shop.id, String(form.get("campaignId")), session.shop);
+
+  return redirect(`/app/campaigns/${copy.id}?duplicated=1`);
+});
+
 /** The same day-of-month in an adjacent month, clamped to a day that exists. */
 function monthStep(date: string, months: number): string {
   const [year, month] = date.split("-").map(Number);
@@ -77,6 +102,8 @@ function monthName(date: string): string {
 export default function Campaigns() {
   const { view, filters, list, calendar } = useLoaderData<typeof loader>();
   const [params] = useSearchParams();
+  // For the row-level Duplicate. See the note on `CampaignListView`'s `fetcher` prop.
+  const fetcher = useFetcher();
 
   const linkTo = (next: Record<string, string>) => {
     const q = new URLSearchParams(params);
@@ -160,7 +187,7 @@ export default function Campaigns() {
       {view === "calendar" && calendar ? (
         <CampaignCalendar {...calendar} />
       ) : (
-        <CampaignListView list={list} filters={filters} linkTo={linkTo} />
+        <CampaignListView list={list} filters={filters} linkTo={linkTo} fetcher={fetcher} />
       )}
 
       <HelpNote label="How campaigns resolve">

--- a/app/services/campaigns/delete-guard.test.ts
+++ b/app/services/campaigns/delete-guard.test.ts
@@ -1,0 +1,87 @@
+/**
+ * There is no campaign delete, and this is what keeps it that way.
+ *
+ * `campaign_runs` cascades from `campaigns`, and `variant_changes` cascades from
+ * `campaign_runs`. So deleting one campaign row does not orphan a ledger row — it erases
+ * every ledger row that campaign ever wrote, which is worse. Invariant I4 says nothing is
+ * written to a storefront without a `variant_changes` row committed first; the ledger is
+ * the evidence that invariant held, and it is what a revert recomputes against.
+ *
+ * The obvious fix is `ON DELETE RESTRICT` on that first relation, and it is wrong here.
+ * The `shop/redact` compliance webhook deletes a `Shop`, and all three tables cascade
+ * from `Shop` as well, so a RESTRICT between two of them can abort a GDPR erasure
+ * depending on the order Postgres processes the referencing tables in. Erasure has to
+ * win; so the constraint stays permissive and the *app* is what does not offer a delete.
+ *
+ * Archive is the answer instead: `archivedAt` takes the campaign out of the list and
+ * leaves the record whole.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/** Comments only, so prose about deleting cannot masquerade as a delete. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+/**
+ * The one place a campaign may legitimately be destroyed.
+ *
+ * `shop.deleteMany` in the compliance webhook, which cascades to everything this shop
+ * owns. That is not a campaign delete — it is an erasure request, where destroying the
+ * ledger is the whole point.
+ */
+const ERASURE = "app/routes/webhooks.compliance.tsx";
+
+/**
+ * Tracked files *and* untracked ones git is not ignoring.
+ *
+ * `git ls-files` alone lists only what is already committed, which means a brand-new file
+ * — the most likely place for a new offender — is invisible to this check until after the
+ * commit that introduced it. Found the hard way: a deliberately broken copy of this rule
+ * passed because the file breaking it had not been `git add`ed yet.
+ */
+function sourceFiles(...paths: string[]): string[] {
+  return execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard", "--", ...paths], {
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+}
+
+describe("nothing in the app deletes a campaign", () => {
+  const files = sourceFiles("app", "prisma")
+    .filter((f) => /\.tsx?$/.test(f))
+    .filter((f) => !f.includes(".test.") && f !== ERASURE);
+
+  it("offers no campaign delete", () => {
+    const offenders = files.filter((file) =>
+      /prisma\.campaign\.delete|campaign\.deleteMany/.test(withoutComments(readFileSync(file, "utf8"))),
+    );
+
+    expect(
+      offenders,
+      "deleting a campaign cascades to its runs and to variant_changes — archive it instead",
+    ).toEqual([]);
+  });
+
+  it("offers no run delete either", () => {
+    // One step further down the same chain, and the same consequence: the ledger rows
+    // hang off the run, so deleting a run is deleting the record of what it wrote.
+    const offenders = files.filter((file) =>
+      /prisma\.campaignRun\.delete|campaignRun\.deleteMany|prisma\.variantChange\.delete/.test(
+        withoutComments(readFileSync(file, "utf8")),
+      ),
+    );
+
+    expect(offenders, "the ledger is the record; nothing may remove rows from it").toEqual([]);
+  });
+
+  it("keeps the erasure path, because a redaction request has to be honoured", () => {
+    // The inverse assertion. If the compliance webhook ever stops deleting the shop,
+    // this file's whole argument for leaving the cascade permissive has gone with it.
+    expect(withoutComments(readFileSync(ERASURE, "utf8"))).toContain("shop.deleteMany");
+  });
+});

--- a/app/services/campaigns/housekeeping.server.test.ts
+++ b/app/services/campaigns/housekeeping.server.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copy it, say why it exists, file it away.
+ *
+ * The assertions worth having here are all about what a duplicate does *not* carry.
+ * Copying a rule is the easy half and its failure is visible in the editor; copying a run
+ * history is invisible and makes the record lie about what has been written to a live
+ * storefront.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { prisma } = vi.hoisted(() => ({
+  prisma: {
+    campaign: { findFirstOrThrow: vi.fn(), findMany: vi.fn(), create: vi.fn(), update: vi.fn() },
+    auditLogEntry: { create: vi.fn() },
+  },
+}));
+vi.mock("../../db.server", () => ({ default: prisma }));
+
+import { duplicateCampaign, setArchived, setNote } from "./housekeeping.server";
+
+const SOURCE = {
+  name: "Summer sale",
+  priority: 100,
+  ruleRows: [{ kind: "percent-change", percent: -20 }],
+  surfaces: { base: true },
+  compareAtPolicy: { kind: "baseline" },
+  compareAtViolationPolicy: "clear",
+  roundingProfileId: "round-1",
+  guardrails: null,
+  guardrailViolationPolicy: "clamp",
+  tagKit: ["summer-sale"],
+  autoEnroll: true,
+  excludedVariantGids: ["gid://shopify/ProductVariant/9"],
+  note: "Matched a competitor",
+  segments: [{ id: "seg-1" }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.campaign.findFirstOrThrow.mockResolvedValue(SOURCE);
+  prisma.campaign.findMany.mockResolvedValue([{ name: "Summer sale" }]);
+  prisma.campaign.create.mockResolvedValue({ id: "copy-1", name: "Summer sale (copy)" });
+  prisma.campaign.update.mockResolvedValue({ name: "Summer sale", note: null });
+});
+
+describe("duplicating a campaign", () => {
+  it("carries everything that decides a price", async () => {
+    await duplicateCampaign("shop", "c1", "ada");
+
+    const { data } = prisma.campaign.create.mock.calls[0]![0];
+    expect(data).toMatchObject({
+      priority: 100,
+      ruleRows: SOURCE.ruleRows,
+      surfaces: SOURCE.surfaces,
+      compareAtPolicy: SOURCE.compareAtPolicy,
+      compareAtViolationPolicy: "clear",
+      roundingProfileId: "round-1",
+      guardrailViolationPolicy: "clamp",
+      tagKit: ["summer-sale"],
+      excludedVariantGids: ["gid://shopify/ProductVariant/9"],
+      note: "Matched a competitor",
+    });
+  });
+
+  it("carries nothing that says what the original did", async () => {
+    // The one that matters. A duplicate holding its source's schedule would arm a run
+    // for a date that has passed; one holding its run history would claim prices had
+    // been written to a storefront that never saw them.
+    await duplicateCampaign("shop", "c1", "ada");
+
+    const { data } = prisma.campaign.create.mock.calls[0]![0];
+    expect(data.status).toBe("DRAFT");
+    for (const field of ["schedule", "startAt", "endAt", "enrollPendingAt", "runs", "id"]) {
+      expect(data, `a copy must not carry ${field}`).not.toHaveProperty(field);
+    }
+  });
+
+  it("connects the segment rather than copying it", async () => {
+    // A segment is a saved definition several campaigns share. Copied rows would stop
+    // tracking the original the first time either one is edited.
+    await duplicateCampaign("shop", "c1", "ada");
+
+    expect(prisma.campaign.create.mock.calls[0]![0].data.segments).toEqual({
+      connect: [{ id: "seg-1" }],
+    });
+  });
+
+  it("names the copy against every campaign in the shop, archived ones included", async () => {
+    prisma.campaign.findMany.mockResolvedValue([{ name: "Summer sale" }, { name: "Summer sale (copy)" }]);
+
+    await duplicateCampaign("shop", "c1", "ada");
+
+    expect(prisma.campaign.create.mock.calls[0]![0].data.name).toBe("Summer sale (copy 2)");
+    expect(prisma.campaign.findMany.mock.calls[0]![0].where).toEqual({ shopId: "shop" });
+  });
+
+  it("reads only from the merchant's own shop", async () => {
+    await duplicateCampaign("shop", "c1", "ada");
+
+    expect(prisma.campaign.findFirstOrThrow.mock.calls[0]![0].where).toEqual({
+      id: "c1",
+      shopId: "shop",
+    });
+  });
+
+  it("records who copied what from where", async () => {
+    await duplicateCampaign("shop", "c1", "ada");
+
+    expect(prisma.auditLogEntry.create.mock.calls[0]![0].data).toMatchObject({
+      actor: "ada",
+      action: "campaign.duplicate",
+      entityId: "copy-1",
+      after: { from: "c1" },
+    });
+  });
+});
+
+describe("archiving", () => {
+  it("stamps a time going in and clears it coming out", async () => {
+    prisma.campaign.findFirstOrThrow.mockResolvedValue({ id: "c1", note: null });
+
+    await setArchived("shop", "c1", true, "ada");
+    expect(prisma.campaign.update.mock.calls[0]![0].data.archivedAt).toBeInstanceOf(Date);
+
+    await setArchived("shop", "c1", false, "ada");
+    expect(prisma.campaign.update.mock.calls[1]![0].data.archivedAt).toBeNull();
+  });
+
+  it("does not touch the lifecycle", async () => {
+    // Archiving an ACTIVE campaign is a filing decision, not a pricing one: the prices
+    // stay live, the scheduler keeps seeing it, and a `status` written here would be the
+    // app quietly ending a campaign a merchant only meant to tidy away.
+    prisma.campaign.findFirstOrThrow.mockResolvedValue({ id: "c1", note: null });
+
+    await setArchived("shop", "c1", true, "ada");
+
+    expect(prisma.campaign.update.mock.calls[0]![0].data).not.toHaveProperty("status");
+  });
+});
+
+describe("the note", () => {
+  it("keeps the replaced text, because nothing else can reconstruct it", async () => {
+    prisma.campaign.findFirstOrThrow.mockResolvedValue({ id: "c1", note: "Old reason" });
+    prisma.campaign.update.mockResolvedValue({ note: "New reason" });
+
+    await setNote("shop", "c1", "New reason", "ada");
+
+    expect(prisma.auditLogEntry.create.mock.calls[0]![0].data).toMatchObject({
+      action: "campaign.note",
+      before: { note: "Old reason" },
+      after: { note: "New reason" },
+    });
+  });
+
+  it("treats blank as no note at all", async () => {
+    prisma.campaign.findFirstOrThrow.mockResolvedValue({ id: "c1", note: "Old" });
+
+    await setNote("shop", "c1", "   ", "ada");
+
+    expect(prisma.campaign.update.mock.calls[0]![0].data.note).toBeNull();
+  });
+});

--- a/app/services/campaigns/housekeeping.server.ts
+++ b/app/services/campaigns/housekeeping.server.ts
@@ -1,0 +1,237 @@
+/**
+ * The three things a merchant does to a campaign as an object rather than as a run:
+ * copy it, say why it exists, and file it away.
+ *
+ * All three are here rather than in the route because all three write, and the route is
+ * already the longest file in the app. They share a shape too: each one is a small
+ * mutation plus an audit entry, and none of them touches a price. Nothing in this file
+ * may write to `variant_changes` or call the Admin API.
+ */
+
+import { Prisma } from "@prisma/client";
+
+import prisma from "../../db.server";
+import { copyName } from "../../lib/campaigns/copy-name";
+import { logger } from "../../lib/logging/logger";
+
+/**
+ * Everything that describes what a campaign *does*, and nothing about what it *did*.
+ *
+ * This list is the whole feature, so it is worth being explicit about both halves.
+ *
+ * Copied: the rule, the scope, the surfaces, the compare-at and guardrail policies, the
+ * rounding profile, the tag kit, the exclusions and the note. A duplicate that dropped
+ * any of these would be a campaign that quietly prices differently from the one it was
+ * copied from, which is worse than no duplicate at all.
+ *
+ * Not copied, and this is the point of the feature: `status` (a copy is a draft),
+ * `schedule`/`startAt`/`endAt` (last month's dates are never the dates the merchant
+ * wants — leaving them would schedule a run in the past), `enrollPendingAt`, the runs,
+ * and the ledger. History belongs to the campaign that made it. A duplicate carrying its
+ * source's run history would be a lie about what has been written to the storefront, and
+ * this app's entire proposition is that the record is true.
+ */
+const COPIED = {
+  name: true,
+  priority: true,
+  ruleRows: true,
+  surfaces: true,
+  compareAtPolicy: true,
+  compareAtViolationPolicy: true,
+  roundingProfileId: true,
+  guardrails: true,
+  guardrailViolationPolicy: true,
+  tagKit: true,
+  autoEnroll: true,
+  excludedVariantGids: true,
+  note: true,
+} as const;
+
+export async function duplicateCampaign(
+  shopId: string,
+  campaignId: string,
+  actor: string | null,
+): Promise<{ id: string; name: string }> {
+  const source = await prisma.campaign.findFirstOrThrow({
+    where: { id: campaignId, shopId },
+    select: { ...COPIED, segments: { select: { id: true } } },
+  });
+
+  // Every name in the shop, not just the unarchived ones. A copy that collides with an
+  // archived campaign's name makes the archive unreadable later, and reading a few
+  // thousand short strings is cheaper than the query that would avoid it.
+  const taken = await prisma.campaign.findMany({ where: { shopId }, select: { name: true } });
+
+  const { segments, ruleRows, surfaces, compareAtPolicy, guardrails, ...fields } = source;
+
+  const copy = await prisma.campaign.create({
+    data: {
+      ...fields,
+      // The Json columns come back as `JsonValue`, which includes `null`, and Prisma's
+      // create input wants `DbNull` for a null Json column -- passing the read value
+      // straight through does not typecheck and, worse, `null` on a required Json column
+      // would mean "JSON null" rather than "no value". Only `guardrails` is nullable, so
+      // only it can take the null branch.
+      ruleRows: ruleRows as Prisma.InputJsonValue,
+      surfaces: surfaces as Prisma.InputJsonValue,
+      compareAtPolicy: compareAtPolicy as Prisma.InputJsonValue,
+      guardrails: guardrails === null ? Prisma.DbNull : (guardrails as Prisma.InputJsonValue),
+      shopId,
+      name: copyName(source.name, taken.map((c) => c.name)),
+      status: "DRAFT",
+      createdBy: actor,
+      // Connected, not copied. A segment is a saved definition shared across campaigns;
+      // duplicating the rows would give the copy a segment that stops tracking the
+      // original the first time the merchant edits either one.
+      segments: { connect: segments.map((s) => ({ id: s.id })) },
+    },
+    select: { id: true, name: true },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor,
+      action: "campaign.duplicate",
+      entity: "campaign",
+      entityId: copy.id,
+      after: { from: campaignId, name: copy.name } as never,
+    },
+  });
+
+  logger.info("campaign duplicated", { shopId, from: campaignId, to: copy.id });
+  return copy;
+}
+
+/**
+ * Out of the list, still in the record.
+ *
+ * Archiving is deliberately allowed in any state, including ACTIVE. A merchant filing a
+ * running campaign away has made a filing decision, not a pricing one, and refusing it
+ * would only teach them that archive is unreliable. The campaign keeps running, the
+ * scheduler keeps seeing it — `archivedAt` is read by the index and by nothing else.
+ */
+export async function setArchived(
+  shopId: string,
+  campaignId: string,
+  archived: boolean,
+  actor: string | null,
+): Promise<{ name: string }> {
+  const campaign = await prisma.campaign.update({
+    // `updateMany`-style scoping through `where` would be safer against a wrong shop,
+    // but `update` cannot take a compound where here, so the shop is checked first.
+    where: { id: (await ownedCampaign(shopId, campaignId)).id },
+    data: { archivedAt: archived ? new Date() : null },
+    select: { name: true },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor,
+      action: archived ? "campaign.archive" : "campaign.unarchive",
+      entity: "campaign",
+      entityId: campaignId,
+      after: { name: campaign.name } as never,
+    },
+  });
+
+  return campaign;
+}
+
+/**
+ * Why this campaign exists, in the merchant's own words.
+ *
+ * The before value is recorded because a note is the one field on a campaign whose
+ * previous contents are not recoverable from anything else — the ledger reconstructs
+ * every price we wrote, and nothing reconstructs a sentence somebody replaced.
+ */
+export async function setNote(
+  shopId: string,
+  campaignId: string,
+  note: string,
+  actor: string | null,
+): Promise<{ note: string | null }> {
+  const before = await ownedCampaign(shopId, campaignId);
+  const trimmed = note.trim();
+
+  const updated = await prisma.campaign.update({
+    where: { id: before.id },
+    // Empty is no note, not an empty one. A blank string would render as a note the
+    // merchant has to look at twice to see is empty.
+    data: { note: trimmed === "" ? null : trimmed },
+    select: { note: true },
+  });
+
+  await prisma.auditLogEntry.create({
+    data: {
+      shopId,
+      actor,
+      action: "campaign.note",
+      entity: "campaign",
+      entityId: campaignId,
+      before: { note: before.note } as never,
+      after: { note: updated.note } as never,
+    },
+  });
+
+  return updated;
+}
+
+/** Refuses a campaign belonging to another shop before anything is written. */
+async function ownedCampaign(shopId: string, campaignId: string) {
+  return prisma.campaign.findFirstOrThrow({
+    where: { id: campaignId, shopId },
+    select: { id: true, note: true },
+  });
+}
+
+/**
+ * The three intents, dispatched in one place.
+ *
+ * The campaign route's action is already the longest in the app and every branch of it
+ * writes prices. These three do not touch a price, so they are answered before that
+ * machinery is reached and the route stays four lines longer rather than forty.
+ *
+ * Returns null for anything it does not recognise, so the caller can carry on to the
+ * intents that do run campaigns. A returned object is the whole response.
+ */
+export async function housekeepingAction(
+  shopId: string,
+  campaignId: string,
+  actor: string | null,
+  form: { get(name: string): FormDataEntryValue | null },
+): Promise<{ ok: true; message: string; redirectTo?: string } | null> {
+  const intent = String(form.get("intent") ?? "");
+
+  if (intent === "duplicate") {
+    const copy = await duplicateCampaign(shopId, campaignId, actor);
+    return {
+      ok: true,
+      message: `Copied to “${copy.name}”.`,
+      // Onto the copy, because a merchant duplicates a campaign in order to change
+      // something about it. Staying here would leave them looking at the original.
+      redirectTo: `/app/campaigns/${copy.id}?duplicated=1`,
+    };
+  }
+
+  if (intent === "archive" || intent === "unarchive") {
+    const { name } = await setArchived(shopId, campaignId, intent === "archive", actor);
+    return {
+      ok: true,
+      // Says what archiving did and did not do. The word means "deleted" to enough
+      // people that leaving it unqualified is how a merchant learns to fear the button.
+      message:
+        intent === "archive"
+          ? `“${name}” is archived. Its runs, its ledger and any prices it has live are unchanged.`
+          : `“${name}” is back in the campaigns list.`,
+    };
+  }
+
+  if (intent === "note") {
+    const { note } = await setNote(shopId, campaignId, String(form.get("note") ?? ""), actor);
+    return { ok: true, message: note ? "Note saved." : "Note cleared." };
+  }
+
+  return null;
+}

--- a/app/services/campaigns/list-archived.test.ts
+++ b/app/services/campaigns/list-archived.test.ts
@@ -1,0 +1,82 @@
+/**
+ * What the campaigns index asks the database for, once archiving exists.
+ *
+ * Two things can go quietly wrong here and neither shows up in a rendered row. The list
+ * can stop excluding archived campaigns, which puts back in front of a merchant exactly
+ * what they filed away. And the "needs a decision" badge can go on counting them, which
+ * is a number pointing at rows that are not in the list — the worst kind of alert,
+ * because the only way to act on it is to guess.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { prisma } = vi.hoisted(() => ({
+  prisma: { campaign: { findMany: vi.fn(), count: vi.fn() } },
+}));
+vi.mock("../../db.server", () => ({ default: prisma }));
+
+import { filtersFrom, listCampaigns } from "./list.server";
+
+const filters = (query = "") => filtersFrom(new URLSearchParams(query));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prisma.campaign.findMany.mockResolvedValue([]);
+  prisma.campaign.count.mockResolvedValue(0);
+});
+
+const rowQuery = () => prisma.campaign.findMany.mock.calls[0]![0].where;
+/** The second `count` is the attention badge; the first is the page total. */
+const attentionQuery = () => prisma.campaign.count.mock.calls[1]![0].where;
+
+describe("the default list", () => {
+  it("leaves out what the merchant filed away", async () => {
+    await listCampaigns("shop", filters());
+
+    expect(rowQuery().archivedAt).toBeNull();
+  });
+
+  it("counts only unarchived campaigns as needing a decision", async () => {
+    // The badge is deliberately unfiltered in every other respect -- a merchant narrowed
+    // to DRAFT still has to be told a run went partial. Archiving is the one exception,
+    // because the campaign is no longer in any list the badge could send them to.
+    await listCampaigns("shop", filters());
+
+    expect(attentionQuery()).toMatchObject({ shopId: "shop", archivedAt: null });
+  });
+});
+
+describe("the archive", () => {
+  it("shows only what was filed away", async () => {
+    await listCampaigns("shop", filters("archived=1"));
+
+    expect(rowQuery().archivedAt).toEqual({ not: null });
+  });
+
+  it("still narrows by status and search, because both controls work at once", async () => {
+    // The reason archiving is not a seventh status tab: a merchant looking for an
+    // archived campaign is usually looking for a finished one.
+    await listCampaigns("shop", filters("archived=1&status=COMPLETED&q=summer"));
+
+    expect(rowQuery()).toMatchObject({ archivedAt: { not: null }, status: "COMPLETED" });
+  });
+});
+
+describe("search", () => {
+  it("looks in the note as well as the name", async () => {
+    // The point of having a note. "Why did we run this" is not a question a merchant can
+    // answer by remembering what they called it.
+    await listCampaigns("shop", filters("q=competitor"));
+
+    expect(rowQuery().OR).toEqual([
+      { name: { contains: "competitor", mode: "insensitive" } },
+      { note: { contains: "competitor", mode: "insensitive" } },
+    ]);
+  });
+
+  it("asks for no name match at all when nothing was typed", async () => {
+    await listCampaigns("shop", filters());
+
+    expect(rowQuery()).not.toHaveProperty("OR");
+  });
+});

--- a/app/services/campaigns/list.server.ts
+++ b/app/services/campaigns/list.server.ts
@@ -24,6 +24,14 @@ export interface CampaignFilters {
   q: string;
   /** A single lifecycle state, or "" for all, or "attention" for the ones needing one. */
   status: string;
+  /**
+   * Whether to show the campaigns that have been filed away.
+   *
+   * Not a value in `status`, because it is not a lifecycle state — a merchant looking for
+   * an archived campaign is usually looking for a *finished* one, and folding the two
+   * into one control would mean losing the status filter to use the archive.
+   */
+  archived: boolean;
   page: number;
 }
 
@@ -31,15 +39,26 @@ export function filtersFrom(params: URLSearchParams): CampaignFilters {
   return {
     q: (params.get("q") ?? "").trim(),
     status: (params.get("status") ?? "").trim(),
+    archived: params.get("archived") === "1",
     page: Math.max(1, Number(params.get("page") ?? 1) || 1),
   };
 }
 
 /** Turns the filters into a Prisma where clause, minus the parts SQL cannot express. */
 function whereFor(shopId: string, filters: CampaignFilters) {
+  const contains = { contains: filters.q, mode: "insensitive" as const };
+
   return {
     shopId,
-    ...(filters.q ? { name: { contains: filters.q, mode: "insensitive" as const } } : {}),
+    // Archived is the *filter*, not a second list: one view, one control, and the row
+    // still says what state the campaign is in. `null` and "not null" rather than a
+    // boolean column, so the archive can be read in the order things were filed.
+    archivedAt: filters.archived ? { not: null } : null,
+    // The note is searched alongside the name, which is the point of having one: "why did
+    // we run this" is not a question a merchant can answer by remembering what they
+    // called it. Prisma leaves a null note out of a `contains` match, so a shop with no
+    // notes searches exactly as it did before.
+    ...(filters.q ? { OR: [{ name: contains }, { note: contains }] } : {}),
     // "attention" is not a status — it is a property of several of them, so it is
     // expanded here rather than being a magic string the database has to understand.
     ...(filters.status === "attention"
@@ -74,7 +93,12 @@ export async function listCampaigns(shopId: string, filters: CampaignFilters) {
     // Counted across the whole shop, not the filtered page. A merchant who has filtered
     // to DRAFT still needs to know something else needs a decision -- hiding it because
     // of an unrelated filter is how a partial run goes unnoticed.
-    prisma.campaign.count({ where: { shopId, status: { in: ATTENTION_STATES } } }),
+    // Archived is the one exception. A campaign a merchant has deliberately filed away
+    // should not go on demanding a decision from the top of a list it is no longer in —
+    // that is a badge counting something the merchant cannot see.
+    prisma.campaign.count({
+      where: { shopId, status: { in: ATTENTION_STATES }, archivedAt: null },
+    }),
   ]);
 
   const rows = campaigns.map((c) => {
@@ -90,6 +114,8 @@ export async function listCampaigns(shopId: string, filters: CampaignFilters) {
       // uses. The index used to say everything *about* a campaign and nothing about what
       // it is.
       ...describeCampaign({ rule: ruleOf(c), ast: astOf(c), segmentName: c.segments[0]?.name }),
+      note: c.note,
+      archived: c.archivedAt !== null,
       createdAt: c.createdAt.toISOString(),
       lastRun: c.runs[0]
         ? {

--- a/app/services/campaigns/list.test.ts
+++ b/app/services/campaigns/list.test.ts
@@ -18,8 +18,19 @@ import { filtersFrom, PAGE_SIZE } from "./list.server";
 const from = (query: string) => filtersFrom(new URLSearchParams(query));
 
 describe("reading the filters", () => {
-  it("defaults to the first page, no search, no status", () => {
-    expect(from("")).toEqual({ q: "", status: "", page: 1 });
+  it("defaults to the first page, no search, no status, and the campaigns still in use", () => {
+    // Archived defaults to false rather than being absent, so the default list is the
+    // unarchived one. A missing parameter meaning "show everything" would put filed-away
+    // campaigns back in front of a merchant who filed them.
+    expect(from("")).toEqual({ q: "", status: "", archived: false, page: 1 });
+  });
+
+  it("opens the archive only when asked", () => {
+    expect(from("archived=1").archived).toBe(true);
+    // Anything else is the active list. "archived=0" is what an unchecked control posts,
+    // and reading it as truthy would open the archive on a link meant to close it.
+    expect(from("archived=0").archived).toBe(false);
+    expect(from("archived=true").archived).toBe(false);
   });
 
   it("trims a search someone typed and mostly deleted", () => {

--- a/app/services/campaigns/run-evidence.server.ts
+++ b/app/services/campaigns/run-evidence.server.ts
@@ -1,0 +1,43 @@
+/**
+ * What the newest run actually did, gathered in one place.
+ *
+ * Three reads that are only ever wanted together — the ledger rows, how many rows there
+ * are in total, and the run's own outcome — and which are meaningless apart: a ledger
+ * page with no total reads as the whole record, and an outcome with no ledger is a
+ * summary of evidence nobody can see.
+ *
+ * The distinction the campaign page turns on lives here too. The preview is the
+ * *intention*; the ledger is the *evidence*, and a partial run is exactly where the two
+ * stop agreeing. Anything that presents one as the other is the failure this app exists
+ * to prevent, so they are fetched by different code and never merged.
+ */
+
+import prisma from "../../db.server";
+import { runLedger } from "./history.server";
+import { campaignResult } from "./result.server";
+
+export async function runEvidence(
+  shopId: string,
+  selectedRunId: string | null,
+): Promise<{
+  ledger: Awaited<ReturnType<typeof runLedger>>;
+  /**
+   * How many rows that run wrote in total, so the table can say what it is not showing.
+   *
+   * The ledger is capped — `s-table` blanks the page past a few hundred cells — and a
+   * capped table that says nothing reads as the whole record, on the one screen whose
+   * entire job is being the record.
+   */
+  ledgerTotal: number;
+  result: Awaited<ReturnType<typeof campaignResult>> | null;
+}> {
+  if (!selectedRunId) return { ledger: [], ledgerTotal: 0, result: null };
+
+  const [ledger, ledgerTotal, result] = await Promise.all([
+    runLedger(shopId, selectedRunId),
+    prisma.variantChange.count({ where: { shopId, runId: selectedRunId } }),
+    campaignResult(shopId, selectedRunId),
+  ]);
+
+  return { ledger, ledgerTotal, result };
+}

--- a/prisma/migrations/20260829120000_campaign_note_and_archive/migration.sql
+++ b/prisma/migrations/20260829120000_campaign_note_and_archive/migration.sql
@@ -1,0 +1,30 @@
+-- A note on a campaign, and archiving instead of deleting.
+--
+-- Expand only, and both columns are nullable with no default, so the previous release
+-- writes rows this schema accepts and this release reads rows that release wrote. Adding
+-- a nullable column takes no table rewrite in Postgres 11+; the index build is the only
+-- part that takes a lock, and campaigns is a small table on every shop we have seen
+-- (thousands, not millions).
+--
+-- Why archiving is a timestamp and not a `CampaignStatus`:
+--
+-- `status` answers "could this campaign's prices be live right now" -- `PRICES_MAY_BE_LIVE`
+-- reads it, the scheduler reads it, and the revert path reads it. Filing a finished
+-- campaign away is not an answer to that question. An ARCHIVED status would force every
+-- transition in `LEGAL` to say what archiving means for it, and would make the state
+-- machine lose the information it had: a partial run that is archived is still partial,
+-- and hiding that behind a filing decision is exactly the kind of quiet loss this app
+-- exists to prevent.
+--
+-- Deliberately NOT in this migration: any change to the `ON DELETE CASCADE` from
+-- campaign_runs to campaigns. Deleting a campaign today cascades to its runs and from
+-- there to variant_changes -- the ledger, which invariant I4 requires to exist before
+-- anything is written to a storefront. Tightening that to RESTRICT looks right and is
+-- not: the shop/redact compliance webhook deletes a Shop, and every one of these tables
+-- cascades from Shop too, so a RESTRICT here can abort a GDPR erasure depending on the
+-- order Postgres processes the referencing tables in. The app offers no campaign delete
+-- at all, and `delete-guard.test.ts` keeps it that way.
+ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "note" TEXT;
+ALTER TABLE "campaigns" ADD COLUMN IF NOT EXISTS "archivedAt" TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS "campaigns_shopId_archivedAt_idx" ON "campaigns" ("shopId", "archivedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -356,6 +356,17 @@ model Campaign {
 
   excludedVariantGids String[] @default([])
 
+  /// Why this campaign exists, in the merchant's own words. Every audit asks it and
+  /// nothing else in the record answers it: the ledger says what we wrote and the
+  /// activity log says who asked, but neither says why.
+  note String?
+
+  /// Out of the list, still in the record. Orthogonal to `status` on purpose -- archiving
+  /// is a filing decision and the lifecycle is a fact about live prices, so a state for it
+  /// would make every transition table answer a question it has no business answering.
+  /// The campaign is still reachable, and its runs and ledger are untouched.
+  archivedAt DateTime?
+
   createdBy String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -370,6 +381,9 @@ model Campaign {
   @@index([shopId, status])
   @@index([shopId, startAt])
   @@index([shopId, endAt])
+  /// The index lists unarchived campaigns on every load, so the default view is the one
+  /// that gets the index.
+  @@index([shopId, archivedAt])
   @@map("campaigns")
 }
 


### PR DESCRIPTION
Three things a merchant does to a campaign as an object rather than as a run. Sami has all three; NA has `Copy to new job` in place of recurrence; RUBIX has duplication only.

## Duplicate

From the campaign header and from the row. **Not** recurrence, which we already have: recurrence re-arms one campaign for its next occurrence and keeps one history, while duplicate is how next month's *different* sale gets built out of last month's sale that worked.

Copies everything that decides a price — rule, scope, surfaces, compare-at and guardrail policies, rounding profile, tag kit, exclusions, note. Copies **nothing** that says what the original did: no schedule (last month's dates would arm a run in the past), no status, no runs, no ledger. A duplicate carrying its source's run history would be a lie about what has been written to a live storefront. The segment is *connected*, not copied — a segment is a shared definition, and copied rows stop tracking the original the first time either is edited.

## Note

Free text, searched alongside the name from the index. The ledger says what we wrote, the activity log says who asked; neither says why. The replaced text goes to the audit log, because a note is the one field here nothing else can reconstruct.

## Archive, and no delete

`archivedAt` is a timestamp, deliberately **not** a `CampaignStatus`. `status` answers "could this campaign's prices be live right now" — the scheduler and the revert path both read it — and filing something away is not an answer to that question. An `ARCHIVED` state would force every transition in `LEGAL` to say what archiving means for it, and would lose what the machine knew: a partial run that is archived is still partial.

Archiving is allowed in any state including ACTIVE, and the header shows both badges, because an archived campaign can still have prices live.

## The part the ticket asked to check, which mattered more than the feature

`campaign_runs` cascades from `campaigns`; `variant_changes` cascades from `campaign_runs`. Deleting a campaign would not *orphan* a ledger row — it would **erase every ledger row that campaign ever wrote**, which is the record invariant I4 exists to produce and what a revert recomputes against.

The obvious fix — `ON DELETE RESTRICT` — is wrong here: `shop/redact` deletes a `Shop`, and all three tables cascade from `Shop` as well, so a RESTRICT between two of them can abort a GDPR erasure depending on the order Postgres processes referencing tables in. Erasure has to win. So the constraint stays permissive, **the app offers no delete at all**, and `delete-guard.test.ts` holds that line for campaigns, runs and ledger rows alike — plus an inverse assertion that the compliance webhook still deletes the shop, since that is the premise the whole argument rests on.

## Two guards sharpened by their own failures

- `polaris-traps.test.ts` now strips whole-line comments. It fired on the comment explaining *why* the field does not use `defaultValue` — a rule that punishes the note documenting compliance with it teaches people to stop writing the note. (Seventh occurrence of this trap; #462 is open to extract the idiom, now in four files.)
- Both source-level guards now read untracked files (`--cached --others --exclude-standard`). A deliberately broken copy of the delete rule **passed**, because the file breaking it had not been `git add`ed yet — and a new file is the likeliest place a new offender appears.

## Verification

typecheck, lint (cache cleared), build, full suite **2555 passed**. Mutations all caught: archived shown in the default list, the attention badge counting archived rows, the note dropped from search, `defaultValue` on a Polaris field, the copy suffix stacking per generation, and an injected `campaign.delete`.

Migration is expand-only — two nullable columns and an index, no rewrite, readable by the previous release.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)