### PR TITLE
A strong price in a table cell renders no differently

### DIFF
--- a/app/lib/ui/catalogue-emphasis.test.ts
+++ b/app/lib/ui/catalogue-emphasis.test.ts
@@ -39,9 +39,22 @@ describe("the state column", () => {
 });
 
 describe("the live price", () => {
-  it("is emphasised only when it differs from the baseline", () => {
-    // The column the page exists for. Weighting every live price weights none of them.
-    expect(CATALOGUE).toMatch(/row\.atBaseline \? \(\s*row\.price\s*\) : \(\s*<s-text type="strong">/);
+  it("does not try to out-weight the table it is in", () => {
+    // `<s-text type="strong">` inside an `s-table-cell` renders at exactly the weight of
+    // the cell beside it. Verified on the deployed page at 4x zoom: a drifted 538.04 and
+    // an untouched 750.03 were indistinguishable. Polaris gives a table one type weight
+    // and means it.
+    //
+    // Pinned because the idea is a natural one to have twice — emphasising the row that
+    // moved is the obvious thing to reach for, and the code for it looks like it works.
+    const cells = [...CATALOGUE.matchAll(/<s-table-cell>([\s\S]*?)<\/s-table-cell>/g)];
+
+    expect(cells.length).toBeGreaterThan(4);
+    for (const [, body] of cells) {
+      expect(body, "a strong price in a table cell renders no differently").not.toContain(
+        'type="strong"',
+      );
+    }
   });
 });
 

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -139,21 +139,19 @@ export default function Catalog() {
                   <s-table-row key={row.variantGid}>
                     <s-table-cell>{row.title}</s-table-cell>
                     <s-table-cell>{row.sku ?? <Blank />}</s-table-cell>
-                    {/* Strong only when it differs from the baseline.
+                    {/* Not emphasised on the rows that moved, though it was worth trying.
                     
-                        This is the column the page exists for: everything else is
-                        reference. On a healthy catalogue every live price equals its
-                        baseline, so weighting all of them weights nothing — the eye needs
-                        to land on the handful that moved. */}
-                    <s-table-cell>
-                      {row.price === null ? (
-                        <Blank />
-                      ) : row.atBaseline ? (
-                        row.price
-                      ) : (
-                        <s-text type="strong">{row.price}</s-text>
-                      )}
-                    </s-table-cell>
+                        `<s-text type="strong">` inside an `s-table-cell` renders at
+                        exactly the weight of the cell beside it — checked on the deployed
+                        page at 4x zoom, where the drifted 538.04 and the untouched 750.03
+                        below it are indistinguishable. Polaris gives a table one type
+                        weight and means it, and nothing in this app had tried to argue
+                        with that before.
+                    
+                        Which is fine: the state column is the signal, and it is now the
+                        only coloured thing on the row. A price that had to be bold to be
+                        found would mean the state column was not doing its job. */}
+                    <s-table-cell>{row.price ?? <Blank />}</s-table-cell>
                     <s-table-cell>{row.baseline ?? <Blank />}</s-table-cell>
                     <s-table-cell>{row.compareAt ?? <Blank />}</s-table-cell>
                     <s-table-cell>{row.cost ?? <Blank />}</s-table-cell>


### PR DESCRIPTION
#499 emphasised the live price on rows where it differs from the baseline. Checked on the deployed page at 4x zoom: the drifted `538.04` and the untouched `750.03` below it are **indistinguishable**. `<s-text type="strong">` inside an `s-table-cell` does nothing — Polaris gives a table one type weight and means it, and no other cell in this app had tried to argue with that.

Removed rather than left in with a comment claiming an effect it does not have. That is the same failure as a guard passing on its own commentary, one layer up.

Which is fine, and arguably better: the state column is the signal, and after #499 it is the only coloured thing on the row. A price that had to be bold to be found would mean the state column was not doing its job.

Pinned by `catalogue-emphasis.test.ts`, because the idea is a natural one to have twice — the code for it looks like it works, and nothing but opening the page says otherwise.

typecheck, lint, build, full suite **2724 passed**; the mutation re-adding the emphasis fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)