### PR TITLE
The spreadsheet option: the select and the page now agree (#494)

### DIFF
--- a/app/components/RuleValueField.tsx
+++ b/app/components/RuleValueField.tsx
@@ -55,11 +55,26 @@ export function RuleValueField({
         label="How should prices change?"
         onChange={(event) => onKindChange(String(event.currentTarget.value))}
       >
-        <s-option value={DRAFT_DEFAULTS.ruleKind} defaultSelected>
+        {/* Selected from `kind`, not hardcoded onto the first option.
+        
+            Four old import URLs open this page with `?ruleKind=from-file`, and with the
+            default pinned here the page did the right thing — no scope, the file section
+            below — while this select went on reading "Percent change from baseline". A
+            control that disagrees with the page it controls is worse than either state:
+            the merchant cannot tell which one is lying. Only visible by opening the
+            page. */}
+        <s-option
+          value={DRAFT_DEFAULTS.ruleKind}
+          defaultSelected={kind === DRAFT_DEFAULTS.ruleKind}
+        >
           Percent change from baseline
         </s-option>
-        <s-option value="fixed-change">Fixed change from baseline</s-option>
-        <s-option value="set-exact">Set an exact price</s-option>
+        <s-option value="fixed-change" defaultSelected={kind === "fixed-change"}>
+          Fixed change from baseline
+        </s-option>
+        <s-option value="set-exact" defaultSelected={kind === "set-exact"}>
+          Set an exact price
+        </s-option>
         {/* A file is a way prices change, not a different door.
             
             #416 dissolved the Imports nav item on the rule that a nav item is a noun; the
@@ -67,7 +82,9 @@ export function RuleValueField({
             one size smaller — two merchants wanting the same object, sent through two
             doors. A spreadsheet is an answer to "how should prices change", so it is an
             option here. */}
-        <s-option value={FROM_FILE}>From a spreadsheet</s-option>
+        <s-option value={FROM_FILE} defaultSelected={kind === FROM_FILE}>
+          From a spreadsheet
+        </s-option>
       </s-select>
 
       {kind === FROM_FILE ? null : money ? (

--- a/app/lib/campaigns/from-file.test.ts
+++ b/app/lib/campaigns/from-file.test.ts
@@ -24,7 +24,7 @@ const RESOURCE = sourceOf("app/routes/app.price-import.tsx");
 
 describe("the choice", () => {
   it("offers a file among the ways prices change", () => {
-    expect(FIELD).toContain(`<s-option value={FROM_FILE}>`);
+    expect(FIELD).toContain("<s-option value={FROM_FILE}");
     expect(FIELD).toContain("How should prices change?");
   });
 
@@ -47,6 +47,24 @@ describe("choosing it", () => {
     // the import's own flow does not read.
     expect(EDITOR).toContain("{fromFile ? null : (");
     expect(EDITOR).toContain("{!fromFile && priceLists.length > 0 ?");
+  });
+
+  it("shows the option it is actually on", () => {
+    // The default used to be pinned to the first option, so a link carrying
+    // `?ruleKind=from-file` produced a page with no scope and a file section whose select
+    // still read "Percent change from baseline". A control that disagrees with the page
+    // it controls is worse than either state — the merchant cannot tell which is lying.
+    expect(FIELD).toContain("defaultSelected={kind === FROM_FILE}");
+    expect(FIELD, "the first option must not be selected regardless of the kind").not.toMatch(
+      /<s-option[^>]*value=\{DRAFT_DEFAULTS\.ruleKind\} defaultSelected>/,
+    );
+  });
+
+  it("hides the rule preview, which would be pricing a rule that is not there", () => {
+    // The panel prices the draft's arithmetic. With a file chosen there is none, so it
+    // renders whatever the controls said before the merchant switched — "3,669 of 3,669
+    // variants would change price" beside a form that will do nothing of the kind.
+    expect(EDITOR).toContain('{fromFile ? null : (\n      <s-section slot="aside"');
   });
 
   it("shows the file, the history and a template", () => {

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -956,7 +956,14 @@ export default function NewCampaign() {
           It is `resolve()`, not an estimate of it: the same planner, the same baselines,
           the draft resolved alongside the shop's other ACTIVE campaigns. The loader
           primes it so the panel arrives populated, and the fetcher replaces it from the
-          first keystroke onward. */}
+          first keystroke onward.
+
+          Not on the spreadsheet path. The panel prices the *rule* — and with a file
+          chosen there is no rule, so what it renders is the arithmetic of whatever the
+          controls said before the merchant switched: "3,669 of 3,669 variants would
+          change price" beside a form that will do nothing of the kind. The import has its
+          own report, and it is about the actual file. Found by opening the page. */}
+      {fromFile ? null : (
       <s-section slot="aside" heading="What this would do">
         <DraftPreview
           preview={previewFetcher.data ?? null}
@@ -971,6 +978,7 @@ export default function NewCampaign() {
           fullPreviewHref={fullPreviewHref}
         />
       </s-section>
+      )}
 
       <HelpNote label="Nothing is written yet">
         <s-paragraph>


### PR DESCRIPTION
Two bugs found by opening the deployed page after #445 merged.

**The select read one thing while the page did another.** `RuleValueField` pinned `defaultSelected` to the percent option, so a link carrying `?ruleKind=from-file` — what four old import URLs redirect to — produced a page that handled it correctly (no scope, file section rendered) with a control above it still reading "Percent change from baseline". A control that disagrees with the page it controls is worse than either state alone: the merchant cannot tell which one is lying about what the button will do.

**The rule preview kept pricing a rule that was not there.** The aside prices the draft's arithmetic. With a file chosen there is none, so it went on rendering whatever the controls said before the switch — *"3,669 of 3,669 variants would change price"*, with a table of before-and-after numbers, beside a form that will do nothing of the kind.

Neither is visible to a test that reads markup: both pages serialise fine, and the wrongness is in what the two halves say about each other. Fifth regression this pass that survived the suite and died on first sight of the real page.

Both pinned in `from-file.test.ts` and mutation-checked. typecheck, lint, build, full suite **2673 passed**.

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)