### PR TITLE
One way for a test to read this app's own source (#462)

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -15,11 +15,13 @@
  * `inlineSize` and about where the aside content ended up.
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
 
 import { HelpNote } from "./HelpNote";
 import { PageShell } from "./PageShell";
@@ -260,7 +262,7 @@ describe("every page in the app goes through the shell", () => {
       const path = join(dir, entry.name);
       if (entry.isDirectory()) return sources(path);
       if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
-      return [{ path: path.replace(`${APP}/`, ""), text: readFileSync(path, "utf8") }];
+      return [{ path: path.replace(`${APP}/`, ""), text: sourceOf(path) }];
     });
 
   /**
@@ -290,7 +292,7 @@ describe("every page in the app goes through the shell", () => {
   it("insets the one thing that renders outside a page", () => {
     // A section's tabs come from the layout route, above the `Outlet`. They are the only
     // markup in the app that has to line up with a page without being inside one.
-    const tabs = readFileSync(join(APP, "components", "SectionTabs.tsx"), "utf8");
+    const tabs = sourceOf(APP, "components", "SectionTabs.tsx");
 
     expect(tabs).toContain("PageWidth");
   });
@@ -368,17 +370,14 @@ describe("pages that can lose typed work", () => {
   const PROVIDERS = ["<UnsavedChanges", "<ImportForm"];
 
   it("the shared import form carries the guard the routes delegate to it", () => {
-    const form = readFileSync(
-      join(process.cwd(), "app", "components", "imports", "ImportForm.tsx"),
-      "utf8",
-    );
+    const form = sourceOf("app", "components", "imports", "ImportForm.tsx");
 
     expect(form).toContain("<UnsavedChanges");
   });
 
   it("guard the ones that hold a form worth keeping", () => {
     const missing = GUARDED.filter((route) => {
-      const source = readFileSync(join(APP_ROUTES, route), "utf8");
+      const source = sourceOf(APP_ROUTES, route);
       return !PROVIDERS.some((provider) => source.includes(provider));
     });
 

--- a/app/components/action-row.test.tsx
+++ b/app/components/action-row.test.tsx
@@ -8,10 +8,12 @@
  * they arrived.
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
 
 import { ActionRow } from "./ActionRow";
 import { SPACE } from "../lib/ui/spacing";
@@ -41,7 +43,7 @@ function sources(dir: string): Array<{ path: string; text: string }> {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) return sources(path);
     if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
-    return [{ path: path.replace(`${APP}/`, ""), text: readFileSync(path, "utf8") }];
+    return [{ path: path.replace(`${APP}/`, ""), text: sourceOf(path) }];
   });
 }
 

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -12,12 +12,14 @@
  * it is a property of the whole app, so it is checked over the source of every file.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { StaticRouter } from "react-router";
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../../lib/testing/source";
 
 import { CampaignHeader } from "./CampaignHeader";
 import { CampaignOverviewTab } from "./CampaignOverviewTab";
@@ -239,7 +241,7 @@ function tsxFiles(dir: string): string[] {
 
 describe("no card is drawn inside another card", () => {
   const offenders = tsxFiles(APP).flatMap((path) => {
-    const source = readFileSync(path, "utf8");
+    const source = sourceOf(path);
     let depth = 0;
     let deepest = 0;
 

--- a/app/components/campaign/sections.test.ts
+++ b/app/components/campaign/sections.test.ts
@@ -9,10 +9,12 @@
  * So this checks the headings themselves, read from the files rather than listed twice.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { rawSource, sourceOf } from "../../lib/testing/source";
 
 const DIR = join(process.cwd(), "app", "components", "campaign");
 const ROUTE = join(process.cwd(), "app", "routes", "app.campaigns.$id.tsx");
@@ -20,11 +22,22 @@ const ROUTE = join(process.cwd(), "app", "routes", "app.campaigns.$id.tsx");
 const everything = [
   ...readdirSync(DIR)
     .filter((f) => f.endsWith(".tsx") && !f.endsWith(".test.tsx"))
-    .map((f) => readFileSync(join(DIR, f), "utf8")),
-  readFileSync(ROUTE, "utf8"),
+    .map((f) => sourceOf(DIR, f)),
+  sourceOf(ROUTE),
 ].join("\n");
 
-/** The thirteen sections the page carried before the split. */
+/**
+ * The sections the page carried before the split.
+ *
+ * "Actions" is not among them any more, and the way it left is the reason this file now
+ * reads source with its comments stripped. The section was dissolved in #395's successor:
+ * a card titled after a *category of thing*, holding a row of buttons, became the header
+ * row itself. The check went on passing for months afterwards — because `CampaignHeader`'s
+ * docstring quotes the `heading="Actions"` it replaced, and a census that reads its own
+ * commentary finds whatever the commentary mentions.
+ *
+ * A guard that a deletion cannot fail is not guarding anything.
+ */
 const SECTIONS = [
   "Preview",
   "Approval",
@@ -33,7 +46,6 @@ const SECTIONS = [
   "Run history",
   "If you revert this campaign",
   "Ledger",
-  "Actions",
   "Schedule",
   "New products",
 ];
@@ -47,13 +59,16 @@ describe("nothing was lost splitting the page into tabs", () => {
     // The tab bodies were carved out of aside panels. Leaving the slot on would make
     // them silently invisible at inlineSize="large" — see PageShell.
     for (const file of readdirSync(DIR).filter((f) => f.endsWith(".tsx"))) {
-      expect(readFileSync(join(DIR, file), "utf8"), `${file} still marks content as aside`)
+      expect(sourceOf(DIR, file), `${file} still marks content as aside`)
         .not.toContain('slot="aside"');
     }
   });
 
   it("keeps the route small enough to read", () => {
-    const lines = readFileSync(ROUTE, "utf8").split("\n").length;
+    // `rawSource`, not `sourceOf`. This one is about the file as a person opens it, and
+    // comments are most of what makes a long file long — measuring the stripped source
+    // would let the route grow past any limit as long as the growth was documented.
+    const lines = rawSource(ROUTE).split("\n").length;
     expect(lines, "the page was 690 lines with everything in one component").toBeLessThan(400);
   });
 });

--- a/app/components/campaign/views.test.ts
+++ b/app/components/campaign/views.test.ts
@@ -9,23 +9,14 @@
  * `?view=week` would otherwise read as "not calendar" and silently show the list.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const route = readFileSync(
-  join(process.cwd(), "app", "routes", "app.campaigns._index.tsx"),
-  "utf8",
-);
-const calendar = readFileSync(
-  join(process.cwd(), "app", "components", "campaign", "CampaignCalendar.tsx"),
-  "utf8",
-);
-const stub = readFileSync(
-  join(process.cwd(), "app", "routes", "app.campaigns.calendar.tsx"),
-  "utf8",
-);
+import { sourceOf } from "../../lib/testing/source";
+
+const route = sourceOf(process.cwd(), "app", "routes", "app.campaigns._index.tsx");
+const calendar = sourceOf(process.cwd(), "app", "components", "campaign", "CampaignCalendar.tsx");
+const stub = sourceOf(process.cwd(), "app", "routes", "app.campaigns.calendar.tsx");
 
 describe("one parameter, one meaning", () => {
   it("uses view for list-or-calendar", () => {

--- a/app/components/counts-row.test.ts
+++ b/app/components/counts-row.test.ts
@@ -11,10 +11,12 @@
  * side-by-side comparison shows one of them is the old one.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
 
 const APP = join(process.cwd(), "app");
 
@@ -23,7 +25,7 @@ function sources(dir: string): Array<{ path: string; text: string }> {
     const path = join(dir, entry.name);
     if (entry.isDirectory()) return sources(path);
     if (!entry.name.endsWith(".tsx") || entry.name.endsWith(".test.tsx")) return [];
-    return [{ path: path.replace(`${APP}/`, ""), text: readFileSync(path, "utf8") }];
+    return [{ path: path.replace(`${APP}/`, ""), text: sourceOf(path) }];
   });
 }
 
@@ -45,7 +47,7 @@ describe("the counts row", () => {
   it("is actually used by the dashboard", () => {
     // Guards the other direction: deleting the duplicate without adopting the component
     // would leave the first screen with no counts at all and still pass the check above.
-    const dashboard = readFileSync(join(APP, "routes", "app._index.tsx"), "utf8");
+    const dashboard = sourceOf(APP, "routes", "app._index.tsx");
     expect(dashboard).toContain("<CountsRow");
   });
 });

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -14,12 +14,14 @@
  * empty branch in the app rather than on the ones somebody remembered.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { StaticRouter } from "react-router";
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
 
 import { EmptyState, NoMatches } from "./AsyncState";
 import { clearedSearch } from "./FilterForm";
@@ -113,7 +115,7 @@ describe("the campaigns index picks the right one of the two", () => {
   });
 
   it("no longer carries a second EmptyState of its own", () => {
-    const source = readFileSync(join(process.cwd(), "app/components/campaign/CampaignListView.tsx"), "utf8");
+    const source = sourceOf("app/components/campaign/CampaignListView.tsx");
 
     expect(source).not.toMatch(/function EmptyState/);
   });
@@ -195,23 +197,9 @@ describe("no page answers 'where are my rows' with a loose paragraph", () => {
     (path) => ![...OUTSIDE_THE_ADMIN, ...NOT_A_PAGE].some((skip) => path.includes(skip)),
   );
 
-  /**
-   * Whole-line `//` comments removed before matching.
-   *
-   * Two of the nine branches explain themselves in a comment between the `(` and the
-   * component — which is the house style, and it hid them from the first version of this
-   * check entirely. A rule that stops seeing the code as soon as somebody documents it is
-   * worse than no rule. Only lines that are *nothing but* a comment go, so the `//` in an
-   * `https://` href is left alone.
-   */
-  const scannable = (source: string) =>
-    source
-      .split("\n")
-      .filter((line) => !line.trimStart().startsWith("//"))
-      .join("\n");
 
   const offenders = admin.flatMap((path) => {
-    const source = scannable(readFileSync(path, "utf8"));
+    const source = sourceOf(path);
     return BRANCHES.flatMap((pattern) =>
       [...source.matchAll(pattern)]
         .filter((match) => !NOT_DATA.includes(match[1]) && !ALLOWED.includes(match[2]))
@@ -221,7 +209,7 @@ describe("no page answers 'where are my rows' with a loose paragraph", () => {
 
   it("finds the empty branches to check", () => {
     const found = admin.flatMap((path) => {
-      const source = scannable(readFileSync(path, "utf8"));
+      const source = sourceOf(path);
       return BRANCHES.flatMap((pattern) =>
         [...source.matchAll(pattern)].filter((match) => !NOT_DATA.includes(match[1])),
       );

--- a/app/components/field-grid.test.ts
+++ b/app/components/field-grid.test.ts
@@ -11,20 +11,16 @@
  * reverts: the comma trap, and a checkbox left in a column.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const grid = readFileSync(join(process.cwd(), "app", "components", "FieldGrid.tsx"), "utf8");
-const settings = readFileSync(
-  join(process.cwd(), "app", "routes", "app.settings._index.tsx"),
-  "utf8",
-);
-const editor = readFileSync(
-  join(process.cwd(), "app", "routes", "app.campaigns.new.tsx"),
-  "utf8",
-);
+import { sourceOf } from "../lib/testing/source";
+
+const grid = sourceOf(process.cwd(), "app", "components", "FieldGrid.tsx");
+const settings = sourceOf(process.cwd(), "app", "routes", "app.settings._index.tsx");
+const editor = sourceOf(process.cwd(), "app", "routes", "app.campaigns.new.tsx");
 
 describe("the field grid", () => {
   it("carries exactly one comma, so the value parses", () => {
@@ -125,7 +121,7 @@ describe("no settings tab leaves a control unbounded", () => {
   });
 
   it.each(TABS)("%s", (name, path) => {
-    const source = readFileSync(path, "utf8");
+    const source = sourceOf(path);
 
     /** How many of these are open at this point in the file. */
     const depth = (tag: string, upTo: number) => {

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -18,16 +18,18 @@
  * page still names the thing it used to explain, wherever that prose now lives.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../lib/testing/source";
+
 import { HelpNote } from "./HelpNote";
 
 const ROUTES = join(process.cwd(), "app", "routes");
-const route = (name: string) => readFileSync(join(ROUTES, name), "utf8");
+const route = (name: string) => sourceOf(ROUTES, name);
 /** Every route module, so a new explanatory sidebar is caught wherever it is added. */
 const ALL_ROUTES = readdirSync(ROUTES).filter((f) => f.endsWith(".tsx"));
 

--- a/app/components/imports/imports.test.ts
+++ b/app/components/imports/imports.test.ts
@@ -21,17 +21,14 @@
  * screenshot would show.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const ROOT = process.cwd();
-const read = (...parts: string[]) => readFileSync(join(ROOT, ...parts), "utf8");
+import { sourceOf } from "../../lib/testing/source";
 
-/** Source with its own commentary removed, so a file explaining its history is not read as doing it. */
-const code = (source: string) =>
-  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+const ROOT = process.cwd();
+const read = (...parts: string[]) => sourceOf(ROOT, ...parts);
+
 
 const PRICE_IMPORT = read("app/routes/app.campaigns.import.tsx");
 const BASELINES = read("app/routes/app.prices.baselines._index.tsx");
@@ -44,7 +41,7 @@ const DROP_ZONE = read("app/components/imports/CsvDropZone.tsx");
 
 describe("the nav is five items, and none of them is a verb", () => {
   it("no longer offers Imports", () => {
-    expect(code(NAV)).not.toContain("/app/imports");
+    expect(NAV).not.toContain("/app/imports");
   });
 
   /**
@@ -60,7 +57,7 @@ describe("the nav is five items, and none of them is a verb", () => {
    * a failure rather than an omission, which is the property that was missing.
    */
   it("keeps the five nouns", () => {
-    const items = [...code(NAV).matchAll(/<s-link href="(\/app[^"]*)"/g)].map((m) => m[1]);
+    const items = [...NAV.matchAll(/<s-link href="(\/app[^"]*)"/g)].map((m) => m[1]);
     expect(items).toEqual([
       "/app",
       "/app/campaigns",
@@ -71,7 +68,7 @@ describe("the nav is five items, and none of them is a verb", () => {
   });
 
   it("has no nav item the assertion above cannot see", () => {
-    const links = [...code(NAV).matchAll(/<s-link\s/g)].length;
+    const links = [...NAV.matchAll(/<s-link\s/g)].length;
 
     expect(links, "an s-link whose href is not a literal path is invisible above").toBe(5);
   });
@@ -81,7 +78,7 @@ describe("the nav is five items, and none of them is a verb", () => {
     // under Imports, meaning "look at them" in one place and "replace them" in the other.
     const prices = read("app/routes/app.prices.tsx");
     for (const noun of ["Baselines", "Costs"]) {
-      const tabs = [...code(prices).matchAll(/label: "([^"]+)"/g)].map((m) => m[1]);
+      const tabs = [...prices.matchAll(/label: "([^"]+)"/g)].map((m) => m[1]);
       expect(tabs.filter((label) => label === noun)).toHaveLength(1);
     }
   });
@@ -159,8 +156,8 @@ describe("the safety properties travelled with the flows", () => {
       ["baseline import", BASELINES],
       ["cost import", COSTS],
     ] as const) {
-      expect(code(source), `${name} decides commit-or-check for itself`).toContain("isCommit(");
-      expect(code(source), `${name} spells out its own comparison`).not.toMatch(
+      expect(source, `${name} decides commit-or-check for itself`).toContain("isCommit(");
+      expect(source, `${name} spells out its own comparison`).not.toMatch(
         /String\(form\.get\("intent"\)\) !== "commit"/,
       );
     }
@@ -189,7 +186,7 @@ describe("the safety properties travelled with the flows", () => {
     // Its own doc comment argued for that, and `planRecapture` counts a scope of up to
     // half a million variants — not something to run on every visit to a page a merchant
     // opens to look one price up.
-    expect(code(BASELINES)).not.toContain("planRecapture");
+    expect(BASELINES).not.toContain("planRecapture");
   });
 });
 
@@ -266,7 +263,7 @@ describe("the three imports are one import", () => {
 });
 
 describe("making a segment is one decision", () => {
-  const segments = code(read("app/routes/app.settings.segments.tsx"));
+  const segments = read("app/routes/app.settings.segments.tsx");
 
   it("offers one create form, not two competing cards", () => {
     expect(segments).not.toContain("New segment from a filter");

--- a/app/components/prices/tabs-layout.test.ts
+++ b/app/components/prices/tabs-layout.test.ts
@@ -10,15 +10,12 @@
  * a stack that stretches its children.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const search = readFileSync(
-  join(process.cwd(), "app", "components", "prices", "VariantSearch.tsx"),
-  "utf8",
-);
+import { sourceOf } from "../../lib/testing/source";
+
+const search = sourceOf(process.cwd(), "app", "components", "prices", "VariantSearch.tsx");
 
 describe("the filter block", () => {
   it("lays its controls out in a grid, not a stretching stack", () => {

--- a/app/components/section-tabs.test.ts
+++ b/app/components/section-tabs.test.ts
@@ -10,29 +10,20 @@
  * on an empty page reads as "nothing here" rather than "wrong page".
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../lib/testing/source";
+
 import { isCurrent } from "./SectionTabs";
 
-const tabs = readFileSync(
-  join(process.cwd(), "app", "components", "SectionTabs.tsx"),
-  "utf8",
-);
+const tabs = sourceOf(process.cwd(), "app", "components", "SectionTabs.tsx");
 // The bar itself is shared with the campaign page and the campaigns index. What stays
 // in SectionTabs is only what is specific to sections: the query string, and what
 // "current" means when the tabs are separate routes.
-const bar = readFileSync(join(process.cwd(), "app", "components", "TabBar.tsx"), "utf8");
-const layout = readFileSync(
-  join(process.cwd(), "app", "routes", "app.prices.tsx"),
-  "utf8",
-);
-const search = readFileSync(
-  join(process.cwd(), "app", "components", "prices", "VariantSearch.tsx"),
-  "utf8",
-);
+const bar = sourceOf(process.cwd(), "app", "components", "TabBar.tsx");
+const layout = sourceOf(process.cwd(), "app", "routes", "app.prices.tsx");
+const search = sourceOf(process.cwd(), "app", "components", "prices", "VariantSearch.tsx");
 
 describe("filters survive a tab switch", () => {
   it("carries the query string onto every tab link", () => {

--- a/app/components/settings.test.ts
+++ b/app/components/settings.test.ts
@@ -10,17 +10,19 @@
  * redirects to actually exists.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
 
 import { LEGACY_ROUTES } from "../lib/routing/legacy-routes";
 
 const ROUTES = join(process.cwd(), "app", "routes");
 const routeFiles = new Set(readdirSync(ROUTES).filter((f) => f.endsWith(".tsx")));
-const layout = readFileSync(join(ROUTES, "app.settings.tsx"), "utf8");
-const index = readFileSync(join(ROUTES, "app.settings._index.tsx"), "utf8");
+const layout = sourceOf(ROUTES, "app.settings.tsx");
+const index = sourceOf(ROUTES, "app.settings._index.tsx");
 
 describe("everything that moved into settings is still reachable", () => {
   it.each([

--- a/app/components/tab-bar.test.tsx
+++ b/app/components/tab-bar.test.tsx
@@ -11,7 +11,7 @@
  * a second one".
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import type { ReactNode } from "react";
@@ -19,11 +19,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { StaticRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../lib/testing/source";
+
 import { TabBar, type Tab } from "./TabBar";
 import { PAD } from "../lib/ui/spacing";
 
 const ROOT = process.cwd();
-const bar = readFileSync(join(ROOT, "app/components/TabBar.tsx"), "utf8");
+const bar = sourceOf("app/components/TabBar.tsx");
 
 /**
  * The bar as a merchant's browser receives it.
@@ -58,7 +60,7 @@ function sources(dir: string): string[] {
 
 const files = sources("app").map((path) => ({
   path,
-  source: readFileSync(join(ROOT, path), "utf8"),
+  source: sourceOf(path),
 }));
 
 describe("every set of tabs uses the shared bar", () => {
@@ -165,10 +167,7 @@ describe("the bar itself", () => {
     // where the merchant was reading; on a real page change it is what they expect,
     // which is why this is the caller's decision and not a constant.
     expect(bar).toContain("preventScrollReset = false");
-    const campaign = readFileSync(
-      join(ROOT, "app/components/campaign/CampaignTabs.tsx"),
-      "utf8",
-    );
+    const campaign = sourceOf("app/components/campaign/CampaignTabs.tsx");
     expect(campaign).toContain("preventScrollReset");
   });
 });
@@ -206,7 +205,7 @@ describe("the rule under the row", () => {
   it("uses the two-value form only where both axes are meant", () => {
     // `PAD.control` is "small-100 base": two values means `block inline`, so the tab is
     // tighter vertically than horizontally. That one is correct and worth not breaking.
-    const spacing = readFileSync(join(ROOT, "app/lib/ui/spacing.ts"), "utf8");
+    const spacing = sourceOf("app/lib/ui/spacing.ts");
     expect(spacing).toContain('control: "small-100 base"');
   });
 });

--- a/app/lib/campaigns/describe-shared.test.ts
+++ b/app/lib/campaigns/describe-shared.test.ts
@@ -1,13 +1,9 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-import { describeCampaign } from "./describe";
+import { sourceOf } from "../testing/source";
 
-/** Comments only, so prose about the formatter cannot masquerade as a call to it. */
-function withoutComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
-}
+import { describeCampaign } from "./describe";
 
 const LIST = "app/services/campaigns/list.server.ts";
 const DETAIL = "app/routes/app.campaigns.$id.tsx";
@@ -20,7 +16,7 @@ const DETAIL = "app/routes/app.campaigns.$id.tsx";
  * makes this a check of the real call and not of a mention in a comment.
  */
 function describeCall(file: string): string {
-  const source = readFileSync(file, "utf8");
+  const source = sourceOf(file);
   const call = /\.\.\.describeCampaign\(\{[^}]*\}\)/.exec(source)?.[0];
 
   expect(call, `${file} no longer builds its sentences with describeCampaign`).toBeTruthy();
@@ -66,7 +62,7 @@ describe("the campaigns index and the campaign page describe a campaign the same
       .filter((f) => !f.includes(".test.") && !f.startsWith("app/lib/campaigns/describe"));
 
     const offenders = files.filter((f) =>
-      /\bdescribe(?:Rule|Scope)\(/.test(withoutComments(readFileSync(f, "utf8"))),
+      /\bdescribe(?:Rule|Scope)\(/.test(sourceOf(f)),
     );
 
     expect(offenders, "call describeCampaign, which returns both").toEqual([]);

--- a/app/lib/campaigns/draft-defaults.test.ts
+++ b/app/lib/campaigns/draft-defaults.test.ts
@@ -14,18 +14,15 @@
  * So: the values live in one object, and this refuses a literal of them anywhere else.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../testing/source";
+
 import { DRAFT_DEFAULTS, draftDefaultParams } from "./draft-defaults";
 
-/** Source with comments removed — they discuss the very literals being grepped for. */
-const sourceOf = (path: string) =>
-  readFileSync(join(process.cwd(), path), "utf8")
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/^\s*\/\/.*$/gm, "");
 
 const EDITOR = sourceOf("app/routes/app.campaigns.new.tsx");
 

--- a/app/lib/catalog/sync-parity.test.ts
+++ b/app/lib/catalog/sync-parity.test.ts
@@ -25,6 +25,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../testing/source";
+
 const paginated = readFileSync(
   join(process.cwd(), "app", "services", "catalog-sync.server.ts"),
   "utf8",
@@ -110,7 +112,7 @@ describe("the bulk path writes everything the paginated path does", () => {
     expect(paginated).toContain("featuredImage { url }");
     expect(paginated).toContain("image { url }");
     expect(
-      readFileSync(join(process.cwd(), "app", "lib", "catalog", "bulk-jsonl.ts"), "utf8"),
+      sourceOf(process.cwd(), "app", "lib", "catalog", "bulk-jsonl.ts"),
     ).toContain("featuredImage { url }");
   });
 });

--- a/app/lib/compliance/built-for-shopify.test.ts
+++ b/app/lib/compliance/built-for-shopify.test.ts
@@ -16,6 +16,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../testing/source";
+
 import { API_VERSION_STRING, supportedUntil } from "../shopify/api-version";
 
 const ROOT = process.cwd();
@@ -89,7 +91,7 @@ describe("design — Polaris and App Bridge", () => {
       const file = routes.find((candidate) => candidate.includes(route));
       expect(file, `${route} is excluded but does not exist`).toBeDefined();
 
-      const source = readFileSync(file!, "utf8");
+      const source = sourceOf(file!);
       expect(source, `${route} is excluded but authenticates as embedded admin`).not.toMatch(
         /authenticate\.admin/,
       );
@@ -103,7 +105,7 @@ describe("design — Polaris and App Bridge", () => {
     // which is both a broken app and a design-criterion failure for full page reloads.
     for (const file of ui) {
       if (file.endsWith("FilterForm.tsx")) continue;
-      const source = readFileSync(file, "utf8");
+      const source = sourceOf(file);
 
       expect(source, `${file} uses a native <form>`).not.toMatch(/<form[\s>]/);
     }
@@ -124,7 +126,7 @@ describe("design — Polaris and App Bridge", () => {
     ];
 
     for (const file of ui) {
-      const source = readFileSync(file, "utf8");
+      const source = sourceOf(file);
 
       for (const field of FIELDS) {
         // Each opening tag with everything up to its closing bracket, so a label on a
@@ -144,7 +146,7 @@ describe("design — Polaris and App Bridge", () => {
     // Hidden inputs carry intent through a form and have no Polaris equivalent. Anything
     // visible should be a Polaris component, or the app has two visual languages in it.
     for (const file of ui) {
-      const source = readFileSync(file, "utf8");
+      const source = sourceOf(file);
 
       for (const match of source.matchAll(/<input\b[^>]*>/gs)) {
         expect(
@@ -160,7 +162,7 @@ describe("integration — API, auth and webhooks", () => {
   it("pins one API version, with no environment override", () => {
     // A worker and a web process on different versions is a class of bug that only ever
     // shows up in production, and only sometimes.
-    const source = readFileSync(join(ROOT, "app/lib/shopify/api-version.ts"), "utf8");
+    const source = sourceOf("app/lib/shopify/api-version.ts");
 
     expect(source).toMatch(/export const API_VERSION\s*=\s*ApiVersion\./);
     expect(source, "the API version must not be overridable by env").not.toMatch(
@@ -197,7 +199,7 @@ describe("integration — API, auth and webhooks", () => {
 
     expect(webhooks.length).toBeGreaterThan(0);
     for (const file of webhooks) {
-      expect(readFileSync(file, "utf8"), `${file} does not authenticate`).toMatch(
+      expect(sourceOf(file), `${file} does not authenticate`).toMatch(
         /authenticate\.webhook\(/,
       );
     }
@@ -209,7 +211,7 @@ describe("integration — API, auth and webhooks", () => {
     );
 
     for (const file of embedded) {
-      const source = readFileSync(file, "utf8");
+      const source = sourceOf(file);
       if (!/export const (loader|action)/.test(source)) continue;
 
       expect(source, `${file} has a loader or action that does not authenticate`).toMatch(
@@ -275,7 +277,7 @@ describe("integration — API, auth and webhooks", () => {
         }
         if (!/\.(ts|tsx)$/.test(entry.name)) continue;
 
-        const source = readFileSync(join(ROOT, path), "utf8");
+        const source = sourceOf(path);
         // A mutation field on the root Mutation type whose name begins with `market`.
         // Deliberately not matching `marketing…` or a `markets` query.
         for (const [match] of source.matchAll(
@@ -319,7 +321,7 @@ describe("the pre-audit sheet names evidence that exists", () => {
     readdirSync(join(ROOT, "app/lib/compliance"))
       .filter((name) => name.endsWith(".test.ts"))
       .flatMap((name) => {
-        const source = readFileSync(join(ROOT, "app/lib/compliance", name), "utf8");
+        const source = sourceOf("app/lib/compliance", name);
         return [...source.matchAll(/^\s*(?:it|describe)\("([^"]+)"/gm)].map((match) => match[1]!);
       }),
   );
@@ -356,7 +358,7 @@ describe("the pre-audit sheet names evidence that exists", () => {
   });
 
   it("cites every criterion test in this file, so nothing is proved but unlisted", () => {
-    const suite = readFileSync(join(ROOT, "app/lib/compliance/built-for-shopify.test.ts"), "utf8");
+    const suite = sourceOf("app/lib/compliance/built-for-shopify.test.ts");
     const here = [...suite.matchAll(/^\s*it\("([^"]+)"/gm)].map((match) => match[1]!);
 
     const exempt = new Set([

--- a/app/lib/compliance/colour-signal.test.ts
+++ b/app/lib/compliance/colour-signal.test.ts
@@ -14,10 +14,12 @@
  * "this matters less", which is not information a reader loses without colour.
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const ROOT = process.cwd();
 
@@ -69,16 +71,16 @@ function tonedElements(source: string): Array<{ tag: string; tone: string; body:
 
 describe("every tone is accompanied by words", () => {
   it("finds tones to check", () => {
-    const total = files.reduce((sum, file) => sum + tonedElements(readFileSync(file, "utf8")).length, 0);
+    const total = files.reduce((sum, file) => sum + tonedElements(sourceOf(file)).length, 0);
 
     // Without this the assertion below passes on an empty set and proves nothing.
     expect(total).toBeGreaterThan(20);
   });
 
-  it.each(files.filter((file) => tonedElements(readFileSync(file, "utf8")).length > 0))(
+  it.each(files.filter((file) => tonedElements(sourceOf(file)).length > 0))(
     "%s",
     (file) => {
-      for (const element of tonedElements(readFileSync(file, "utf8"))) {
+      for (const element of tonedElements(sourceOf(file))) {
         // Literal words, or an interpolation — which is content, even though this cannot
         // read it. What fails here is an element with neither: colour and nothing else.
         const hasContent = /[A-Za-z]{3,}/.test(element.body) || /\{[^}]+\}/.test(element.body);
@@ -98,7 +100,7 @@ describe("the result banner says which outcome it is, not just which colour", ()
     // The specific banner this rule exists for: a partial run is `critical`, a clean one
     // `success`, and a merchant who cannot tell those apart by colour has to be able to
     // read the difference.
-    const source = readFileSync(join(ROOT, "app/components/RunResultSection.tsx"), "utf8");
+    const source = sourceOf("app/components/RunResultSection.tsx");
 
     expect(source).toContain("result.summary");
     // And the summary itself is built from words — `describeRun` is tested separately for

--- a/app/lib/compliance/deploy-config.test.ts
+++ b/app/lib/compliance/deploy-config.test.ts
@@ -10,13 +10,15 @@
  * services differ only where they are supposed to.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../testing/source";
+
 const ROOT = process.cwd();
-const runbook = readFileSync(join(ROOT, "docs/deploying-to-railway.md"), "utf8");
+const runbook = sourceOf(ROOT, "docs/deploying-to-railway.md");
 
 /** Every `process.env.X` the app or its scripts read. */
 function environmentKeys(): Set<string> {
@@ -32,7 +34,7 @@ function environmentKeys(): Set<string> {
       if (!/\.(ts|tsx)$/.test(entry.name)) continue;
       if (/\.test\.tsx?$/.test(entry.name)) continue;
 
-      const source = readFileSync(join(ROOT, path), "utf8");
+      const source = sourceOf(ROOT, path);
       for (const [, key] of source.matchAll(/process\.env\.([A-Z0-9_]+)/g)) keys.add(key);
     }
   };
@@ -54,8 +56,8 @@ describe("the worker's Railway config", () => {
    * Nothing in that error names the healthcheck as the wrong setting for this service
    * rather than a broken app, which is why it is worth a test rather than a paragraph.
    */
-  const web = JSON.parse(readFileSync(join(ROOT, "railway.json"), "utf8"));
-  const worker = JSON.parse(readFileSync(join(ROOT, "railway.worker.json"), "utf8"));
+  const web = JSON.parse(sourceOf(ROOT, "railway.json"));
+  const worker = JSON.parse(sourceOf(ROOT, "railway.worker.json"));
 
   it("gives the web service a healthcheck", () => {
     expect(web.deploy?.healthcheckPath, "the web service must be health-checked").toBe(
@@ -102,7 +104,7 @@ describe("the webhooks the manifest subscribes to", () => {
    * Shopify addresses all three of `customers/data_request`, `customers/redact` and
    * `shop/redact` at one uri.
    */
-  const manifest = readFileSync(join(ROOT, "shopify.app.toml"), "utf8");
+  const manifest = sourceOf(ROOT, "shopify.app.toml");
 
   const declared = [...manifest.matchAll(/^\s*uri\s*=\s*"([^"]+)"/gm)].map(([, uri]) => uri);
 
@@ -147,18 +149,18 @@ describe("the Railway runbook", () => {
     // Three places state the scope set and all three are load-bearing: the manifest is
     // what Shopify grants, `SCOPES` is what the app asks the session layer for, and a
     // mismatch shows up as an authorisation failure with no obvious cause.
-    const toml = readFileSync(join(ROOT, "shopify.app.toml"), "utf8");
+    const toml = sourceOf(ROOT, "shopify.app.toml");
     const declared = /scopes\s*=\s*"([^"]*)"/.exec(toml)?.[1];
 
     expect(declared).toBeTruthy();
     expect(runbook, "the runbook's SCOPES row disagrees with the manifest").toContain(declared!);
 
-    const example = readFileSync(join(ROOT, ".env.example"), "utf8");
+    const example = sourceOf(ROOT, ".env.example");
     expect(example, ".env.example disagrees with the manifest").toContain(`SCOPES=${declared}`);
   });
 
   it("points the healthcheck at a route that exists", () => {
-    const config = JSON.parse(readFileSync(join(ROOT, "railway.json"), "utf8"));
+    const config = JSON.parse(sourceOf(ROOT, "railway.json"));
     const path = config.deploy?.healthcheckPath;
 
     expect(path).toBe("/healthz");
@@ -171,7 +173,7 @@ describe("the Railway runbook", () => {
     // Only the web service migrates. Two services racing `prisma migrate deploy` is a lock
     // fight at best and a half-applied schema at worst, so the worker's command must not
     // reach it.
-    const scripts = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")).scripts;
+    const scripts = JSON.parse(sourceOf(ROOT, "package.json")).scripts;
 
     expect(scripts["docker-start"]).toContain("setup");
     expect(scripts.worker).not.toContain("setup");
@@ -186,7 +188,7 @@ describe("the Railway runbook", () => {
     //
     // `generate` produces code and belongs to the build. `migrate` changes a database and
     // belongs to one service at deploy time. The test below still holds the second rule.
-    const dockerfile = readFileSync(join(ROOT, "Dockerfile"), "utf8");
+    const dockerfile = sourceOf(ROOT, "Dockerfile");
 
     expect(
       dockerfile,
@@ -203,7 +205,7 @@ describe("the Railway runbook", () => {
     // The worker starts through `tsx`. As a dev dependency it would build cleanly under
     // `npm ci --omit=dev` and then fail to start — in the deployed environment, which is
     // the worst place to discover a missing package.
-    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+    const pkg = JSON.parse(sourceOf(ROOT, "package.json"));
     const binary = pkg.scripts.worker.split(" ")[0];
 
     expect(pkg.dependencies).toHaveProperty(binary);

--- a/app/lib/flow/manifest.test.ts
+++ b/app/lib/flow/manifest.test.ts
@@ -16,6 +16,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../testing/source";
+
 import { parseFlowManifest } from "./manifest";
 
 const EXTENSIONS = join(process.cwd(), "extensions");
@@ -87,7 +89,7 @@ describe("every action route reads the keys its manifest declares", () => {
   it.each(actions)("$handle", (manifest) => {
     expect(manifest.fieldKeys.length).toBeGreaterThan(0);
 
-    const source = readFileSync(join(ROUTES, `flow.actions.${manifest.handle}.tsx`), "utf8");
+    const source = sourceOf(ROUTES, `flow.actions.${manifest.handle}.tsx`);
     const read = [...source.matchAll(/properties\?\.\["([^"]+)"\]/g)].map((match) => match[1]);
 
     expect(read.length).toBeGreaterThan(0);
@@ -112,7 +114,7 @@ describe("every trigger field's declared type matches what the payload sends", (
    * asserting it here, statically, rather than hoping somebody runs a live trigger again.
    */
   const triggers = manifests().filter((manifest) => manifest.type === "flow_trigger");
-  const server = readFileSync(join(process.cwd(), "app", "services", "flow.server.ts"), "utf8");
+  const server = sourceOf("app", "services", "flow.server.ts");
   const payload = server.slice(
     server.indexOf("export interface TriggerPayload"),
     server.indexOf("export function containsPrice"),
@@ -145,7 +147,7 @@ describe("every trigger field's declared type matches what the payload sends", (
 
 describe("every trigger key exists on TriggerPayload", () => {
   const triggers = manifests().filter((manifest) => manifest.type === "flow_trigger");
-  const server = readFileSync(join(process.cwd(), "app", "services", "flow.server.ts"), "utf8");
+  const server = sourceOf("app", "services", "flow.server.ts");
   const payload = server.slice(
     server.indexOf("export interface TriggerPayload"),
     server.indexOf("export function containsPrice"),

--- a/app/lib/format/display.test.ts
+++ b/app/lib/format/display.test.ts
@@ -11,10 +11,12 @@
  * mistimes a sale.
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 import { formatAgo, formatCount, formatDay, formatWhen } from "./display";
 
@@ -87,7 +89,7 @@ describe("nothing formats against the ambient environment", () => {
 
   it("never calls toLocale* without naming a locale", () => {
     for (const file of files) {
-      const source = readFileSync(file, "utf8");
+      const source = sourceOf(file);
 
       for (const match of source.matchAll(/\.toLocale[A-Za-z]*\(\s*\)/g)) {
         expect.fail(
@@ -100,7 +102,7 @@ describe("nothing formats against the ambient environment", () => {
 
   it("never formats a date without a timezone", () => {
     for (const file of files) {
-      const source = readFileSync(file, "utf8");
+      const source = sourceOf(file);
 
       // A locale but no `timeZone` still renders in the server's zone.
       for (const match of source.matchAll(/\.toLocale(?:Date|Time)?String\("[^"]*"\s*\)/g)) {
@@ -130,7 +132,7 @@ describe("counts a merchant reads are grouped, wherever they appear", () => {
   ];
 
   it.each(merchantFacing)("%s formats its counts", (file) => {
-    const source = readFileSync(join(process.cwd(), file), "utf8");
+    const source = sourceOf(process.cwd(), file);
 
     expect(source, `${file} shows counts without grouping them`).toContain("formatCount");
   });

--- a/app/lib/observability/metrics-contract.test.ts
+++ b/app/lib/observability/metrics-contract.test.ts
@@ -16,6 +16,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../testing/source";
+
 const ROOT = process.cwd();
 
 /** Every `metric("name", …)` call in the app. */
@@ -31,7 +33,7 @@ function emitted(): Set<string> {
       }
       if (!/\.(ts|tsx)$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) continue;
 
-      const source = readFileSync(join(ROOT, path), "utf8");
+      const source = sourceOf(path);
       for (const [, name] of source.matchAll(/\bmetric\(\s*"([a-z0-9_.]+)"/g)) names.add(name);
     }
   };
@@ -42,7 +44,7 @@ function emitted(): Set<string> {
 
 /** The registry in `otel.server.ts`, which decides each metric's instrument type. */
 function declared(): Set<string> {
-  const source = readFileSync(join(ROOT, "app/lib/observability/otel.server.ts"), "utf8");
+  const source = sourceOf("app/lib/observability/otel.server.ts");
   const table = source.slice(source.indexOf("{"), source.indexOf("};") + 1);
   return new Set([...table.matchAll(/"([a-z0-9_]+\.[a-z0-9_]+)":\s*"(counter|gauge|histogram)"/g)].map(
     ([, name]) => name,

--- a/app/lib/routing/legacy-routes.test.ts
+++ b/app/lib/routing/legacy-routes.test.ts
@@ -12,10 +12,12 @@
  * keeps finding: two halves nothing validates.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf, withoutComments } from "../testing/source";
 
 import { LEGACY_ROUTES, routeFilesFor } from "./legacy-routes";
 
@@ -39,7 +41,7 @@ describe("every URL this app has published still resolves", () => {
 
   it.each(Object.entries(LEGACY_ROUTES))("%s redirects rather than rendering", (oldUrl) => {
     const file = redirectFileFor(oldUrl).find((f) => routeFiles.has(f))!;
-    const source = readFileSync(join(ROUTES_DIR, file), "utf8");
+    const source = sourceOf(ROUTES_DIR, file);
     expect(
       source.includes("LEGACY_ROUTES"),
       `${file} should redirect via LEGACY_ROUTES, so the destination is stated once`,
@@ -86,7 +88,7 @@ describe("nothing inside the app links through a redirect", () => {
         // belong. Keyed on referencing LEGACY_ROUTES at all rather than on a particular
         // call shape: the first version matched `redirect(LEGACY_ROUTES` literally and
         // missed a stub that built its destination with a template literal.
-        const source = readFileSync(path, "utf8");
+        const source = sourceOf(path);
         if (path.includes("legacy-routes")) continue;
         if (source.includes("LEGACY_ROUTES")) continue;
 
@@ -96,9 +98,7 @@ describe("nothing inside the app links through a redirect", () => {
         // repo has been caught grepping source that includes its own commentary; the
         // compliance check that rejects a native form element still trips on the word
         // `<form` in a sentence.
-        const code = source
-          .replace(/\/\*[\s\S]*?\*\//g, "")
-          .replace(/^\s*\/\/.*$/gm, "");
+        const code = withoutComments(source);
 
         for (const match of code.matchAll(/["'`](\/app\/[a-z0-9/$._-]*)["'`?#]/gi)) {
           found.push({ file: path, url: match[1] });

--- a/app/lib/testing/source-guard.test.ts
+++ b/app/lib/testing/source-guard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * No test reads this app's source without stripping its commentary first.
+ *
+ * The rule the helper exists for, enforced. Seven times a check here has fired on a
+ * comment explaining the very string it greps for; each time the fix was two lines
+ * pasted into one more file, and each new source-level test started the count again.
+ *
+ * The check is narrow on purpose. Plenty of tests read files legitimately — a migration,
+ * a manifest, a JSON schema, this repo's own `package.json` — and none of them are the
+ * trap. Only reading a `.ts` or `.tsx` file is, because that is the only kind of file
+ * whose comments are written in the same words as its code.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { rawSource, testFiles } from "./source";
+
+/**
+ * Reading a file through `node:fs` inside a test.
+ *
+ * Deliberately not "reading a path that ends in `.ts`". The first version of this rule
+ * matched only literal filenames, and a reverted call site sailed through it because the
+ * path was a variable from a directory walk — which is the shape most of these checks
+ * have. Any read is caught, and the exemptions below say which ones are not source.
+ */
+const READS_A_FILE = /\breadFileSync\s*\(/;
+
+/** Any of the helper's exports being imported from this directory. */
+const USES_HELPER = /from "[^"]*testing\/source"/;
+
+/**
+ * Tests that read source and mean to see the comments.
+ *
+ * `source.test.ts` is the helper's own, and half its assertions are about what survives.
+ * Anything else added here needs a reason in this list, not a comment at the call site —
+ * a per-file exemption nobody has to justify centrally is how the rule erodes.
+ */
+const READS_SOMETHING_ELSE: Record<string, string> = {
+  "app/lib/testing/source.test.ts": "the helper's own test, which checks what it strips",
+  "app/lib/billing/listing-parity.test.ts": "the App Store listing, which is markdown",
+  "app/lib/compliance/built-for-shopify.test.ts": "shopify.app.toml and the criteria sheet",
+  "app/lib/compliance/deploy-config.test.ts": "shopify.app.toml and the deployment workflow",
+  "app/lib/errors/help-links.contract.test.ts": "the help centre's markdown pages",
+  "app/lib/help/nav.server.test.ts": "the help centre's markdown pages",
+  "app/lib/help/promises.test.ts": "the help centre's markdown pages",
+  "app/lib/help/search.server.test.ts": "the help centre's markdown pages",
+  "app/lib/observability/alerts.test.ts": "the alert rules, which are YAML",
+  "app/lib/observability/metrics-contract.test.ts": "the runbook, which is markdown",
+  "app/lib/observability/runbook-coverage.test.ts": "the runbook, which is markdown",
+  "app/lib/format/label.test.ts": "the humanise fixtures, which are JSON",
+  "app/lib/ui/spacing.test.ts": "the design tokens, which are JSON",
+  "app/lib/flow/manifest.test.ts": "the Flow manifests, which are JSON",
+  "app/lib/ui/settings-form.test.ts": "the settings schema, which is JSON",
+  "app/lib/catalog/sync-parity.test.ts": "the GraphQL documents",
+  "app/lib/shopify/scope-probe.test.ts": "shopify.app.toml",
+  "app/components/campaign/sections.test.ts": "measures the route as written, comments included",
+  "app/worker/queue-runtime.test.ts": "the Dockerfile and the process manifest",
+};
+
+describe("every source-level check goes through the helper", () => {
+  const tests = testFiles("app").map((path) => ({ path, source: rawSource(path) }));
+
+  it("finds the source-level checks it is protecting", () => {
+    // A floor, so this file cannot quietly pass by finding nothing — the failure mode of
+    // every census check, and the reason the ones in this repo carry a number. Counting
+    // helper *users* rather than raw readers, because the whole point is that there are
+    // no raw readers left: a floor on those would now be a floor on zero.
+    const readers = tests.filter(({ source }) => USES_HELPER.test(source));
+
+    expect(readers.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("refuses a raw read of a .ts or .tsx file", () => {
+    // Not "unless the file also imports the helper". A file that uses `sourceOf` in
+    // eight places and `readFileSync` in the ninth is the exact shape this rule is for,
+    // and an import-based exemption would wave it through — which it did, until a
+    // deliberately reverted call site passed.
+    const offenders = tests
+      .filter(({ path }) => !(path in READS_SOMETHING_ELSE))
+      .filter(({ source }) => READS_A_FILE.test(source))
+      .map(({ path }) => path);
+
+    expect(
+      offenders,
+      "use sourceOf/withoutComments from app/lib/testing/source — a comment naming the " +
+        "string being grepped for must not satisfy the grep",
+    ).toEqual([]);
+  });
+});

--- a/app/lib/testing/source.test.ts
+++ b/app/lib/testing/source.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The helper that keeps a dozen source-level checks from reading their own explanations.
+ *
+ * Worth testing directly because every one of its callers only fails *silently* when it
+ * is wrong: a stripper that removes too little makes a guard fire on a comment, and one
+ * that removes too much makes a guard stop firing at all. The second is the dangerous
+ * one, and nothing downstream would notice.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { rawSource, sourceFiles, sourceOf, withoutComments } from "./source";
+
+describe("withoutComments", () => {
+  it("removes a whole-line comment that names the thing being grepped for", () => {
+    // The trap itself, seven times over: the check that no route uses a native form
+    // element greps for the tag, and the comment saying why trips it.
+    const source = ['// never reach for a native <form here', 'const x = "<s-box>";'].join("\n");
+
+    expect(withoutComments(source)).not.toContain("<form");
+    expect(withoutComments(source)).toContain("<s-box>");
+  });
+
+  it("removes a block comment wherever it sits, including beside code", () => {
+    expect(withoutComments("/* Update match count was removed */\nconst a = 1;")).not.toContain(
+      "Update match count",
+    );
+    expect(withoutComments("const a = 1; /* and why */")).toContain("const a = 1;");
+    expect(withoutComments("const a = 1; /* and why */")).not.toContain("and why");
+  });
+
+  it("removes a JSX comment, which is a block comment in braces", () => {
+    const jsx = '{/* the Search button posts to /app/campaigns */}\n<s-button>Go</s-button>';
+
+    expect(withoutComments(jsx)).not.toContain("Search button");
+    expect(withoutComments(jsx)).toContain("<s-button>");
+  });
+
+  it("leaves the slashes in a URL alone", () => {
+    // The reason only whole-line `//` goes. A stripper that took everything after `//`
+    // anywhere would delete half of every link in the file, and a guard checking a href
+    // would then fail for a reason nobody would guess.
+    const source = 'const help = "https://help.example.com/pricing";';
+
+    expect(withoutComments(source)).toContain("https://help.example.com/pricing");
+  });
+
+  it("leaves a trailing comment's code intact", () => {
+    expect(withoutComments("const rows = 40; // not a table")).toContain("const rows = 40;");
+  });
+
+  it("keeps the line count, so a check that counts lines still can", () => {
+    // `table-size.test.ts` and the route-length guards read positions and counts out of
+    // the same string. Collapsing the stripped lines would move every line after a
+    // comment and make those numbers quietly wrong.
+    expect(withoutComments("// a\n// b\nconst x = 1;").split("\n")).toHaveLength(3);
+  });
+});
+
+describe("sourceOf", () => {
+  it("reads a file from the repo root with its commentary gone", () => {
+    const source = sourceOf("app/lib/testing/source.ts");
+
+    expect(source).toContain("export function withoutComments");
+    // This file's own header explains the trap at length. If any of it survives, the
+    // helper is not doing to itself what it does to everything else.
+    expect(source).not.toContain("The trap");
+  });
+
+  it("hands back the comments when a check actually wants them", () => {
+    expect(rawSource("app/lib/testing/source.ts")).toContain("The trap");
+  });
+});
+
+describe("sourceFiles", () => {
+  const files = sourceFiles("app");
+
+  it("lists source and leaves out tests", () => {
+    // Tests assert *about* the control names and URLs a guard greps for, which is the
+    // other half of the trap the comment stripping exists for.
+    expect(files).toContain("app/lib/testing/source.ts");
+    expect(files.filter((f) => f.includes(".test."))).toEqual([]);
+  });
+
+  it("asks git for untracked files too", () => {
+    // Not observable from the result on a clean tree, so this checks the flag rather than
+    // the output. Without it a guard cannot see the file being added in the very commit
+    // under review — which is where a new offender lives.
+    expect(rawSource("app/lib/testing/source.ts")).toContain('"--others", "--exclude-standard"');
+  });
+});

--- a/app/lib/testing/source.ts
+++ b/app/lib/testing/source.ts
@@ -1,0 +1,101 @@
+/**
+ * Reading this app's own source, for the tests that check it as text.
+ *
+ * A dozen tests here assert something about a file rather than about a value: that the
+ * campaign editor puts the rule before the scope, that no component hard-codes a row
+ * limit, that nothing reaches for a native `<form`. Those checks are worth having —
+ * several guard behaviour that only exists in a browser — and they all share one failure.
+ *
+ * ## The trap
+ *
+ * A test greps for a string, and a *comment explaining that string* satisfies the grep.
+ * It has now happened seven times in this repo. The two that make the point:
+ *
+ *   - The check that no route uses a native form element greps for `<form`, and a comment
+ *     saying why a route must not use one contains `<form`.
+ *   - The editor layout check asserts the "Update match count" button is gone, and the
+ *     comment recording that it was removed names it.
+ *
+ * Both times the rule fired on the note documenting compliance with it. That is worse
+ * than a rule with a gap, because it teaches people that writing the explanation breaks
+ * the build — and the explanation is the part that survives longest.
+ *
+ * ## Whole-line comments only
+ *
+ * `// ...` is stripped only where the line is nothing else, so the `//` in an `https://`
+ * href is left alone. A stripper that took everything after `//` anywhere would quietly
+ * delete half of every URL in the file being checked, and a grep for a link would then
+ * fail for a reason nobody would guess.
+ *
+ * Block comments go wherever they are, including the trailing block comment after code,
+ * because JSX comments are written that way and are the ones most likely to describe the
+ * markup beside them.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = process.cwd();
+
+/** Source with its own commentary removed. See the note above for why only some of it. */
+export function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+/**
+ * One file's source, comments removed, read from the repo root.
+ *
+ * The path is repo-relative and joined here, so a test never repeats `process.cwd()` —
+ * which is the other half of what these files kept copying.
+ */
+export function sourceOf(...parts: string[]): string {
+  return withoutComments(rawSource(...parts));
+}
+
+/**
+ * The same file, exactly as written.
+ *
+ * For the checks that are genuinely about the prose — the compliance sheet counting its
+ * own assertions, this helper's own test — and for reading anything that is not
+ * TypeScript. Saying `rawSource` rather than reaching for `readFileSync` is the point:
+ * it makes "I meant to keep the comments" a decision somebody wrote down.
+ */
+export function rawSource(...parts: string[]): string {
+  // `resolve` rather than `join`, so a caller that already has an absolute path — the
+  // directory walkers here all build one — gets that path rather than the repo root with
+  // an absolute path glued onto the end of it.
+  return readFileSync(resolve(ROOT, ...parts), "utf8");
+}
+
+/**
+ * Every TypeScript source file under the given paths — tracked, and untracked ones git is
+ * not ignoring.
+ *
+ * The untracked half is not a detail. A guard that lists only committed files cannot see
+ * the file being added in the very commit under review, which is the likeliest place for
+ * a new offender: a deliberately-broken copy of the no-delete rule passed for exactly
+ * that reason while it was being written.
+ *
+ * Test files are left out. They assert *about* the strings being grepped for — a control
+ * name, a URL, a literal — and are the other half of the same trap the comment stripping
+ * exists for. A check that wants them can list them itself.
+ */
+export function sourceFiles(...paths: string[]): string[] {
+  return listed(...paths).filter((file) => !file.includes(".test."));
+}
+
+/** The other half: only the test files, for the checks that are about the checks. */
+export function testFiles(...paths: string[]): string[] {
+  return listed(...paths).filter((file) => file.includes(".test."));
+}
+
+function listed(...paths: string[]): string[] {
+  return execFileSync(
+    "git",
+    ["ls-files", "--cached", "--others", "--exclude-standard", "--", ...paths],
+    { encoding: "utf8" },
+  )
+    .split("\n")
+    .filter((file) => /\.tsx?$/.test(file));
+}

--- a/app/lib/ui/activity-vocabulary.test.ts
+++ b/app/lib/ui/activity-vocabulary.test.ts
@@ -15,21 +15,19 @@
  *
  * It lives under `lib/ui/` and not beside the route it is about, which is not a filing
  * preference. React Router's flat-routes reads *every* file in `app/routes/`, so a test
- * there becomes a route module and gets bundled for the browser — where `node:fs` does not
- * exist, and the build fails with "readFileSync is not exported by
+ * there becomes a route module and gets bundled for the browser — where `node:fs`, which
+ * `sourceOf` reads through, does not exist. The build fails with "not exported by
  * __vite-browser-external". Vitest is happy either way; only `npm run build` says so.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 import { describeAction } from "../audit/action";
 
-const ROOT = process.cwd();
-const ROUTE = readFileSync(join(ROOT, "app/routes/app.activity.tsx"), "utf8");
-const TABLE = readFileSync(join(ROOT, "app/components/ActivityTable.tsx"), "utf8");
+const ROUTE = sourceOf("app/routes/app.activity.tsx");
+const TABLE = sourceOf("app/components/ActivityTable.tsx");
 
 describe("the filter and the column it filters use one vocabulary", () => {
   it("renders both through describeAction", () => {

--- a/app/lib/ui/amount-currency.test.ts
+++ b/app/lib/ui/amount-currency.test.ts
@@ -17,14 +17,12 @@
  * field, so a currency gets chosen by something that is not the shop.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const EDITOR = readFileSync(join(process.cwd(), "app/routes/app.campaigns.new.tsx"), "utf8")
-  .replace(/\/\*[\s\S]*?\*\//g, "")
-  .replace(/^\s*\/\/.*$/gm, "");
+import { sourceOf } from "../testing/source";
+
+const EDITOR = sourceOf("app/routes/app.campaigns.new.tsx");
 
 describe("nothing labels an amount from the sorted list", () => {
   it("passes the shop's own currency to the amount field", () => {

--- a/app/lib/ui/baseline-vocabulary.test.ts
+++ b/app/lib/ui/baseline-vocabulary.test.ts
@@ -14,23 +14,20 @@
  * improves the help centre's sentence this fails instead of quietly disagreeing.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const read = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
+import { sourceOf } from "../testing/source";
 
-/** Source without its own commentary, which discusses the very words being grepped. */
-const code = (source: string) =>
-  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+const read = (path: string) => sourceOf(path);
 
-const EDITOR = code(read("app/routes/app.campaigns.new.tsx"));
-const PREVIEW = code(read("app/components/DraftPreview.tsx"));
-const EXAMPLE = code(read("app/components/StorefrontExample.tsx"));
-const OVERLAP = code(read("app/components/OverlapPanel.tsx"));
-const REVERT_MODAL = code(read("app/components/campaign/RevertConfirmation.tsx"));
-const REVERT_TAB = code(read("app/components/campaign/CampaignRevertTab.tsx"));
+
+const EDITOR = read("app/routes/app.campaigns.new.tsx");
+const PREVIEW = read("app/components/DraftPreview.tsx");
+const EXAMPLE = read("app/components/StorefrontExample.tsx");
+const OVERLAP = read("app/components/OverlapPanel.tsx");
+const REVERT_MODAL = read("app/components/campaign/RevertConfirmation.tsx");
+const REVERT_TAB = read("app/components/campaign/CampaignRevertTab.tsx");
 const CONCEPT = read("docs/help/concepts/baselines.md");
 const REVERT = read("docs/help/concepts/revert.md");
 

--- a/app/lib/ui/control-vocabulary.test.ts
+++ b/app/lib/ui/control-vocabulary.test.ts
@@ -20,14 +20,16 @@
  * `{resolution}` was, and what a label written on purpose never is.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { rawSource, sourceOf } from "../testing/source";
+
 const APP = join(process.cwd(), "app");
-const DRIFT = readFileSync(join(APP, "routes/app.prices.drift.tsx"), "utf8");
-const HELP = readFileSync(join(process.cwd(), "docs/help/concepts/drift.md"), "utf8");
+const DRIFT = sourceOf(APP, "routes/app.prices.drift.tsx");
+const HELP = rawSource("docs/help/concepts/drift.md");
 
 /** The three labels, extracted from the table the page renders them from. */
 function resolutions(): { value: string; label: string; tone: string }[] {
@@ -117,7 +119,7 @@ describe("no button is labelled with a raw value", () => {
   const isLabel = (name: string) => /label$/i.test(name);
 
   const offenders = tsxFiles(APP).flatMap((path) => {
-    const source = readFileSync(path, "utf8");
+    const source = sourceOf(path);
     return [...source.matchAll(RAW_LABEL)]
       .filter((match) => !isLabel(match[1]))
       .map((match) => `${path.replace(`${APP}/`, "")}: {${match[1]}}`);

--- a/app/lib/ui/editor-layout.test.ts
+++ b/app/lib/ui/editor-layout.test.ts
@@ -18,10 +18,10 @@
  *   between the rule and the thing the merchant came to set.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 /**
  * The editor's source with its comments removed.
@@ -32,9 +32,7 @@ import { describe, expect, it } from "vitest";
  * repo has now hit five times. The same two lines appear in `table-size.test.ts` and
  * `imports.test.ts`; extracting them is #462.
  */
-const EDITOR = readFileSync(join(process.cwd(), "app/routes/app.campaigns.new.tsx"), "utf8")
-  .replace(/\/\*[\s\S]*?\*\//g, "")
-  .replace(/^\s*\/\/.*$/gm, "");
+const EDITOR = sourceOf("app/routes/app.campaigns.new.tsx");
 
 /** Where a name first appears in the file, or -1. Source order is render order here. */
 const at = (needle: string) => EDITOR.indexOf(needle);

--- a/app/lib/ui/home-vocabulary.test.ts
+++ b/app/lib/ui/home-vocabulary.test.ts
@@ -10,16 +10,14 @@
  * how it renders — and because the route cannot be rendered here without a data router.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const HOME = readFileSync(join(process.cwd(), "app/routes/app._index.tsx"), "utf8")
-  .replace(/\/\*[\s\S]*?\*\//g, "")
-  .replace(/^\s*\/\/.*$/gm, "");
+import { sourceOf } from "../testing/source";
 
-const ACTIVITY = readFileSync(join(process.cwd(), "app/routes/app.activity.tsx"), "utf8");
+const HOME = sourceOf("app/routes/app._index.tsx");
+
+const ACTIVITY = sourceOf(process.cwd(), "app/routes/app.activity.tsx");
 
 describe("the dashboard leaves the app's own upkeep to the log", () => {
   it("filters the feed through the one place that decides", () => {
@@ -57,7 +55,7 @@ describe("every figure on the dashboard is a front door", () => {
   it("uses the campaigns index's own filter vocabulary, not a second one", () => {
     // `attention` spans PARTIAL and HELD in `list.server.ts`, which is exactly what the
     // "Need attention" tile counts. Two queries that merely agree today would drift.
-    const LIST = readFileSync(join(process.cwd(), "app/services/campaigns/list.server.ts"), "utf8");
+    const LIST = sourceOf(process.cwd(), "app/services/campaigns/list.server.ts");
 
     expect(LIST).toContain('"attention"');
     expect(HOME).toContain("status=attention");

--- a/app/lib/ui/money-input.test.ts
+++ b/app/lib/ui/money-input.test.ts
@@ -12,10 +12,12 @@
  * covered without anyone remembering this file exists.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const ROUTES = join(process.cwd(), "app", "routes");
 const COMPONENTS = join(process.cwd(), "app", "components");
@@ -24,7 +26,7 @@ function sources(): Array<{ name: string; text: string }> {
   const read = (dir: string) =>
     readdirSync(dir, { withFileTypes: true })
       .filter((e) => e.isFile() && e.name.endsWith(".tsx"))
-      .map((e) => ({ name: e.name, text: readFileSync(join(dir, e.name), "utf8") }));
+      .map((e) => ({ name: e.name, text: sourceOf(dir, e.name) }));
 
   return [...read(ROUTES), ...read(COMPONENTS)];
 }
@@ -60,7 +62,7 @@ describe("price inputs", () => {
 });
 
 describe("the rule amount changes with the rule", () => {
-  const field = readFileSync(join(COMPONENTS, "RuleValueField.tsx"), "utf8");
+  const field = sourceOf(COMPONENTS, "RuleValueField.tsx");
 
   it("is a percentage for a percent rule and money for a fixed one", () => {
     // One input served both as a generic number field, so "-20" meant 20% off under one

--- a/app/lib/ui/page-width.test.ts
+++ b/app/lib/ui/page-width.test.ts
@@ -14,10 +14,12 @@
  * covered without anyone remembering this file exists.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const ROUTES_DIR = join(process.cwd(), "app", "routes");
 
@@ -25,7 +27,7 @@ const ROUTES_DIR = join(process.cwd(), "app", "routes");
 function renderingRoutes(): Array<{ name: string; source: string }> {
   return readdirSync(ROUTES_DIR)
     .filter((f) => f.endsWith(".tsx"))
-    .map((name) => ({ name, source: readFileSync(join(ROUTES_DIR, name), "utf8") }))
+    .map((name) => ({ name, source: sourceOf(ROUTES_DIR, name) }))
     .filter(({ source }) => source.includes("export default function"));
 }
 
@@ -47,7 +49,7 @@ describe("every page is full width", () => {
   });
 
   it("keeps the aside rebuild in one place", () => {
-    const shell = readFileSync(join(process.cwd(), "app", "components", "PageShell.tsx"), "utf8");
+    const shell = sourceOf(process.cwd(), "app", "components", "PageShell.tsx");
 
     expect(shell).toContain('inlineSize="large"');
     expect(

--- a/app/lib/ui/polaris-attributes.test.ts
+++ b/app/lib/ui/polaris-attributes.test.ts
@@ -22,10 +22,12 @@
  * whether a prop name exists, and the types will.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const POLARIS_TYPES = join(
   process.cwd(),
@@ -38,7 +40,7 @@ const POLARIS_TYPES = join(
 
 /** Every property name Polaris declares anywhere in its type surface. */
 function polarisProps(): Set<string> {
-  const source = readFileSync(POLARIS_TYPES, "utf8");
+  const source = sourceOf(POLARIS_TYPES);
   const names = new Set<string>();
   for (const match of source.matchAll(/^\s*([a-zA-Z][a-zA-Z0-9]*)\??:/gm)) names.add(match[1]);
   return names;
@@ -69,7 +71,7 @@ function propsUsed(): Array<{ file: string; element: string; prop: string }> {
   const app = join(process.cwd(), "app");
 
   for (const path of tsxFiles(app)) {
-    const source = readFileSync(path, "utf8");
+    const source = sourceOf(path);
     for (const tag of source.matchAll(/<(s-[a-z-]+)((?:\s+[^<>]*?)?)\/?>/g)) {
       const [, element, attrs] = tag;
       if (!attrs) continue;

--- a/app/lib/ui/polaris-props.test.ts
+++ b/app/lib/ui/polaris-props.test.ts
@@ -17,10 +17,12 @@
  * mistake that reaches for the right word silently does nothing at all.
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const APP = join(process.cwd(), "app");
 
@@ -37,7 +39,7 @@ const OUTSIDE_THE_ADMIN = ["routes/_index", "routes/help.$"];
 
 const files = tsxFiles(APP)
   .filter((path) => !OUTSIDE_THE_ADMIN.some((skip) => path.includes(skip)))
-  .map((path) => ({ path: path.replace(`${APP}/`, ""), source: readFileSync(path, "utf8") }));
+  .map((path) => ({ path: path.replace(`${APP}/`, ""), source: sourceOf(path) }));
 
 describe("emphasis is a colour, status is a tone", () => {
   it("finds files to check", () => {

--- a/app/lib/ui/polaris-traps.test.ts
+++ b/app/lib/ui/polaris-traps.test.ts
@@ -11,10 +11,12 @@
  * form elements and never forwards it to the custom element.
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const ROOT = process.cwd();
 
@@ -46,27 +48,11 @@ function owningTag(source: string, at: number): string {
   return /^<\s*([A-Za-z][\w.-]*)/.exec(source.slice(open, at))?.[1] ?? "";
 }
 
-/**
- * Whole-line `//` comments removed before matching.
- *
- * The seventh time a source-level check in this repo has been fooled by its own subject
- * appearing in prose, and the first where the offending comment was the one explaining
- * *why the field does not use the banned attribute*. A rule that fires on the note
- * documenting compliance with it teaches people to stop writing the note. Only lines that
- * are nothing but a comment go, so a `//` inside an href is left alone. #462 is open to
- * extract this — it now exists in four files.
- */
-const scannable = (source: string) =>
-  source
-    .split("\n")
-    .filter((line) => !line.trimStart().startsWith("//"))
-    .join("\n");
-
 describe("defaultValue and defaultChecked never reach a Polaris element", () => {
   // React intercepts both on form elements and never forwards them to the custom element,
   // so the field renders empty. It compiles, and it is in the TypeScript types.
   it.each(FILES)("%s", (file) => {
-    const source = scannable(readFileSync(join(ROOT, file), "utf8"));
+    const source = sourceOf(file);
 
     for (const match of source.matchAll(/\b(defaultValue|defaultChecked)\b/g)) {
       const tag = owningTag(source, match.index!);
@@ -83,7 +69,7 @@ describe("s-button is never given name or value", () => {
   // It has neither, so a form with two submit buttons cannot tell them apart. The app's
   // pattern is a hidden input the buttons set before submitting.
   it.each(FILES)("%s", (file) => {
-    const source = readFileSync(join(ROOT, file), "utf8");
+    const source = sourceOf(file);
 
     for (const match of source.matchAll(/<s-button\b([^>]*)>/g)) {
       const attributes = match[1];
@@ -114,7 +100,7 @@ describe("s-button is never given name or value", () => {
  * catches the link.
  */
 describe("every app nav item is a path inside the app", () => {
-  const layout = readFileSync(join(ROOT, "app/routes/app.tsx"), "utf8");
+  const layout = sourceOf("app/routes/app.tsx");
 
   const hrefs = (() => {
     const nav = /<s-app-nav>([\s\S]*?)<\/s-app-nav>/.exec(layout);
@@ -165,7 +151,7 @@ describe("no native form on an embedded surface", () => {
   });
 
   it.each(embedded)("%s", (file) => {
-    const source = readFileSync(join(ROOT, file), "utf8");
+    const source = sourceOf(file);
     // Lowercase only: React Router's <Form> is the correct thing and is capitalised.
     expect(
       /<form[\s>]/.test(source),
@@ -204,7 +190,7 @@ describe("no component pulls a server module into the browser bundle", () => {
 
   const files = componentFiles("app/components").map((path) => ({
     path,
-    source: readFileSync(join(ROOT, path), "utf8"),
+    source: sourceOf(path),
   }));
 
   it("finds the components, so it cannot pass by checking nothing", () => {

--- a/app/lib/ui/quick-create.test.ts
+++ b/app/lib/ui/quick-create.test.ts
@@ -11,14 +11,12 @@
  * action does, not how either looks.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-const HOME = readFileSync(join(process.cwd(), "app/routes/app._index.tsx"), "utf8")
-  .replace(/\/\*[\s\S]*?\*\//g, "")
-  .replace(/^\s*\/\/.*$/gm, "");
+import { sourceOf } from "../testing/source";
+
+const HOME = sourceOf("app/routes/app._index.tsx");
 
 const at = (needle: string) => HOME.indexOf(needle);
 

--- a/app/lib/ui/section-tabs.test.ts
+++ b/app/lib/ui/section-tabs.test.ts
@@ -16,10 +16,12 @@
  * the way this is checking for.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const ROUTES = join(process.cwd(), "app", "routes");
 
@@ -34,7 +36,7 @@ function sections() {
 
   return files
     .filter((file) => /^app\.[a-z-]+\.tsx$/.test(file))
-    .map((file) => ({ file, source: readFileSync(join(ROUTES, file), "utf8") }))
+    .map((file) => ({ file, source: sourceOf(ROUTES, file) }))
     .filter(({ source }) => source.includes("<SectionTabs"))
     .map(({ file, source }) => ({
       file,

--- a/app/lib/ui/spacing.test.ts
+++ b/app/lib/ui/spacing.test.ts
@@ -22,6 +22,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../testing/source";
+
 import { PAD, SPACE, type Space } from "./spacing";
 
 const ROOT = process.cwd();
@@ -151,9 +153,7 @@ describe("nothing in the app sets a distance by hand", () => {
     // check that rejects a native form element greps for `<form`, so the word in a
     // comment trips it — and half the files here explain in prose which literal they
     // replaced and why.
-    const source = readFileSync(join(ROOT, file), "utf8")
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/^\s*\/\/.*$/gm, "");
+    const source = sourceOf(file);
 
     const literals = [
       ...source.matchAll(

--- a/app/lib/ui/table-designation.test.ts
+++ b/app/lib/ui/table-designation.test.ts
@@ -31,10 +31,12 @@
  * been decided, and does not stand in the way of deciding about something else.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 const APP = join(process.cwd(), "app");
 
@@ -69,7 +71,7 @@ interface Table {
  */
 function tables(): Table[] {
   return tsxFiles(APP).flatMap((path) => {
-    const source = readFileSync(path, "utf8");
+    const source = sourceOf(path);
     const file = path.replace(`${APP}/`, "");
 
     return [...source.matchAll(/<s-table-header-row[^>]*>([\s\S]*?)<\/s-table-header-row>/g)].map(

--- a/app/lib/ui/table-size.test.ts
+++ b/app/lib/ui/table-size.test.ts
@@ -16,20 +16,19 @@
  *   are all of them" to a merchant checking their prices.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
 
 import { ROWS_PER_VIEW, rowsThatFit, CELL_BUDGET } from "./table-budget";
 import { rowsToShow } from "../../components/RollbackReportTable";
 
 const ROOT = process.cwd();
-const read = (...parts: string[]) => readFileSync(join(ROOT, ...parts), "utf8");
+const read = (...parts: string[]) => sourceOf(ROOT, ...parts);
 
-/** Source without its own commentary, so a file explaining a number is not read as setting one. */
-const code = (source: string) =>
-  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
 
 function sources(dir: string): string[] {
   return readdirSync(join(ROOT, dir), { withFileTypes: true }).flatMap((entry) => {
@@ -39,7 +38,7 @@ function sources(dir: string): string[] {
   });
 }
 
-const FILES = sources("app").map((path) => ({ path, source: code(read(path)) }));
+const FILES = sources("app").map((path) => ({ path, source: read(path) }));
 
 describe("one number decides how many rows a view holds", () => {
   it("is small enough to be a view rather than a document", () => {

--- a/app/services/campaigns/delete-guard.test.ts
+++ b/app/services/campaigns/delete-guard.test.ts
@@ -18,13 +18,9 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-/** Comments only, so prose about deleting cannot masquerade as a delete. */
-function withoutComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
-}
+import { sourceOf } from "../../lib/testing/source";
 
 /**
  * The one place a campaign may legitimately be destroyed.
@@ -58,7 +54,7 @@ describe("nothing in the app deletes a campaign", () => {
 
   it("offers no campaign delete", () => {
     const offenders = files.filter((file) =>
-      /prisma\.campaign\.delete|campaign\.deleteMany/.test(withoutComments(readFileSync(file, "utf8"))),
+      /prisma\.campaign\.delete|campaign\.deleteMany/.test(sourceOf(file)),
     );
 
     expect(
@@ -72,7 +68,7 @@ describe("nothing in the app deletes a campaign", () => {
     // hang off the run, so deleting a run is deleting the record of what it wrote.
     const offenders = files.filter((file) =>
       /prisma\.campaignRun\.delete|campaignRun\.deleteMany|prisma\.variantChange\.delete/.test(
-        withoutComments(readFileSync(file, "utf8")),
+        sourceOf(file),
       ),
     );
 
@@ -82,6 +78,6 @@ describe("nothing in the app deletes a campaign", () => {
   it("keeps the erasure path, because a redaction request has to be honoured", () => {
     // The inverse assertion. If the compliance webhook ever stops deleting the shop,
     // this file's whole argument for leaving the cascade permissive has gone with it.
-    expect(withoutComments(readFileSync(ERASURE, "utf8"))).toContain("shop.deleteMany");
+    expect(sourceOf(ERASURE)).toContain("shop.deleteMany");
   });
 });

--- a/app/worker/queue-runtime.test.ts
+++ b/app/worker/queue-runtime.test.ts
@@ -6,10 +6,10 @@
  * so the fallback has to actually run the work rather than drop it.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
 
 import { inlineRuntime, runtimeFor } from "./queue-runtime.server";
 import type { JobRef, QueueName } from "./queues";
@@ -94,7 +94,7 @@ describe("both ends of a job's life are traced", () => {
    * record of when it was asked for. The interesting number in a backlog is the gap
    * between the two, and a counter cannot express a gap.
    */
-  const source = readFileSync(join(process.cwd(), "app/worker/queue-runtime.server.ts"), "utf8");
+  const source = sourceOf(process.cwd(), "app/worker/queue-runtime.server.ts");
 
   it("spans the enqueue as well as the run", () => {
     expect(source, "the enqueue is not spanned").toMatch(/span\(\s*`enqueue \$\{name\}`/);


### PR DESCRIPTION
A test greps for a string, and a comment *explaining that string* satisfies the grep. Seven occurrences here. Two that make the point:

- the check that no route uses a native form element greps for the tag, and the comment saying why a route must not use one contains it;
- the editor-layout check asserts the "Update match count" button is gone, and the comment recording its removal names it.

Both times the rule fired on the note documenting compliance with it — worse than a rule with a gap, because it teaches people that writing the explanation breaks the build. The fix was two lines pasted into one more file, every time, and the copies had drifted: some stripped block comments, some whole lines, two stripped everything after `//` anywhere and would have eaten half of any URL they were pointed at.

## The helper

`app/lib/testing/source.ts` — `withoutComments`, `sourceOf`, `rawSource`, `sourceFiles`, `testFiles`. Whole-line `//` only (so `https://` survives), block comments wherever they sit (JSX comments are written that way).

`rawSource` exists so that *keeping* the comments is a decision somebody wrote down: the compliance sheet counts its own assertions, and the campaign route's 400-line limit measures the file as a person opens it — comments are most of what makes a long file long, and stripping them would let the route grow past any limit as long as the growth was documented.

**32 test files** migrated. `source-guard.test.ts` refuses a raw `readFileSync` in any test outside an exemption list naming what each one reads instead (a toml, a runbook, a JSON fixture).

## Two findings from the sweep, both the trap itself

**`sections.test.ts` asserted the campaign page still renders an "Actions" section.** It has not for months — the card became the header row — and the check kept passing because `CampaignHeader`'s docstring quotes the `heading="Actions"` it replaced. A guard that a deletion cannot fail is not guarding anything.

**`sourceFiles` lists untracked files too.** A guard reading only committed files cannot see the file being added in the commit under review, which is the likeliest place a new offender appears. Found when a deliberately broken copy of the no-delete rule passed while it was being written.

The first version of the guard rule matched only literal filenames, and a reverted call site walked straight past it because the path was a variable from a directory walk — which is the shape most of these checks have. It now catches any read.

## Verification

typecheck, lint (cache cleared), build, full suite **2566 passed**. Mutations caught: the stripper stopping stripping, it eating the slashes in a URL, `sourceFiles` including tests, `--others` dropped from the git listing, and a call site reverted to `readFileSync`.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)