### PR TITLE
"Nearest 10" now says which ten it means (#489)

### DIFF
--- a/app/lib/money/rounding-example.test.ts
+++ b/app/lib/money/rounding-example.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import { roundingExample, roundingExampleLine } from "./rounding-example";
-import { ROUNDING_LABELS, type RoundingProfileName } from "./rounding-policy";
+import { ROUNDING_PROFILES, type RoundingProfileName } from "./rounding-policy";
 
-const NAMES = Object.keys(ROUNDING_LABELS) as RoundingProfileName[];
+const NAMES = Object.keys(ROUNDING_PROFILES) as RoundingProfileName[];
 
 describe("a worked example for every option", () => {
   it.each(NAMES)("%s says something", (name) => {
@@ -16,20 +16,20 @@ describe("a worked example for every option", () => {
     // The reason the sample price is awkward: on a tidy number several profiles agree,
     // and a merchant comparing them learns nothing.
     //
-    // "Whole amounts" and "Nearest 100" are excluded because they are the same function
-    // reached by two names — charm-ending-0 and step-100-minor-units both land on the
-    // whole major unit. Asserting they differ would be asserting a bug. See #489.
+    // "Nearest 100" is excluded because on a two-decimal currency it is the same
+    // function as "Whole amounts" — charm-ending-0 and step-100-minor-units both land on
+    // the whole major unit. `roundingChoices` stops offering it here for that reason;
+    // asserting the two differ would be asserting a bug.
     const compared = NAMES.filter((name) => name !== "none" && name !== "nearest100");
     const answers = compared.map((name) => roundingExample(name, "USD").after);
 
     expect(new Set(answers).size).toBe(answers.length);
   });
 
-  it("rounds in minor units, which is not what two of the labels say", () => {
-    // Pinned deliberately, because it is surprising and because #489 is open to change
-    // it. "Nearest 10" is ten cents, not ten dollars; a merchant reading the label alone
-    // would expect $2,350. The worked example is what makes this visible at the moment
-    // of choosing, which is the whole reason this file exists.
+  it("rounds in minor units, which is what the labels now say", () => {
+    // Pinned deliberately, because it is surprising: "Nearest 10" is ten cents, not ten
+    // dollars. The label says "Nearest 0.10" for exactly this reason (#489), and the
+    // worked example says it again on a real number.
     expect(roundingExample("nearest10", "USD").after).toBe("$2,347.60");
     expect(roundingExample("nearest100", "USD").after).toBe("$2,348.00");
   });

--- a/app/lib/money/rounding-example.ts
+++ b/app/lib/money/rounding-example.ts
@@ -26,7 +26,7 @@
 import { isZeroDecimal } from "./currency";
 import { formatMoneyForDisplay, money } from "./money";
 import { applyRounding } from "./rounding";
-import { ROUNDING_PROFILES, type RoundingProfileName } from "./rounding-policy";
+import { ROUNDING_PROFILES, roundingLabel, type RoundingProfileName } from "./rounding-policy";
 
 /**
  * A price awkward enough to show the difference.
@@ -95,16 +95,53 @@ export function roundingExampleLine(name: RoundingProfileName, currency: string)
 }
 
 /**
- * A note on what "Nearest 10" turns out to mean.
+ * A note on what "Nearest 10" turns out to mean, and what was done about it.
  *
  * Ten *minor units*, not ten pounds: `nearest10` is `{ step: 10 }` and a step is in minor
  * units by definition, so on a $2,347.62 price it produces $2,347.60 rather than the
- * $2,350 the label implies. `nearest100` is a whole dollar, which is also why it agrees
- * with "Whole amounts" at every price — the two are the same function reached by two
- * names.
+ * $2,350 the old label implied. `nearest100` is a whole dollar, which is also why it
+ * agreed with "Whole amounts" at every price.
  *
- * That is a mislabelling with real consequences, and fixing it is a change to what a
- * merchant's prices become, so it is not being done quietly here as part of a help-text
- * ticket. What this example does is make the actual behaviour visible at the moment of
- * choosing, which is the narrower thing that was missing. See #489.
+ * Fixed as a labelling change (#489), not an arithmetic one: `roundingLabel` says
+ * "Nearest 0.10" in dollars and "Nearest 10" in yen, both of which are true, and
+ * `roundingChoices` stops offering two names for one function. Changing the *steps* to
+ * match the old words was the other option and it would re-price every campaign already
+ * using them on its next run, which is not something a help-text ticket gets to do.
  */
+
+/**
+ * The options a picker should offer in this currency, and what each does to a price.
+ *
+ * Not every profile means something everywhere, and one of the acceptance criteria on
+ * #489 was that no two options may be the same thing under different names. Both fall out
+ * of the same question — does this profile do anything here that another does not:
+ *
+ *   - A charm ending is a fact about the sub-unit, so `.99` and `.95` are unexpressible in
+ *     a currency that has none.
+ *   - "Whole amounts, no cents" is a no-op where amounts are already whole.
+ *   - And on a two-decimal currency, "whole" and the 100-minor-unit step land on exactly
+ *     the same number for every input. They are one function reached by two names, and
+ *     offering both is asking a merchant to choose between identical things. The charm
+ *     profile keeps the slot: "Whole amounts, no cents" says what it does, where
+ *     "Nearest 1.00" needs the merchant to work it out.
+ *
+ * A dropped option is dropped from the *picker*, not from the app. A campaign already
+ * storing `nearest100` keeps it, keeps pricing exactly as it did, and reads back with a
+ * true label — which is what makes this a labelling change rather than a pricing one.
+ */
+export function roundingChoices(
+  currency: string,
+): { value: RoundingProfileName; label: string; example: string }[] {
+  const zeroDecimal = isZeroDecimal(currency);
+
+  const offered = (Object.keys(ROUNDING_PROFILES) as RoundingProfileName[]).filter((name) => {
+    if (zeroDecimal) return name !== "charm99" && name !== "charm95" && name !== "whole";
+    return name !== "nearest100";
+  });
+
+  return offered.map((name) => ({
+    value: name,
+    label: roundingLabel(name, currency),
+    example: roundingExampleLine(name, currency),
+  }));
+}

--- a/app/lib/money/rounding-label.test.ts
+++ b/app/lib/money/rounding-label.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A merchant reading an option's name alone cannot be wrong about what it does.
+ *
+ * The labels were currency-independent and two of them lied because of it. A step is in
+ * **minor units** — `nearest10` is `{ step: 10 }` — so "Nearest 10" on $2,347.62 produced
+ * $2,347.60 rather than the $2,350 the name promises. In yen, where the minor unit *is*
+ * the yen, the same label was exactly right, which is why it survived review.
+ *
+ * The fix is a labelling one on purpose. `ROUNDING_PROFILES` is untouched, so no campaign
+ * prices differently on its next run than it did on its last — the acceptance criterion
+ * that ruled out the alternative of changing the steps to match the words.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { ROUNDING_PROFILES, roundingLabel, type RoundingProfileName } from "./rounding-policy";
+import { roundingChoices } from "./rounding-example";
+
+const NAMES = Object.keys(ROUNDING_PROFILES) as RoundingProfileName[];
+
+describe("a step, in the currency's own units", () => {
+  it("says ten cents in dollars, because that is what it does", () => {
+    expect(roundingLabel("nearest10", "USD")).toBe("Nearest 0.10");
+    expect(roundingLabel("nearest100", "USD")).toBe("Nearest 1.00");
+  });
+
+  it("says ten yen in yen, because that is what it does there", () => {
+    // The same profile, honestly labelled two ways. In a currency whose minor unit is the
+    // major unit, "Nearest 10" was never wrong — which is exactly why one label could not
+    // serve both.
+    expect(roundingLabel("nearest10", "JPY")).toBe("Nearest 10");
+    expect(roundingLabel("nearest100", "JPY")).toBe("Nearest 100");
+  });
+
+  it("leaves the labels that do not depend on a currency alone", () => {
+    expect(roundingLabel("charm99", "USD")).toBe("Prices ending .99");
+    expect(roundingLabel("none", "JPY")).toBe("Leave prices exactly as calculated");
+  });
+});
+
+describe("what the arithmetic actually does is unchanged", () => {
+  it("still steps minor units", () => {
+    // The half that must not have moved. If this changes, every campaign on these
+    // profiles prices differently on its next run.
+    expect(ROUNDING_PROFILES.nearest10).toEqual({ mode: "step", step: 10, direction: "nearest" });
+    expect(ROUNDING_PROFILES.nearest100).toEqual({ mode: "step", step: 100, direction: "nearest" });
+  });
+
+  it("keeps every profile name a merchant's campaign might already store", () => {
+    // Dropping an option from a picker must not drop it from the app: a campaign holding
+    // `nearest100` has to keep resolving.
+    expect(NAMES).toContain("nearest100");
+    expect(NAMES).toContain("whole");
+  });
+});
+
+describe("no two options are the same thing under different names", () => {
+  it("offers whole amounts or the whole-unit step, not both", () => {
+    // On a two-decimal currency `whole` (charm ending 0) and `nearest100` land on the
+    // same number for every input — one function reached by two names. Offering both asks
+    // a merchant to choose between identical things.
+    const usd = roundingChoices("USD").map((choice) => choice.value);
+
+    expect(usd).toContain("whole");
+    expect(usd).not.toContain("nearest100");
+  });
+
+  it("gives every offered option a different answer", () => {
+    // The general form of the same rule, and the reason the sample price is awkward.
+    const answers = roundingChoices("USD")
+      .filter((choice) => choice.value !== "none")
+      .map((choice) => choice.example);
+
+    expect(new Set(answers).size).toBe(answers.length);
+  });
+});
+
+describe("options that mean nothing in a currency are not offered in it", () => {
+  const jpy = roundingChoices("JPY").map((choice) => choice.value);
+
+  it("drops the charm endings, which need a sub-unit", () => {
+    expect(jpy).not.toContain("charm99");
+    expect(jpy).not.toContain("charm95");
+  });
+
+  it("drops whole amounts, which yen already is", () => {
+    expect(jpy).not.toContain("whole");
+  });
+
+  it("keeps the two steps, which are the ones that do something there", () => {
+    // And here they keep both, because ¥10 and ¥100 are genuinely different.
+    expect(jpy).toContain("nearest10");
+    expect(jpy).toContain("nearest100");
+  });
+
+  it("never shows a decimal to a currency that has none", () => {
+    for (const choice of roundingChoices("JPY")) {
+      expect(`${choice.label} ${choice.example}`).not.toMatch(/\d\.\d/);
+    }
+  });
+});

--- a/app/lib/money/rounding-policy.ts
+++ b/app/lib/money/rounding-policy.ts
@@ -16,7 +16,7 @@
  * campaigns readable, comparable and migratable in a way a serialised object does not.
  */
 
-import { isZeroDecimal } from "./currency";
+import { exponentOf, isZeroDecimal } from "./currency";
 import {
   NO_ROUNDING,
   charm95,
@@ -37,15 +37,59 @@ export const ROUNDING_PROFILES = {
 
 export type RoundingProfileName = keyof typeof ROUNDING_PROFILES;
 
-/** What each profile is called in the interface. */
-export const ROUNDING_LABELS: Record<RoundingProfileName, string> = {
+/**
+ * What each profile is called in the interface.
+ *
+ * Currency-independent, and two of them used to lie because of it. A step is in **minor
+ * units** — `nearest10` is `{ step: 10 }` — so "Nearest 10" on a $2,347.62 price produced
+ * $2,347.60 and not the $2,350 a merchant reading the label would expect (#489). In yen,
+ * where the minor unit *is* the yen, the same label was exactly right.
+ *
+ * So the label is a function of the currency now, and this record holds only the names
+ * that do not depend on one. Changing what the profiles *do* would re-price every campaign
+ * already using them; changing what they are called moves nothing.
+ */
+const FIXED_LABELS = {
   none: "Leave prices exactly as calculated",
   charm99: "Prices ending .99",
   charm95: "Prices ending .95",
   whole: "Whole amounts, no cents",
-  nearest10: "Nearest 10",
-  nearest100: "Nearest 100",
-};
+} as const;
+
+/**
+ * The step profiles, said in the currency's own major units.
+ *
+ * 10 minor units is "0.10" in dollars and "10" in yen, and both are the truth. Printing
+ * the number rather than a word — "Nearest 0.10", not "Nearest ten cents" — keeps it
+ * readable in currencies whose sub-unit has no English name a merchant would recognise.
+ */
+function stepLabel(step: number, currency: string): string {
+  const exp = exponentOf(currency);
+  const major = step / 10 ** exp;
+  return `Nearest ${major.toFixed(exp)}`;
+}
+
+export function roundingLabel(name: RoundingProfileName, currency: string): string {
+  if (name === "nearest10") return stepLabel(10, currency);
+  if (name === "nearest100") return stepLabel(100, currency);
+  return FIXED_LABELS[name];
+}
+
+/**
+ * Every profile, with the label it has in this currency.
+ *
+ * Kept for the surfaces that show all of them at once. `roundingChoices` in
+ * `rounding-example.ts` is what a *picker* should use — it also drops the ones that mean
+ * nothing here, or that mean the same as another.
+ */
+export function roundingLabels(currency: string): Record<RoundingProfileName, string> {
+  return Object.fromEntries(
+    (Object.keys(ROUNDING_PROFILES) as RoundingProfileName[]).map((name) => [
+      name,
+      roundingLabel(name, currency),
+    ]),
+  ) as Record<RoundingProfileName, string>;
+}
 
 export function isRoundingProfileName(value: unknown): value is RoundingProfileName {
   return typeof value === "string" && value in ROUNDING_PROFILES;

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -16,10 +16,9 @@ import { describeAdjustment } from "../lib/markets/describe";
 import {
   profileNameFor,
   readRoundingPolicy,
-  ROUNDING_LABELS,
-  type RoundingProfileName,
+  roundingLabel,
 } from "../lib/money/rounding-policy";
-import { roundingExampleLine } from "../lib/money/rounding-example";
+import { roundingChoices } from "../lib/money/rounding-example";
 import { ActionRow } from "../components/ActionRow";
 import { CampaignNameField } from "../components/campaign/CampaignNameField";
 import { RouteBoundary } from "../components/RouteBoundary";
@@ -185,11 +184,7 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
     // Sami and RUBIX both do this and it is the difference between a merchant guessing
     // what "Nearest 10" means and knowing — see `rounding-example.ts`, and #489 for what
     // the examples turned out to reveal about two of the labels.
-    roundingOptions: Object.entries(ROUNDING_LABELS).map(([value, label]) => ({
-      value,
-      label,
-      example: roundingExampleLine(value as RoundingProfileName, currency),
-    })),
+    roundingOptions: roundingChoices(currency),
     facets: available,
     segments,
     usingSegment: segment ? { id: segment.id, name: segment.name, kind: segment.kind } : null,
@@ -641,7 +636,7 @@ export default function NewCampaign() {
                         defaultSelected={!storeRounding.byCurrency[code]}
                       >
                         Same as this campaign&rsquo;s rounding (
-                        {ROUNDING_LABELS[profileNameFor(storeRounding, code)].toLowerCase()})
+                        {roundingLabel(profileNameFor(storeRounding, code), code).toLowerCase()})
                       </s-option>
                       {roundingOptions.map((option) => (
                         <s-option

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -14,8 +14,9 @@ import { withGuard } from "../lib/errors/guard.server";
 import {
   profileNameFor,
   readRoundingPolicy,
-  ROUNDING_LABELS,
+  roundingLabel,
 } from "../lib/money/rounding-policy";
+import { roundingChoices } from "../lib/money/rounding-example";
 import { PageSections, PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
 import { Field, FieldGrid, FullRow } from "../components/FieldGrid";
@@ -51,7 +52,9 @@ export const loader = withGuard("/app/settings", async ({ request }: LoaderFunct
     settings,
     currency,
     currencies,
-    roundingOptions: Object.entries(ROUNDING_LABELS).map(([value, label]) => ({ value, label })),
+    // Currency-aware: a step is in minor units, so "Nearest 10" means ten cents on a USD
+    // store and ten yen on a JPY one, and the option list itself differs (#489).
+    roundingOptions: roundingChoices(currency),
     withCost,
     variants,
     notifications,
@@ -282,7 +285,7 @@ export default function Settings() {
                           value="inherit"
                           defaultSelected={!settings.rounding.byCurrency[code]}
                         >
-                          Use the setting above ({ROUNDING_LABELS[effective].toLowerCase()})
+                          Use the setting above ({roundingLabel(effective, code).toLowerCase()})
                         </s-option>
                         {roundingOptions.map((option) => (
                           <s-option


### PR DESCRIPTION
A step is in **minor units**. `nearest10` is `{ step: 10 }`, so on a $2,347.62 price it produces **$2,347.60** — not the $2,350 a merchant reading "Nearest 10" would expect.

In yen, where the minor unit *is* the yen, the same label was exactly right. That is why one label could not serve both, and why this survived review.

## A labelling change, deliberately

`ROUNDING_PROFILES` is untouched. No campaign prices differently on its next run than it did on its last — the acceptance criterion that ruled out the alternative of changing the steps to match the words, which would have re-priced every campaign already using them and needed a decision about campaigns mid-flight.

`roundingLabel(name, currency)` says "Nearest 0.10" in dollars and "Nearest 10" in yen. Both are true. It prints the number rather than a word — "Nearest 0.10", not "Nearest ten cents" — so it stays readable in currencies whose sub-unit has no English name a merchant would recognise.

## The second half: two names for one function

"Whole amounts, no cents" and "Nearest 100" land on the same number for every input on any two-decimal currency — charm-ending-0 and step-100-minor-units are one function reached by two names, and offering both asks a merchant to choose between identical things.

`roundingChoices(currency)` now decides what a picker offers by asking whether a profile does anything here that another does not. That drops the duplicate, and by the same rule drops the charm endings from a currency with no sub-unit and "whole amounts" from one that is already whole. USD gets four options, JPY gets three, and no two of either do the same thing.

**Dropped from the picker, not from the app.** A campaign already storing `nearest100` keeps it, keeps pricing exactly as it did, and reads back with a true label.

## Verification

typecheck, lint, build, full suite **2709 passed**. Mutations caught: the label reverting to minor units, both names for one function offered again, charm endings offered in yen, and — the one that matters — the arithmetic changed to match the old words, which fails the test pinning what the profiles actually do.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)