### PR TITLE
A price aligned with the price above it

### DIFF
--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -1,5 +1,5 @@
 import { formatCount } from "../lib/format/display";
-import { Blank } from "./Blank";
+import { MoneyCell } from "./MoneyCell";
 import { ActionRow } from "./ActionRow";
 import { EmptyState } from "./AsyncState";
 import { exampleRowFrom, StorefrontExample } from "./StorefrontExample";
@@ -204,17 +204,17 @@ export function DraftPreview({
                   </s-stack>
                 </s-table-cell>
                 <s-table-cell>
-                  {row.before ?? <Blank />}
-                  {row.beforeCompareAt ? ` (was ${row.beforeCompareAt})` : ""}
-                  {/* Only when the storefront disagrees with the baseline, which means
-                      the variant is mid-campaign or has drifted. Silence is the ordinary
-                      case; a merchant reading "40.00 becomes 32.00" beside a storefront
-                      showing 28.00 needs to be told which number we are working from. */}
-                  {row.live ? (
-                    <s-paragraph>
-                      <s-text tone="caution">live {row.live}</s-text>
-                    </s-paragraph>
-                  ) : null}
+                  <MoneyCell
+                    amount={row.before}
+                    compareAt={row.beforeCompareAt}
+                    /* Only when the storefront disagrees with the baseline, which means
+                       the variant is mid-campaign or has drifted. Silence is the ordinary
+                       case; a merchant reading "40.00 becomes 32.00" beside a storefront
+                       showing 28.00 needs to be told which number we are working from. */
+                    note={
+                      row.live ? <s-text tone="caution">live {row.live}</s-text> : undefined
+                    }
+                  />
                 </s-table-cell>
                 <s-table-cell>
                   {row.skippedReason ? (
@@ -222,10 +222,7 @@ export function DraftPreview({
                   ) : row.unchanged ? (
                     <s-text color="subdued">no change</s-text>
                   ) : (
-                    <s-text>
-                      {row.after ?? <Blank />}
-                      {row.afterCompareAt ? ` (was ${row.afterCompareAt})` : ""}
-                    </s-text>
+                    <MoneyCell amount={row.after} compareAt={row.afterCompareAt} />
                   )}
                 </s-table-cell>
               </s-table-row>

--- a/app/components/MoneyCell.tsx
+++ b/app/components/MoneyCell.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from "react";
+
+import { Blank } from "./Blank";
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * A price in a table cell: the number on its own line, and anything qualifying it below.
+ *
+ * ## The bug this exists to make unwriteable
+ *
+ * A money column is declared `format="currency"`, which right-aligns it, and the whole
+ * reason to right-align a column of prices is that they line up on the decimal. Three
+ * tables were then writing the qualifier into the same text run as the number:
+ *
+ * ```tsx
+ * <s-table-cell>
+ *   {row.after}
+ *   {row.afterCompareAt ? ` (was ${row.afterCompareAt})` : ""}
+ * </s-table-cell>
+ * ```
+ *
+ * Which renders, in the editor's preview panel at its real width:
+ *
+ * ```
+ *      Baseline        Would become
+ *         10.02     8.02 (was 10.02)
+ *         41.34        33.07 (was
+ *                          41.34)
+ *  1799.32 (was       1439.46 (was
+ *     2598.79)           1799.32)
+ * ```
+ *
+ * Two things are wrong there and only one of them is the wrapping. Because each suffix is
+ * a different length, **no two prices in the column start at the same place** — the
+ * alignment the `currency` format was asked for is destroyed on exactly the rows that
+ * have something to say. And a price broken across a line at `(was` is not a price a
+ * merchant can read at all.
+ *
+ * The rule that comes out of it: **a money cell's first line holds a number and nothing
+ * else.** Everything else goes underneath.
+ *
+ * ## Why the compare-at is struck through rather than parenthesised
+ *
+ * `(was 10.02)` had a second problem the wrapping hid: in the preview table it appeared
+ * in two adjacent columns meaning two different things — the baseline's compare-at in one
+ * and the campaign's compare-at in the other — so row three read "1799.32 (was 2598.79)"
+ * beside "1439.46 (was 1799.32)" and the same word pointed at two different facts.
+ *
+ * A struck-through number is not ambiguous, because it is what a storefront draws. It is
+ * also already this app's vocabulary: `StorefrontExample` sits directly above this table
+ * in the editor and renders the same pair that way, so the card and the table now say the
+ * same thing in the same language rather than in two.
+ *
+ * `type="redundant"` and not a CSS line-through: Polaris documents that type for this
+ * exact case and renders it as `<s>`, so a screen reader announces it. A line drawn in
+ * CSS is a line only sighted merchants get.
+ */
+export function MoneyCell({
+  amount,
+  compareAt,
+  note,
+}: {
+  /** The price. Null renders the app's em dash, like every other empty cell. */
+  amount: string | null | undefined;
+  /**
+   * The price it is compared against, struck through beneath it.
+   *
+   * Ignored when it equals the amount, which is not a sale and must not be dressed as
+   * one — the same rule `StorefrontExample` applies to the card above this table. Left as
+   * string equality rather than a numeric comparison on purpose: a preview row carries no
+   * currency, so there is no way to parse these into minor units here, and rule 7 rules
+   * out comparing them as floats. The caller knows the semantics; this only knows how a
+   * price looks.
+   */
+  compareAt?: string | null;
+  /**
+   * One short line under the price — "live 28.00", a reason a row will not be written.
+   *
+   * A slot rather than a string so the caller keeps its own tone. It sits below the
+   * number for the reason the whole component exists: beside it, it moves the number.
+   */
+  note?: ReactNode;
+}) {
+  const struck = compareAt && compareAt !== amount ? compareAt : null;
+
+  // No stack when there is only a number. A single `s-text` is what every other money
+  // cell in the app renders, and wrapping the ordinary case in a layout element to serve
+  // the exceptional one is how a table grows row height it did not need.
+  if (!struck && !note) return amount ? <s-text>{amount}</s-text> : <Blank />;
+
+  return (
+    // `alignItems="end"` is load-bearing, and its absence is invisible in a diff.
+    //
+    // What `format="currency"` actually does, from `polaris.js` — the only account of it
+    // that is true, since none of this is documented:
+    //
+    //     .table-cell { display: table-cell; padding: .5rem .75rem;
+    //                   min-block-size: 2rem; vertical-align: middle }
+    //     .format-currency, .format-numeric { font-feature-settings: "tnum";
+    //                   font-variant-numeric: tabular-nums; text-align: end }
+    //
+    // So the alignment is `text-align` on the *cell*, and it reaches a text node by
+    // inheritance. A stack is a flex container that fills the cell and positions its own
+    // children, so the moment one is introduced the number stops taking the column's
+    // alignment and starts taking the stack's — which defaults to the inline start.
+    // Rendered, that put every row with a compare-at a few pixels left of every row
+    // without one, so the column was ragged in a way that read as a rendering fault
+    // rather than as anything anyone chose. Seen in the admin on this component's first
+    // build, and it is why the ordinary case above returns a bare `s-text` rather than a
+    // one-child stack.
+    //
+    // The same CSS is why nothing here sets `tabular-nums`: the format already does, and
+    // a column of prices needs it more than anywhere else in the app.
+    <s-stack gap={SPACE.tight} alignItems="end">
+      {amount ? <s-text>{amount}</s-text> : <Blank />}
+      {struck ? (
+        <s-text color="subdued" type="redundant">
+          {struck}
+        </s-text>
+      ) : null}
+      {note}
+    </s-stack>
+  );
+}

--- a/app/components/PreviewTable.tsx
+++ b/app/components/PreviewTable.tsx
@@ -1,4 +1,5 @@
 import { humanise } from "../lib/format/label";
+import { MoneyCell } from "./MoneyCell";
 import { EmptyState } from "./AsyncState";
 import { ShowingSome } from "./Pagination";
 import type { MarketPreview, PreviewRow } from "../services/campaigns/index.server";
@@ -61,14 +62,31 @@ export function PreviewTable({
         {rows.map((row) => (
           <s-table-row key={row.variantGid}>
             <s-table-cell>{row.title}</s-table-cell>
-            <s-table-cell>{row.before ?? "\u2014"}</s-table-cell>
-            <s-table-cell>{row.after ?? "\u2014"}</s-table-cell>
-            <s-table-cell>{row.compareAt ?? "\u2014"}</s-table-cell>
-            {markets.map((market) => (
-              <s-table-cell key={market.priceListGid}>
-                {describeCell(row, market.priceListGid)}
-              </s-table-cell>
-            ))}
+            <s-table-cell>
+              <MoneyCell amount={row.before} />
+            </s-table-cell>
+            <s-table-cell>
+              <MoneyCell amount={row.after} />
+            </s-table-cell>
+            <s-table-cell>
+              <MoneyCell amount={row.compareAt} />
+            </s-table-cell>
+            {markets.map((market) => {
+              const cell = describeCell(row, market.priceListGid);
+              return (
+                <s-table-cell key={market.priceListGid}>
+                  {cell.kind === "price" ? (
+                    <MoneyCell amount={cell.amount} compareAt={cell.compareAt} />
+                  ) : (
+                    // Not a number, so not a `MoneyCell`. "Not sold here" and a skip
+                    // reason are phrases, and the column stays right-aligned under them
+                    // for the reason the header comment gives: one phrase must not cost
+                    // every price in the column its decimal alignment.
+                    <s-text color="subdued">{cell.text}</s-text>
+                  )}
+                </s-table-cell>
+              );
+            })}
             <s-table-cell>
               <s-badge tone={toneFor(PREVIEW_TONE, row.status)}>
                 {humanise(row.status)}
@@ -92,20 +110,36 @@ export function PreviewTable({
 }
 
 /**
- * One variant's price on one market.
+ * One variant's price on one market: either a price, or a phrase saying why there isn't
+ * one.
+ *
+ * Returns the two apart rather than as one string. It used to build
+ * `` `${price} was ${cell.compareAt}` ``, which put a number and a word in the same text
+ * run of a right-aligned column \u2014 so a market cell wrapped at "was" and no two prices in
+ * the column started at the same place. `MoneyCell` carries the full account; the shape
+ * of this function is the half of the fix that lives here, because a caller cannot
+ * right-align a number it has already glued a word to.
  *
  * "Not sold here" rather than a dash for a variant the market has no price for. A dash
  * reads as "no change", and the difference matters: one means the campaign leaves the
  * price alone, the other means there is no price there to leave alone.
  */
-function describeCell(row: PreviewRow, priceListGid: string): string {
+type MarketCell =
+  | { kind: "price"; amount: string | null; compareAt: string | null }
+  | { kind: "text"; text: string };
+
+function describeCell(row: PreviewRow, priceListGid: string): MarketCell {
   const cell = row.surfaces?.[priceListGid];
-  if (!cell) return "Not sold here";
+  if (!cell) return { kind: "text", text: "Not sold here" };
 
   if (cell.status !== "pending") {
-    return cell.reason ? `${humanise(cell.status)} \u00b7 ${cell.reason}` : humanise(cell.status);
+    return {
+      kind: "text",
+      text: cell.reason
+        ? `${humanise(cell.status)} \u00b7 ${cell.reason}`
+        : humanise(cell.status),
+    };
   }
 
-  const price = cell.after ?? "\u2014";
-  return cell.compareAt ? `${price} was ${cell.compareAt}` : price;
+  return { kind: "price", amount: cell.after ?? null, compareAt: cell.compareAt ?? null };
 }

--- a/app/lib/ui/money-cell.test.ts
+++ b/app/lib/ui/money-cell.test.ts
@@ -1,0 +1,134 @@
+/**
+ * A money cell holds a number, and its qualifier goes underneath.
+ *
+ * ## What went wrong
+ *
+ * A money column is declared `format="currency"`, which right-aligns it, and the only
+ * reason to right-align prices is so they line up on the decimal. Three tables then wrote
+ * the qualifier into the same text run as the number — `` ` (was ${row.afterCompareAt})` ``
+ * in the editor's preview panel and in the full-preview route, `` `${price} was ${cell.compareAt}` ``
+ * in each market column of the review step.
+ *
+ * On screen, in the panel at its real width:
+ *
+ * ```
+ *      Baseline        Would become
+ *         10.02     8.02 (was 10.02)
+ *         41.34        33.07 (was
+ *                          41.34)
+ *  1799.32 (was       1439.46 (was
+ *     2598.79)           1799.32)
+ * ```
+ *
+ * Two separate failures, and the wrapping is the less serious one. Because every suffix is
+ * a different length, **no two prices in the column start at the same place** — the
+ * alignment `format="currency"` was asked for is destroyed on precisely the rows that have
+ * something to say. And row three reads "1799.32 (was 2598.79)" beside "1439.46 (was
+ * 1799.32)": the same word pointing at the baseline's compare-at in one column and the
+ * campaign's in the next.
+ *
+ * ## What is checked here
+ *
+ * The grep is deliberately narrow — the literal `(was ` and a `was ` glued to an
+ * interpolation — because those are the two spellings that actually shipped, and a broad
+ * rule against words in table cells would fail every legitimate one ("Not sold here",
+ * "Already at this price", a skip reason). The `sourceOf` helper strips comments first, so
+ * the paragraphs above do not trip the rule they describe. That has caught this repo out
+ * seven times; see `app/lib/testing/source.ts`.
+ *
+ * The second test is the one that will save someone an afternoon. `alignItems="end"` on
+ * `MoneyCell`'s stack looks like a stylistic flourish and is load-bearing: a stack is a
+ * block that fills the cell and aligns its own children, so without it the number inside
+ * stops taking the column's alignment and takes the stack's default instead — putting
+ * every row that has a compare-at a few pixels left of every row that does not. It is
+ * invisible in a diff and obvious in the admin, which is the combination worth pinning.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const APP = join(process.cwd(), "app");
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.isFile() && entry.name.endsWith(".tsx") && !entry.name.includes(".test.")
+      ? [path]
+      : [];
+  });
+}
+
+interface Cell {
+  file: string;
+  body: string;
+}
+
+/** Every `s-table-cell` in the app, with its comments already stripped. */
+function cells(): Cell[] {
+  return tsxFiles(APP).flatMap((path) => {
+    const source = sourceOf(path);
+    return [...source.matchAll(/<s-table-cell[^>]*>([\s\S]*?)<\/s-table-cell>/g)].map(
+      (match) => ({ file: path.replace(`${APP}/`, ""), body: match[1] }),
+    );
+  });
+}
+
+const CELLS = cells();
+
+describe("a price and the price it is compared against are not one string", () => {
+  it("finds the app's table cells", () => {
+    // A floor, so adding a table is not a failing test. Ninety-odd when this landed.
+    expect(CELLS.length).toBeGreaterThan(50);
+  });
+
+  it("never appends a parenthetical to a cell's value", () => {
+    // A string literal opening with a space and a bracket — `" (current)"`,
+    // `` ` (was ${row.afterCompareAt})` `` — is the shape of a suffix glued to whatever
+    // expression precedes it. Both spellings shipped, in two different tables, so the
+    // rule is written against the shape rather than against either wording: the next one
+    // will be `" (est.)"` and nobody will remember this file.
+    //
+    // A parenthetical that is genuinely part of a label is written in the JSX, not in a
+    // string beginning with a space, so this does not stand in the way of one.
+    const offenders = CELLS.filter((cell) => /["'`] \(/.test(cell.body)).map(
+      (cell) => cell.file,
+    );
+
+    expect(
+      [...new Set(offenders)],
+      "a suffix in the same text run as a number wraps mid-value and pushes it off the column's right edge — put it in MoneyCell's note or compareAt",
+    ).toEqual([]);
+  });
+
+  it("never glues the word 'was' to an interpolated price", () => {
+    // `${price} was ${cell.compareAt}` — the market-column spelling of the same bug.
+    const offenders = CELLS.filter((cell) => /\}\s*was\s*\$\{/.test(cell.body)).map(
+      (cell) => cell.file,
+    );
+
+    expect([...new Set(offenders)]).toEqual([]);
+  });
+});
+
+describe("MoneyCell keeps the alignment the currency format asked for", () => {
+  const SOURCE = sourceOf("app/components/MoneyCell.tsx");
+
+  it("aligns its stack to the inline end", () => {
+    expect(
+      /<s-stack[^>]*alignItems="end"/.test(SOURCE),
+      "without this the number takes the stack's alignment instead of the column's, and rows with a compare-at sit left of rows without one",
+    ).toBe(true);
+  });
+
+  it("renders a bare price without a stack at all", () => {
+    // The ordinary cell is one number. Wrapping it in a layout element to serve the
+    // exceptional case is how a table grows row height it did not need — and it is the
+    // difference between a one-line and a two-line row on every clean row in the table.
+    expect(SOURCE).toMatch(/if \(!struck && !note\) return/);
+  });
+});

--- a/app/lib/ui/table-designation.test.ts
+++ b/app/lib/ui/table-designation.test.ts
@@ -148,7 +148,7 @@ describe("every table is designed for the shape Polaris might collapse it into",
 const MONEY = [
   "Baseline", "Live", "Live price", "Live now", "Before", "After", "Intended", "Compare at",
   "Cost", "Price", "We applied", "Reverts to", "Campaign set", "Now shows", "Now",
-  "Would become",
+  "Would become", "Price a month",
 ];
 
 const COUNTS = [

--- a/app/routes/app.campaigns.preview.tsx
+++ b/app/routes/app.campaigns.preview.tsx
@@ -24,6 +24,7 @@
 
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { Blank } from "../components/Blank";
+import { MoneyCell } from "../components/MoneyCell";
 import { useLoaderData, useSearchParams } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -125,13 +126,25 @@ export default function FullPreview() {
                 {rows.map((row) => (
                   <s-table-row key={row.variantGid}>
                     <s-table-cell>{row.title}</s-table-cell>
-                    <s-table-cell>{row.before ?? <Blank />}</s-table-cell>
-                    <s-table-cell>{row.after ?? <Blank />}</s-table-cell>
+                    {/* The same pair the editor's panel shows, rendered the same way.
+                        This page is where its "See all N rows" button goes, and it used
+                        to drop both compare-ats — so a merchant who followed that button
+                        to check a sale arrived at a table with the strike-through
+                        missing, and the fuller view said less than the summary it came
+                        from. */}
+                    <s-table-cell>
+                      <MoneyCell amount={row.before} compareAt={row.beforeCompareAt} />
+                    </s-table-cell>
+                    <s-table-cell>
+                      <MoneyCell amount={row.after} compareAt={row.afterCompareAt} />
+                    </s-table-cell>
                     {/* Only when it disagrees with the baseline, which is when it means
                         something. `live` is null in the ordinary case. */}
-                    <s-table-cell>{row.live ?? <Blank />}</s-table-cell>
                     <s-table-cell>
-                      {row.skippedReason ?? (row.unchanged ? "Already at this price" : "")}
+                      <MoneyCell amount={row.live} />
+                    </s-table-cell>
+                    <s-table-cell>
+                      {row.skippedReason ?? (row.unchanged ? "Already at this price" : <Blank />)}
                     </s-table-cell>
                   </s-table-row>
                 ))}

--- a/app/routes/app.prices.baselines._index.tsx
+++ b/app/routes/app.prices.baselines._index.tsx
@@ -17,6 +17,7 @@
 
 import { humanise } from "../lib/format/label";
 import { Blank } from "../components/Blank";
+import { MoneyCell } from "../components/MoneyCell";
 import { formatCount, formatWhen } from "../lib/format/display";
 import type { ActionFunctionArgs, HeadersFunction, LoaderFunctionArgs } from "react-router";
 import { useFetcher, useLoaderData, useSearchParams } from "react-router";
@@ -272,9 +273,17 @@ export default function Baselines() {
               {history.map((entry) => (
                 <s-table-row key={entry.capturedAt}>
                   <s-table-cell>{formatWhen(entry.capturedAt, timeZone)}</s-table-cell>
+                  {/* "(current)" used to be appended to the price itself, which put a
+                      word in the same text run as a number in a right-aligned column —
+                      so the one row that had it started several characters left of every
+                      other row's price, in a table whose whole purpose is comparing this
+                      variant's prices down the column. It is a note about the row, so it
+                      goes under the number like every other note. */}
                   <s-table-cell>
-                    {entry.price}
-                    {entry.current ? " (current)" : ""}
+                    <MoneyCell
+                      amount={entry.price}
+                      note={entry.current ? <s-text color="subdued">current</s-text> : undefined}
+                    />
                   </s-table-cell>
                   <s-table-cell>{entry.compareAt ?? <Blank />}</s-table-cell>
                   <s-table-cell>{humanise(entry.source)}</s-table-cell>

--- a/app/routes/app.settings.plan.tsx
+++ b/app/routes/app.settings.plan.tsx
@@ -57,7 +57,12 @@ export const loader = withGuard("/app/settings/plan", async ({ request }: Loader
       return {
         id,
         name: plan.name,
-        price: plan.priceMinor === 0 ? "Free" : `${formatMinorUnits(BigInt(plan.priceMinor), "USD")}/month`,
+        // The amount alone. "/month" used to be glued on here, which put a unit in the
+        // same text run as a number in a right-aligned column: "14.90/month" and
+        // "Free" then aligned on the "h" of month rather than on the decimal, so the
+        // one column a merchant compares down did not line up. The unit is a fact
+        // about the column, so it is said once, in the header.
+        price: plan.priceMinor === 0 ? "Free" : formatMinorUnits(BigInt(plan.priceMinor), "USD"),
         variantLimit: plan.variantLimit,
         markets: plan.markets,
         b2b: plan.b2b,
@@ -125,7 +130,7 @@ export default function PlanPage() {
         <s-table>
           <s-table-header-row>
             <s-table-header listSlot="primary">Plan</s-table-header>
-            <s-table-header listSlot="secondary" format="currency">Price</s-table-header>
+            <s-table-header listSlot="secondary" format="currency">Price a month</s-table-header>
             {/* Numeric, and it holds "Unlimited" on the top plan. A ceiling and the
                 absence of one belong in the same column, right-aligned together: the
                 comparison a merchant is making down this column is how far each plan

--- a/docs/polaris-notes.md
+++ b/docs/polaris-notes.md
@@ -274,3 +274,57 @@ a layout symptom surfaces somewhere other than the change that caused it — as 
 that is legitimate at some width and therefore reads as a design rather than a bug. Three
 deploys were spent on causes that turned out to be wrong; all three were narrowed by
 looking at one more page, never by reasoning harder.
+
+## A table cell's alignment reaches its text by inheritance, so nesting defeats it
+
+`format="currency"` and `format="numeric"` on an `s-table-header` are the app's only
+control over a money column, and it is worth knowing exactly what they do. From
+`polaris.js`, which is the only account of it that exists:
+
+```css
+.table-cell { display: table-cell; padding: .5rem .75rem;
+              min-block-size: 2rem; vertical-align: middle }
+.format-currency, .format-numeric { font-feature-settings: "tnum";
+              font-variant-numeric: tabular-nums; text-align: end }
+```
+
+Two things follow, and the second one cost a release.
+
+**Nothing in this app needs to set `tabular-nums` on a table cell.** The format already
+does, and a column of prices is where it matters most.
+
+**The alignment is `text-align` on the cell, so it reaches a number by inheritance.** Put
+a flex container in the cell — an `s-stack`, which is what you reach for the moment a cell
+holds a price *and* something qualifying it — and the number stops taking the column's
+alignment and starts taking the stack's, which defaults to the inline start. The column
+then renders with every row that has a compare-at sitting a few pixels left of every row
+that does not, which reads as a rendering fault rather than as anything anyone chose.
+
+`alignItems="end"` on the stack restores it. `MoneyCell` is the one place that knows this;
+`money-cell.test.ts` refuses a build without it, because the prop looks decorative and its
+absence is invisible in a diff.
+
+### The related trap: prose in the same text run as a number
+
+`text-align: end` aligns the *whole* cell's content. A qualifier concatenated onto the
+number — `` ` (was ${row.afterCompareAt})` ``, `" (current)"`, `"/month"` — is part of that
+run, so each row's number starts wherever its own suffix leaves room:
+
+```
+     Baseline        Would become
+        10.02     8.02 (was 10.02)
+        41.34        33.07 (was
+                         41.34)
+ 1799.32 (was       1439.46 (was
+    2598.79)           1799.32)
+```
+
+The wrapping is the obvious half. The expensive half is that no two prices in the column
+begin at the same place, so the decimal alignment the format was asked for is destroyed on
+exactly the rows that have something to say — and the whole reason to right-align money is
+that alignment. A money cell's first line holds a number and nothing else; everything else
+goes underneath it.
+
+Found in five tables at once (the editor's preview panel, the full-preview route, each
+market column of the review step, the baseline history, and the plans table). Pinned by
+`app/lib/ui/money-cell.test.ts`.


### PR DESCRIPTION
Closes #501

A money column is right-aligned by `format="currency"`, and the only reason to right-align prices is to compare them down the column. Five tables defeated that by gluing a qualifier into the same text run as the number.

```
     Baseline        Would become          Baseline    Would become
        10.02     8.02 (was 10.02)            10.02          8.02
        41.34        33.07 (was                                0̶.̶5̶8̶
                         41.34)               41.34         33.07
 1799.32 (was       1439.46 (was                             3̶5̶.̶7̶7̶
    2598.79)           1799.32)            1799.32       1439.46
                                           2̶5̶9̶8̶.̶7̶9̶       1̶7̶9̶9̶.̶3̶2̶
        before                                    after
```

The wrapping is the obvious half. The expensive half is that every suffix is a different length, so no two prices begin at the same place — on exactly the rows that have something to say.

### What changed

`MoneyCell` is now the one place that knows how a price, its compare-at and a note are rendered, and five tables go through it. The compare-at is struck through rather than parenthesised: unambiguous because it is what a storefront draws, and already the vocabulary of the `StorefrontExample` card sitting directly above the same table. `type="redundant"` renders as `<s>`, so a screen reader says so — and unlike `type="strong"` it *does* survive inside a table cell.

Two more, found while looking: the full preview showed neither compare-at, so "See all N rows" said less than the panel linking to it; and the plans table put `"/month"` in a currency column, so `Free` and `14.90/month` aligned on the "h" of month.

### The trap worth knowing

`alignItems="end"` on `MoneyCell`'s stack looks decorative and is not. From `polaris.js`:

```css
.format-currency, .format-numeric { font-feature-settings: "tnum";
        font-variant-numeric: tabular-nums; text-align: end }
```

The alignment is `text-align` on the cell, reaching the number by inheritance — so a flex container in the cell takes it over, and rows with a compare-at sit left of rows without one. Written up in `docs/polaris-notes.md`.

### Checks

`npm run typecheck`, `npm run lint` (0 errors) and all 2,733 tests green. Both new assertions mutated against the source they protect and confirmed failing. Verified in the admin on `anchor-perf`, not in serialised markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)