### PR TITLE
A run notification that can be acted on (#475)

### DIFF
--- a/app/components/campaign/ApplyConfirmation.tsx
+++ b/app/components/campaign/ApplyConfirmation.tsx
@@ -37,6 +37,7 @@ export function ApplyConfirmation({
   preview,
   rule,
   scope,
+  notifyEmail,
   scheduleText,
   children,
 }: {
@@ -44,6 +45,13 @@ export function ApplyConfirmation({
   /** From `describeCampaign`, the same call the campaigns index makes. */
   rule: string;
   scope: string;
+  /**
+   * Where the outcome will be emailed, or null if notifications are off.
+   *
+   * From the shop's notification preferences, not from anything about this campaign —
+   * the address is one per shop, and the run report goes to whoever is listed there.
+   */
+  notifyEmail: string | null;
   /** The schedule sentence the header shows, restated here where the decision is made. */
   scheduleText?: string | null;
   /**
@@ -107,10 +115,14 @@ export function ApplyConfirmation({
             {describeRunDuration(writePath === "bulk" ? "bulk" : "sync", counts.planned)}
           </Fact>
 
-          {/* NA's modal says who gets emailed when the job completes. We have no
-              per-shop notification address to name — the alerting in
-              `lib/observability` is operator-facing, not merchant-facing — so this says
-              nothing rather than promising a message that will not arrive. #475. */}
+          {/* NA's modal says who gets emailed when the job completes, and this is the
+              moment a merchant decides whether to sit and watch. Both branches are worth
+              rendering: naming the address is a promise kept, and saying plainly that
+              nobody will be told is the thing they need *before* closing the tab on a
+              run over a hundred thousand variants — not after. */}
+          <Fact label="When it finishes">
+            {notifyEmail ? `We will email ${notifyEmail}` : "Nobody is emailed — set an address in Settings"}
+          </Fact>
         </s-stack>
 
         {/* The one thing this app can say that none of the three competitors can. It is

--- a/app/components/campaign/CampaignHeader.tsx
+++ b/app/components/campaign/CampaignHeader.tsx
@@ -43,6 +43,7 @@ export function CampaignHeader({
   rule,
   scope,
   archived,
+  notifyEmail,
   scheduleText,
   lifecycle,
   fetcher,
@@ -194,6 +195,7 @@ export function CampaignHeader({
         preview={preview}
         rule={rule}
         scope={scope}
+        notifyEmail={notifyEmail}
         scheduleText={scheduleText}
       >
         <fetcher.Form method="post" slot="primary-action">

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -70,6 +70,7 @@ const props = (over: Partial<CampaignDetailProps> = {}) =>
       rule: { kind: "percent-change", percent: -20 },
       ast: { groups: [{ conditions: [{ field: "collection", value: "Outerwear" }] }] },
     }),
+    notifyEmail: "ops@shop.com",
     keepers: null,
     keepersPending: false,
     ...over,
@@ -455,5 +456,22 @@ describe("the confirmation and the index describe a campaign the same way", () =
 
     expect(html).toContain("20% off");
     expect(html).toContain("In Outerwear");
+  });
+});
+
+describe("the confirmation says who hears about the outcome", () => {
+  it("names the address a run report goes to", () => {
+    // The moment a merchant decides whether they have to sit and watch. NA's modal says
+    // this; ours said nothing until there was an address to name.
+    expect(render(<CampaignHeader {...props()} />)).toContain("ops@shop.com");
+  });
+
+  it("says plainly when nobody will be told", () => {
+    // The branch that matters more. Silence reads as "we will let you know", and the
+    // merchant finds out about a partial run from a customer.
+    const html = render(<CampaignHeader {...props({ notifyEmail: null })} />);
+
+    expect(html).toContain("Nobody is emailed");
+    expect(html).toContain("Settings");
   });
 });

--- a/app/lib/notifications/campaign-link.test.ts
+++ b/app/lib/notifications/campaign-link.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { campaignUrl, driftUrl } from "./campaign-link";
+
+const KEY = "5401aeddaf37aac5c9e1650bf6abb462";
+
+describe("campaignUrl", () => {
+  it("enters the app through the admin, not through our own host", () => {
+    // Our own URL loads the app outside the admin frame — no host, no id_token, no
+    // session — and the merchant lands on an authentication error rather than on the
+    // partial run the email was about.
+    expect(campaignUrl("boltify-apps.myshopify.com", "c1", KEY)).toBe(
+      `https://admin.shopify.com/store/boltify-apps/apps/${KEY}/app/campaigns/c1`,
+    );
+  });
+
+  it("gives nothing rather than a guess when the app is not configured", () => {
+    // Local development and self-hosted installs have no key. A link that will not load
+    // is worse than the missing line it replaces.
+    expect(campaignUrl("boltify-apps.myshopify.com", "c1", undefined)).toBeUndefined();
+    expect(campaignUrl("boltify-apps.myshopify.com", "c1", "")).toBeUndefined();
+  });
+
+  it("gives nothing when it has no campaign or no shop to point at", () => {
+    expect(campaignUrl("boltify-apps.myshopify.com", "", KEY)).toBeUndefined();
+    expect(campaignUrl("", "c1", KEY)).toBeUndefined();
+  });
+
+  it("takes the store name off the domain, and only from the end", () => {
+    // A store legitimately called "myshopify-tools" keeps its name.
+    expect(campaignUrl("myshopify-tools.myshopify.com", "c1", KEY)).toContain(
+      "/store/myshopify-tools/",
+    );
+  });
+});
+
+describe("driftUrl", () => {
+  it("points at the queue, because drift is about no single campaign", () => {
+    expect(driftUrl("boltify-apps.myshopify.com", KEY)).toBe(
+      `https://admin.shopify.com/store/boltify-apps/apps/${KEY}/app/prices/drift`,
+    );
+  });
+
+  it("is silent when unconfigured, like every other link here", () => {
+    expect(driftUrl("boltify-apps.myshopify.com", undefined)).toBeUndefined();
+  });
+});

--- a/app/lib/notifications/campaign-link.ts
+++ b/app/lib/notifications/campaign-link.ts
@@ -1,0 +1,46 @@
+/**
+ * Where an email about a campaign should send the merchant.
+ *
+ * Every run notification already ends with "Open the campaign to review and resume", and
+ * until now none of them carried a link: `campaignUrl` was optional on the notification
+ * type, no caller ever set it, and the template's `link()` helper quietly returned an
+ * empty string. So the one message whose entire purpose is to reach somebody who is *not*
+ * looking at the app told them a run had gone partial and gave them no way to get to it.
+ *
+ * ## Why the admin URL and not ours
+ *
+ * `SHOPIFY_APP_URL` points at the Railway service, and opening it directly loads the app
+ * outside the admin frame — no `host`, no `id_token`, no session. The merchant would land
+ * on an authentication error. The embedded route has to be entered *through* the admin,
+ * which is what `admin.shopify.com/store/<store>/apps/<client id>/<path>` does.
+ *
+ * ## Why it may return nothing
+ *
+ * No API key configured means local development or a self-hosted install, and the same
+ * rule the mail transport follows applies here: unconfigured is a no-op, not an error. A
+ * missing link drops one line from an email. A guessed link sends a merchant to a page
+ * that will not load, which is worse than no link at all.
+ */
+
+export function campaignUrl(
+  shopDomain: string,
+  campaignId: string,
+  apiKey: string | undefined,
+): string | undefined {
+  if (!apiKey) return undefined;
+
+  const store = shopDomain.replace(/\.myshopify\.com$/, "");
+  if (!store || !campaignId) return undefined;
+
+  return `https://admin.shopify.com/store/${store}/apps/${apiKey}/app/campaigns/${campaignId}`;
+}
+
+/** The drift queue, for the one notification that is about no single campaign. */
+export function driftUrl(shopDomain: string, apiKey: string | undefined): string | undefined {
+  if (!apiKey) return undefined;
+
+  const store = shopDomain.replace(/\.myshopify\.com$/, "");
+  if (!store) return undefined;
+
+  return `https://admin.shopify.com/store/${store}/apps/${apiKey}/app/prices/drift`;
+}

--- a/app/lib/notifications/templates.test.ts
+++ b/app/lib/notifications/templates.test.ts
@@ -28,7 +28,7 @@ const counts = (over: Partial<RunCounts> = {}): RunCounts => ({
 describe("compose", () => {
   it("leads with the outcome, not the campaign name, in the subject", () => {
     // A merchant scanning an inbox needs the verdict before the label.
-    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    const email = compose({ kind: "run-completed", campaignId: "c1", campaignName: "Summer", counts: counts() });
     expect(email.subject).toContain("finished");
     expect(email.subject).toContain("12 variants updated");
   });
@@ -36,6 +36,7 @@ describe("compose", () => {
   it("says a partial run is partial, and how to finish it", () => {
     const email = compose({
       kind: "run-partial",
+      campaignId: "c1",
       campaignName: "Summer",
       counts: counts({ verified: 8, failed: 4 }),
       reasons: ["Shopify rate-limited this write. It will be retried automatically."],
@@ -49,7 +50,7 @@ describe("compose", () => {
 
   it("omits zero counts rather than listing them", () => {
     // "0 failed, 0 skipped, 0 clamped" is noise that hides the number that matters.
-    const email = compose({ kind: "run-completed", campaignName: "Summer", counts: counts() });
+    const email = compose({ kind: "run-completed", campaignId: "c1", campaignName: "Summer", counts: counts() });
     expect(email.text).not.toContain("Failed: 0");
     expect(email.text).not.toContain("Skipped: 0");
   });
@@ -59,6 +60,7 @@ describe("compose", () => {
     // to snap back to full will read a correct revert as a bug without this.
     const email = compose({
       kind: "revert-completed",
+      campaignId: "c1",
       campaignName: "Summer",
       counts: counts(),
     });
@@ -67,7 +69,7 @@ describe("compose", () => {
   });
 
   it("tells a drift email that the edits were deliberate and untouched", () => {
-    const email = compose({ kind: "drift-hold", campaignName: "Summer", driftedCount: 3 });
+    const email = compose({ kind: "drift-hold", campaignId: "c1", campaignName: "Summer", driftedCount: 3 });
     expect(email.subject).toContain("changed outside the app");
     expect(email.text).toContain("has not overwritten them");
   });
@@ -107,6 +109,7 @@ describe("no price values in any email body", () => {
         (generated, kind) => {
           const email = compose({
             kind: kind as "run-completed",
+            campaignId: "c1",
             campaignName: "Summer sale",
             counts: generated,
           });
@@ -124,6 +127,7 @@ describe("no price values in any email body", () => {
     // money-shaped string can legitimately appear.
     const email = compose({
       kind: "run-completed",
+      campaignId: "c1",
       campaignName: "$5 off everything",
       counts: counts(),
     });

--- a/app/lib/notifications/templates.ts
+++ b/app/lib/notifications/templates.ts
@@ -33,16 +33,27 @@ export interface RunCounts {
 
 export interface RunNotification {
   kind: Exclude<NotificationKind, "weekly-digest" | "drift-hold">;
+  /**
+   * Which campaign, so the email can link to it.
+   *
+   * Required, and that is the point. `campaignUrl` was optional, no caller ever set it,
+   * and the `link()` helper below silently rendered nothing — so every one of these
+   * emails ended with a promise to open a campaign and no way to. An optional field is a
+   * contract only a reader notices is broken; a required one is a compiler error at every
+   * call site.
+   */
+  campaignId: string;
   campaignName: string;
   counts: RunCounts;
   /** Merchant-facing reasons, already through the error taxonomy. Never raw errors. */
   reasons?: string[];
-  /** Deep link back into the app, where the specifics live. */
+  /** Deep link back into the app, filled in by `notify` — see `campaign-link.ts`. */
   campaignUrl?: string;
 }
 
 export interface DriftNotification {
   kind: "drift-hold";
+  campaignId: string;
   campaignName: string;
   driftedCount: number;
   campaignUrl?: string;

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -34,6 +34,7 @@ import {
 } from "../lib/lifecycle/transitions";
 import { transitionHistory } from "../services/campaigns/lifecycle.server";
 import { housekeepingAction } from "../services/campaigns/housekeeping.server";
+import { readPreferences } from "../services/notifications.server";
 import { approvalFor, approvalSummary, decideApproval, requestApproval, SelfApprovalError } from "../services/approvals.server";
 import { PageShell } from "../components/PageShell";
 import { CampaignTabs, currentTab, tabsFor } from "../components/campaign/CampaignTabs";
@@ -114,6 +115,9 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     ...describeCampaign({ rule: ruleOf(record), ast: astOf(record), segmentName: record.segments[0]?.name }),
     note: record.note,
     archived: record.archivedAt !== null,
+    // Where the run report goes, so the confirmation can say so at the moment a merchant
+    // decides whether they have to sit and watch. See #475.
+    notifyEmail: (await readPreferences(shop.id)).email,
     autoEnroll: record.autoEnroll,
     enrollPendingAt: record.enrollPendingAt !== null,
     state,

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -505,6 +505,7 @@ async function executeCampaignRun(
   // provider is allowed to change what happened to their prices, so this never throws
   // and never blocks the outcome being returned.
   void notify(shopId, {
+    campaignId,
     kind: options.revert
       ? "revert-completed"
       : result.clean

--- a/app/services/drift.server.ts
+++ b/app/services/drift.server.ts
@@ -338,5 +338,5 @@ async function notifyDrift(shopId: string, campaignId: string, campaignName: str
     },
   });
 
-  void notify(shopId, { kind: "drift-hold", campaignName, driftedCount: pending });
+  void notify(shopId, { kind: "drift-hold", campaignId, campaignName, driftedCount: pending });
 }

--- a/app/services/notification-link.test.ts
+++ b/app/services/notification-link.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Every notification about a campaign carries a way back to it.
+ *
+ * The bug this covers was invisible in both halves. `campaignUrl` was optional on the
+ * notification type, so nothing complained that no caller set it; the template's `link()`
+ * helper rendered an empty string for a missing URL, so nothing looked wrong in the
+ * output either. The result was an email that said "Open the campaign to review and
+ * resume" and then stopped — sent to somebody who by definition was not looking at the
+ * app, about a run that had gone partial.
+ *
+ * The same shape as every other contract bug here: two halves that only a third party
+ * ever checks. So the link is built inside `notify`, where the shop is already being
+ * read, and this is the third party.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { prisma } = vi.hoisted(() => ({
+  prisma: { shop: { findUnique: vi.fn() } },
+}));
+vi.mock("../db.server", () => ({ default: prisma }));
+
+import { notify } from "./notifications.server";
+
+const KEY = "5401aeddaf37aac5c9e1650bf6abb462";
+
+const COUNTS = { verified: 3, failed: 1, unverified: 0, skipped: 0, clamped: 0 };
+
+/** The body Resend was asked to send, or null if it was never called. */
+function sentBody(fetchMock: ReturnType<typeof vi.fn>): { text: string; subject: string } | null {
+  const call = fetchMock.mock.calls[0];
+  return call ? JSON.parse(String((call[1] as { body: string }).body)) : null;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubEnv("RESEND_API_KEY", "re_test");
+  vi.stubEnv("NOTIFICATION_FROM_EMAIL", "anchor@example.com");
+  vi.stubEnv("SHOPIFY_API_KEY", KEY);
+  // One mock for both reads `notify` makes: the preferences, and the domain the link is
+  // built from. The real `readPreferences` runs against it rather than being stubbed —
+  // a stub there would have hidden that the shop row is read twice.
+  prisma.shop.findUnique.mockResolvedValue({
+    domain: "boltify-apps.myshopify.com",
+    settings: { notifications: { email: "ops@shop.com", onCompletion: true } },
+  });
+});
+
+describe("a run notification", () => {
+  it("carries a link into the campaign it is about", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await notify("shop", {
+      kind: "run-partial",
+      campaignId: "c1",
+      campaignName: "Summer sale",
+      counts: COUNTS,
+    });
+
+    expect(sentBody(fetchMock)?.text).toContain(
+      `https://admin.shopify.com/store/boltify-apps/apps/${KEY}/app/campaigns/c1`,
+    );
+  });
+
+  it("still sends when there is no link to include", async () => {
+    // Local development and self-hosted installs have no API key. The email losing one
+    // line is fine; the email not arriving because of a missing link would not be.
+    vi.stubEnv("SHOPIFY_API_KEY", "");
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await notify("shop", {
+      kind: "run-partial",
+      campaignId: "c1",
+      campaignName: "Summer sale",
+      counts: COUNTS,
+    });
+
+    expect(result.sent).toBe(true);
+    expect(sentBody(fetchMock)?.text).not.toContain("admin.shopify.com");
+  });
+});
+
+describe("a drift notification", () => {
+  it("links to the queue, not to a campaign page", async () => {
+    // Drift is a queue of variants a merchant edited under running campaigns. Sending
+    // them to one campaign would answer a narrower question than the one being raised.
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await notify("shop", {
+      kind: "drift-hold",
+      campaignId: "c1",
+      campaignName: "Summer sale",
+      driftedCount: 4,
+    });
+
+    expect(sentBody(fetchMock)?.text).toContain("/app/prices/drift");
+  });
+});

--- a/app/services/notifications.server.ts
+++ b/app/services/notifications.server.ts
@@ -20,6 +20,7 @@
 import prisma from "../db.server";
 import { logger } from "../lib/logging/logger";
 import { compose, type Notification } from "../lib/notifications/templates";
+import { campaignUrl, driftUrl } from "../lib/notifications/campaign-link";
 
 const RESEND_ENDPOINT = "https://api.resend.com/emails";
 
@@ -134,7 +135,7 @@ export async function notify(
     if (!preferences.email) return { sent: false, reason: "no-recipient" };
     if (!wants(preferences, notification)) return { sent: false, reason: "muted" };
 
-    const email = compose(notification);
+    const email = compose(await withLink(shopId, notification));
 
     const response = await fetch(RESEND_ENDPOINT, {
       method: "POST",
@@ -171,4 +172,32 @@ export async function notify(
     });
     return { sent: false, reason: "failed" };
   }
+}
+
+/**
+ * The deep link, added here rather than at the call sites.
+ *
+ * Three places send notifications and each one already knows the campaign, so passing the
+ * URL along would have worked — right up until the fourth. This is the shape of bug this
+ * repo keeps finding: two halves of a contract, and only a third party ever checks they
+ * agree. Building the link where the shop is already being read means a caller cannot
+ * forget it, and a new kind of notification gets one for free.
+ *
+ * A shop that has somehow lost its domain, or an install with no API key, produces no
+ * link and one line fewer in the email. See `campaign-link.ts` for why a guess is worse.
+ */
+async function withLink(shopId: string, notification: Notification): Promise<Notification> {
+  if (notification.kind === "weekly-digest") return notification;
+
+  const shop = await prisma.shop.findUnique({ where: { id: shopId }, select: { domain: true } });
+  if (!shop) return notification;
+
+  // eslint-disable-next-line no-undef
+  const apiKey = process.env.SHOPIFY_API_KEY;
+  const url =
+    notification.kind === "drift-hold"
+      ? driftUrl(shop.domain, apiKey)
+      : campaignUrl(shop.domain, notification.campaignId, apiKey);
+
+  return { ...notification, campaignUrl: url };
 }

--- a/app/services/notifications.test.ts
+++ b/app/services/notifications.test.ts
@@ -37,7 +37,7 @@ describe("parsePreferences", () => {
 describe("wants", () => {
   const prefs = { ...DEFAULT_PREFERENCES, email: "ops@shop.com" };
   const run = (kind: "run-completed" | "run-partial" | "run-failed" | "revert-completed") =>
-    ({ kind, campaignName: "Summer", counts: { verified: 1, skipped: 0, clamped: 0, failed: 0, unverified: 0 } }) as const;
+    ({ kind, campaignId: "c1", campaignName: "Summer", counts: { verified: 1, skipped: 0, clamped: 0, failed: 0, unverified: 0 } }) as const;
 
   it("routes partial and failed through the same preference", () => {
     // They are the same question to a merchant: something needs me.
@@ -53,7 +53,7 @@ describe("wants", () => {
   it("honours the revert and drift preferences separately", () => {
     expect(wants({ ...prefs, onRevert: false }, run("revert-completed"))).toBe(false);
     expect(
-      wants({ ...prefs, onDrift: false }, { kind: "drift-hold", campaignName: "S", driftedCount: 2 }),
+      wants({ ...prefs, onDrift: false }, { kind: "drift-hold", campaignId: "c1", campaignName: "S", driftedCount: 2 }),
     ).toBe(false);
   });
 });


### PR DESCRIPTION
The ticket's premise was stale. `notifications.server.ts` has had a per-shop address for a while, Settings edits it, and `runCampaign` already fires on completion, partial and revert — including for scheduled runs, which is the case the feature exists for.

## What was actually broken

Worse than missing, because it looked finished. `campaignUrl` was optional on the notification type, **no caller ever set it**, and the template's `link()` helper rendered an empty string when it was absent. So the partial-run email ended with "Open the campaign to review and resume" and then stopped — sent, by definition, to somebody not looking at the app, about the one outcome that needs them.

Both halves were individually plausible: nothing complained that the optional field was unset, and nothing looked wrong in the rendered email either.

## The fix, and why not at the call sites

`campaignId` is now **required** on the notification, so every caller is a compiler error until it supplies one, and the link is built inside `notify` where the shop is already being read. Three places send notifications and passing the URL along would have worked — right up until the fourth.

The link goes through the admin (`admin.shopify.com/store/<store>/apps/<client id>/…`), not through `SHOPIFY_APP_URL`: ours loads the app outside the admin frame with no `host`, no `id_token` and no session, so the merchant lands on an authentication error instead of their campaign. Drift links to the queue rather than to one campaign, because that is the question being raised.

With no API key configured there is no link and one line fewer in the email — the same rule the mail transport already follows. A guessed link that will not load is worse than the line it replaces.

## The confirmation modal

Now says where the report goes. Both branches earn their place: naming the address is a promise kept, and *"Nobody is emailed — set an address in Settings"* is what a merchant needs **before** closing the tab on a run over a hundred thousand variants.

## Verification

typecheck, lint (cache cleared), build, full suite **2577 passed**. Mutations caught: the link never attached, drift pointing at a campaign page, an unconfigured install emitting a broken link, and the modal falling silent when nobody is notified.

Telemetry rule holds — the link carries a shop domain and a campaign id, no prices.

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)