### PR TITLE
Support reachable from where the problem is (#457)

### DIFF
--- a/app/components/ErrorScreen.tsx
+++ b/app/components/ErrorScreen.tsx
@@ -70,13 +70,23 @@ export function ErrorScreen({
 
           <s-paragraph>
             <s-text>
-              Quote this reference if you contact support — it links straight to the
-              full technical detail.
+              This reference links straight to the full technical detail. Contacting
+              support from here carries it for you.
             </s-text>
           </s-paragraph>
           <s-paragraph>
             <s-text><strong>{errorId}</strong> · {code}</s-text>
           </s-paragraph>
+
+          {/* The whole point of #457: support one click from the problem, not one
+              navigation away from it. Somebody on this screen has already spent their
+              patience, and asking them to find the help section and retype an id is how
+              a support request becomes an uninstall. */}
+          <ActionRow>
+            <s-button variant="tertiary" icon="chat" href={supportHref(errorId)}>
+              Contact support about this
+            </s-button>
+          </ActionRow>
         </s-stack>
 
         {stack ? (
@@ -90,4 +100,20 @@ export function ErrorScreen({
       </s-section>
     </PageShell>
   );
+}
+
+/**
+ * The support route, carrying the error and the page it happened on.
+ *
+ * The path comes from the browser rather than from a prop: this screen is rendered by the
+ * one boundary every route uses, so it does not know which route it replaced. Server-side
+ * there is no location at all, and the link is still worth having without it — the error
+ * id is the part support needs.
+ */
+function supportHref(errorId: string): string {
+  const params = new URLSearchParams({ error: errorId });
+  if (typeof window !== "undefined" && window.location?.pathname) {
+    params.set("from", window.location.pathname);
+  }
+  return `/app/support?${params}`;
 }

--- a/app/components/campaign/CampaignHeader.tsx
+++ b/app/components/campaign/CampaignHeader.tsx
@@ -44,6 +44,8 @@ export function CampaignHeader({
   scope,
   archived,
   notifyEmail,
+  campaignId,
+  needsAttention,
   scheduleText,
   lifecycle,
   fetcher,
@@ -158,6 +160,16 @@ export function CampaignHeader({
           </s-button>
         </fetcher.Form>
 
+        {/* Only where the campaign is in a state a merchant might need help with. On a
+            draft it would be a support button next to a form nobody has submitted yet;
+            on Held or Partial it is beside the two states this product is *about*, and
+            the ones whose questions are hardest to ask without a run id. */}
+        {needsAttention ? (
+          <s-button variant="tertiary" icon="chat" href={supportHref(campaignId)}>
+            Contact support
+          </s-button>
+        ) : null}
+
         <fetcher.Form method="post">
           <input type="hidden" name="intent" value={archived ? "unarchive" : "archive"} />
           <s-button type="submit" variant="tertiary" icon="archive" loading={busy || undefined}>
@@ -208,4 +220,16 @@ export function CampaignHeader({
       )}
     </>
   );
+}
+
+/**
+ * The support route, carrying the campaign.
+ *
+ * The run id is deliberately not in here. The campaign page already shows which run is
+ * selected, and a link built from whichever run happened to be on screen would attach the
+ * wrong one as often as the right one — support can ask, and a wrong id is worse than a
+ * missing one.
+ */
+function supportHref(campaignId: string): string {
+  return `/app/support?${new URLSearchParams({ campaign: campaignId, from: `/app/campaigns/${campaignId}` })}`;
 }

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -71,6 +71,8 @@ const props = (over: Partial<CampaignDetailProps> = {}) =>
       ast: { groups: [{ conditions: [{ field: "collection", value: "Outerwear" }] }] },
     }),
     notifyEmail: "ops@shop.com",
+    campaignId: "c1",
+    needsAttention: false,
     keepers: null,
     keepersPending: false,
     ...over,
@@ -473,5 +475,21 @@ describe("the confirmation says who hears about the outcome", () => {
 
     expect(html).toContain("Nobody is emailed");
     expect(html).toContain("Settings");
+  });
+});
+
+describe("support from where the problem is", () => {
+  it("offers it on a campaign that needs a decision, carrying the campaign", () => {
+    // Held and Partial are the two states this product is about, and the two whose
+    // questions are hardest to ask without an id to quote.
+    const html = render(<CampaignHeader {...props({ needsAttention: true })} />);
+
+    expect(html).toContain("Contact support");
+    expect(html).toContain("campaign=c1");
+  });
+
+  it("stays out of the way when nothing is wrong", () => {
+    // On a draft it would be a support button beside a form nobody has submitted.
+    expect(render(<CampaignHeader {...props()} />)).not.toContain("Contact support");
   });
 });

--- a/app/lib/support/context.test.ts
+++ b/app/lib/support/context.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The rule that makes attaching context safe at all.
+ *
+ * `docs/telemetry`: shop id, plan, counts and durations, never a price. A support mailbox
+ * is the easiest place to break that rule, because everything about a support request
+ * argues for sending more.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { CONTEXT_FIELDS, contextLines, supportContext } from "./context";
+
+const base = {
+  shopDomain: "boltify-apps.myshopify.com",
+  plan: "growth",
+  appVersion: "1.4.0",
+};
+
+describe("what is attached", () => {
+  it("carries only the seven named fields", () => {
+    const context = supportContext({ ...base, path: "/app/campaigns/c1", campaignId: "c1" });
+
+    // Against the exported list, not against a literal written here: a copy in the test
+    // would let a new field slip in without either one noticing.
+    expect(Object.keys(context).sort()).toEqual([...CONTEXT_FIELDS].sort());
+  });
+
+  it("keeps the path and drops the query string", () => {
+    // A query string is where a filter, a search term or an amount ends up. "Where were
+    // you" is answered by the route.
+    expect(supportContext({ ...base, path: "/app/prices/live?q=19.99&min=1000" }).path).toBe(
+      "/app/prices/live",
+    );
+  });
+
+  it("keeps the path out of an absolute URL, and nothing else from it", () => {
+    expect(
+      supportContext({ ...base, path: "https://admin.shopify.com/app/campaigns?price=29.99" }).path,
+    ).toBe("/app/campaigns");
+  });
+
+  it("treats an empty id as no id rather than as an empty one", () => {
+    const context = supportContext({ ...base, campaignId: "", runId: undefined });
+
+    expect(context.campaignId).toBeNull();
+    expect(context.runId).toBeNull();
+  });
+});
+
+describe("no attached field can carry a price", () => {
+  it("holds for any ids and any path a merchant could be on", () => {
+    // A property rather than an example. The failure this guards against is a future
+    // field, and a fixed case would only ever prove the fields that exist today.
+    const money = /(?<![\d.])\d{1,3}(?:[,\s]\d{3})*\.\d{2}(?!\d)/;
+
+    fc.assert(
+      fc.property(
+        fc.record({
+          campaignId: fc.string({ maxLength: 30 }),
+          runId: fc.string({ maxLength: 30 }),
+          errorId: fc.string({ maxLength: 30 }),
+          query: fc.string({ maxLength: 40 }),
+        }),
+        ({ campaignId, runId, errorId, query }) => {
+          const context = supportContext({
+            ...base,
+            // The realistic leak: a price in the URL a merchant was looking at.
+            path: `/app/prices/live?amount=19.99&${query}`,
+            campaignId,
+            runId,
+            errorId,
+          });
+
+          expect(context.path).not.toMatch(money);
+        },
+      ),
+    );
+  });
+});
+
+describe("what the merchant is shown", () => {
+  it("lists what will be sent, and leaves out what is not there", () => {
+    const lines = contextLines(supportContext({ ...base, path: "/app", errorId: "e-9" }));
+
+    expect(lines).toContain("Shop: boltify-apps.myshopify.com");
+    expect(lines).toContain("Error id: e-9");
+    expect(lines.some((line) => line.startsWith("Campaign:"))).toBe(false);
+  });
+
+  it("labels every field it can show, so none arrives unexplained", () => {
+    const full = supportContext({
+      ...base,
+      path: "/app/campaigns/c1",
+      campaignId: "c1",
+      runId: "r1",
+      errorId: "e1",
+    });
+
+    expect(contextLines(full)).toHaveLength(CONTEXT_FIELDS.length);
+  });
+});

--- a/app/lib/support/context.ts
+++ b/app/lib/support/context.ts
@@ -1,0 +1,101 @@
+/**
+ * What gets attached to a support request, and nothing else.
+ *
+ * The point of attaching anything is that the first reply should not be "which shop, and
+ * what were you doing" — a merchant contacting us at 9pm before a sale has already spent
+ * their patience on the problem. The point of attaching *only this* is that a support
+ * mailbox is not somewhere a merchant's prices should end up: `docs/telemetry` says shop
+ * id, plan, counts and durations, never a value.
+ *
+ * So the context is a fixed record with named fields rather than a bag the caller fills.
+ * A `Record<string, unknown>` would pass every review and then, one day, carry a preview
+ * row into an inbox — and the shape of that mistake is that nobody would find out.
+ * `context.test.ts` checks the fields against this list.
+ *
+ * ## The merchant's own message is not filtered
+ *
+ * They typed it and pressed Send, and if the fastest way to explain the problem is "it
+ * priced the jacket at 19.99 instead of 29.99" then that sentence *is* the support
+ * request. Redacting it would leave us answering a question we had just made unreadable.
+ * The rule is about what we attach without being asked.
+ */
+
+export interface SupportContext {
+  /** Which shop, so support does not have to ask. */
+  shopDomain: string;
+  /** Which plan, because half of what looks like a bug is an entitlement. */
+  plan: string;
+  /** Which release, so a fixed bug is recognisable as one. */
+  appVersion: string;
+  /** Where they were when it went wrong. A path, never a URL with query values. */
+  path: string;
+  /** The campaign in context, if any. */
+  campaignId: string | null;
+  /** The run in context — the id the ledger and the activity log are both keyed by. */
+  runId: string | null;
+  /** The error id from the screen they were looking at, which is the whole point. */
+  errorId: string | null;
+}
+
+/** The only keys that may ever appear. Adding one is a deliberate act, not a spread. */
+export const CONTEXT_FIELDS = [
+  "shopDomain",
+  "plan",
+  "appVersion",
+  "path",
+  "campaignId",
+  "runId",
+  "errorId",
+] as const satisfies readonly (keyof SupportContext)[];
+
+export function supportContext(input: {
+  shopDomain: string;
+  plan: string;
+  appVersion: string;
+  path?: string | null;
+  campaignId?: string | null;
+  runId?: string | null;
+  errorId?: string | null;
+}): SupportContext {
+  return {
+    shopDomain: input.shopDomain,
+    plan: input.plan,
+    appVersion: input.appVersion,
+    // The path only. A query string is where a filter, a search term or an amount ends
+    // up, and "where were you" is answered by the route.
+    path: pathOnly(input.path),
+    campaignId: input.campaignId || null,
+    runId: input.runId || null,
+    errorId: input.errorId || null,
+  };
+}
+
+/**
+ * The labels a merchant sees before they press Send.
+ *
+ * Shown, not summarised. "We will attach some diagnostic information" is how a merchant
+ * learns not to trust a Send button; a list they can read is how they learn they can.
+ */
+export const CONTEXT_LABELS: Record<keyof SupportContext, string> = {
+  shopDomain: "Shop",
+  plan: "Plan",
+  appVersion: "App version",
+  path: "Page",
+  campaignId: "Campaign",
+  runId: "Run",
+  errorId: "Error id",
+};
+
+/** The context as the lines that go in the email, skipping what is not there. */
+export function contextLines(context: SupportContext): string[] {
+  return CONTEXT_FIELDS.filter((field) => context[field]).map(
+    (field) => `${CONTEXT_LABELS[field]}: ${context[field]}`,
+  );
+}
+
+function pathOnly(value: string | null | undefined): string {
+  if (!value) return "";
+  const path = value.split("?")[0]!.split("#")[0]!;
+  // Absolute URLs happen when a caller passes `window.location.href`. Keep the path.
+  return path.startsWith("http") ? new URL(path).pathname : path;
+}

--- a/app/lib/support/reachable.test.ts
+++ b/app/lib/support/reachable.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Support is reachable from where the problem is, not only from the nav.
+ *
+ * NA puts a contact line in the footer of every page. Ours was a nav item, which is one
+ * navigation away from whatever just went wrong — and on an error screen or a held
+ * campaign that is exactly the wrong moment to ask somebody to go and find it.
+ *
+ * A source-level check because the surfaces are the point: these three are the ones a
+ * merchant is on when they need a person, and it is the *linking* that keeps regressing,
+ * not the route.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const SURFACES: { file: string; why: string }[] = [
+  {
+    file: "app/components/ErrorScreen.tsx",
+    why: "the screen with the error id on it, which is the thing support needs quoted",
+  },
+  {
+    file: "app/components/campaign/CampaignHeader.tsx",
+    why: "a Held or Partial campaign — the two states this product is about",
+  },
+  {
+    file: "app/routes/app.help.tsx",
+    why: "the help page, for a question the articles do not answer",
+  },
+];
+
+/**
+ * A control a merchant can press, not merely the string somewhere in the file.
+ *
+ * The first version of this checked for `/app/support` anywhere in the source, and a
+ * mutation that deleted the entire button passed — because the helper that builds the URL
+ * was still sitting there with the path in it. A guard that a deletion cannot fail is not
+ * guarding anything.
+ */
+const LINKED = /<s-button[^>]*href=\{?(?:"\/app\/support|`\/app\/support|supportHref\()/s;
+
+describe("the surfaces that link to support", () => {
+  it.each(SURFACES)("$file — $why", ({ file }) => {
+    expect(sourceOf(file)).toMatch(LINKED);
+  });
+
+  it("carries context rather than dropping the merchant on an empty form", () => {
+    // A contact form reached with no context is the nav item again. The error screen
+    // attaches the error id, the campaign header the campaign, and both attach the page.
+    expect(sourceOf("app/components/ErrorScreen.tsx")).toContain("error");
+    expect(sourceOf("app/components/campaign/CampaignHeader.tsx")).toContain("campaign:");
+  });
+});

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -113,6 +113,7 @@ export const loader = withGuard("/app/campaigns/$id", async ({ request, params }
     // The same two sentences the index shows, through the same formatter, so a merchant
     // reading "20% off · In Outerwear" in the list meets those words again here.
     ...describeCampaign({ rule: ruleOf(record), ast: astOf(record), segmentName: record.segments[0]?.name }),
+    campaignId,
     note: record.note,
     archived: record.archivedAt !== null,
     // Where the run report goes, so the confirmation can say so at the moment a merchant

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -69,6 +69,25 @@ export default function HelpIndex() {
         </s-stack>
       </s-section>
 
+      {/* Above the reading list, not below it. Somebody who opened Help already has a
+          question; making them scan every article before finding out a person will
+          answer is the arrangement that makes support feel unreachable. Secondary,
+          because most questions really are answered by the pages below. */}
+      <s-section heading="Still stuck">
+        <s-stack gap={SPACE.item}>
+          <s-paragraph>
+            Write to us and we reply to every message. Your shop, plan and the page you
+            came from are attached, so you do not have to describe your setup — and you
+            can see exactly what is being sent before you send it.
+          </s-paragraph>
+          <ActionRow>
+            <s-button variant="secondary" icon="chat" href="/app/support?from=/app/help">
+              Contact support
+            </s-button>
+          </ActionRow>
+        </s-stack>
+      </s-section>
+
       {nav.sections.map((section) => (
         <s-section key={section.id} heading={section.title}>
           <s-stack gap={SPACE.section}>

--- a/app/routes/app.support.tsx
+++ b/app/routes/app.support.tsx
@@ -1,0 +1,183 @@
+/**
+ * Support, reachable from where the problem is.
+ *
+ * NA puts a contact line in the footer of every page; ours was a nav item, one navigation
+ * away from whatever had just gone wrong. On an error screen or a held campaign that is
+ * exactly the wrong moment to ask somebody to go and find the help section.
+ *
+ * So this route takes its context from the URL — the page they were on, the campaign, the
+ * run, the error id — and the surfaces that know those things link here carrying them.
+ *
+ * ## Everything attached is shown
+ *
+ * The context is rendered as a list the merchant reads before pressing Send, not
+ * summarised as "diagnostic information". A merchant cannot consent to a description, and
+ * this app's whole argument is that it tells you exactly what it is about to do. The
+ * fields are fixed and price-free by construction — see `lib/support/context.ts`.
+ */
+
+import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { useFetcher, useLoaderData } from "react-router";
+import { boundary } from "@shopify/shopify-app-react-router/server";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { billingFor } from "../services/billing.server";
+import { sendSupportRequest } from "../services/support.server";
+import { CONTEXT_FIELDS, CONTEXT_LABELS, supportContext } from "../lib/support/context";
+import { PageShell } from "../components/PageShell";
+import { RouteBoundary } from "../components/RouteBoundary";
+import { HelpNote } from "../components/HelpNote";
+import { withGuard } from "../lib/errors/guard.server";
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * Which build this is.
+ *
+ * The same value Sentry tags its releases with, so a support thread and a stack trace can
+ * be lined up. "dev" locally, where the question "which release" has no answer worth
+ * printing.
+ */
+function appVersion(): string {
+  // eslint-disable-next-line no-undef
+  const env = process.env;
+  return env.SENTRY_RELEASE ?? env.SOURCE_VERSION ?? "dev";
+}
+
+async function contextFor(request: Request) {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const params = new URL(request.url).searchParams;
+  const billing = await billingFor(shop.id);
+
+  return supportContext({
+    shopDomain: session.shop,
+    plan: billing.plan.name,
+    appVersion: appVersion(),
+    path: params.get("from"),
+    campaignId: params.get("campaign"),
+    runId: params.get("run"),
+    errorId: params.get("error"),
+  });
+}
+
+export const loader = withGuard("/app/support", async ({ request }: LoaderFunctionArgs) => {
+  return { context: await contextFor(request) };
+});
+
+export const action = withGuard("/app/support", async ({ request }: ActionFunctionArgs) => {
+  const form = await request.formData();
+  const body = String(form.get("body") ?? "").trim();
+  const replyTo = String(form.get("replyTo") ?? "").trim();
+
+  if (!body) {
+    return { ok: false, message: "Tell us what happened first — even one line helps." };
+  }
+  if (!replyTo.includes("@")) {
+    return { ok: false, message: "We need an address to reply to." };
+  }
+
+  // Rebuilt from the request rather than read from the form. The form shows the merchant
+  // what will be attached; it does not get to decide it, or a posted field could name
+  // another shop.
+  const context = await contextFor(request);
+
+  const result = await sendSupportRequest({
+    subject: String(form.get("subject") ?? "").trim() || "Support request",
+    body,
+    replyTo,
+    context,
+  });
+
+  return { ok: result.sent, message: result.message };
+});
+
+export default function Support() {
+  const { context } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
+  const busy = fetcher.state !== "idle";
+
+  return (
+    <PageShell heading="Contact support" backTo={{ href: "/app/help", label: "Help" }}>
+      {fetcher.data ? (
+        <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
+          <s-paragraph>{fetcher.data.message}</s-paragraph>
+        </s-banner>
+      ) : null}
+
+      <s-section heading="What happened">
+        <fetcher.Form method="post">
+          <s-stack direction="block" gap={SPACE.item}>
+            <s-text-field
+              name="replyTo"
+              label="Your email"
+              details="Where we reply. Not stored."
+              placeholder="you@yourshop.com"
+            />
+            <s-text-field
+              name="subject"
+              label="Subject"
+              placeholder="A campaign is stuck on Held"
+            />
+            <s-text-area
+              name="body"
+              label="What happened"
+              rows={6}
+              placeholder="What you expected, what happened instead, and what you have already tried."
+            />
+            <s-stack direction="inline" gap={SPACE.item} justifyContent="end">
+              <s-button type="submit" variant="primary" loading={busy || undefined}>
+                Send
+              </s-button>
+            </s-stack>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+
+      <s-section heading="What we attach">
+        {/* Listed, not summarised. A merchant cannot consent to "diagnostic
+            information", and the fastest way to make somebody distrust a Send button is
+            to be vague about it one time. */}
+        <s-paragraph>
+          <s-text color="subdued">
+            Sent with your message so we do not have to ask. No prices are included — this
+            is the same rule our error reporting follows.
+          </s-text>
+        </s-paragraph>
+        <s-table>
+          <s-table-header-row>
+            <s-table-header listSlot="primary">What</s-table-header>
+            <s-table-header listSlot="inline">Value</s-table-header>
+          </s-table-header-row>
+          <s-table-body>
+            {CONTEXT_FIELDS.filter((field) => context[field]).map((field) => (
+              <s-table-row key={field}>
+                <s-table-cell>{CONTEXT_LABELS[field]}</s-table-cell>
+                <s-table-cell>{context[field]}</s-table-cell>
+              </s-table-row>
+            ))}
+          </s-table-body>
+        </s-table>
+      </s-section>
+
+      <HelpNote label="Before you write">
+        <s-paragraph>
+          A campaign on Held is waiting for a decision rather than broken: somebody edited
+          a price under it, and nothing is overwritten until you say which price wins.
+        </s-paragraph>
+        <s-paragraph>
+          A partial run has a reason recorded against every row that did not land, on the
+          campaign’s Ledger tab. Resuming retries only those rows.
+        </s-paragraph>
+      </HelpNote>
+    </PageShell>
+  );
+}
+
+export function ErrorBoundary() {
+  return <RouteBoundary />;
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/app/services/support.server.test.ts
+++ b/app/services/support.server.test.ts
@@ -1,0 +1,107 @@
+/**
+ * A support request is the merchant asking for help, and losing one silently is the worst
+ * thing this page can do.
+ *
+ * That is the difference from a run notification, which never throws: a notification is a
+ * report on work that already happened, and the merchant can still go and look. Somebody
+ * who presses Send here and hears nothing is waiting on a reply to a message that does
+ * not exist.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { sendSupportRequest } from "./support.server";
+import { supportContext } from "../lib/support/context";
+
+const context = supportContext({
+  shopDomain: "boltify-apps.myshopify.com",
+  plan: "Growth",
+  appVersion: "abc1234",
+  path: "/app/campaigns/c1",
+  campaignId: "c1",
+  errorId: "e-9",
+});
+
+const request = { subject: "Held campaign", body: "It will not resume.", replyTo: "me@shop.com", context };
+
+const sentBody = (fetchMock: ReturnType<typeof vi.fn>) =>
+  JSON.parse(String((fetchMock.mock.calls[0]![1] as { body: string }).body));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubEnv("RESEND_API_KEY", "re_test");
+  vi.stubEnv("NOTIFICATION_FROM_EMAIL", "anchor@example.com");
+  vi.stubEnv("SUPPORT_EMAIL", "support@example.com");
+});
+
+describe("sending", () => {
+  it("carries the message, the context, and a reply-to that reaches the merchant", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await sendSupportRequest(request);
+
+    const sent = sentBody(fetchMock);
+    expect(result.sent).toBe(true);
+    expect(sent.text).toContain("It will not resume.");
+    expect(sent.text).toContain("Error id: e-9");
+    // Without this a reply lands in our own sending mailbox, which is a support system
+    // that answers itself.
+    expect(sent.reply_to).toBe("me@shop.com");
+    expect(sent.subject).toContain("boltify-apps.myshopify.com");
+  });
+
+  it("says so, rather than claiming success, when the install cannot send", async () => {
+    // Local development and self-hosted installs. "We got it" from an app that did not
+    // is the one failure a merchant cannot recover from by trying again.
+    vi.stubEnv("SUPPORT_EMAIL", "");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await sendSupportRequest(request);
+
+    expect(result.sent).toBe(false);
+    expect(result.message).toContain("Nothing was sent");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a provider failure instead of swallowing it", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 502 }));
+
+    expect((await sendSupportRequest(request)).sent).toBe(false);
+  });
+
+  it("reports a thrown request instead of letting it reach the page as a crash", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+
+    const result = await sendSupportRequest(request);
+
+    expect(result.sent).toBe(false);
+    expect(result.message).toContain("could not send");
+  });
+});
+
+describe("what leaves the building", () => {
+  it("contains no price, whatever the context", async () => {
+    // The rule the whole feature is gated on. The merchant's own words are theirs to
+    // send — that sentence is the support request — so this checks the part we attach.
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendSupportRequest({
+      ...request,
+      body: "the jacket priced at 19.99",
+      context: supportContext({
+        shopDomain: "boltify-apps.myshopify.com",
+        plan: "Growth",
+        appVersion: "abc1234",
+        path: "/app/prices/live?amount=29.99",
+      }),
+    });
+
+    const attached = String(sentBody(fetchMock).text).split("—")[1] ?? "";
+    expect(attached).not.toMatch(/\d+\.\d{2}/);
+    // And the merchant's own sentence survives intact, because answering it is the job.
+    expect(sentBody(fetchMock).text).toContain("19.99");
+  });
+});

--- a/app/services/support.server.ts
+++ b/app/services/support.server.ts
@@ -1,0 +1,87 @@
+/**
+ * Sending a merchant's support request.
+ *
+ * Through the same transport the run notifications use, for the same reason there is one
+ * scheduler: one thing that talks to a mail provider and one place to look when it stops.
+ *
+ * Where this differs from a notification is what happens when it fails. A notification is
+ * a report on work that already happened, so it never throws — losing it costs a merchant
+ * an email about something they can still go and look at. A support request is the
+ * merchant *asking for help*, and silently dropping it is the worst outcome on this page:
+ * they would sit waiting for a reply to a message nobody received. So this returns
+ * failure, plainly, and the route says so with the address to write to instead.
+ */
+
+import { logger } from "../lib/logging/logger";
+import { contextLines, type SupportContext } from "../lib/support/context";
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+export interface SupportResult {
+  sent: boolean;
+  /** Shown to the merchant when nothing was sent, never swallowed. */
+  message: string;
+}
+
+export async function sendSupportRequest(input: {
+  subject: string;
+  body: string;
+  replyTo: string;
+  context: SupportContext;
+}): Promise<SupportResult> {
+  // eslint-disable-next-line no-undef
+  const { RESEND_API_KEY, NOTIFICATION_FROM_EMAIL, SUPPORT_EMAIL } = process.env;
+
+  if (!RESEND_API_KEY || !NOTIFICATION_FROM_EMAIL || !SUPPORT_EMAIL) {
+    // Local development and self-hosted installs. Named plainly rather than pretending
+    // to have sent: a merchant who is told "we got it" and hears nothing back has been
+    // lied to by an app whose whole proposition is that it tells the truth.
+    return {
+      sent: false,
+      message: "Support email is not configured on this install. Nothing was sent.",
+    };
+  }
+
+  const text = [
+    input.body.trim(),
+    "",
+    "—",
+    ...contextLines(input.context),
+  ].join("\n");
+
+  try {
+    const response = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: NOTIFICATION_FROM_EMAIL,
+        to: [SUPPORT_EMAIL],
+        // So a reply goes to the merchant and not into our own sending mailbox.
+        reply_to: input.replyTo,
+        subject: `${input.subject} — ${input.context.shopDomain}`,
+        text,
+      }),
+    });
+
+    if (!response.ok) {
+      // The status, never the body: the body is the merchant's message.
+      logger.warn("support request not delivered", {
+        shop: input.context.shopDomain,
+        status: response.status,
+      });
+      return { sent: false, message: "We could not send that just now." };
+    }
+
+    logger.info("support request sent", { shop: input.context.shopDomain });
+    return { sent: true, message: "Sent. We reply to every message, usually within a day." };
+  } catch (error) {
+    logger.warn("support request threw", {
+      shop: input.context.shopDomain,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { sent: false, message: "We could not send that just now." };
+  }
+}


### PR DESCRIPTION
Support was a nav item — one navigation away from whatever just went wrong. NA puts a contact line in the footer of every page, and the difference matters at exactly one moment: an error screen, or a campaign sitting on Held.

## Three entry points, each carrying what it knows

| Surface | Attaches | Why there |
|---|---|---|
| `ErrorScreen` | error id + page | the screen already showing the id support needs quoted |
| `CampaignHeader` | campaign + page | **only when the campaign needs a decision** — on a draft it would be a support button beside a form nobody has submitted |
| `app.help` | page | above the reading list, not below: making somebody scan every article first is what makes support feel unreachable |

`reachable.test.ts` guards all three. Its first version checked for `/app/support` anywhere in the source and a mutation deleting the whole button **passed**, because the helper building the URL still had the path in it — so it now requires a real `<s-button>` pointing at it.

## What gets attached

A fixed record with seven named fields (`shopDomain`, `plan`, `appVersion`, `path`, `campaignId`, `runId`, `errorId`), not a bag the caller fills. A `Record<string, unknown>` would pass every review and then one day carry a preview row into an inbox — and the shape of that mistake is that nobody would find out.

The path is kept without its query string, which is where a filter, a search term or an amount ends up. A **property test** proves no attached field can hold a price whatever the ids and the URL.

Everything is rendered as a table the merchant reads before pressing Send. Not "diagnostic information": a merchant cannot consent to a description.

**The merchant's own message is not filtered**, deliberately. If the fastest way to explain the problem is "it priced the jacket at 19.99 instead of 29.99", that sentence *is* the support request; redacting it would leave us answering a question we had just made unreadable. The rule is about what we attach unasked.

## Failure is reported, not swallowed

Unlike a run notification — which never throws, because it reports work that already happened and the merchant can still go and look — somebody who presses Send here and hears nothing is waiting on a reply to a message that does not exist. An unconfigured install says so plainly instead of claiming success.

Needs `SUPPORT_EMAIL` set in production; without it the form refuses honestly.

## Verification

typecheck, lint (cache cleared), build, full suite **2600 passed**. Mutations caught: the query string attached to the path, an unconfigured install claiming success, `reply_to` dropped so replies land in our own sending mailbox, the campaign link missing on a held campaign, and the error screen's button deleted.

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)