### PR TITLE
A scope that says what it means, in a row that fits

### DIFF
--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -192,7 +192,21 @@ export function CampaignListView({
                 {list.campaigns.map((campaign) => (
                   <s-table-row key={campaign.id}>
                     <s-table-cell>
-                      {campaign.name}
+                      {/* The name is the way in, which is what freed the action column.
+                          It used to carry a second "Open" button beside Duplicate, and
+                          the last of seven columns in a `table-layout: fixed` table is
+                          not wide enough for two — so they wrapped onto two lines and
+                          every row in the table was twice as tall as it needed to be.
+                          A row's identity opening the row is also the convention the
+                          admin sets everywhere else.
+
+                          Tertiary, not `s-link`: `ActionRow`'s vocabulary reserves blue
+                          for a word inside a sentence, and names a row-leading title as
+                          exactly what tertiary is for. It keeps an anchor's behaviour,
+                          so middle-click still opens a tab. */}
+                      <s-button variant="tertiary" href={`/app/campaigns/${campaign.id}`}>
+                        {campaign.name}
+                      </s-button>
                       {/* Only in the archive view, where every row has it, and on a
                           campaign that turns up in a search from the active list —
                           which is the case that would otherwise be confusing, because
@@ -229,9 +243,6 @@ export function CampaignListView({
                             Duplicate
                           </s-button>
                         </fetcher.Form>
-                        <s-button variant="tertiary" href={`/app/campaigns/${campaign.id}`}>
-                          Open
-                        </s-button>
                       </ActionRow>
                     </s-table-cell>
                   </s-table-row>

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -456,7 +456,7 @@ describe("the confirmation and the index describe a campaign the same way", () =
     // and `campaign-describe-shared.test.ts` refuses a second formatter.
     const html = render(<CampaignHeader {...props()} />);
 
-    expect(html).toContain("20% off");
+    expect(html).toContain("20%\u00a0off");
     expect(html).toContain("In Outerwear");
   });
 });

--- a/app/components/campaign/campaign-list-view.test.tsx
+++ b/app/components/campaign/campaign-list-view.test.tsx
@@ -89,15 +89,17 @@ describe("the table survives being collapsed into a list", () => {
 
   it("keeps the status, the rule and the way in on the row itself", () => {
     // All three `inline`, so a collapsed row reads as one line — "Autumn sale · Active ·
-    // 20% off · Open" — and answers what state this is in, what it does, and how to open
-    // it without unfolding into a block. The scope is `labeled` because it is longer and
-    // reads better stacked under its own word than run on after the rule.
+    // 20% off" — and answers what state this is in and what it does without unfolding
+    // into a block. The way in is the name itself, in the primary slot, rather than a
+    // second button in the action column; see the note on that cell. The scope is
+    // `labeled` because it is longer and reads better stacked under its own word than
+    // run on after the rule.
     expect(html.split('listSlot="inline"').length - 1).toBe(3);
   });
 
   it("says what each campaign does and what to", () => {
     // The gap this table had: everything *about* a campaign and nothing about what it is.
-    expect(html).toContain("20% off");
+    expect(html).toContain("20%\u00a0off");
     expect(html).toContain("Tagged sale");
   });
 

--- a/app/lib/campaigns/describe-shared.test.ts
+++ b/app/lib/campaigns/describe-shared.test.ts
@@ -80,7 +80,7 @@ describe("describeCampaign", () => {
         ast: { groups: [{ conditions: [{ field: "tag", value: "sale" }] }] },
         segmentName: "Winter clearance",
       }),
-    ).toEqual({ rule: "20% off", scope: "Winter clearance" });
+    ).toEqual({ rule: "20%\u00a0off", scope: "Winter clearance" });
   });
 
   it("still answers when a campaign has neither", () => {

--- a/app/lib/campaigns/describe.test.ts
+++ b/app/lib/campaigns/describe.test.ts
@@ -16,19 +16,26 @@ import { describe, expect, it } from "vitest";
 import { describeRule, describeScope } from "./describe";
 import { money } from "../money/money";
 
+/**
+ * The space between an amount and its word is non-breaking — "20%\u00a0off", not
+ * "20% off". `describeRule` carries the reason: a two-word value under a four-letter
+ * header is the column an auto-layout table always chooses to wrap, and the campaigns
+ * index was rendering "25%" over "off". Spelled as an escape in these assertions rather
+ * than pasted in as an invisible character, so a reader can see which space is meant.
+ */
 describe("the rule, as a merchant would say it", () => {
   it("says off for a discount, not a minus sign", () => {
     // "-20%" is a worse way to say it: a minus is one character wide in a scanned column.
-    expect(describeRule({ kind: "percent-change", percent: -20 })).toBe("20% off");
+    expect(describeRule({ kind: "percent-change", percent: -20 })).toBe("20%\u00a0off");
   });
 
   it("says increase for a rise, so the two cannot be confused", () => {
-    expect(describeRule({ kind: "percent-change", percent: 15 })).toBe("15% increase");
+    expect(describeRule({ kind: "percent-change", percent: 15 })).toBe("15%\u00a0increase");
   });
 
   it("keeps a fractional percentage without inventing precision", () => {
-    expect(describeRule({ kind: "percent-change", percent: -12.5 })).toBe("12.5% off");
-    expect(describeRule({ kind: "percent-change", percent: -20.0 })).toBe("20% off");
+    expect(describeRule({ kind: "percent-change", percent: -12.5 })).toBe("12.5%\u00a0off");
+    expect(describeRule({ kind: "percent-change", percent: -20.0 })).toBe("20%\u00a0off");
   });
 
   it("formats an amount in its own currency", () => {
@@ -84,6 +91,82 @@ describe("what it applies to", () => {
         ],
       }),
     ).toBe("In Outerwear · Tagged sale");
+  });
+
+  it("reads separate groups as OR, because that is what they are", () => {
+    // `astToWhere` ANDs the conditions inside a group and ORs the groups. `describeScope`
+    // used to flatten both into one `·` run, so the two structures the merchant can build
+    // came out as the same sentence — and `·` reads as AND.
+    expect(
+      describeScope({
+        groups: [
+          { conditions: [{ field: "collection", value: "Outerwear" }] },
+          { conditions: [{ field: "tag", value: "clearance" }] },
+        ],
+      }),
+    ).toBe("In Outerwear or Tagged clearance");
+  });
+
+  it("keeps AND inside a group and OR between groups", () => {
+    expect(
+      describeScope({
+        groups: [
+          {
+            conditions: [
+              { field: "collection", value: "Outerwear" },
+              { field: "tag", value: "sale" },
+            ],
+          },
+          { conditions: [{ field: "vendor", value: "Nike" }] },
+        ],
+      }),
+    ).toBe("In Outerwear · Tagged sale or By Nike");
+  });
+
+  it("lists values once when every group is the same field", () => {
+    // The commonest scope anyone builds, and the one that was worst. Five product types
+    // came out as "productType: Backpack · productType: Boots · ..." — a hundred-odd
+    // characters describing, in this function's own spelling of AND, a scope that would
+    // match nothing. It was also the widest cell in the campaigns table, which on
+    // `s-table`'s auto layout wrapped "25% off" onto two lines to make room for it.
+    expect(
+      describeScope({
+        groups: [
+          { conditions: [{ field: "productType", value: "Backpack" }] },
+          { conditions: [{ field: "productType", value: "Boots" }] },
+          { conditions: [{ field: "productType", value: "Gloves" }] },
+        ],
+      }),
+    ).toBe("Type Backpack, Boots or Gloves");
+  });
+
+  it("does not list values for a field whose phrase quotes them", () => {
+    // "Title contains “parka”, boots" would read as though only the first is quoted.
+    expect(
+      describeScope({
+        groups: [
+          { conditions: [{ field: "title", value: "parka" }] },
+          { conditions: [{ field: "title", value: "boots" }] },
+        ],
+      }),
+    ).toBe("Title contains “parka” or Title contains “boots”");
+  });
+
+  it("names the fields the filter builder actually offers", () => {
+    // These fell through to `field: value` — the branch meant for a field nobody
+    // anticipated — while being four of the nine `conditionToWhere` handles.
+    expect(
+      describeScope({ groups: [{ conditions: [{ field: "productType", value: "Boots" }] }] }),
+    ).toBe("Type Boots");
+    expect(
+      describeScope({ groups: [{ conditions: [{ field: "status", value: "active" }] }] }),
+    ).toBe("Status active");
+    expect(
+      describeScope({ groups: [{ conditions: [{ field: "sku", value: "ANC-1" }] }] }),
+    ).toBe("SKU contains “ANC-1”");
+    expect(
+      describeScope({ groups: [{ conditions: [{ field: "barcode", value: "5012" }] }] }),
+    ).toBe("Barcode contains “5012”");
   });
 
   it("counts a pinned variant list rather than listing gids", () => {

--- a/app/lib/campaigns/describe.ts
+++ b/app/lib/campaigns/describe.ts
@@ -18,6 +18,27 @@ import type { FilterAst } from "../../services/segments.server";
  * before #400. `describe.test.ts` checks the callers go through here.
  */
 
+/**
+ * The space between an amount and the word that gives it meaning.
+ *
+ * Non-breaking, because "25% off" is one phrase and there is no reading of it in which
+ * breaking after the number helps. `s-table` has no `table-layout: fixed` and no width
+ * control on a column, so the browser distributes the width and wraps whichever column
+ * has the most give — and a four-letter header over a two-word value is always the one
+ * with the most give. On the campaigns index the Rule column was rendering
+ *
+ *     25%
+ *     off
+ *
+ * beside a scope that had taken half the table. Binding the pair is the only lever there
+ * is, and it is also just correct: it says the two words are one unit, which is the same
+ * reason a typesetter would do it.
+ *
+ * Only on the short pairs. "Set to €9.99" and "Prices from a file" are sentences, and a
+ * sentence that cannot break is a column that cannot shrink.
+ */
+const NB = "\u00a0";
+
 /** The rule, as a merchant would say it. */
 export function describeRule(rule: AdjustmentRule | null | undefined): string {
   if (!rule) return "No rule";
@@ -29,14 +50,14 @@ export function describeRule(rule: AdjustmentRule | null | undefined): string {
       // wide. Zero is neither, and saying "0% off" would imply a sale that is not one.
       if (rule.percent === 0) return "No change";
       return rule.percent < 0
-        ? `${strip(-rule.percent)}% off`
-        : `${strip(rule.percent)}% increase`;
+        ? `${strip(-rule.percent)}%${NB}off`
+        : `${strip(rule.percent)}%${NB}increase`;
 
     case "fixed-change":
       if (rule.amount.amount === 0) return "No change";
       return rule.amount.amount < 0
-        ? `${format({ ...rule.amount, amount: -rule.amount.amount })} off`
-        : `${format(rule.amount)} more`;
+        ? `${format({ ...rule.amount, amount: -rule.amount.amount })}${NB}off`
+        : `${format(rule.amount)}${NB}more`;
 
     case "set-exact":
       return `Set to ${format(rule.amount)}`;
@@ -70,8 +91,10 @@ function strip(percent: number): string {
 export function describeScope(ast: FilterAst | null | undefined, segmentName?: string | null): string {
   if (segmentName) return segmentName;
 
-  const conditions = (ast?.groups ?? []).flatMap((group) => group.conditions);
-  if (conditions.length === 0) return "All variants";
+  const groups = (ast?.groups ?? []).filter((group) => (group.conditions ?? []).length > 0);
+  if (groups.length === 0) return "All variants";
+
+  const conditions = groups.flatMap((group) => group.conditions);
 
   const pinned = conditions.find((condition) => condition.field === "variantGid");
   if (pinned) {
@@ -79,30 +102,83 @@ export function describeScope(ast: FilterAst | null | undefined, segmentName?: s
     return `${count} chosen ${count === 1 ? "variant" : "variants"}`;
   }
 
-  return conditions.map(describeCondition).join(" · ");
+  /*
+   * One group per value, all on the same field, is an OR over values — and it is by far
+   * the commonest scope anyone builds: "these five product types".
+   *
+   * Written out condition by condition it came to
+   * "productType: Backpack · productType: Boots · productType: Gloves · productType:
+   * Goggles · productType: Helmet", which is wrong twice over. `·` is this function's
+   * spelling of AND, and no product is five types at once, so the sentence describes a
+   * scope that matches nothing while the campaign it labels matched 62,535 variants.
+   * And at a hundred-odd characters it was the widest cell in the campaigns table, which
+   * on `s-table`'s auto layout squeezed every other column — "25% off" was wrapping onto
+   * two lines to make room for a field name repeated five times.
+   *
+   * Listing the values once says what it means and is less than half as long.
+   */
+  const field = conditions[0].field;
+  const oneEach =
+    groups.length > 1 &&
+    groups.every((group) => group.conditions.length === 1) &&
+    conditions.every((condition) => condition.field === field);
+
+  if (oneEach && field in PREFIX) {
+    const values = conditions.map((condition) => String(condition.value));
+    return `${PREFIX[field]} ${listOut(values)}`;
+  }
+
+  // Otherwise, the structure as it actually is: AND within a group, OR between them.
+  // Flattening the two into one `·` run was what hid the case above.
+  return groups
+    .map((group) => group.conditions.map(describeCondition).join(" · "))
+    .join(" or ");
+}
+
+/**
+ * Fields whose phrase is a prefix and a value, so several values can be listed after one
+ * prefix.
+ *
+ * `title`, `sku` and `barcode` are deliberately absent: they read as
+ * `Title contains “parka”`, and a bare list appended to a quoted phrase
+ * — `Title contains “parka”, boots or gloves` — reads as though only the first is quoted.
+ * They fall through to the OR join below, which is longer and correct.
+ */
+const PREFIX: Record<string, string> = {
+  collection: "In",
+  tag: "Tagged",
+  vendor: "By",
+  productType: "Type",
+  status: "Status",
+};
+
+/** "a", "a or b", "a, b or c" — the last two joined by a word rather than a comma. */
+function listOut(values: string[]): string {
+  if (values.length <= 1) return values[0] ?? "";
+  return `${values.slice(0, -1).join(", ")} or ${values[values.length - 1]}`;
 }
 
 function describeCondition(condition: { field: string; value: unknown }): string {
   const value = String(condition.value);
 
   switch (condition.field) {
-    case "collection":
-      return `In ${value}`;
-    case "tag":
-      return `Tagged ${value}`;
     case "excludeTag":
       // Said as an exception rather than as another condition, because that is what it
       // is: "In Outerwear · except tagged no-sale" is a sentence a merchant can check
       // against what they meant.
       return `except tagged ${value}`;
-    case "vendor":
-      return `By ${value}`;
     case "title":
       return `Title contains “${value}”`;
+    case "sku":
+      return `SKU contains “${value}”`;
+    case "barcode":
+      return `Barcode contains “${value}”`;
     default:
       // A field nobody anticipated still gets a readable phrase rather than nothing —
       // the same argument `describeAction` makes about not being a lookup table.
-      return `${condition.field}: ${value}`;
+      return condition.field in PREFIX
+        ? `${PREFIX[condition.field]} ${value}`
+        : `${condition.field}: ${value}`;
   }
 }
 


### PR DESCRIPTION
Closes #503

Three faults in one screenshot of the campaigns index, and the first is about meaning rather than layout.

### The scope sentence said AND where it meant OR

`astToWhere` ANDs the conditions inside a group and ORs the groups. `describeScope` flattened both into one `·` run — its own spelling of AND — so a campaign scoped to five product types read:

> productType: Backpack · productType: Boots · productType: Gloves · productType: Goggles · productType: Helmet

No product is five types at once, so that describes a scope matching nothing, next to a campaign whose last run verified 62,535 variants. Groups now join with "or"; conditions within a group still join with `·`; and the commonest shape — one group per value on the same field — lists the values once:

> Type Backpack, Boots, Gloves, Goggles or Helmet

`productType`, `status`, `sku` and `barcode` were also falling through to the `field: value` branch meant for *a field nobody anticipated*, while being four of the nine fields `conditionToWhere` handles.

### That cell was also the widest in the table

```css
.table { all: unset; display: table; inline-size: 100%; border-collapse: collapse }
```

No `table-layout: fixed`, and `s-table-header` takes only `listSlot` and `format` — there is no width control anywhere. The browser distributes width and wraps whichever column has the most give, which is a four-letter header over a two-word value. The Rule column was rendering `25%` over `off`. Halving the scope cell gives it room, and the space between an amount and its word is now non-breaking — the only lever there is, and correct typography besides.

### The action column could not hold two buttons

`Duplicate` and `Open` in the last of seven columns wrapped, making every row twice as tall as needed. The name is the way in now — the convention the admin sets everywhere else, and what freed the column.

### Result

Rows are one line where the data allows, down from three.

### Checks

`npm run typecheck`, `npm run lint` (0 errors), 2,738 tests green. New assertions mutated against the source they protect and confirmed failing. Verified in the admin on `anchor-perf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)