### PR TITLE
One name per column, and two tiles that are not halves

### DIFF
--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -185,8 +185,15 @@ export function DraftPreview({
             <s-table-header listSlot="inline" format="currency">Baseline</s-table-header>
             {/* Inline, both of them: collapsed, the row reads "Cotton tee - $24.00
                 $19.20", which is the whole question this panel answers. Labelled pairs
-                would put the two halves of a before-and-after on separate lines. */}
-            <s-table-header listSlot="inline" format="currency">Would become</s-table-header>
+                would put the two halves of a before-and-after on separate lines.
+
+                "Becomes", the same word the full-preview route uses for this column.
+                They are two views of one draft — this panel's "See all N rows" is what
+                opens that page — and they had two names for the column a merchant goes
+                there to check. It is also two syllables shorter, which matters here:
+                once the compare-at moved under the price the column narrowed, and
+                "Would become" started wrapping onto two lines in the header. */}
+            <s-table-header listSlot="inline" format="currency">Becomes</s-table-header>
           </s-table-header-row>
           <s-table-body>
             {preview.rows.map((row) => (

--- a/app/lib/ui/table-designation.test.ts
+++ b/app/lib/ui/table-designation.test.ts
@@ -148,7 +148,7 @@ describe("every table is designed for the shape Polaris might collapse it into",
 const MONEY = [
   "Baseline", "Live", "Live price", "Live now", "Before", "After", "Intended", "Compare at",
   "Cost", "Price", "We applied", "Reverts to", "Campaign set", "Now shows", "Now",
-  "Would become", "Price a month",
+  "Becomes", "Price a month",
 ];
 
 const COUNTS = [

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -570,7 +570,22 @@ export default function Dashboard() {
           <CountsRow
             items={[
               { label: "Variants", value: health.variants },
-              { label: "With a baseline", value: health.withBaseline },
+              /* "Baselines captured", not "With a baseline".
+              
+                 These are three different axes, but the middle and right tiles were
+                 named closely enough to read as two halves of one: "With a baseline
+                 3,669" beside "Not at baseline 1" invites the arithmetic, and the
+                 arithmetic does not work — 3,669 + 1 is not 3,669. They are not
+                 complements. One counts variants that *have* a reference price; the
+                 other counts variants whose storefront has moved away from theirs.
+              
+                 It is self-correcting at full coverage, because a merchant can see the
+                 first two numbers match. At 95% coverage it is not, and that is exactly
+                 the shop that needs to read it right. Naming the capture removes the
+                 reading; "Not at baseline" stays, because it is what the catalogue's
+                 badge and the help note already call this and one thing should not have
+                 two names. */
+              { label: "Baselines captured", value: health.withBaseline },
               { label: "Not at baseline", value: health.drifted },
             ]}
           />


### PR DESCRIPTION
Closes #507

Both found by opening the deployed pages after #502 and #506.

### The two previews named one column differently

The editor's panel headed it `Would become`; the full-preview route its own "See all N rows" button opens headed the same value `Becomes`. #464 already settled that the two ways into the preview should describe the same campaign — and this is the column a merchant goes there to check.

It had also started wrapping. Once #502 moved the compare-at underneath the price the column narrowed, and `s-table` has auto layout and no width control, so a shorter word is the only lever. The shorter word was already in use next door.

### Two Home tiles read as complements and are not

```
Variants 3,669    With a baseline 3,669    Not at baseline 1
```

The middle and right tiles invite the arithmetic, and it does not work: 3,669 + 1 is not 3,669. They are different axes — one counts variants that *have* a reference price, the other counts variants whose storefront has moved *away from* theirs.

Self-correcting at 100% coverage, because the first two numbers visibly match. Not self-correcting at 95%, which is exactly the shop that needs to read it right.

`Not at baseline` stays — it is what the catalogue badge and the help note already call this, and one thing should not have two names. The capture gets named instead.

### Checks

`npm run typecheck`, `npm run lint` (0 errors), 2,749 tests green. Verified in the admin on `anchor-perf`: the header now fits on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)