### PR TITLE
One counter on the campaign name, not two (#492)

### DIFF
--- a/app/components/campaign/CampaignNameField.tsx
+++ b/app/components/campaign/CampaignNameField.tsx
@@ -4,41 +4,33 @@
  * Sami prefills `New task` and shows `8/100`; NA prefills a timestamped title and says
  * "This title is just for internal use, customers won't see it". Both are answering the
  * same two questions a merchant has about the first field on the page: does this matter,
- * and how much can I write. Ours prefilled and explained, and left the second unanswered
- * — so a merchant typing a long, useful name had no idea whether it would be accepted
- * until they submitted.
+ * and how much can I write. Ours prefilled and explained, and left the second unanswered.
  *
- * ## Why the counter is client state
+ * ## The counter is Polaris', not ours
  *
- * There is no server round trip that could produce it, and the alternative — a static
- * "maximum 100 characters" — tells somebody who is already over the limit nothing about
- * how far. The field stays uncontrolled: `value` seeds it and `onInput` only reads the
- * length, so React is never the authority on what is in the box. A controlled Polaris
- * field would need every keystroke to survive a re-render to keep the cursor where the
- * merchant left it.
+ * `maxLength` is all it takes: the field renders `17/100` at its trailing edge itself.
+ * This component briefly kept its own count in React state and put it in the help text,
+ * which rendered *both* — the same number twice, three centimetres apart, one of them
+ * inside the box and one at the end of a sentence about storefront tags. It looked like a
+ * bug because it was one. Only visible by opening the page: the markup serialises fine
+ * and no test can see two counters and know they are the same counter.
  */
-
-import { useState } from "react";
 
 /**
  * Long enough for "Black Friday · outerwear · US and CA only", short enough that the
  * campaigns index does not become one column. Not a database constraint — `name` is
- * `String` — so this is a kindness, not a rule, and the counter says so by counting up
- * rather than warning.
+ * `String` — so this is a kindness rather than a rule.
  */
 export const NAME_LIMIT = 100;
 
 export function CampaignNameField({ defaultName }: { defaultName: string }) {
-  const [length, setLength] = useState(defaultName.length);
-
   return (
     <s-text-field
       name="name"
       label="Campaign name"
       value={defaultName}
       maxLength={NAME_LIMIT}
-      onInput={(event) => setLength((event.target as HTMLInputElement).value.length)}
-      details={`For you and your team — customers never see it. Use the storefront tags below if you want your theme to badge the sale. ${length}/${NAME_LIMIT}`}
+      details="For you and your team — customers never see it. Use the storefront tags below if you want your theme to badge the sale."
       required
     />
   );

--- a/app/lib/ui/editor-layout.test.ts
+++ b/app/lib/ui/editor-layout.test.ts
@@ -110,8 +110,14 @@ describe("the rule is what a merchant meets first", () => {
     expect(field).toMatch(/customers never see it/i);
     // The counter: "how much can I write" is the other question the first field on the
     // page raises, and a static maximum tells somebody already over it nothing.
-    expect(field).toContain("maxLength");
-    expect(field).toContain("${length}/${NAME_LIMIT}");
+    //
+    // `maxLength` and nothing else. Polaris renders the count itself, and a second one in
+    // the help text put the same number on screen twice — which only opening the page
+    // showed, because the markup serialises fine either way.
+    expect(field).toContain("maxLength={NAME_LIMIT}");
+    expect(field, "Polaris already counts; a second counter renders the number twice").not.toMatch(
+      /\$\{[^}]*length[^}]*\}\/\$\{NAME_LIMIT\}/,
+    );
   });
 
   it("previews the rule beside it, in the aside, rather than under it", () => {


### PR DESCRIPTION
#455 gave the campaign name field a counter and it rendered **twice**: Polaris draws `17/100` at the field's trailing edge from `maxLength`, and the component also interpolated its own count into the `details` string — the same number three centimetres apart, once inside the box and once at the end of a sentence about storefront tags.

Only visible by opening the deployed page. The markup serialises fine either way, and no unit test can see two counters and know they are the same counter. This is the fourth regression this pass that survived the whole suite and died on first sight of the real page.

Deleting ours removes the component's client state entirely — `maxLength` was always the whole feature. The layout guard now refuses a hand-rolled `${length}/${NAME_LIMIT}` in the help text.

typecheck, lint, build, full suite **2671 passed**.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)