### PR TITLE
Rule 2 now describes the design it is supposed to protect (#299)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,12 @@ storefront, which is the failure mode the whole product exists to prevent.
 
 1. **Campaign math reads the baseline, never the live price.** Relative edits against live
    values are why competitors' campaigns compound and their reverts drift.
-2. **The web process never writes prices.** The worker is the only writer.
+2. **One writer per occurrence, whichever process it is.** A price write requires holding
+   the `campaign_runs` row for `(campaign, occurrence, kind)` — a unique index, so the
+   loser of the race defers rather than writing twice. The web process may write, and does:
+   Apply, Revert, Resume and both Flow actions run inline. What bounds that is
+   `MAX_INLINE_ROWS`, because a request that outlives its dyno leaves writes in flight with
+   nobody reading the result.
 3. **Ledger before write.** No Admin API price mutation without a `variant_changes` row
    already committed (invariant I4).
 4. **Preview and execution share one code path.** `resolve()` runs in both modes; a preview

--- a/app/services/campaigns/one-writer.test.ts
+++ b/app/services/campaigns/one-writer.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `CLAUDE.md` rule 2, pinned to what the code actually does.
+ *
+ * The rule used to read "The web process never writes prices. The worker is the only
+ * writer." That was false, and had been for a long time: Apply, Revert, Resume and both
+ * Flow actions call `runCampaign` inline from the web dyno. The design never assumed one
+ * writer *process* — it coordinates several, by making them race for a row.
+ *
+ * A stated invariant that is false is worse than none, because the next person reasons
+ * from it. That happened: #177 was told an undeployed worker meant "there is no writer",
+ * which was wrong.
+ *
+ * So the rule was rewritten to the invariant the code enforces, and this holds it there.
+ * Both halves are checked — the sentence in `CLAUDE.md` and the mechanism in the source —
+ * because the failure to guard against is not one of them changing. It is them drifting
+ * apart again, quietly, in either direction.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { rawSource, sourceFiles, sourceOf } from "../../lib/testing/source";
+
+const RUN = sourceOf("app/services/campaigns/run.server.ts");
+
+describe("the claim is what grants the right to write", () => {
+  it("takes the occurrence row before executing anything", () => {
+    // `campaignRun.create` is the claim: `(campaignId, occurrenceKey, kind)` is unique, so
+    // exactly one caller can hold it. Executing before taking it would let two processes
+    // write the same campaign's prices at once.
+    const claim = RUN.indexOf("prisma.campaignRun.create");
+    const execute = RUN.indexOf("await executeRows(");
+
+    expect(claim, "the run must claim its occurrence").toBeGreaterThan(-1);
+    expect(execute, "the run must execute rows").toBeGreaterThan(-1);
+    expect(claim, "writing before claiming is two processes on one campaign").toBeLessThan(
+      execute,
+    );
+  });
+
+  it("stands down instead of failing when it loses the race", () => {
+    // Losing must not look like a failure. It is what happens in the window after a Redis
+    // restart drops the leader lock, and a scheduler that reports a crash where it should
+    // report "already running" is a scheduler nobody can read.
+    expect(RUN).toContain("isOccurrenceTaken(error)");
+    expect(RUN).toContain("deferredTo");
+  });
+
+  it("keeps the uniqueness in the database, not in a check", () => {
+    // A read-then-create would have a window between the two. The schema is the guard.
+    expect(rawSource("prisma/schema.prisma")).toContain(
+      "@@unique([campaignId, occurrenceKey, kind])",
+    );
+  });
+});
+
+describe("nothing writes prices outside a claimed run", () => {
+  it("is the only caller of the executor", () => {
+    // `executeRows` is the function that talks to the Admin API about prices. Anything
+    // else calling it would be writing without a claim — and without the ledger rows and
+    // the read-back verification that `runCampaign` wraps it in.
+    const callers = sourceFiles("app", "chaos", "scripts").filter(
+      (file) =>
+        file !== "app/services/campaigns/execute.server.ts" &&
+        /\bexecuteRows\s*\(/.test(sourceOf(file)),
+    );
+
+    expect(callers, "only runCampaign may execute rows").toEqual([
+      "app/services/campaigns/run.server.ts",
+    ]);
+  });
+});
+
+describe("the rule in CLAUDE.md says this and not the old thing", () => {
+  const rules = rawSource("CLAUDE.md");
+
+  it("no longer claims the worker is the only writer", () => {
+    // The specific false sentence, so reinstating it fails here rather than misleading
+    // the next person to read the file.
+    expect(rules).not.toContain("The worker is the only writer");
+    expect(rules).not.toContain("The web process never writes prices");
+  });
+
+  it("states the invariant that is actually enforced", () => {
+    expect(rules).toContain("One writer per occurrence");
+    expect(rules).toContain("MAX_INLINE_ROWS");
+  });
+
+  it("names a bound that exists", () => {
+    // The rule points at the thing that makes web writing safe. If that constant is
+    // renamed or deleted, the rule is describing a guard the app no longer has.
+    expect(sourceOf("app/lib/execution/inline-budget.ts")).toContain(
+      "export const MAX_INLINE_ROWS",
+    );
+  });
+});


### PR DESCRIPTION
`CLAUDE.md` opened its architectural rules with *"The web process never writes prices. The worker is the only writer."* It has been false for a long time: Apply, Revert, Resume and both Flow actions call `runCampaign` inline from the web dyno.

## What the code actually enforces

The design never assumed one writer *process*. It coordinates several by making them race for a row — `campaign_runs` is unique on `(campaignId, occurrenceKey, kind)`, whoever wins holds the write, and the loser returns `deferredTo` rather than failing. That is a real invariant, enforced by the database rather than by a check with a window in it, and it is the one that stops two processes writing one campaign's prices at once.

The rule now says that, plus the bound that makes web writing survivable: `MAX_INLINE_ROWS`, merged in #374, because a request that outlives its dyno leaves writes in flight with nobody reading the result.

## Why not make the code meet the old rule

That was the other option and it is worse. Every Apply becomes an enqueue and a progress view — which throws away the synchronous per-row report that is the best thing about the campaign page — and the Railway worker has **never been deployed**, so it would take Apply offline today.

## Why this needed fixing either way

A stated invariant that is false is worse than no invariant, because the next person reasons from it. That already happened: #177 was told an undeployed worker meant "there is no writer".

## The guard

`one-writer.test.ts` holds **both halves** — the sentence in `CLAUDE.md` and the mechanism in the source — because the failure to guard against is not either one changing. It is the two drifting apart again, quietly, in either direction.

It also refuses any caller of `executeRows` other than `runCampaign`. That function is what talks to the Admin API about prices, and reaching it another way would skip the claim, the ledger rows and the read-back verification in one go.

typecheck, lint, build, full suite **2698 passed**. Mutations caught: the false rule reinstated, losing the occurrence race turned back into a crash, and a route calling `executeRows` directly.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)