### PR TITLE
Put the weight on the rows that moved (#498)

### DIFF
--- a/app/components/BaselineTable.tsx
+++ b/app/components/BaselineTable.tsx
@@ -1,4 +1,5 @@
 import { humanise } from "../lib/format/label";
+import { Blank } from "./Blank";
 import { ActionRow } from "./ActionRow";
 import type { BaselineRow } from "../services/baseline-browser.server";
 
@@ -33,10 +34,10 @@ export function BaselineTable({
         {rows.map((row) => (
           <s-table-row key={row.variantGid}>
             <s-table-cell>{row.title}</s-table-cell>
-            <s-table-cell>{row.sku ?? "—"}</s-table-cell>
-            <s-table-cell>{row.baseline ?? "—"}</s-table-cell>
+            <s-table-cell>{row.sku ?? <Blank />}</s-table-cell>
+            <s-table-cell>{row.baseline ?? <Blank />}</s-table-cell>
             <s-table-cell>
-              {row.live ?? "—"}
+              {row.live ?? <Blank />}
               {row.diverged ? (
                 // Expected during a campaign, a warning outside one — so the badge
                 // says "differs" rather than "wrong".
@@ -46,7 +47,7 @@ export function BaselineTable({
                 </>
               ) : null}
             </s-table-cell>
-            <s-table-cell>{row.source ? humanise(row.source) : "—"}</s-table-cell>
+            <s-table-cell>{row.source ? humanise(row.source) : <Blank />}</s-table-cell>
             <s-table-cell>
               {/* `gap="small"` -- which the scale documents as *larger* than
                   `small-100` -- so the two halves of one cell sat further apart than

--- a/app/components/Blank.tsx
+++ b/app/components/Blank.tsx
@@ -1,0 +1,21 @@
+/**
+ * The absence of a value, in a table.
+ *
+ * Every table in this app writes `—` where a row has no SKU, no cost, no compare-at. At
+ * full text weight that dash reads as *content*: on the catalogue, a store with no SKUs
+ * renders a column of forty identical dashes with exactly the visual weight of the prices
+ * beside them, and the eye keeps stopping on them. Three of the seven columns can look
+ * like that at once.
+ *
+ * Subdued, so the column reads as empty at a glance and the numbers are the only things
+ * with weight. This is `neutral`/de-emphasis rather than a status tone — it says "there is
+ * nothing here", which is not information a reader loses without colour, so it does not
+ * fall under the WCAG rule `colour-signal.test.ts` enforces.
+ *
+ * An em dash and not "None" or an empty cell. Empty reads as a rendering failure — the
+ * merchant cannot tell a missing value from a broken page — and a word in every gap is
+ * more noise than the dash it replaces.
+ */
+export function Blank() {
+  return <s-text color="subdued">—</s-text>;
+}

--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -1,4 +1,5 @@
 import { formatCount } from "../lib/format/display";
+import { Blank } from "./Blank";
 import { ActionRow } from "./ActionRow";
 import { EmptyState } from "./AsyncState";
 import { exampleRowFrom, StorefrontExample } from "./StorefrontExample";
@@ -203,7 +204,7 @@ export function DraftPreview({
                   </s-stack>
                 </s-table-cell>
                 <s-table-cell>
-                  {row.before ?? "—"}
+                  {row.before ?? <Blank />}
                   {row.beforeCompareAt ? ` (was ${row.beforeCompareAt})` : ""}
                   {/* Only when the storefront disagrees with the baseline, which means
                       the variant is mid-campaign or has drifted. Silence is the ordinary
@@ -222,7 +223,7 @@ export function DraftPreview({
                     <s-text color="subdued">no change</s-text>
                   ) : (
                     <s-text>
-                      {row.after ?? "—"}
+                      {row.after ?? <Blank />}
                       {row.afterCompareAt ? ` (was ${row.afterCompareAt})` : ""}
                     </s-text>
                   )}

--- a/app/components/LedgerTable.tsx
+++ b/app/components/LedgerTable.tsx
@@ -1,4 +1,5 @@
 import { humanise } from "../lib/format/label";
+import { Blank } from "./Blank";
 import { ShowingSome } from "./Pagination";
 import type { ReactNode } from "react";
 
@@ -49,12 +50,12 @@ export function LedgerTable({
         {rows.map((row) => (
           <s-table-row key={row.variantGid}>
             <s-table-cell>{row.title}</s-table-cell>
-            <s-table-cell>{row.before ?? "—"}</s-table-cell>
-            <s-table-cell>{row.intended ?? "—"}</s-table-cell>
+            <s-table-cell>{row.before ?? <Blank />}</s-table-cell>
+            <s-table-cell>{row.intended ?? <Blank />}</s-table-cell>
             <s-table-cell>
               <s-badge tone={toneFor(LEDGER_TONE, row.status)}>{humanise(row.status)}</s-badge>
             </s-table-cell>
-            <s-table-cell>{row.failureReason ?? "—"}</s-table-cell>
+            <s-table-cell>{row.failureReason ?? <Blank />}</s-table-cell>
             {renderAction ? <s-table-cell>{renderAction(row)}</s-table-cell> : null}
           </s-table-row>
         ))}

--- a/app/components/ReconciliationTable.tsx
+++ b/app/components/ReconciliationTable.tsx
@@ -1,4 +1,5 @@
 import { NoMatches } from "./AsyncState";
+import { Blank } from "./Blank";
 import type { ReconciliationRow } from "../services/reconciliation.server";
 import { stateLabel } from "../lib/reporting/reconciliation-csv";
 
@@ -61,15 +62,15 @@ export function ReconciliationTable({
                 {row.title}
               </s-button>
             </s-table-cell>
-            <s-table-cell>{row.live ?? "—"}</s-table-cell>
-            <s-table-cell>{row.baseline ?? "—"}</s-table-cell>
+            <s-table-cell>{row.live ?? <Blank />}</s-table-cell>
+            <s-table-cell>{row.baseline ?? <Blank />}</s-table-cell>
             <s-table-cell>
               {row.campaignId ? (
                 <s-button variant="tertiary" href={`/app/campaigns/${row.campaignId}`}>
                   {row.campaignName}
                 </s-button>
               ) : (
-                "—"
+                <Blank />
               )}
             </s-table-cell>
             <s-table-cell>

--- a/app/components/RollbackReportTable.tsx
+++ b/app/components/RollbackReportTable.tsx
@@ -1,4 +1,5 @@
 import type { RollbackRow } from "../services/campaigns/index.server";
+import { Blank } from "./Blank";
 import { ShowingSome } from "./Pagination";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 
@@ -68,9 +69,9 @@ export function RollbackReportTable({ rows }: { rows: RollbackRow[] }) {
             <s-table-cell>
               <s-badge tone={STATE[row.kind].tone}>{STATE[row.kind].label}</s-badge>
             </s-table-cell>
-            <s-table-cell>{row.applied ?? "—"}</s-table-cell>
-            <s-table-cell>{row.live ?? "—"}</s-table-cell>
-            <s-table-cell>{row.revertsTo ?? "—"}</s-table-cell>
+            <s-table-cell>{row.applied ?? <Blank />}</s-table-cell>
+            <s-table-cell>{row.live ?? <Blank />}</s-table-cell>
+            <s-table-cell>{row.revertsTo ?? <Blank />}</s-table-cell>
             <s-table-cell>
               {row.kind === "drifted" ? (
                 // Named `keep`, and read as a list by the revert action. Unchecked by

--- a/app/components/RunHistoryTable.tsx
+++ b/app/components/RunHistoryTable.tsx
@@ -1,4 +1,5 @@
 import { humanise } from "../lib/format/label";
+import { Blank } from "./Blank";
 import { formatWhen } from "../lib/format/display";
 import type { RunSummary } from "../services/campaigns/index.server";
 import { RUN_TONE, toneFor } from "./tone";
@@ -35,7 +36,7 @@ export function RunHistoryTable({ runs, selectedRunId, timeZone }: Props) {
             <s-table-cell>{run.verified}</s-table-cell>
             <s-table-cell>{run.failed}</s-table-cell>
             <s-table-cell>
-              {run.finishedAt ? formatWhen(run.finishedAt, timeZone) : "—"}
+              {run.finishedAt ? formatWhen(run.finishedAt, timeZone) : <Blank />}
             </s-table-cell>
             <s-table-cell>
               {run.id === selectedRunId ? (

--- a/app/components/blank-cell.test.tsx
+++ b/app/components/blank-cell.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * A missing value is not content, and should not look like it.
+ *
+ * Every table here writes `—` where a row has no SKU, no cost, no compare-at. At full text
+ * weight that dash has exactly the visual weight of the prices beside it, so a store with
+ * no SKUs renders a column of forty identical dashes that the eye keeps stopping on — and
+ * on the catalogue, three of seven columns can look like that at once.
+ *
+ * Forty-four of them were written as the bare string. One component now, so "nothing here"
+ * is styled in one place rather than in whichever table somebody is editing.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Blank } from "./Blank";
+import { sourceFiles, sourceOf } from "../lib/testing/source";
+
+describe("Blank", () => {
+  const html = renderToStaticMarkup(<Blank />);
+
+  it("is an em dash, so a gap is distinguishable from a broken page", () => {
+    // Not an empty cell: a merchant cannot tell a missing value from a render that
+    // failed. Not a word either — "None" in every gap is more noise than the dash.
+    expect(html).toContain("—");
+  });
+
+  it("is subdued, so a column of them reads as empty", () => {
+    expect(html).toContain('color="subdued"');
+  });
+
+  it("carries no status tone", () => {
+    // De-emphasis, not a signal. A `tone` here would put it under the WCAG rule in
+    // `colour-signal.test.ts`, which is about meanings carried by colour alone —
+    // "there is nothing here" is not one of those.
+    expect(html).not.toMatch(/tone="(critical|success|warning|caution|info)"/);
+  });
+});
+
+describe("no table writes the dash itself", () => {
+  /**
+   * Prose, where a subdued dash inside a sentence would be worse than a plain one.
+   *
+   * `StorefrontExample` renders "was 40.00, becomes 32.00" as a shopper would see it, and
+   * the after-price is deliberately `type="strong"` — a subdued em dash inside a strong
+   * price is two weights fighting in one span.
+   */
+  const NOT_A_CELL: Record<string, string> = {
+    "app/components/StorefrontExample.tsx": "prose, not a table cell",
+  };
+
+  it("uses the component everywhere a cell can be empty", () => {
+    const offenders = sourceFiles("app/routes", "app/components")
+      .filter((file) => !(file in NOT_A_CELL))
+      .filter((file) => sourceOf(file).includes('"—"'));
+
+    expect(offenders, "render <Blank /> rather than the string").toEqual([]);
+  });
+
+  it("finds the tables it is protecting", () => {
+    // A floor, so this cannot pass by finding nothing — the failure mode of every census
+    // check in this repo.
+    const users = sourceFiles("app/routes", "app/components").filter((file) =>
+      sourceOf(file).includes("<Blank />"),
+    );
+
+    expect(users.length).toBeGreaterThanOrEqual(12);
+  });
+});

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -1,4 +1,5 @@
 import type { useFetcher } from "react-router";
+import { Blank } from "../Blank";
 
 import { humanise } from "../../lib/format/label";
 import { ActionRow } from "../ActionRow";
@@ -213,7 +214,7 @@ export function CampaignListView({
                               ? `, ${campaign.lastRun.failed} failed`
                               : ""
                           }`
-                        : "—"}
+                        : <Blank />}
                     </s-table-cell>
                     <s-table-cell>
                       <ActionRow>

--- a/app/components/campaign/CampaignOverviewTab.tsx
+++ b/app/components/campaign/CampaignOverviewTab.tsx
@@ -6,6 +6,7 @@
  */
 
 import { formatWhen } from "../../lib/format/display";
+import { Blank } from "../Blank";
 import { describeActor } from "../../lib/audit/actor";
 import { ALL_STATES, describeState } from "../../lib/lifecycle/transitions";
 import { humanise } from "../../lib/format/label";
@@ -63,7 +64,7 @@ export function CampaignOverviewTab(props: CampaignDetailProps) {
                   <s-table-cell>
                     {stateName(entry.from)} → {stateName(entry.to)}
                   </s-table-cell>
-                  <s-table-cell>{entry.reason || "—"}</s-table-cell>
+                  <s-table-cell>{entry.reason || <Blank />}</s-table-cell>
                   <s-table-cell>{describeActor(entry.actor)}</s-table-cell>
                 </s-table-row>
               ))}

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -177,7 +177,14 @@ describe("no page answers 'where are my rows' with a loose paragraph", () => {
    */
   const NOT_DATA = ["aside"];
 
-  const ALLOWED = ["<EmptyState", "<NoMatches", "<>"];
+  /**
+   * `<Blank />` is a cell with nothing in it, not a page with no rows.
+   *
+   * "This segment is used by no campaigns" is a true statement about one row that
+   * exists — answering it with a centred heading and a call to action would be a page
+   * announcing its own emptiness inside a table cell.
+   */
+  const ALLOWED = ["<EmptyState", "<NoMatches", "<>", "<Blank"];
 
   /** Rendered outside the embedded admin, with their own CSS and no Polaris. */
   const OUTSIDE_THE_ADMIN = ["routes/help.$", "routes/_index"];

--- a/app/components/imports/ImportForm.tsx
+++ b/app/components/imports/ImportForm.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Blank } from "../Blank";
 import { useRef } from "react";
 import type { FetcherWithComponents } from "react-router";
 
@@ -262,7 +263,7 @@ export function ImportReport({
               {problems.slice(0, limit).map((problem) => (
                 <s-table-row key={`${problem.line}-${problem.identifier}-${problem.reason}`}>
                   <s-table-cell>{problem.line}</s-table-cell>
-                  <s-table-cell>{problem.identifier || "—"}</s-table-cell>
+                  <s-table-cell>{problem.identifier || <Blank />}</s-table-cell>
                   <s-table-cell>{problem.kind ?? "Will not import"}</s-table-cell>
                   <s-table-cell>{problem.reason}</s-table-cell>
                 </s-table-row>

--- a/app/components/imports/PriceImportHistory.tsx
+++ b/app/components/imports/PriceImportHistory.tsx
@@ -15,6 +15,7 @@
  */
 
 import { EmptyState } from "../AsyncState";
+import { Blank } from "../Blank";
 import { formatCount } from "../../lib/format/display";
 
 export interface PriceImportRow {
@@ -75,7 +76,7 @@ export function PriceImportHistory({
                       </s-text>
                     ) : null}
                   </s-table-cell>
-                  <s-table-cell>{row.createdBy ?? "—"}</s-table-cell>
+                  <s-table-cell>{row.createdBy ?? <Blank />}</s-table-cell>
                 </s-table-row>
               ))}
             </s-table-body>

--- a/app/lib/ui/catalogue-emphasis.test.ts
+++ b/app/lib/ui/catalogue-emphasis.test.ts
@@ -1,0 +1,60 @@
+/**
+ * On the catalogue, weight goes to the rows that moved.
+ *
+ * The page lists every variant with its live price, its baseline, and a state. Almost all
+ * of them are at baseline almost all of the time — that is what a healthy store looks
+ * like — and the page was giving each of those rows a green `At baseline` badge. A
+ * screenful of success badges is a screenful of colour drawing the eye to variants that
+ * need nothing, with the one row that had drifted competing against forty that had not.
+ *
+ * Colour spent on the normal case is colour that carries no information. So the normal
+ * case is quiet now, and the two exceptions keep their tone.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const CATALOGUE = sourceOf("app/routes/app.prices._index.tsx");
+
+describe("the state column", () => {
+  it("does not give the normal case a success badge", () => {
+    // The specific thing that was wrong, so reinstating it fails here.
+    expect(CATALOGUE).not.toContain('<s-badge tone="success">At baseline</s-badge>');
+  });
+
+  it("says the normal case quietly, and still says it", () => {
+    // Quiet is not absent. WCAG 1.4.1 is about meaning carried by colour alone, and the
+    // fix for a screenful of green is not an empty cell — a merchant scanning the column
+    // has to be able to tell "checked and fine" from "not checked yet".
+    expect(CATALOGUE).toContain('<s-text color="subdued">At baseline</s-text>');
+  });
+
+  it("keeps a tone on both exceptions", () => {
+    // Drifted, and never captured. These are the two a merchant is looking for, and they
+    // are now the only coloured things in the column.
+    expect(CATALOGUE).toContain('<s-badge tone="info">Not at baseline</s-badge>');
+    expect(CATALOGUE).toContain('<s-badge tone="warning">No baseline</s-badge>');
+  });
+});
+
+describe("the live price", () => {
+  it("is emphasised only when it differs from the baseline", () => {
+    // The column the page exists for. Weighting every live price weights none of them.
+    expect(CATALOGUE).toMatch(/row\.atBaseline \? \(\s*row\.price\s*\) : \(\s*<s-text type="strong">/);
+  });
+});
+
+describe("the currency", () => {
+  it("is named once, under the table", () => {
+    // Four money columns of bare numbers said nothing about which currency they were in.
+    // Naming it in each header spends four headings saying one thing.
+    expect(CATALOGUE).toContain("Amounts are your store&rsquo;s base price, in {currency}");
+  });
+
+  it("comes from the shop rather than from the first row", () => {
+    // The row currency is per-variant and a page showing a mixture would label them all
+    // with whichever sorted first — the shape of #473.
+    expect(CATALOGUE).toContain("currency: await shopCurrency(shop.id)");
+  });
+});

--- a/app/routes/app.campaigns.preview.tsx
+++ b/app/routes/app.campaigns.preview.tsx
@@ -23,6 +23,7 @@
  */
 
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { Blank } from "../components/Blank";
 import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -124,11 +125,11 @@ export default function FullPreview() {
                 {rows.map((row) => (
                   <s-table-row key={row.variantGid}>
                     <s-table-cell>{row.title}</s-table-cell>
-                    <s-table-cell>{row.before ?? "—"}</s-table-cell>
-                    <s-table-cell>{row.after ?? "—"}</s-table-cell>
+                    <s-table-cell>{row.before ?? <Blank />}</s-table-cell>
+                    <s-table-cell>{row.after ?? <Blank />}</s-table-cell>
                     {/* Only when it disagrees with the baseline, which is when it means
                         something. `live` is null in the ordinary case. */}
-                    <s-table-cell>{row.live ?? "—"}</s-table-cell>
+                    <s-table-cell>{row.live ?? <Blank />}</s-table-cell>
                     <s-table-cell>
                       {row.skippedReason ?? (row.unchanged ? "Already at this price" : "")}
                     </s-table-cell>

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -1,4 +1,6 @@
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { shopCurrency } from "../services/settings.server";
+import { Blank } from "../components/Blank";
 import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -91,11 +93,14 @@ export const loader = withGuard("/app/prices", async ({ request }: LoaderFunctio
     };
   });
 
-  return { rows, total, page, query, pageSize: PAGE_SIZE };
+  // Named once under the table rather than in four column headers. Every amount here is
+  // the base surface in the shop's own currency, and "Live price (USD) · Baseline (USD) ·
+  // Compare at (USD) · Cost (USD)" spends four headings saying one thing.
+  return { rows, total, page, query, pageSize: PAGE_SIZE, currency: await shopCurrency(shop.id) };
 });
 
 export default function Catalog() {
-  const { rows, total, page, query, pageSize } = useLoaderData<typeof loader>();
+  const { rows, total, page, query, pageSize, currency } = useLoaderData<typeof loader>();
   const [params] = useSearchParams();
 
   return (
@@ -133,16 +138,42 @@ export default function Catalog() {
                 {rows.map((row) => (
                   <s-table-row key={row.variantGid}>
                     <s-table-cell>{row.title}</s-table-cell>
-                    <s-table-cell>{row.sku ?? "—"}</s-table-cell>
-                    <s-table-cell>{row.price ?? "—"}</s-table-cell>
-                    <s-table-cell>{row.baseline ?? "—"}</s-table-cell>
-                    <s-table-cell>{row.compareAt ?? "—"}</s-table-cell>
-                    <s-table-cell>{row.cost ?? "—"}</s-table-cell>
+                    <s-table-cell>{row.sku ?? <Blank />}</s-table-cell>
+                    {/* Strong only when it differs from the baseline.
+                    
+                        This is the column the page exists for: everything else is
+                        reference. On a healthy catalogue every live price equals its
+                        baseline, so weighting all of them weights nothing — the eye needs
+                        to land on the handful that moved. */}
+                    <s-table-cell>
+                      {row.price === null ? (
+                        <Blank />
+                      ) : row.atBaseline ? (
+                        row.price
+                      ) : (
+                        <s-text type="strong">{row.price}</s-text>
+                      )}
+                    </s-table-cell>
+                    <s-table-cell>{row.baseline ?? <Blank />}</s-table-cell>
+                    <s-table-cell>{row.compareAt ?? <Blank />}</s-table-cell>
+                    <s-table-cell>{row.cost ?? <Blank />}</s-table-cell>
+                    {/* Only the exceptions carry a colour.
+                    
+                        "At baseline" was a green badge, and on a healthy catalogue that is
+                        every row: a screenful of success badges, each one drawing the eye
+                        to a variant that needs nothing, and the one row that had moved
+                        competing with forty that had not. Colour spent on the normal case
+                        is colour that carries no information.
+                    
+                        Subdued text rather than a neutral badge, because a badge is a
+                        shape as well as a colour — forty grey pills read as forty things
+                        to look at. `colour-signal.test.ts` still holds: each state says
+                        its own name, so nothing here is carried by colour alone. */}
                     <s-table-cell>
                       {row.baseline === null ? (
                         <s-badge tone="warning">No baseline</s-badge>
                       ) : row.atBaseline ? (
-                        <s-badge tone="success">At baseline</s-badge>
+                        <s-text color="subdued">At baseline</s-text>
                       ) : (
                         <s-badge tone="info">Not at baseline</s-badge>
                       )}
@@ -151,6 +182,12 @@ export default function Catalog() {
                 ))}
               </s-table-body>
             </s-table>
+
+            <s-paragraph>
+              <s-text color="subdued">
+                Amounts are your store&rsquo;s base price, in {currency}.
+              </s-text>
+            </s-paragraph>
 
             <Pagination page={page} total={total} pageSize={pageSize} />
           </>

--- a/app/routes/app.prices.baselines._index.tsx
+++ b/app/routes/app.prices.baselines._index.tsx
@@ -16,6 +16,7 @@
  */
 
 import { humanise } from "../lib/format/label";
+import { Blank } from "../components/Blank";
 import { formatCount, formatWhen } from "../lib/format/display";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData, useSearchParams } from "react-router";
@@ -275,10 +276,10 @@ export default function Baselines() {
                     {entry.price}
                     {entry.current ? " (current)" : ""}
                   </s-table-cell>
-                  <s-table-cell>{entry.compareAt ?? "—"}</s-table-cell>
+                  <s-table-cell>{entry.compareAt ?? <Blank />}</s-table-cell>
                   <s-table-cell>{humanise(entry.source)}</s-table-cell>
                   <s-table-cell>
-                    {entry.supersededAt ? formatWhen(entry.supersededAt, timeZone) : "—"}
+                    {entry.supersededAt ? formatWhen(entry.supersededAt, timeZone) : <Blank />}
                   </s-table-cell>
                 </s-table-row>
               ))}

--- a/app/routes/app.prices.drift.tsx
+++ b/app/routes/app.prices.drift.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from "react";
+import { Blank } from "../components/Blank";
 import { useRef } from "react";
 import type {
   ActionFunctionArgs,
@@ -208,13 +209,13 @@ function DriftDecision({
   return (
     <s-table-row>
       <s-table-cell>{event.title}</s-table-cell>
-      <s-table-cell>{event.expected ?? "—"}</s-table-cell>
+      <s-table-cell>{event.expected ?? <Blank />}</s-table-cell>
       {/* Was a warning badge wrapped round the price. A badge is a status and a price is
           a value, so the column could not align with the one beside it and the number a
           merchant came here to compare rendered as a label. Every row on this page is
           drift; the page says so once, at the top, rather than once per row. */}
-      <s-table-cell>{event.observed ?? "—"}</s-table-cell>
-      <s-table-cell>{event.campaignName ?? "—"}</s-table-cell>
+      <s-table-cell>{event.observed ?? <Blank />}</s-table-cell>
+      <s-table-cell>{event.campaignName ?? <Blank />}</s-table-cell>
       <s-table-cell>
         <fetcher.Form method="post" ref={form}>
           <input type="hidden" name="eventId" value={event.id} />

--- a/app/routes/app.settings.diagnostics.tsx
+++ b/app/routes/app.settings.diagnostics.tsx
@@ -8,6 +8,7 @@
  */
 
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { Blank } from "../components/Blank";
 import { Form, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -143,7 +144,7 @@ export default function Debug() {
             </s-paragraph>
             <s-paragraph>
               <s-text>
-                {match.createdAt} · {match.method ?? "—"} {match.route ?? "—"}
+                {match.createdAt} · {match.method ?? <Blank />} {match.route ?? <Blank />}
               </s-text>
             </s-paragraph>
 
@@ -208,7 +209,7 @@ export default function Debug() {
                         {row.code}
                       </s-badge>
                     </s-table-cell>
-                    <s-table-cell>{row.route ?? "—"}</s-table-cell>
+                    <s-table-cell>{row.route ?? <Blank />}</s-table-cell>
                   </s-table-row>
                 ))}
               </s-table-body>

--- a/app/routes/app.settings.plan.tsx
+++ b/app/routes/app.settings.plan.tsx
@@ -8,6 +8,7 @@
  */
 
 import { formatCount, formatDay } from "../lib/format/display";
+import { Blank } from "../components/Blank";
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -147,9 +148,9 @@ export default function PlanPage() {
                     ? "Unlimited"
                     : formatCount(plan.variantLimit)}
                 </s-table-cell>
-                <s-table-cell>{plan.markets ? "Yes" : "—"}</s-table-cell>
-                <s-table-cell>{plan.b2b ? "Yes" : "—"}</s-table-cell>
-                <s-table-cell>{plan.trialDays > 0 ? `${plan.trialDays} days` : "—"}</s-table-cell>
+                <s-table-cell>{plan.markets ? "Yes" : <Blank />}</s-table-cell>
+                <s-table-cell>{plan.b2b ? "Yes" : <Blank />}</s-table-cell>
+                <s-table-cell>{plan.trialDays > 0 ? `${plan.trialDays} days` : <Blank />}</s-table-cell>
               </s-table-row>
             ))}
           </s-table-body>

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useState } from "react";
+import { Blank } from "../components/Blank";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
@@ -197,9 +198,11 @@ export default function Segments() {
                   </s-table-cell>
                   <s-table-cell>{segment.size}</s-table-cell>
                   <s-table-cell>
-                    {segment.usedBy.length === 0
-                      ? "—"
-                      : segment.usedBy.map((c) => c.name).join(", ")}
+                    {segment.usedBy.length === 0 ? (
+                      <Blank />
+                    ) : (
+                      segment.usedBy.map((c) => c.name).join(", ")
+                    )}
                   </s-table-cell>
                   <s-table-cell>
                     {segment.usedBy.length > 0 ? (


### PR DESCRIPTION
Three things on the catalogue table, all about where a reader's eye goes.

## Green on every row

`At baseline` was a `tone="success"` badge, and on a healthy catalogue that is **every row** — a screenful of colour drawing attention to variants that need nothing, with the one drifted row competing against forty that are fine.

It is subdued text now. Quiet, but still saying its own name: WCAG 1.4.1 is about meaning carried by colour alone, and "checked and fine" has to stay distinguishable from "not checked yet". Text rather than a neutral badge, because a badge is a shape as well as a colour and forty grey pills still read as forty things to look at.

Both exceptions — `Not at baseline`, `No baseline` — keep their tone, and are now the only coloured things in the column.

## The live price carries weight only where it moved

`type="strong"` on the rows that differ from their baseline. That is the column the page exists for; everything else is reference, and weighting all of them weights none of them.

## The currency, named once

Four money columns of bare numbers said nothing about which currency they were in. Naming it in each header spends four headings on one fact, so it goes under the table — and it comes from `shopCurrency`, not from the first row, which is the shape of #473.

## Em dashes with the weight of data

`—` renders exactly as heavily as the prices beside it, so a store with no SKUs gets a column of forty identical dashes that the eye keeps stopping on. Three of the seven columns can look like that at once.

Forty-four of them were written as a bare string across twelve files. One `Blank` component now, so "there is nothing here" is styled in one place rather than in whichever table somebody happens to be editing. `blank-cell.test.tsx` refuses the raw string in a cell.

Left alone deliberately: the two in `StorefrontExample`, which are prose — a subdued dash inside a `type="strong"` price is two weights fighting in one span.

## Verification

typecheck, lint, build, full suite **2724 passed**. Mutations caught: the dash back at full weight, a table writing the string itself, the normal case going green again, and the currency taken from the first row.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)