### PR TITLE
CSV is a way prices change, not a different door (#445)

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -354,7 +354,9 @@ describe("pages that can lose typed work", () => {
     // the pages that list the thing they write. The guard travelled with each of them —
     // which is the point of listing the routes here rather than the section they used to
     // share.
-    "app.campaigns.import.tsx",
+    // The price import's form is in the campaign editor now (#445); the old URL is a
+    // redirect with nothing to type into.
+    "app.campaigns.new.tsx",
     "app.prices.baselines._index.tsx",
     "app.prices.costs.tsx",
   ];

--- a/app/components/RuleValueField.tsx
+++ b/app/components/RuleValueField.tsx
@@ -1,6 +1,13 @@
-import { useState } from "react";
-
 import { DRAFT_DEFAULTS } from "../lib/campaigns/draft-defaults";
+
+/**
+ * The rule kind that has no amount, because the file carries every price.
+ *
+ * Named rather than written out at each of the four places that branch on it: the string
+ * is load-bearing — it decides whether a scope section renders — and a typo would produce
+ * a page that silently keeps the wrong half.
+ */
+export const FROM_FILE = "from-file";
 
 /**
  * The rule's amount, which is a percentage or a price depending on the rule.
@@ -20,31 +27,50 @@ import { DRAFT_DEFAULTS } from "../lib/campaigns/draft-defaults";
  */
 export function RuleValueField({
   currency,
+  kind,
+  onKindChange,
   name = "ruleValue",
   selectName = "ruleKind",
 }: {
   currency: string;
+  /**
+   * Which rule is chosen, held by the route rather than here.
+   *
+   * It used to be local state, which was right while every option was an arithmetic on
+   * the baseline. `from-import` is not: choosing it removes the scope section and swaps
+   * the whole rule for a file, and a page cannot react to a choice a component is keeping
+   * to itself.
+   */
+  kind: string;
+  onKindChange: (kind: string) => void;
   name?: string;
   selectName?: string;
 }) {
-  const [kind, setKind] = useState<string>(DRAFT_DEFAULTS.ruleKind);
   const money = kind === "fixed-change" || kind === "set-exact";
 
   return (
     <>
       <s-select
         name={selectName}
-        label="Adjustment"
-        onChange={(event) => setKind(String(event.currentTarget.value))}
+        label="How should prices change?"
+        onChange={(event) => onKindChange(String(event.currentTarget.value))}
       >
         <s-option value={DRAFT_DEFAULTS.ruleKind} defaultSelected>
           Percent change from baseline
         </s-option>
         <s-option value="fixed-change">Fixed change from baseline</s-option>
         <s-option value="set-exact">Set an exact price</s-option>
+        {/* A file is a way prices change, not a different door.
+            
+            #416 dissolved the Imports nav item on the rule that a nav item is a noun; the
+            page survived as a button on the campaigns index, which is the same mistake
+            one size smaller — two merchants wanting the same object, sent through two
+            doors. A spreadsheet is an answer to "how should prices change", so it is an
+            option here. */}
+        <s-option value={FROM_FILE}>From a spreadsheet</s-option>
       </s-select>
 
-      {money ? (
+      {kind === FROM_FILE ? null : money ? (
         <s-money-field
           name={name}
           label={kind === "set-exact" ? `Price (${currency})` : `Amount (${currency})`}

--- a/app/components/help-note.test.tsx
+++ b/app/components/help-note.test.tsx
@@ -134,7 +134,9 @@ describe("the prose each page used to keep in a column", () => {
     ["app.prices.baselines.recapture.tsx", "If you get this wrong", "Baselines are append-only"],
     ["app.campaigns._index.tsx", "How campaigns resolve", "They never stack"],
     ["app.campaigns.new.tsx", "Nothing is written yet", "records the rule"],
-    ["app.campaigns.import.tsx", "Only price files are listed", "do not record a file yet"],
+    // Moved with the table it qualifies when the import stopped being a page of its own
+    // (#445). The note is the point, not the file it lives in.
+    ["app.campaigns.new.tsx", "Only price files are listed", "do not record a file yet"],
     ["app.activity.tsx", "What is kept", "Retention is not a paid tier"],
     ["app.settings._index.tsx", "Why floors are checked last", "Rounding down can push"],
     ["app.settings.segments.tsx", "Dynamic or frozen", "re-checks its filter every time"],

--- a/app/components/imports/ImportForm.tsx
+++ b/app/components/imports/ImportForm.tsx
@@ -54,6 +54,8 @@ export function ImportForm({
   commitLabel,
   ready,
   intent = INTENT,
+  action,
+  template,
   children,
 }: {
   heading: string;
@@ -84,6 +86,23 @@ export function ImportForm({
    * two things. The route reads it back with `isCommit(value, intent.commit)`.
    */
   intent?: { check: string; commit: string };
+  /**
+   * Where to post, when that is not the route this form is rendered on.
+   *
+   * The campaign editor offers a spreadsheet as one of the ways prices change, and the
+   * whole point of doing it that way is that the import's action, parsing, dry run and
+   * error reporting are untouched — so the form still posts to `/app/campaigns/import`
+   * from wherever it is shown.
+   */
+  action?: string;
+  /**
+   * A starter file, offered beside the drop zone.
+   *
+   * All three competitors give one, and it is the difference between "paste a CSV" and
+   * a merchant guessing at column names. Omitted where a source has no template yet
+   * rather than linking to one that does not exist.
+   */
+  template?: { href: string; label: string };
   /** Extra fields this source needs, above the file. */
   children?: ReactNode;
 }) {
@@ -103,7 +122,7 @@ export function ImportForm({
 
       {description}
 
-      <fetcher.Form method="post" ref={form}>
+      <fetcher.Form method="post" action={action} ref={form}>
         {/* `s-button` takes no name or value, so the intent rides in a hidden field the
             buttons set before submitting. One form rather than two, because both actions
             read the same rows and duplicating the textarea would let them drift apart —
@@ -112,6 +131,20 @@ export function ImportForm({
         <s-stack gap={SPACE.section}>
           {children}
           <CsvDropZone target="csv" />
+
+          {/* Beside the drop zone, not in the prose above it. Somebody who has got as far
+              as looking for where to put a file is the person who needs the column names,
+              and a link three paragraphs up has already been scrolled past. */}
+          {template ? (
+            <ActionRow>
+              {/* `download=""`, not `download`. The Polaris button types the attribute
+                  as a string — the filename to save as — and a bare boolean does not
+                  typecheck; empty means "use the name the server sends". */}
+              <s-button variant="tertiary" icon="download" href={template.href} download="">
+                {template.label}
+              </s-button>
+            </ActionRow>
+          ) : null}
 
           <s-text-area
             name="csv"

--- a/app/components/imports/PriceImportHistory.tsx
+++ b/app/components/imports/PriceImportHistory.tsx
@@ -1,0 +1,90 @@
+/**
+ * Every price file this shop has imported.
+ *
+ * A campaign can price *from* an import, so "which file is this campaign reading?" is a
+ * question about campaigns — and `price_imports` had recorded every one since the feature
+ * shipped with nothing displaying them until #351. It moved here when the import stopped
+ * being a page of its own (#445) and became one of the ways prices change.
+ *
+ * Its own component rather than more markup in the editor: the editor is the longest file
+ * in the app, and a table that only renders on one branch of one option is exactly the
+ * kind of thing that makes a long file unreadable.
+ *
+ * Baselines and costs record no import row. A real gap rather than an omission here, and
+ * still said out loud rather than papered over.
+ */
+
+import { EmptyState } from "../AsyncState";
+import { formatCount } from "../../lib/format/display";
+
+export interface PriceImportRow {
+  id: string;
+  name: string;
+  currency: string;
+  rowsRead: number;
+  rowsMatched: number;
+  createdBy: string | null;
+  /** Already formatted, in the shop's zone — see `formatWhen`. */
+  createdAt: string;
+}
+
+export function PriceImportHistory({
+  imports,
+  timeZone,
+}: {
+  imports: PriceImportRow[];
+  timeZone: string;
+}) {
+  return (
+    <s-section heading="Price files you have imported">
+      {imports.length === 0 ? (
+        <EmptyState
+          title="Nothing imported yet"
+          description="Every file you import is recorded here with its row counts and who ran it, so you can always answer which file a campaign is pricing from."
+        />
+      ) : (
+        <>
+          <s-table>
+            <s-table-header-row>
+              <s-table-header listSlot="kicker">Imported</s-table-header>
+              <s-table-header listSlot="primary">File</s-table-header>
+              <s-table-header listSlot="labeled" format="numeric">
+                Rows read
+              </s-table-header>
+              <s-table-header listSlot="secondary" format="numeric">
+                Matched a variant
+              </s-table-header>
+              <s-table-header listSlot="labeled">By</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {imports.map((row) => (
+                <s-table-row key={row.id}>
+                  <s-table-cell>{row.createdAt}</s-table-cell>
+                  <s-table-cell>
+                    {row.name} <s-text color="subdued">({row.currency})</s-text>
+                  </s-table-cell>
+                  <s-table-cell>{formatCount(row.rowsRead)}</s-table-cell>
+                  <s-table-cell>
+                    {/* The gap between these two is the number worth reading: rows that
+                        named a variant this shop does not have. */}
+                    {formatCount(row.rowsMatched)}
+                    {row.rowsMatched < row.rowsRead ? (
+                      <s-text tone="caution">
+                        {" "}
+                        · {formatCount(row.rowsRead - row.rowsMatched)} matched nothing
+                      </s-text>
+                    ) : null}
+                  </s-table-cell>
+                  <s-table-cell>{row.createdBy ?? "—"}</s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+          <s-paragraph>
+            <s-text color="subdued">Times are your store&rsquo;s, in {timeZone}.</s-text>
+          </s-paragraph>
+        </>
+      )}
+    </s-section>
+  );
+}

--- a/app/components/imports/imports.test.ts
+++ b/app/components/imports/imports.test.ts
@@ -30,7 +30,21 @@ const ROOT = process.cwd();
 const read = (...parts: string[]) => sourceOf(ROOT, ...parts);
 
 
-const PRICE_IMPORT = read("app/routes/app.campaigns.import.tsx");
+/**
+ * The price import is now three files, and it is worth naming why.
+ *
+ * #445 made a spreadsheet one of the ways prices change rather than a door of its own, so
+ * the *entrance* is the campaign editor. The POST it makes moved to a resource route —
+ * the editor's own action creates a campaign from a rule, and a second submit target on
+ * one route is a misrouted request away from creating the wrong thing. The old URL still
+ * resolves, as a redirect.
+ *
+ * Every capability below is still checked; only the file it lives in changed.
+ */
+const PRICE_IMPORT = read("app/routes/app.price-import.tsx");
+const EDITOR = read("app/routes/app.campaigns.new.tsx");
+const IMPORT_REDIRECT = read("app/routes/app.campaigns.import.tsx");
+const HISTORY = read("app/components/imports/PriceImportHistory.tsx");
 const BASELINES = read("app/routes/app.prices.baselines._index.tsx");
 const COSTS = read("app/routes/app.prices.costs.tsx");
 const RECAPTURE = read("app/routes/app.prices.baselines.recapture.tsx");
@@ -96,9 +110,11 @@ describe("every capability the Imports section had still exists", () => {
 
   it("still lists the price files a shop has imported", () => {
     // `price_imports` was written since the feature shipped and read by nothing until
-    // #351. Losing the page again in a restructure would put it back the way it was.
-    expect(PRICE_IMPORT).toContain("prisma.priceImport.findMany");
-    expect(PRICE_IMPORT).toContain("Price files you have imported");
+    // #351. Losing it again in a restructure would put it back the way it was — so the
+    // table moved with the entrance rather than being dropped along the way.
+    expect(EDITOR).toContain("prisma.priceImport.findMany");
+    expect(HISTORY).toContain("Price files you have imported");
+    expect(EDITOR).toContain("<PriceImportHistory");
   });
 
   it("imports baselines, on the page that lists baselines", () => {
@@ -121,9 +137,19 @@ describe("every capability the Imports section had still exists", () => {
 });
 
 describe("every one of them is reachable without typing a URL", () => {
-  it("the price import is offered on the campaigns index", () => {
-    expect(CAMPAIGNS).toContain('href="/app/campaigns/import"');
-    expect(CAMPAIGNS).toContain("From a spreadsheet");
+  it("the price import is a way prices change, not a second door", () => {
+    // The index had two buttons and a merchant had to know which of their two intentions
+    // the app had filed their case under before they could start. There is one now, and
+    // the file is an option inside it.
+    expect(CAMPAIGNS).not.toContain('href="/app/campaigns/import"');
+    expect(EDITOR).toContain("<ImportForm");
+    expect(EDITOR).toContain("FROM_FILE");
+  });
+
+  it("keeps the URL it used to have, pointing at the editor", () => {
+    // Linked from runbooks and whatever a merchant bookmarked.
+    expect(IMPORT_REDIRECT).toContain("LEGACY_ROUTES");
+    expect(IMPORT_REDIRECT).not.toContain("<ImportForm");
   });
 
   it("the baseline and cost imports are on the tabs that own those nouns", () => {
@@ -199,7 +225,9 @@ describe("dropping a file", () => {
   });
 
   it.each([
-    ["prices", PRICE_IMPORT],
+    // Prices is read from the editor and not from the resource route: #445 split the
+    // *entrance* from the POST, and it is the entrance that has to offer a drop zone.
+    ["prices", EDITOR],
     ["baselines", BASELINES],
     ["costs", COSTS],
   ])("%s accepts a file as well as pasted text", (_name, source) => {
@@ -233,7 +261,7 @@ describe("the three imports are one import", () => {
   });
 
   it.each([
-    ["prices", PRICE_IMPORT],
+    ["prices", EDITOR],
     ["baselines", BASELINES],
     ["costs", COSTS],
   ])("%s carries no copy of the form", (_name, source) => {
@@ -245,7 +273,7 @@ describe("the three imports are one import", () => {
   });
 
   it.each([
-    ["prices", PRICE_IMPORT],
+    ["prices", EDITOR],
     ["baselines", BASELINES],
     ["costs", COSTS],
   ])("%s reports its counts as figures rather than a sentence", (_name, source) => {

--- a/app/lib/campaigns/from-file.test.ts
+++ b/app/lib/campaigns/from-file.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A spreadsheet is a way prices change, not a different door.
+ *
+ * The campaigns index had two buttons — "Create campaign" and "From a spreadsheet" — so a
+ * merchant had to know which of their two intentions the app had filed their case under
+ * before they could start, to make the same object either way. We had already learned
+ * this once: #416 dissolved the Imports nav item on the rule that a nav item is a noun,
+ * and the page surviving as a button was the same mistake one size smaller.
+ *
+ * What must not move is the safety. The two-phase dry-run-then-commit, the parsing and
+ * the per-row reporting are the reason writing prices from a file is survivable, so the
+ * editor posts to the same action rather than growing its own.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { FROM_FILE } from "../../components/RuleValueField";
+import { LEGACY_ROUTES } from "../routing/legacy-routes";
+import { sourceOf } from "../testing/source";
+
+const EDITOR = sourceOf("app/routes/app.campaigns.new.tsx");
+const FIELD = sourceOf("app/components/RuleValueField.tsx");
+const RESOURCE = sourceOf("app/routes/app.price-import.tsx");
+
+describe("the choice", () => {
+  it("offers a file among the ways prices change", () => {
+    expect(FIELD).toContain(`<s-option value={FROM_FILE}>`);
+    expect(FIELD).toContain("How should prices change?");
+  });
+
+  it("is a named constant, not a string spelled out at each branch", () => {
+    // It decides whether a scope section renders. A typo would produce a page that keeps
+    // the wrong half and looks deliberate.
+    expect(FROM_FILE).toBe("from-file");
+  });
+});
+
+describe("choosing it", () => {
+  it("removes the scope rather than leaving it inert", () => {
+    // The acceptance criterion, and the reason the second page was confusing: a file
+    // names its own variants, so a scope a merchant fills in would be discarded.
+    expect(EDITOR).toMatch(/\{fromFile \? null : \(\s*<s-section heading=\{headings\.scope\}/);
+  });
+
+  it("removes the arithmetic controls too", () => {
+    // Same argument. Compare-at, rounding, markets, schedule and priority are all things
+    // the import's own flow does not read.
+    expect(EDITOR).toContain("{fromFile ? null : (");
+    expect(EDITOR).toContain("{!fromFile && priceLists.length > 0 ?");
+  });
+
+  it("shows the file, the history and a template", () => {
+    expect(EDITOR).toContain("<ImportForm");
+    expect(EDITOR).toContain("<PriceImportHistory");
+    expect(EDITOR).toContain("Get a template");
+  });
+});
+
+describe("the safety did not move", () => {
+  it("posts to the import's own action rather than to the editor's", () => {
+    // The editor's action creates a campaign from a rule. A second submit target on one
+    // route is a misrouted request away from creating the wrong thing — the argument
+    // `app.preview-draft.tsx` already makes about its own resource route.
+    expect(EDITOR).toContain('action="/app/price-import"');
+  });
+
+  it("still falls safe on a missing intent", () => {
+    // `isCommit` is exercised in `app/lib/imports/intent.test.ts`. What matters here is
+    // that this path still goes through it rather than growing its own comparison.
+    expect(RESOURCE).toContain("const dryRun = !isCommit(form.get(\"intent\"));");
+    expect(RESOURCE).not.toMatch(/String\(form\.get\("intent"\)\) !== "commit"/);
+  });
+
+  it("still creates a campaign rather than writing prices", () => {
+    expect(RESOURCE).toContain("createCampaign(");
+    expect(RESOURCE).toContain("redirect(`/app/campaigns/${campaign.id}`)");
+  });
+});
+
+describe("the URLs that used to lead here", () => {
+  it("all point at the editor, opened on the file", () => {
+    for (const old of [
+      "/app/campaigns/import",
+      "/app/imports",
+      "/app/imports/prices",
+      "/app/prices/import",
+    ]) {
+      expect(LEGACY_ROUTES[old], `${old} should open the editor on the file`).toContain(
+        `ruleKind=${FROM_FILE}`,
+      );
+    }
+  });
+
+  it("opens on the file when the URL says so", () => {
+    // A merchant following an old bookmark lands on the file, not on a percentage.
+    expect(EDITOR).toContain('url.searchParams.get("ruleKind") === FROM_FILE');
+  });
+});

--- a/app/lib/routing/legacy-routes.ts
+++ b/app/lib/routing/legacy-routes.ts
@@ -16,6 +16,14 @@
  * nothing inside the app links through a redirect rather than at the real thing.
  */
 
+/**
+ * The campaign editor, opened on the spreadsheet option.
+ *
+ * Named once because four old URLs point at it, and a query string repeated four times
+ * is four chances to write `rule-kind` in one of them.
+ */
+const FROM_A_FILE = "/app/campaigns/new?ruleKind=from-file";
+
 export const LEGACY_ROUTES: Readonly<Record<string, string>> = {
   // Prices — five tables over the same variant rows.
   "/app/catalog": "/app/prices",
@@ -32,13 +40,25 @@ export const LEGACY_ROUTES: Readonly<Record<string, string>> = {
   // than being added to — pointing `/app/prices/import` at `/app/imports/prices` and
   // `/app/imports/prices` onward is exactly the two-hop chain this file's test forbids,
   // so both go straight to the page.
-  "/app/prices/import": "/app/campaigns/import",
+  "/app/prices/import": FROM_A_FILE,
   "/app/baselines/import": "/app/prices/baselines",
   "/app/costs/import": "/app/prices/costs",
   "/app/baselines/recapture": "/app/prices/baselines/recapture",
 
-  "/app/imports": "/app/campaigns/import",
-  "/app/imports/prices": "/app/campaigns/import",
+  "/app/imports": FROM_A_FILE,
+  "/app/imports/prices": FROM_A_FILE,
+
+  // And the page those three used to land on.
+  //
+  // #445 made a spreadsheet one of the ways prices change rather than a door of its own:
+  // a merchant who wants "these exact prices from this file" and one who wants "20% off
+  // this collection" were being sent to two places to make the same object. The import's
+  // action, parsing, dry run and error reporting are unchanged — it is the *entrance*
+  // that moved, and this route still serves the form's POST.
+  //
+  // The three above were repointed rather than left aimed here: `/app/imports/prices` →
+  // `/app/campaigns/import` → the editor is the two-hop chain this file's test forbids.
+  "/app/campaigns/import": FROM_A_FILE,
   "/app/imports/baselines": "/app/prices/baselines",
   "/app/imports/costs": "/app/prices/costs",
   "/app/imports/recapture": "/app/prices/baselines/recapture",

--- a/app/lib/ui/amount-currency.test.ts
+++ b/app/lib/ui/amount-currency.test.ts
@@ -26,7 +26,9 @@ const EDITOR = sourceOf("app/routes/app.campaigns.new.tsx");
 
 describe("nothing labels an amount from the sorted list", () => {
   it("passes the shop's own currency to the amount field", () => {
-    expect(EDITOR).toContain("<RuleValueField currency={baseCurrency} />");
+    // Across lines: the component took two more props when a spreadsheet became one of
+    // the ways prices change, so it is no longer written on one.
+    expect(EDITOR).toMatch(/<RuleValueField[\s\S]{0,120}currency=\{baseCurrency\}/);
   });
 
   it("never indexes the sorted currency list", () => {

--- a/app/lib/ui/editor-layout.test.ts
+++ b/app/lib/ui/editor-layout.test.ts
@@ -74,7 +74,11 @@ describe("the rule is what a merchant meets first", () => {
     // Sami by picking the field to edit — because it is the decision that was already
     // made before the page loaded.
     expect(at('headings.rule')).toBeLessThan(at('headings.scope'));
-    expect(at('name="name"'), "the campaign's name is below the scope again").toBeLessThan(
+    // `<CampaignNameField`, not `name="name"`. The field moved into a component when it
+    // grew a counter, and the spreadsheet path has a `name="name"` of its own further
+    // down the file — so matching the attribute now finds the wrong one and would pass
+    // or fail for reasons unrelated to the order these sections are in.
+    expect(at("<CampaignNameField"), "the campaign's name is below the scope again").toBeLessThan(
       at('name="collection"'),
     );
     expect(at("<RuleValueField")).toBeLessThan(at('name="collection"'));

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -152,15 +152,15 @@ export default function Campaigns() {
       <TabBar
         label="Campaign views"
         action={
-          // Two ways in, one of them black. A spreadsheet of exact prices creates a
-          // campaign just as a rule does -- it was filed under an "Imports" nav item,
-          // which read as a fourth kind of import rather than as the second way to start
-          // a sale. Secondary, not primary: most campaigns are a rule, and two black
-          // buttons is two answers to "what should I do next".
+          // One way in.
+          //
+          // There were two, and the second was the last of the "Imports" thinking: a
+          // spreadsheet of exact prices creates a campaign exactly as a rule does, so
+          // "From a spreadsheet" was a second door to the same object — and a merchant
+          // had to know which of their two intentions the app had filed their case under
+          // before they could start. It is an option inside the editor now (#445), which
+          // is where the question "how should prices change" is actually asked.
           <ActionRow>
-            <s-button variant="secondary" icon="import" href="/app/campaigns/import">
-              From a spreadsheet
-            </s-button>
             <s-button variant="primary" href="/app/campaigns/new">
               Create campaign
             </s-button>

--- a/app/routes/app.campaigns.import.tsx
+++ b/app/routes/app.campaigns.import.tsx
@@ -1,267 +1,28 @@
 /**
- * A campaign made from a spreadsheet.
+ * `/app/campaigns/import` moved into the campaign editor.
  *
- * This lived at `/app/imports/prices` under a nav item of its own, and the first line of
- * its own doc comment said why that was wrong: **the file does not set prices — it
- * creates a campaign that does.** That is not ceremony. It is what gives an import a
- * preview, guardrails, rounding, market surfaces and a revert, all of which a direct
- * write would have had none of, on the one path where a merchant most needs them.
+ * #445 made a spreadsheet one of the ways prices change rather than a door of its own: a
+ * merchant who wants "these exact prices from this file" and one who wants "20% off this
+ * collection" were being sent to two places to make the same object. We had already
+ * learned that once — #416 dissolved the Imports nav item on the rule that a nav item is
+ * a noun — and this page surviving as a button on the campaigns index was the same
+ * mistake one size smaller.
  *
- * A flow whose entire output is a campaign belongs with campaigns. Filed under "Imports"
- * it read as a fourth kind of import beside baselines and costs, which are genuinely
- * different things — they write reference data, this one starts a sale.
+ * Kept because this URL is linked from runbooks and whatever a merchant bookmarked. The
+ * POST it used to serve lives at `/app/price-import`, unchanged.
  *
- * The list of files a shop has imported comes with it, for the same reason: a campaign
- * can price *from* an import, so "which file is this campaign reading?" is a question
- * about campaigns. `price_imports` had recorded every one since the feature shipped and
- * nothing displayed them until #351; that page's whole content is below the form now.
- *
- * Baselines and costs record no import row. A real gap rather than an omission here, and
- * still said out loud rather than papered over.
+ * Authenticates before redirecting rather than leaving it to the destination: an embedded
+ * route reached without a session has to go through OAuth, and doing that here means the
+ * merchant lands on the editor rather than bouncing off a second redirect.
  */
 
-import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
-import { redirect, useFetcher, useLoaderData } from "react-router";
-import { boundary } from "@shopify/shopify-app-react-router/server";
+import type { LoaderFunctionArgs } from "react-router";
+import { redirect } from "react-router";
 
 import { authenticate } from "../shopify.server";
-import { ensureShop } from "../services/shop.server";
-import { shopCurrency } from "../services/settings.server";
-import {
-  importedVariantGids,
-  importPrices,
-  type PriceImportResult,
-} from "../services/price-import.server";
-import { createCampaign } from "../services/campaigns/index.server";
-import { linesOf } from "../lib/reporting/lines";
-import { actorFor } from "../lib/audit/actor";
-import { RouteBoundary } from "../components/RouteBoundary";
-import { withGuard } from "../lib/errors/guard.server";
-import prisma from "../db.server";
-import { PageShell } from "../components/PageShell";
-import { formatCount, formatWhen } from "../lib/format/display";
-import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
-import { EmptyState } from "../components/AsyncState";
-import { HelpNote } from "../components/HelpNote";
-import { isCommit } from "../lib/imports/intent";
-import {
-  ImportForm,
-  ImportReport,
-  type ImportProblem,
-} from "../components/imports/ImportForm";
+import { LEGACY_ROUTES } from "../lib/routing/legacy-routes";
 
-export const loader = withGuard("/app/campaigns/import", async ({ request }: LoaderFunctionArgs) => {
-  const { session } = await authenticate.admin(request);
-  const shop = await ensureShop(session.shop);
-
-  const imports = await prisma.priceImport.findMany({
-    where: { shopId: shop.id },
-    orderBy: { createdAt: "desc" },
-    take: ROWS_PER_VIEW,
-    select: {
-      id: true,
-      name: true,
-      currency: true,
-      rowsRead: true,
-      rowsMatched: true,
-      createdBy: true,
-      createdAt: true,
-    },
-  });
-
-  return {
-    currency: await shopCurrency(shop.id),
-    timeZone: shop.timezone,
-    imports: imports.map((row) => ({
-      ...row,
-      // `formatWhen`, not a second call to toLocaleString: the locale is centralised
-      // there, and a page that picks its own drifts from every other page's dates.
-      createdAt: formatWhen(row.createdAt, shop.timezone),
-    })),
-  };
-});
-
-type ActionData = { ok: boolean; message: string; result?: PriceImportResult };
-
-export const action = withGuard("/app/campaigns/import", async ({ request }: ActionFunctionArgs) => {
-  const { session, sessionToken } = await authenticate.admin(request);
-  const shop = await ensureShop(session.shop);
-  const form = await request.formData();
-
-  const currency = await shopCurrency(shop.id);
-  const dryRun = !isCommit(form.get("intent"));
-  const name = String(form.get("name") ?? "Imported prices").trim() || "Imported prices";
-  const actor = actorFor(sessionToken, session.shop);
-
-  const result = await importPrices(
-    shop.id,
-    name,
-    linesOf(String(form.get("csv") ?? "")),
-    currency,
-    { dryRun, actor },
-  );
-
-  if (dryRun || !result.importId) {
-    return {
-      ok: true,
-      result,
-      message: `${result.ready} of ${result.total} rows matched a product. Nothing has been created yet.`,
-    };
-  }
-
-  // Frozen to exactly the variants the file named. A dynamic filter would let products
-  // added later fall into a campaign whose rule can say nothing about them.
-  const gids = await importedVariantGids(result.importId);
-  const segment = await prisma.segment.create({
-    data: {
-      shopId: shop.id,
-      name: `${name} (imported)`,
-      kind: "FROZEN",
-      filterAst: { groups: [] } as never,
-      frozenVariantGids: gids,
-    },
-  });
-
-  const campaign = await createCampaign(shop.id, {
-    name,
-    ast: { groups: [] },
-    segmentId: segment.id,
-    rule: { kind: "from-import", importId: result.importId },
-    compareAtPolicy: { kind: "leave" },
-    rounding: { default: "none", byCurrency: {} },
-  });
-
-  // Straight to the preview. The whole argument for routing an import through a campaign
-  // is that the merchant sees what it will do before it does it.
-  return redirect(`/app/campaigns/${campaign.id}`);
-});
-
-export default function ImportPrices() {
-  const { currency, imports, timeZone } = useLoaderData<typeof loader>();
-  const fetcher = useFetcher<ActionData>();
-  const busy = fetcher.state !== "idle";
-  const result = fetcher.data?.result;
-
-  const problems: ImportProblem[] = result
-    ? [
-        ...result.invalid.map((p) => ({ ...p, kind: "Will not parse" })),
-        ...result.unmatched.map((p) => ({ ...p, kind: "No match" })),
-        ...result.ambiguous.map((p) => ({ ...p, kind: "Matches several" })),
-        ...result.duplicates.map((p) => ({ ...p, kind: "Listed twice" })),
-      ].sort((a, b) => a.line - b.line)
-    : [];
-
-  return (
-    <PageShell heading="Import prices" backTo={{ href: "/app/campaigns", label: "Campaigns" }}>
-      {fetcher.data ? (
-        <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
-          <s-paragraph>{fetcher.data.message}</s-paragraph>
-        </s-banner>
-      ) : null}
-
-      <ImportForm
-        heading="Set prices from a spreadsheet"
-        fetcher={fetcher}
-        busy={busy}
-        ready={result?.ready ?? null}
-        commitLabel={(ready) => `Create a campaign from ${formatCount(ready)} rows`}
-        placeholder={"Variant SKU,Variant Price\nCH-1,129.00\nCH-2,149.00"}
-        description={
-          <>
-            <s-paragraph>
-              <s-text>
-                This creates a campaign rather than changing prices straight away. You get
-                a preview of every product first, your guardrails still apply, and you can
-                undo the whole thing in one click &mdash; none of which a direct import
-                would give you.
-              </s-text>
-            </s-paragraph>
-            <s-paragraph>
-              <s-text>
-                One row per variant: a SKU, barcode or variant ID, then the price. Prices
-                are read in {currency} and must be plain numbers. A Matrixify export works
-                as it is.
-              </s-text>
-            </s-paragraph>
-          </>
-        }
-      >
-        <s-text-field name="name" label="Call this" value="Imported prices" />
-      </ImportForm>
-
-      <s-section heading="Price files you have imported">
-        {imports.length === 0 ? (
-          <EmptyState
-            title="Nothing imported yet"
-            description="Every file you import is recorded here with its row counts and who ran it, so you can always answer which file a campaign is pricing from."
-          />
-        ) : (
-          <>
-            <s-table>
-              <s-table-header-row>
-                <s-table-header listSlot="kicker">Imported</s-table-header>
-                <s-table-header listSlot="primary">File</s-table-header>
-                <s-table-header listSlot="labeled" format="numeric">Rows read</s-table-header>
-                <s-table-header listSlot="secondary" format="numeric">
-                  Matched a variant
-                </s-table-header>
-                <s-table-header listSlot="labeled">By</s-table-header>
-              </s-table-header-row>
-              <s-table-body>
-                {imports.map((row) => (
-                  <s-table-row key={row.id}>
-                    <s-table-cell>{row.createdAt}</s-table-cell>
-                    <s-table-cell>
-                      {row.name} <s-text color="subdued">({row.currency})</s-text>
-                    </s-table-cell>
-                    <s-table-cell>{formatCount(row.rowsRead)}</s-table-cell>
-                    <s-table-cell>
-                      {/* The gap between these two is the number worth reading: rows
-                          that named a variant this shop does not have. */}
-                      {formatCount(row.rowsMatched)}
-                      {row.rowsMatched < row.rowsRead ? (
-                        <s-text tone="caution">
-                          {" "}
-                          · {formatCount(row.rowsRead - row.rowsMatched)} matched nothing
-                        </s-text>
-                      ) : null}
-                    </s-table-cell>
-                    <s-table-cell>{row.createdBy ?? "—"}</s-table-cell>
-                  </s-table-row>
-                ))}
-              </s-table-body>
-            </s-table>
-            <s-paragraph>
-              <s-text color="subdued">Times are your store&rsquo;s, in {timeZone}.</s-text>
-            </s-paragraph>
-          </>
-        )}
-      </s-section>
-
-      <HelpNote label="Only price files are listed">
-        <s-paragraph>
-          Baseline and cost imports do not record a file yet. Their results are shown when
-          you run them, on the pages they belong to.
-        </s-paragraph>
-      </HelpNote>
-
-      {result ? (
-        <ImportReport
-          heading={result.dryRun ? "What would happen" : "What happened"}
-          counts={[
-            { label: "Rows read", value: result.total },
-            { label: "Ready", value: result.ready },
-            { label: "Need attention", value: problems.length },
-          ]}
-          problems={problems}
-        />
-      ) : null}
-    </PageShell>
-  );
-}
-
-export const headers: HeadersFunction = (args) => boundary.headers(args);
-
-export function ErrorBoundary() {
-  return <RouteBoundary />;
-}
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  await authenticate.admin(request);
+  return redirect(LEGACY_ROUTES["/app/campaigns/import"]);
+};

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -9,7 +9,9 @@ import { facets } from "../services/segments.server";
 import { createCampaign } from "../services/campaigns/index.server";
 import { joinDateAndTime, localInputToUtc, type Schedule } from "../lib/scheduling/window";
 import { presetStartFor } from "../lib/scheduling/calendar";
-import { formatClock, formatDay } from "../lib/format/display";
+import { formatClock, formatCount, formatDay, formatWhen } from "../lib/format/display";
+import { PriceImportHistory } from "../components/imports/PriceImportHistory";
+import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { describeAdjustment } from "../lib/markets/describe";
 import {
   profileNameFor,
@@ -36,7 +38,14 @@ import {
 import { PageSections, PageShell } from "../components/PageShell";
 import { UnsavedChanges } from "../components/UnsavedChanges";
 import { DraftPreview } from "../components/DraftPreview";
-import { RuleValueField } from "../components/RuleValueField";
+import { FROM_FILE, RuleValueField } from "../components/RuleValueField";
+import { DRAFT_DEFAULTS } from "../lib/campaigns/draft-defaults";
+import {
+  ImportForm,
+  ImportReport,
+  type ImportProblem,
+} from "../components/imports/ImportForm";
+import type { PriceImportResult } from "../services/price-import.server";
 import { FieldGrid, FullRow } from "../components/FieldGrid";
 import { HelpNote } from "../components/HelpNote";
 import { firstPreviewParams } from "../lib/campaigns/first-preview";
@@ -63,7 +72,7 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
       })
     : null;
 
-  const [available, segments, priceLists, settings, currency, shopRecord] =
+  const [available, segments, priceLists, settings, currency, shopRecord, priceImports] =
     await Promise.all([
     facets(shop.id),
     prisma.segment.findMany({
@@ -96,6 +105,24 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
         subscriptionStatus: true,
         trialEndsAt: true,
         developerStore: true,
+      },
+    }),
+    // The files this shop has already imported, for the spreadsheet option. One indexed
+    // read alongside six others — cheap enough not to be worth loading conditionally,
+    // and loading it on demand would mean a table that appears a beat after the option
+    // that reveals it.
+    prisma.priceImport.findMany({
+      where: { shopId: shop.id },
+      orderBy: { createdAt: "desc" },
+      take: ROWS_PER_VIEW,
+      select: {
+        id: true,
+        name: true,
+        currency: true,
+        rowsRead: true,
+        rowsMatched: true,
+        createdBy: true,
+        createdAt: true,
       },
     }),
   ]);
@@ -170,6 +197,17 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
     guided,
     // Set when the merchant arrived by clicking a day on the calendar.
     presetStart: presetStartFor(url.searchParams.get("startAt")),
+    // Which way prices change, when a link says so. Four old import URLs redirect here
+    // with `ruleKind=from-file`, and a merchant following one of them should land on the
+    // file, not on a percentage.
+    initialRuleKind:
+      url.searchParams.get("ruleKind") === FROM_FILE ? FROM_FILE : DRAFT_DEFAULTS.ruleKind,
+    priceImports: priceImports.map((row) => ({
+      ...row,
+      // `formatWhen`, not a second call to toLocaleString: the locale is centralised
+      // there, and a page that picks its own drifts from every other page's dates.
+      createdAt: formatWhen(row.createdAt, shop.timezone),
+    })),
     selected: {
       collection: url.searchParams.get("collection") ?? "",
       tag: url.searchParams.get("tag") ?? "",
@@ -279,6 +317,8 @@ export default function NewCampaign() {
     guided,
     timeZone,
     timeZoneNow,
+    initialRuleKind,
+    priceImports,
     priceLists,
     currencies,
     storeRounding,
@@ -306,6 +346,23 @@ export default function NewCampaign() {
    * send a merchant to a different campaign than the one they were reading about.
    */
   const [fullPreviewHref, setFullPreviewHref] = useState<string | undefined>(undefined);
+
+  /**
+   * Which way prices change, held here because two sections depend on the answer.
+   *
+   * A file carries every price it sets, so there is no scope to choose and no amount to
+   * enter — and leaving those on screen inert would be worse than a second page, which is
+   * what this replaced. #445.
+   */
+  const [ruleKind, setRuleKind] = useState<string>(initialRuleKind);
+  const fromFile = ruleKind === FROM_FILE;
+
+  // Its own fetcher, posting to the import route. Sharing the editor's would mean one
+  // `state` for two very different submissions, so a dry run in flight would put the
+  // create button into a loading state it never leaves.
+  const importFetcher = useFetcher<{ result?: PriceImportResult }>();
+  const importResult = importFetcher.data?.result;
+  const importProblems = problemsFrom(importResult);
 
   const submitPreview = useCallback(() => {
     const form = formRef.current;
@@ -440,8 +497,18 @@ export default function NewCampaign() {
                   adjustment and its amount — as a fragment, so as bare grid children they
                   land side by side, which is the pair a merchant reads as one decision.
                   Inside a `FullRow` they would both go in one cell and stack. */}
-              <RuleValueField currency={baseCurrency} />
+              <RuleValueField
+                currency={baseCurrency}
+                kind={ruleKind}
+                onKindChange={setRuleKind}
+              />
 
+              {/* Everything below is about arithmetic on a baseline, and a file has
+                  none — it names a price per variant. Rendered inert they would be four
+                  controls a merchant sets and the import ignores, which is exactly the
+                  confusion having two pages caused. */}
+              {fromFile ? null : (
+                <>
               <s-select name="compareAt" label="Compare-at price">
                 <s-option value="set-to-baseline" defaultSelected>
                   Set to baseline (shows a strike-through)
@@ -469,6 +536,8 @@ export default function NewCampaign() {
                   </s-option>
                 ))}
               </s-select>
+                </>
+              )}
             </FieldGrid>
 
             {/* What "from the baseline" means, next to the field that says it.
@@ -479,14 +548,25 @@ export default function NewCampaign() {
                 sentence is the consequence, which is the part that sells it: every
                 competitor computes from the live price, which is why RUBIX's own FAQ has
                 to explain that running two sales leaves a product wrong for ever. */}
-            <s-paragraph>
-              <s-text color="subdued">
-                Changes are computed from each variant&rsquo;s <s-text type="strong">baseline</s-text> —
-                the price it would be if no campaign were running — never from what the
-                storefront shows today. So running this campaign twice gives the same
-                result as running it once.
-              </s-text>
-            </s-paragraph>
+            {fromFile ? (
+              <s-paragraph>
+                <s-text color="subdued">
+                  A spreadsheet sets each price directly, so there is no baseline
+                  arithmetic and no scope to choose — the file names the variants. It
+                  still becomes a campaign, which is what gives it a preview, your
+                  guardrails and a one-click revert.
+                </s-text>
+              </s-paragraph>
+            ) : (
+              <s-paragraph>
+                <s-text color="subdued">
+                  Changes are computed from each variant&rsquo;s{" "}
+                  <s-text type="strong">baseline</s-text> — the price it would be if no
+                  campaign were running — never from what the storefront shows today. So
+                  running this campaign twice gives the same result as running it once.
+                </s-text>
+              </s-paragraph>
+            )}
 
             {/* What this rule does to prices, from the same resolver the run uses --
                 not an estimate of it. Sits with the rule rather than at the bottom of
@@ -494,7 +574,7 @@ export default function NewCampaign() {
                 the merchant is still deciding. With the rarely-touched settings moved to
                 the end, it now lands directly under the rule it is previewing. */}
 
-            {priceLists.length > 0 ? (
+            {!fromFile && priceLists.length > 0 ? (
               <>
                 <s-divider />
 
@@ -578,6 +658,14 @@ export default function NewCampaign() {
               </>
             ) : null}
 
+            {/* Everything from here to the submit belongs to the rule path.
+                
+                A file import creates its campaign through its own two-phase flow — dry
+                run, then commit — so a schedule, a priority and a tag kit set here would
+                be silently discarded. The import block below has the submit for that
+                path. */}
+            {fromFile ? null : (
+              <>
             <s-divider />
 
             <s-heading>Schedule (optional)</s-heading>
@@ -680,8 +768,15 @@ export default function NewCampaign() {
                 {practice ? "Preview it — nothing will be written" : "Create and preview"}
               </s-button>
             </ActionRow>
+              </>
+            )}
           </s-stack>
       </s-section>
+      {/* Not rendered at all, rather than rendered and ignored. A file names its own
+          variants — a frozen list of exactly the rows it matched — so a scope here would
+          be a control a merchant fills in and the import discards, which is the confusion
+          the second page caused in the first place. */}
+      {fromFile ? null : (
       <s-section heading={headings.scope}>
         <s-paragraph>
           Which variants the rule above applies to. Leave everything blank to target the
@@ -784,9 +879,72 @@ export default function NewCampaign() {
           </FullRow>
         </FieldGrid>
       </s-section>
+      )}
 
         </PageSections>
       </Form>
+
+      {/* Outside the form, and that is not a detail.
+          
+          A form cannot contain a form, and the import has one of its own — its two-phase
+          dry-run-then-commit is the guard that makes writing prices from a file safe, and
+          it posts to `/app/campaigns/import`, whose action, parsing and error reporting
+          are untouched by any of this. Rendering it here rather than reimplementing it is
+          the whole point: one door for the merchant, one code path for the prices. */}
+      {fromFile ? (
+        <ImportForm
+          heading="The file"
+          fetcher={importFetcher}
+          action="/app/price-import"
+          busy={importFetcher.state !== "idle"}
+          ready={importResult?.ready ?? null}
+          commitLabel={(ready) => `Create a campaign from ${formatCount(ready)} rows`}
+          template={{ href: "/app/campaigns/template.csv", label: "Get a template" }}
+          placeholder={`Variant SKU,Variant Price\nCH-1,129.00\nCH-2,149.00`}
+          description={
+            <s-paragraph>
+              <s-text>
+                One row per variant: a SKU, barcode or variant ID, then the price. Prices
+                are read in {baseCurrency} and must be plain numbers. A Matrixify export
+                works as it is. Checking the file changes nothing — you see what would
+                happen first.
+              </s-text>
+            </s-paragraph>
+          }
+        >
+          {/* The campaign's name, again, because this form posts on its own and the one
+              in the section above goes with the form it belongs to. */}
+          <s-text-field name="name" label="Call this" value={defaultName} />
+        </ImportForm>
+      ) : null}
+
+      {fromFile ? (
+        <>
+          <PriceImportHistory imports={priceImports} timeZone={timeZone} />
+
+          {/* Moved here with the table it qualifies. Said out loud rather than papered
+              over: the gap is real, and a merchant who imports a baseline file and then
+              looks for it in a list is owed the reason it is not there. */}
+          <HelpNote label="Only price files are listed">
+            <s-paragraph>
+              Baseline and cost imports do not record a file yet. Their results are shown
+              when you run them, on the pages they belong to.
+            </s-paragraph>
+          </HelpNote>
+        </>
+      ) : null}
+
+      {importResult ? (
+        <ImportReport
+          heading={importResult.dryRun ? "What would happen" : "What happened"}
+          counts={[
+            { label: "Rows read", value: importResult.total },
+            { label: "Ready", value: importResult.ready },
+            { label: "Need attention", value: importProblems.length },
+          ]}
+          problems={importProblems}
+        />
+      ) : null}
 
       {/* Beside the rule, not below it.
 
@@ -850,4 +1008,21 @@ function queryFrom(fields: FormData): string {
     if (value !== "") params.append(key, value);
   }
   return params.toString();
+}
+
+/**
+ * Every row the import could not use, in the order they appear in the file.
+ *
+ * Sorted by line rather than grouped by kind, because a merchant fixing a spreadsheet
+ * works down it — and the four categories are already named on each row.
+ */
+function problemsFrom(result: PriceImportResult | undefined): ImportProblem[] {
+  if (!result) return [];
+
+  return [
+    ...result.invalid.map((problem) => ({ ...problem, kind: "Will not parse" })),
+    ...result.unmatched.map((problem) => ({ ...problem, kind: "No match" })),
+    ...result.ambiguous.map((problem) => ({ ...problem, kind: "Matches several" })),
+    ...result.duplicates.map((problem) => ({ ...problem, kind: "Listed twice" })),
+  ].sort((a, b) => a.line - b.line);
 }

--- a/app/routes/app.campaigns.template[.csv].tsx
+++ b/app/routes/app.campaigns.template[.csv].tsx
@@ -1,0 +1,50 @@
+/**
+ * The starter file for a price import.
+ *
+ * All three competitors offer one, and it is the difference between "paste a CSV" and a
+ * merchant guessing at column names — which is the failure that produces a file where
+ * every row matched nothing, after they have already exported it from their own system.
+ *
+ * A route rather than a static asset, because the currency in the example has to be the
+ * shop's own: a US merchant shown `129.00` and a Japanese merchant shown `129.00` are
+ * being told different things, and only one of them is true. Nothing here is a real
+ * price — the SKUs are obviously placeholders — so this is a template, not data.
+ *
+ * The `[.csv]` in the filename is React Router's escape for a literal dot in a flat
+ * route, so the path is `/app/campaigns/template.csv` and the browser saves something
+ * with an extension a spreadsheet will open.
+ */
+
+import type { LoaderFunctionArgs } from "react-router";
+
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { shopCurrency } from "../services/settings.server";
+import { isZeroDecimal } from "../lib/money/currency";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const currency = await shopCurrency(shop.id);
+
+  // Whole numbers where the currency has no sub-unit. A template showing "129.00" to a
+  // JPY store teaches a merchant to write a column the importer will reject on every row.
+  const example = (major: number) => (isZeroDecimal(currency) ? `${major}` : `${major}.00`);
+
+  const rows = [
+    "Variant SKU,Variant Price",
+    `EXAMPLE-1,${example(129)}`,
+    `EXAMPLE-2,${example(149)}`,
+    `EXAMPLE-3,${example(99)}`,
+  ];
+
+  return new Response(`${rows.join("\n")}\n`, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="price-import-template-${currency}.csv"`,
+      // Not cached: the currency comes from the shop, and a cached copy would hand a
+      // second store the first one's example.
+      "Cache-Control": "no-store",
+    },
+  });
+};

--- a/app/routes/app.price-import.tsx
+++ b/app/routes/app.price-import.tsx
@@ -1,0 +1,86 @@
+/**
+ * The POST a price import makes.
+ *
+ * A resource route rather than an action on the campaign editor, for the reason
+ * `app.preview-draft.tsx` gives about its own: the editor's action creates a campaign
+ * from a rule, and a second submit target on the same route is one misrouted request away
+ * from creating the wrong thing. It is also why the URL is outside `/app/campaigns/*` —
+ * `app.campaigns.$id` would otherwise read `import` as a campaign id.
+ *
+ * #445 moved the *entrance*. Everything here is unchanged: the two-phase
+ * dry-run-then-commit, the parsing, the per-row error reporting, and the rule that a
+ * missing intent falls safe. That is the guard which makes writing prices from a file
+ * survivable, and the editor posts here rather than reimplementing any of it.
+ *
+ * The campaign it creates is the point. The file does not set prices — it creates a
+ * campaign that does, which is what gives an import a preview, guardrails, rounding,
+ * market surfaces and a revert, none of which a direct write would have had.
+ */
+
+import type { ActionFunctionArgs } from "react-router";
+import { redirect } from "react-router";
+
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+import { ensureShop } from "../services/shop.server";
+import { shopCurrency } from "../services/settings.server";
+import { importedVariantGids, importPrices } from "../services/price-import.server";
+import { createCampaign } from "../services/campaigns/index.server";
+import { linesOf } from "../lib/reporting/lines";
+import { actorFor } from "../lib/audit/actor";
+import { withGuard } from "../lib/errors/guard.server";
+import { isCommit } from "../lib/imports/intent";
+
+export const action = withGuard("/app/price-import", async ({ request }: ActionFunctionArgs) => {
+  const { session, sessionToken } = await authenticate.admin(request);
+  const shop = await ensureShop(session.shop);
+  const form = await request.formData();
+
+  const currency = await shopCurrency(shop.id);
+  const dryRun = !isCommit(form.get("intent"));
+  const name = String(form.get("name") ?? "Imported prices").trim() || "Imported prices";
+  const actor = actorFor(sessionToken, session.shop);
+
+  const result = await importPrices(
+    shop.id,
+    name,
+    linesOf(String(form.get("csv") ?? "")),
+    currency,
+    { dryRun, actor },
+  );
+
+  if (dryRun || !result.importId) {
+    return {
+      ok: true,
+      result,
+      message: `${result.ready} of ${result.total} rows matched a product. Nothing has been created yet.`,
+    };
+  }
+
+  // Frozen to exactly the variants the file named. A dynamic filter would let products
+  // added later fall into a campaign whose rule can say nothing about them.
+  const gids = await importedVariantGids(result.importId);
+  const segment = await prisma.segment.create({
+    data: {
+      shopId: shop.id,
+      name: `${name} (imported)`,
+      kind: "FROZEN",
+      filterAst: { groups: [] } as never,
+      frozenVariantGids: gids,
+    },
+  });
+
+  const campaign = await createCampaign(shop.id, {
+    name,
+    ast: { groups: [] },
+    segmentId: segment.id,
+    rule: { kind: "from-import", importId: result.importId },
+    compareAtPolicy: { kind: "leave" },
+    rounding: { default: "none", byCurrency: {} },
+  });
+
+  // Straight to the preview. The whole argument for routing an import through a campaign
+  // is that the merchant sees what it will do before it does it.
+  return redirect(`/app/campaigns/${campaign.id}`);
+});
+


### PR DESCRIPTION
The campaigns index had two buttons. "Create campaign" and "From a spreadsheet" made **the same object**, so a merchant had to know which of their two intentions the app had filed their case under before they could start.

We had already learned this once: #416 dissolved the Imports nav item on the rule that a nav item is a noun. The page surviving as a button was the same mistake one size smaller.

## The change

A file is an answer to "how should prices change", so it is an option in that select — which is also now labelled with the question instead of "Adjustment".

Choosing it **removes the scope section** rather than leaving it inert: a file names its own variants, and a scope a merchant fills in and the import discards is exactly the confusion the second page caused. The same argument removes compare-at, rounding, markets, the schedule and the priority — none of which the import's flow reads.

The index has one button now.

## None of the safety moved

The two-phase dry-run-then-commit, the parsing, the per-row error reporting and the rule that a missing intent falls safe are what make writing prices from a file survivable. The editor **posts to them** rather than growing its own.

That action is now a resource route at `/app/price-import`, for the reason `app.preview-draft.tsx` gives about its own: the editor's action creates a campaign from a rule, and a second submit target on one route is one misrouted request away from creating the wrong thing. (It also has to sit outside `/app/campaigns/*`, or `app.campaigns.$id` reads `import` as a campaign id.)

## URLs

Four old URLs — including `/app/campaigns/import` itself — open the editor on the file, and the editor reads `?ruleKind=from-file` so a bookmark lands on the file rather than on a percentage. They were **repointed**, not aimed at each other: `/app/imports/prices` → `/app/campaigns/import` → the editor is the two-hop chain `legacy-routes.test.ts` forbids.

## Two smaller things

- **`Get a template`**, beside the drop zone where somebody looking for where to put a file actually is. A route rather than a static asset, because the example has to be in the shop's own currency — a template showing `129.00` to a JPY store teaches a merchant to write a column the importer rejects on every row.
- **The import history travelled with the entrance**, as its own component. `price_imports` was written since the feature shipped and read by nothing until #351; losing it in a restructure would put it straight back.

## Verification

typecheck, lint (cache cleared), build, full suite **2671 passed**. Mutations caught: the scope hidden on every path, the import posting to the editor's own action, the dry-run guard spelled out again instead of going through `isCommit`, and an old URL redirecting into a redirect.

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)