### PR TITLE
The ordinary outcome stops asking to be looked at

### DIFF
--- a/app/components/LedgerTable.tsx
+++ b/app/components/LedgerTable.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 
 import type { LedgerRow } from "../services/campaigns/index.server";
 import { LEDGER_TONE, toneFor } from "./tone";
+import { RowState } from "./RowState";
 
 /**
  * Every row we wrote, with what it was and what we intended.
@@ -53,7 +54,14 @@ export function LedgerTable({
             <s-table-cell>{row.before ?? <Blank />}</s-table-cell>
             <s-table-cell>{row.intended ?? <Blank />}</s-table-cell>
             <s-table-cell>
-              <s-badge tone={toneFor(LEDGER_TONE, row.status)}>{humanise(row.status)}</s-badge>
+              {/* A clean run is every row VERIFIED, so badging it puts sixty green
+                  pills on the page and leaves the one FAILED row competing with them.
+                  See `RowState`. */}
+              <RowState
+                label={humanise(row.status)}
+                tone={toneFor(LEDGER_TONE, row.status)}
+                ordinary={row.status === "VERIFIED"}
+              />
             </s-table-cell>
             <s-table-cell>{row.failureReason ?? <Blank />}</s-table-cell>
             {renderAction ? <s-table-cell>{renderAction(row)}</s-table-cell> : null}

--- a/app/components/PreviewTable.tsx
+++ b/app/components/PreviewTable.tsx
@@ -1,5 +1,6 @@
 import { humanise } from "../lib/format/label";
 import { MoneyCell } from "./MoneyCell";
+import { RowState } from "./RowState";
 import { EmptyState } from "./AsyncState";
 import { ShowingSome } from "./Pagination";
 import type { MarketPreview, PreviewRow } from "../services/campaigns/index.server";
@@ -88,10 +89,13 @@ export function PreviewTable({
               );
             })}
             <s-table-cell>
-              <s-badge tone={toneFor(PREVIEW_TONE, row.status)}>
-                {humanise(row.status)}
-                {row.reason ? ` \u00b7 ${row.reason}` : ""}
-              </s-badge>
+              {/* Every row a campaign will write is "pending", so it is the whole
+                  table. `clamped` and `skipped` are the rows worth finding. */}
+              <RowState
+                label={`${humanise(row.status)}${row.reason ? ` \u00b7 ${row.reason}` : ""}`}
+                tone={toneFor(PREVIEW_TONE, row.status)}
+                ordinary={row.status === "pending" && !row.reason}
+              />
             </s-table-cell>
           </s-table-row>
         ))}

--- a/app/components/ReconciliationTable.tsx
+++ b/app/components/ReconciliationTable.tsx
@@ -2,6 +2,7 @@ import { NoMatches } from "./AsyncState";
 import { Blank } from "./Blank";
 import type { ReconciliationRow } from "../services/reconciliation.server";
 import { stateLabel } from "../lib/reporting/reconciliation-csv";
+import { RowState } from "./RowState";
 
 /**
  * Every price, next to the reason it is that price.
@@ -74,9 +75,13 @@ export function ReconciliationTable({
               )}
             </s-table-cell>
             <s-table-cell>
-              <s-badge tone={row.drifted ? "critical" : row.offBaseline ? "info" : "success"}>
-                {stateLabel(row)}
-              </s-badge>
+              {/* A store that reconciles is every row matching, and this table exists to
+                  be scanned for the ones that do not. */}
+              <RowState
+                label={stateLabel(row)}
+                tone={row.drifted ? "critical" : row.offBaseline ? "info" : "success"}
+                ordinary={!row.drifted && !row.offBaseline}
+              />
             </s-table-cell>
           </s-table-row>
         ))}

--- a/app/components/RollbackReportTable.tsx
+++ b/app/components/RollbackReportTable.tsx
@@ -2,6 +2,7 @@ import type { RollbackRow } from "../services/campaigns/index.server";
 import { Blank } from "./Blank";
 import { ShowingSome } from "./Pagination";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
+import { RowState } from "./RowState";
 
 /**
  * What reverting would do, row by row, with the drifted ones first.
@@ -67,7 +68,13 @@ export function RollbackReportTable({ rows }: { rows: RollbackRow[] }) {
           <s-table-row key={row.variantGid}>
             <s-table-cell>{row.title}</s-table-cell>
             <s-table-cell>
-              <s-badge tone={STATE[row.kind].tone}>{STATE[row.kind].label}</s-badge>
+              {/* "Unchanged" is what most rows of a revert are, and what the merchant
+                  is not being asked to decide about. The decisions are `drifted`. */}
+              <RowState
+                label={STATE[row.kind].label}
+                tone={STATE[row.kind].tone}
+                ordinary={row.kind === "clean"}
+              />
             </s-table-cell>
             <s-table-cell>{row.applied ?? <Blank />}</s-table-cell>
             <s-table-cell>{row.live ?? <Blank />}</s-table-cell>

--- a/app/components/RowState.tsx
+++ b/app/components/RowState.tsx
@@ -1,0 +1,49 @@
+import type { Tone } from "./tone";
+
+/**
+ * A row's state, badged only when it is worth looking at.
+ *
+ * ## The rule
+ *
+ * Colour spent on the normal case is colour that carries no information. A campaign's
+ * ledger after a clean run is sixty rows all reading "Verified", and badging every one of
+ * them produces a screenful of green pills, each drawing the eye to a variant that needs
+ * nothing — while the one row that failed competes with fifty-nine that did not.
+ *
+ * The catalogue page argued this out first and fixed itself: `At baseline` is subdued
+ * text, `No baseline` and `Not at baseline` are badges. Four other tables kept the old
+ * shape, so this is that decision made once rather than a fifth time.
+ *
+ * **Subdued text, not a neutral badge.** This is the part that is easy to get wrong. A
+ * badge is a shape as well as a colour, so recolouring forty green pills grey leaves
+ * forty things that still look like forty things to look at. Removing the pill is the
+ * de-emphasis that works.
+ *
+ * ## Why this does not break `colour-signal.test.ts`
+ *
+ * WCAG 1.4.1 forbids carrying information by colour alone. Nothing here does: the state
+ * still says its own name in words, in both branches. What changes is only how loudly the
+ * ordinary answer is said.
+ *
+ * ## Choosing `ordinary`
+ *
+ * It is not "the state whose tone is success". `Skipped` is toned neutral and is very
+ * much worth noticing — it is a row the merchant expected to be priced and which was not.
+ * The question is whether the state is the *expected outcome of the operation this table
+ * reports on*, which is a judgement each caller makes about its own table, so it is a
+ * prop rather than a lookup here.
+ */
+export function RowState({
+  label,
+  tone,
+  ordinary = false,
+}: {
+  label: string;
+  tone: Tone;
+  /** True when this is the expected outcome, and so not worth a badge. */
+  ordinary?: boolean;
+}) {
+  if (ordinary) return <s-text color="subdued">{label}</s-text>;
+
+  return <s-badge tone={tone}>{label}</s-badge>;
+}

--- a/app/components/row-state.test.tsx
+++ b/app/components/row-state.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * The ordinary outcome is not worth a badge.
+ *
+ * A campaign's ledger after a clean run is sixty rows all reading "Verified". Badged, that
+ * is sixty green pills, each drawing the eye to a variant that needs nothing, and the one
+ * FAILED row competing with fifty-nine that succeeded. The same shape was in the
+ * reconciliation table (every row matching), the rollback report (every row unchanged) and
+ * the review step's preview (every row pending).
+ *
+ * The catalogue page reached this conclusion first and fixed only itself. `RowState` is
+ * that decision made once, and this file is the part of it that cannot be un-made by
+ * accident — because the failure is not an exception or a broken layout, it is a page
+ * that looks busy, which nobody files a bug about.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { RowState } from "./RowState";
+import { sourceOf } from "../lib/testing/source";
+
+describe("RowState", () => {
+  const ordinary = renderToStaticMarkup(<RowState label="Verified" tone="success" ordinary />);
+  const exceptional = renderToStaticMarkup(<RowState label="Failed" tone="critical" />);
+
+  it("renders the ordinary state without a badge", () => {
+    // Subdued text rather than a neutral badge, which is the distinction that matters: a
+    // badge is a shape as well as a colour, so recolouring forty pills grey still leaves
+    // forty things that look like forty things to look at.
+    expect(ordinary).not.toContain("s-badge");
+    expect(ordinary).toContain('color="subdued"');
+  });
+
+  it("still says the state's own name, so nothing is carried by colour alone", () => {
+    // WCAG 1.4.1, the rule `colour-signal.test.ts` enforces. De-emphasis is allowed;
+    // dropping the word would not be.
+    expect(ordinary).toContain("Verified");
+    expect(exceptional).toContain("Failed");
+  });
+
+  it("badges a state that is not the expected outcome", () => {
+    expect(exceptional).toContain("s-badge");
+    expect(exceptional).toContain('tone="critical"');
+  });
+});
+
+describe("no table badges its own ordinary state", () => {
+  /**
+   * The four that did. Listed by name rather than discovered by pattern: the check is
+   * that these specific tables went through `RowState`, and a new table that badges
+   * everything is a review comment rather than something this file can see.
+   */
+  const TABLES = [
+    "app/components/LedgerTable.tsx",
+    "app/components/ReconciliationTable.tsx",
+    "app/components/RollbackReportTable.tsx",
+    "app/components/PreviewTable.tsx",
+  ];
+
+  it.each(TABLES)("%s renders its state through RowState", (path) => {
+    const source = sourceOf(path);
+
+    expect(source, `${path} should import RowState`).toContain('from "./RowState"');
+    expect(
+      source,
+      `${path} still writes an <s-badge> for its state column — the ordinary outcome then gets a pill on every row`,
+    ).not.toContain("<s-badge");
+  });
+});


### PR DESCRIPTION
Closes #505

#500 argued this out on the catalogue and fixed only the catalogue: **colour spent on the normal case is colour that carries no information.** Four tables still badge their own ordinary outcome — and they are the four where it matters most, because each is opened specifically to find the exception.

| Table | Ordinary state | What a healthy page looked like |
|---|---|---|
| `LedgerTable` | `VERIFIED` | a clean run is 60 green pills, and the one FAILED row competes with 59 that succeeded |
| `ReconciliationTable` | matches | the view exists to be scanned for rows that do not |
| `RollbackReportTable` | `clean` | the rows needing a decision are the drifted ones, which looked the same |
| `PreviewTable` | `pending` | every row a campaign will write, so it is the whole table |

Seen on `anchor-perf`: the ledger of a completed 62,535-variant campaign rendered every visible row as a green `Verified` badge.

### Subdued text, not a neutral badge

The part that is easy to get wrong. A badge is a shape as well as a colour, so recolouring forty green pills grey leaves forty things that still look like forty things to look at. Removing the pill is the de-emphasis that works.

`colour-signal.test.ts` is unaffected — the state still says its own name in words in both branches, so nothing is carried by colour alone (WCAG 1.4.1).

### Why `ordinary` is a prop and not `tone === "success"`

`SKIPPED` is toned `neutral` and is very much worth noticing: it is a row the merchant expected to be priced and which was not. Whether a state is the *expected outcome* is a judgement about the operation each table reports on.

### One thing deliberately not changed

With the badges gone, `Revert this variant` is the heaviest thing on a ledger row, and shortening it to `Revert` is tempting. The page-level Revert button ends the whole campaign — a row action reading identically to it is a worse problem than a repeated phrase.

### Checks

`npm run typecheck`, `npm run lint` (0 errors), 2,749 tests green. Both new assertions mutated against the source they protect and confirmed failing. Verified in the admin on a real 60-row ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)