### PR TITLE
Measure what the planner asks Postgres, not what we think it asks

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -102,3 +102,9 @@ Webhook lag under load, likewise. Twenty sequential edits on an idle store is th
 case; the number that would matter during an incident is lag while a bulk import is
 draining the same queue. `webhook.lag_ms` is emitted every tick now, so the panel will
 answer that once there is traffic to look at.
+
+## Query plans
+
+The numbers above are wall clock. [`queries.md`](queries.md) is the layer under them —
+what the filter engine and the planner ask Postgres, and which of those questions it can
+answer from an index. Run with `npm run measure:queries`.

--- a/docs/perf/queries.md
+++ b/docs/perf/queries.md
@@ -1,0 +1,135 @@
+# Query plans for targeting and planning
+
+What the filter engine and the planner actually ask Postgres, and how Postgres answers it
+against a real 102,132-variant catalogue.
+
+```shell
+npm run measure:queries -- --shop anchor-perf
+```
+
+The script runs the real service functions — `previewMatches`, `facets`,
+`resolveVariantGids`, `loadCandidates` — captures every statement Prisma emits, and runs
+`EXPLAIN (ANALYZE, BUFFERS)` on each one. It writes nothing.
+
+**Why it captures rather than quotes.** An EXPLAIN of a hand-copied query measures the
+query you believe the ORM builds. The first finding below exists precisely because those
+two things had diverged: the filter engine asks for `equals` with `mode: "insensitive"`,
+Prisma emits `ILIKE`, and the `lower(vendor)`-shaped indexes built to serve it cannot be
+used by `ILIKE` at all. Nothing on the Prisma side says so, and the index had recorded
+zero scans since it was created.
+
+## Baseline, 30 August 2026 — before any change
+
+`anchor-perf.myshopify.com`, 102,132 variants, 106,889 baselines, 116,000 surface entries.
+Warm cache, one request at a time.
+
+| Path | Wall | Statements | Reading a whole table |
+|---|---|---|---|
+| scope: whole catalogue | 44 ms | 2 | 1 |
+| scope: tag | 13 ms | 2 | 0 |
+| scope: collection | 1 ms | 2 | 0 |
+| scope: vendor | 31 ms | 2 | **2** |
+| scope: product type | 35 ms | 2 | **2** |
+| scope: title contains | 54 ms | 2 | **2** |
+| scope: sku contains | 29 ms | 2 | **2** |
+| scope: price floor | 19 ms | 2 | 2 |
+| facets: the scope picker's options | **330 ms** | 1 | 1 |
+| enrol: every gid in scope | 24 ms | 1 | 0 |
+| plan: candidates for a tag | 274 ms | 9 | 8 |
+| plan: candidates for the whole catalogue | 1,288 ms | 43 | **43** |
+
+**63 of 70 statements read a whole table.** That headline is worth less than it looks,
+because three different things are hiding behind it and only two are defects.
+
+### A full scan is not automatically a bug
+
+`scope: price floor` matches 90,589 of 105,869 rows and `scope: whole catalogue` matches
+all of them. Reading the table is the correct plan for both — an index that returns 86% of
+a table costs more than the scan it replaces. Those rows stay in the table above as
+context, not as work.
+
+The distinction matters because the obvious response to a scan count is to add indexes
+until it reaches zero, which buys write amplification on the sync path in exchange for
+plans Postgres will decline to use.
+
+### Finding 1 — four filter conditions cannot use an index, and two indexes cannot be used
+
+`vendor`, `productType`, `title` and `sku` all compile to `ILIKE`. `variant_index` carries
+`variant_index_title_lower` (14 MB) and `variant_index_sku_lower` (7.3 MB), both btrees on
+`lower(col)`, and Postgres cannot serve `ILIKE` from either. Both report **zero scans**
+since creation, and no raw SQL in `app/` uses `lower(` — so this is structural, not a
+sampling artefact.
+
+Measured against a trigram index instead:
+
+| Condition | Matches | Seq scan | `gin_trgm_ops` |
+|---|---|---|---|
+| `sku contains "APF-927"` | 52 | 24.7 ms | **0.6 ms** |
+| `title contains "Alpine"` | 8,354 | 38.9 ms | **4.0 ms** |
+| `productType = "Boots"` | 12,680 | 27.5 ms | **5.6 ms** |
+| `vendor = "Northwind"` | 11,973 | 28.5 ms | 25.9 ms |
+
+The win tracks selectivity, which is the honest way to read it: a search that finds 52
+rows gets 42× and a filter that matches 11% of the catalogue gets nothing worth having.
+The trigram indexes are also *smaller* than the dead ones they replace — 6.5 MB for
+`title` against 14 MB, 2.5 MB for `sku` against 7.3 MB.
+
+Tracked as its own ticket. `vendor` and `productType` are deliberately left scanning:
+low-cardinality equality over a large fraction of the table is a scan whatever index
+exists, and two more GIN indexes maintained on every one of 102K sync upserts is a poor
+trade for 9%.
+
+### Finding 2 — `facets()` reads the whole catalogue to fill four dropdowns
+
+330 ms, one statement, every non-deleted row, four columns including two arrays — to
+produce 16 vendors, 15 product types, 18 tags and 10 collections, each then
+`.slice(0, 100)`. Three route loaders await it: the campaign editor, the costs page and
+the segments page.
+
+Only ~44 ms of that is Postgres. The rest is transferring and materialising 102,132 rows
+to build four `Set`s. `SELECT DISTINCT` does the same work in the database in 37 ms and
+returns 53 rows.
+
+Tracked as its own ticket.
+
+### Finding 3 — planning issues one full scan of `baselines` per chunk, and that is currently correct
+
+`loadCandidates` over the whole catalogue emits 43 statements: 21 chunks × `baselines`,
+21 × `price_surface_entries`, plus the scope query. Every one is a sequential scan, each
+discarding ~100,869 rows.
+
+This looks worse than it is. With 5,000 values in the `IN` list, Postgres correctly
+judges one pass over a 106,889-row table cheaper than 5,000 index probes. Measured across
+chunk sizes, planning the full catalogue:
+
+| `IN_CHUNK` | Batches | baselines | surfaces | Total |
+|---|---|---|---|---|
+| 250 | 409 | 3,272 ms | 3,082 ms | 6,354 ms |
+| 500 | 205 | 2,224 ms | 2,185 ms | 4,409 ms |
+| 1,000 | 103 | 2,194 ms | 2,299 ms | 4,493 ms |
+| 2,000 | 52 | 1,122 ms | 964 ms | 2,087 ms |
+| **5,000 (current)** | 21 | 983 ms | 758 ms | **1,740 ms** |
+| 10,000 | 11 | 908 ms | 740 ms | 1,648 ms |
+| 20,000 | 6 | 865 ms | 712 ms | 1,577 ms |
+
+**5,000 is the right value and stays.** Dropping to 250 is 3.7× slower; the 9% available
+above it is not worth spending the headroom that `IN_CHUNK` exists to preserve — that gap
+is deliberate room under Postgres's 32,767 bind-variable ceiling for a caller to add
+another filter years from now, not tuning slack. See `app/lib/db/chunk.ts`.
+
+**The part that is a real risk, and is not visible here.** Chunks scale with the size of
+the *scope* and each scan costs the size of the *table*, so total work is O(scope × table).
+At 102K variants that product is small enough that the scan wins. It is not obvious that
+it still wins at ten times the ledger, and this catalogue cannot answer that. Recorded
+rather than guessed at.
+
+## What this does not cover
+
+Concurrency, same as `measure-admin`. Every number here is one statement at a time against
+an otherwise idle database, so they are a floor. A merchant paging the catalogue while a
+100K campaign plans is a different question.
+
+Nor is any of it from a real beta merchant. `anchor-perf` is synthetic — uniform variant
+counts, 16 vendors, tags applied evenly. Real catalogues are lumpy, and lumpy is what
+breaks a plan that depends on a selectivity estimate. #160's "worst-performing real beta
+store" clause stays open until there is one.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "scope:probe": "tsx scripts/scope-probe.ts",
     "measure:admin": "tsx scripts/measure-admin.ts",
     "measure:import": "tsx scripts/measure-import.ts",
-    "drill:mirror": "tsx scripts/drill-mirror.ts"
+    "drill:mirror": "tsx scripts/drill-mirror.ts",
+    "measure:queries": "tsx scripts/measure-queries.ts"
   },
   "type": "module",
   "engines": {

--- a/scripts/measure-queries.test.ts
+++ b/scripts/measure-queries.test.ts
@@ -1,0 +1,193 @@
+/**
+ * What the query harness concludes from a plan.
+ *
+ * The numbers need a hundred thousand variants; the reading of them does not. And the
+ * reading is where a harness like this fails silently — by finding no full scan in a plan
+ * that has one, and reporting a clean bill of health for a catalogue it did look at. That
+ * is worse than not running it, because it is the result somebody quotes.
+ *
+ * Postgres nests the interesting node inside three or four wrappers (Aggregate over
+ * Gather over Nested Loop over the scan), so "did anything read a whole table" is a
+ * question about the whole tree and never about its root.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NOT_EXPLAINABLE, parseParams, summarise, walk } from "./measure-queries";
+
+/** The shape Postgres returns for `EXPLAIN (FORMAT JSON)`, trimmed to what is read. */
+const node = (
+  type: string,
+  over: Record<string, unknown> = {},
+): Record<string, unknown> => ({ "Node Type": type, ...over });
+
+describe("finding the scans", () => {
+  it("reports a sequential scan at the root", () => {
+    const plan = summarise("select 1", node("Seq Scan", { "Relation Name": "variant_index" }), 12);
+
+    expect(plan.scannedRelations).toEqual(["variant_index"]);
+  });
+
+  it("finds one buried under the aggregate that Prisma's counts always add", () => {
+    // Every `count()` Prisma emits arrives as Aggregate → Subquery Scan → the real node.
+    // A check that looked only at the root would call every count in the app indexed.
+    const plan = summarise(
+      "select count(*)",
+      node("Aggregate", {
+        Plans: [
+          node("Subquery Scan", {
+            Plans: [node("Seq Scan", { "Relation Name": "baselines" })],
+          }),
+        ],
+      }),
+      40,
+    );
+
+    expect(plan.scannedRelations).toEqual(["baselines"]);
+  });
+
+  it("counts a parallel sequential scan as a full scan", () => {
+    // Postgres names it differently once it parallelises, and a table read by three
+    // workers is still a table read.
+    const plan = summarise(
+      "select 1",
+      node("Gather", {
+        Plans: [node("Parallel Seq Scan", { "Relation Name": "variant_index" })],
+      }),
+      9,
+    );
+
+    expect(plan.scannedRelations).toEqual(["variant_index"]);
+  });
+
+  it("names each scanned relation once however often it appears", () => {
+    const plan = summarise(
+      "select 1",
+      node("Hash Join", {
+        Plans: [
+          node("Seq Scan", { "Relation Name": "baselines" }),
+          node("Seq Scan", { "Relation Name": "baselines" }),
+        ],
+      }),
+      3,
+    );
+
+    expect(plan.scannedRelations).toEqual(["baselines"]);
+  });
+
+  it("reports nothing for a plan served entirely by indexes", () => {
+    const plan = summarise(
+      "select 1",
+      node("Aggregate", {
+        Plans: [
+          node("Bitmap Heap Scan", {
+            "Relation Name": "variant_index",
+            Plans: [node("Bitmap Index Scan", { "Relation Name": "variant_index_tags_gin" })],
+          }),
+        ],
+      }),
+      4,
+    );
+
+    expect(plan.scannedRelations).toEqual([]);
+  });
+});
+
+describe("rows discarded", () => {
+  it("multiplies by the loop count", () => {
+    // A scan inside a nested loop reports its per-iteration figure. Reporting that
+    // number understates the work by however many times the loop ran, which on a
+    // chunked `IN` list is the difference between 900 rows and four million.
+    const plan = summarise(
+      "select 1",
+      node("Nested Loop", {
+        Plans: [node("Seq Scan", { "Rows Removed by Filter": 900, "Actual Loops": 21 })],
+      }),
+      50,
+    );
+
+    expect(plan.rowsRemovedByFilter).toBe(18_900);
+  });
+
+  it("sums across every node in the tree", () => {
+    const plan = summarise(
+      "select 1",
+      node("Hash Join", {
+        "Rows Removed by Filter": 5,
+        Plans: [node("Seq Scan", { "Rows Removed by Filter": 10 })],
+      }),
+      1,
+    );
+
+    expect(plan.rowsRemovedByFilter).toBe(15);
+  });
+});
+
+describe("buffers", () => {
+  it("adds cache hits and disk reads across the tree", () => {
+    const plan = summarise(
+      "select 1",
+      node("Aggregate", {
+        "Shared Hit Blocks": 10,
+        "Shared Read Blocks": 2,
+        Plans: [node("Seq Scan", { "Shared Hit Blocks": 100, "Shared Read Blocks": 30 })],
+      }),
+      1,
+    );
+
+    expect(plan.sharedBlocks).toBe(142);
+  });
+});
+
+describe("walking the tree", () => {
+  it("returns every node, parents before children", () => {
+    const types = walk(
+      node("A", { Plans: [node("B", { Plans: [node("C")] }), node("D")] }),
+    ).map((n) => n["Node Type"]);
+
+    expect(types).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("handles a leaf with no children", () => {
+    expect(walk(node("Seq Scan"))).toHaveLength(1);
+  });
+});
+
+describe("the statements EXPLAIN will not take", () => {
+  it.each(["BEGIN", "COMMIT", "ROLLBACK", "DEALLOCATE ALL", "SET NAMES", "SAVEPOINT s1"])(
+    "skips %s",
+    (sql) => {
+      expect(NOT_EXPLAINABLE.test(sql)).toBe(true);
+    },
+  );
+
+  it("skips one Prisma sent with leading whitespace", () => {
+    expect(NOT_EXPLAINABLE.test("  begin")).toBe(true);
+  });
+
+  it("does not skip a select that merely begins with a matching word", () => {
+    // `\b` on the keyword, so a column called `settings` in a real query cannot make
+    // the harness quietly ignore the statement that reads it.
+    expect(NOT_EXPLAINABLE.test('SELECT "settings" FROM shops')).toBe(false);
+  });
+});
+
+describe("the parameters Prisma logs", () => {
+  it("parses a scalar list", () => {
+    expect(parseParams('["shop_1","ACTIVE",0]')).toEqual(["shop_1", "ACTIVE", 0]);
+  });
+
+  it("keeps a nested array, which is what a tag filter binds", () => {
+    // `tags @> $2` binds an array. Flattening it would make the EXPLAIN fail and the
+    // path silently report no plans at all.
+    expect(parseParams('["shop_1",["sale"]]')).toEqual(["shop_1", ["sale"]]);
+  });
+
+  it("gives back nothing for a statement with no parameters", () => {
+    expect(parseParams("[]")).toEqual([]);
+  });
+
+  it("gives back nothing rather than throwing on a log line it cannot read", () => {
+    expect(parseParams("not json")).toEqual([]);
+  });
+});

--- a/scripts/measure-queries.ts
+++ b/scripts/measure-queries.ts
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Runs the real targeting and planning code paths and EXPLAINs every statement they emit.
+ *
+ *   npm run measure:queries -- --shop anchor-perf
+ *
+ * `measure:admin` answers "how long does this page take". This answers the question
+ * underneath it: *why*, and whether the answer survives a catalogue ten times bigger. A
+ * query that seq-scans 100K rows in 40ms looks healthy on a laptop and is still a table
+ * scan that grows with the merchant.
+ *
+ * The statements are captured from Prisma's query event rather than written out here, so
+ * what gets EXPLAINed is by construction what the app sends. That distinction is the
+ * whole point of the script: hand-copying a query into an EXPLAIN measures the query you
+ * believe the ORM builds. `vendor` is the case in point -- the filter engine asks for
+ * `equals` with `mode: "insensitive"`, Prisma emits `ILIKE`, and a `lower(vendor)` index
+ * cannot serve `ILIKE`. Nothing about the Prisma call says so, and the index that was
+ * built for it recorded zero scans for as long as it existed.
+ *
+ * Read-only: every path here is a count or a select, so unlike the other scripts in this
+ * directory it writes nothing to the store.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+import { chooseShop, shopArg } from "../app/lib/seed/target-shop";
+
+/** A statement Prisma sent, with the parameters it bound. */
+export interface Captured {
+  sql: string;
+  params: unknown[];
+}
+
+/** What EXPLAIN said about one statement. */
+export interface Plan {
+  sql: string;
+  scannedRelations: string[];
+  rowsRemovedByFilter: number;
+  executionMs: number;
+  sharedBlocks: number;
+}
+
+/**
+ * Transaction and housekeeping statements, which EXPLAIN rejects.
+ *
+ * Matched on the leading keyword rather than the whole statement: Prisma emits
+ * `DEALLOCATE ALL` and bare `BEGIN`, and a future version emitting `SET` or `SAVEPOINT`
+ * should be skipped too rather than crashing the run.
+ */
+export const NOT_EXPLAINABLE = /^\s*(BEGIN|COMMIT|ROLLBACK|DEALLOCATE|SET|SAVEPOINT|RELEASE)\b/i;
+
+/** The plan node types that mean "read every row of this table". */
+const FULL_SCAN = /^(Seq Scan|Parallel Seq Scan)$/;
+
+/**
+ * Parses the parameter array Prisma logs.
+ *
+ * It arrives as a JSON string, and every value in it is already in a form Postgres will
+ * take back as a bind parameter -- including arrays, which is what `tags @> $2` sends.
+ */
+export function parseParams(raw: string): unknown[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Every node in an EXPLAIN plan tree, parents before children. */
+export function walk(node: Record<string, unknown>): Record<string, unknown>[] {
+  const children = (node["Plans"] as Record<string, unknown>[] | undefined) ?? [];
+  return [node, ...children.flatMap(walk)];
+}
+
+export function summarise(sql: string, root: Record<string, unknown>, executionMs: number): Plan {
+  const nodes = walk(root);
+
+  return {
+    sql,
+    scannedRelations: [
+      ...new Set(
+        nodes
+          .filter((n) => FULL_SCAN.test(String(n["Node Type"])))
+          .map((n) => String(n["Relation Name"] ?? "?")),
+      ),
+    ],
+    // Multiplied by loops: a scan inside a nested loop reports its per-iteration figure,
+    // and the per-iteration figure of a scan run 5,000 times is the misleading one.
+    rowsRemovedByFilter: nodes.reduce(
+      (total, n) =>
+        total + Number(n["Rows Removed by Filter"] ?? 0) * Number(n["Actual Loops"] ?? 1),
+      0,
+    ),
+    executionMs,
+    sharedBlocks: nodes.reduce(
+      (total, n) =>
+        total + Number(n["Shared Hit Blocks"] ?? 0) + Number(n["Shared Read Blocks"] ?? 0),
+      0,
+    ),
+  };
+}
+
+/**
+ * EXPLAINs one captured statement.
+ *
+ * `ANALYZE` means the statement genuinely runs, which is why this script is restricted to
+ * reads. Returns null for anything Postgres will not plan -- a statement that cannot be
+ * explained is not a finding, and failing the whole run over one is how a measurement
+ * tool stops being used.
+ */
+async function explain(client: PrismaClient, captured: Captured): Promise<Plan | null> {
+  if (NOT_EXPLAINABLE.test(captured.sql)) return null;
+
+  try {
+    const rows = await client.$queryRawUnsafe<Array<Record<string, unknown>>>(
+      `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${captured.sql}`,
+      ...captured.params,
+    );
+
+    // Postgres returns one row holding the whole plan; the column name differs by
+    // version, so take whatever the single column holds.
+    const payload = Object.values(rows[0] ?? {})[0];
+    const plan = (Array.isArray(payload) ? payload[0] : payload) as
+      | { Plan: Record<string, unknown>; "Execution Time": number }
+      | undefined;
+    if (!plan?.Plan) return null;
+
+    return summarise(captured.sql, plan.Plan, Number(plan["Execution Time"] ?? 0));
+  } catch {
+    // Statements Prisma parameterises in ways EXPLAIN will not accept back. Silent
+    // rather than noisy: that is a property of the driver, not of our schema.
+    return null;
+  }
+}
+
+/** One named code path, its wall clock, and the plans behind it. */
+interface PathResult {
+  label: string;
+  wallMs: number;
+  statements: number;
+  plans: Plan[];
+}
+
+function report(result: PathResult): void {
+  const scans = result.plans.filter((p) => p.scannedRelations.length > 0);
+
+  console.log(
+    `\n  ${result.label}\n` +
+      `    ${result.wallMs.toFixed(0)}ms wall · ${result.statements} statements · ` +
+      `${scans.length} reading a whole table`,
+  );
+
+  for (const plan of [...result.plans].sort((a, b) => b.executionMs - a.executionMs).slice(0, 3)) {
+    const how = plan.scannedRelations.length
+      ? `SEQ SCAN ${plan.scannedRelations.join(", ")}`
+      : "indexed";
+    console.log(
+      `      ${plan.executionMs.toFixed(1).padStart(7)}ms  ` +
+        `${String(plan.sharedBlocks).padStart(6)} blocks  ` +
+        `${String(plan.rowsRemovedByFilter).padStart(7)} discarded  ${how}`,
+    );
+    console.log(`               ${plan.sql.replace(/\s+/g, " ").slice(0, 128)}`);
+  }
+}
+
+async function main(): Promise<void> {
+  // The observing client is installed as the global *before* anything that imports
+  // `db.server` is loaded. `db.server` binds its export at module evaluation, so a swap
+  // afterwards would leave every service holding the client it first saw -- the paths
+  // would run, nothing would be captured, and the script would report a clean bill of
+  // health for a catalogue it never looked at.
+  const observed = new PrismaClient({ log: [{ emit: "event", level: "query" }] });
+  globalThis.prismaGlobal = observed;
+
+  const captured: Captured[] = [];
+  let capturing = false;
+  observed.$on("query", (event) => {
+    if (capturing) captured.push({ sql: event.query, params: parseParams(event.params) });
+  });
+
+  const { default: prisma } = await import("../app/db.server");
+  if (prisma !== observed) {
+    throw new Error(
+      "db.server did not take the observing client, so no statement would be captured.",
+    );
+  }
+
+  const { loadCandidates } = await import("../app/services/campaigns/candidates.server");
+  const segments = await import("../app/services/segments.server");
+  const { facets, previewMatches, resolveVariantGids } = segments;
+  type FilterAst = import("../app/services/segments.server").FilterAst;
+
+  // A second, plain client for EXPLAIN itself. Running it on `observed` would capture
+  // the EXPLAIN statements too and measure the measurement.
+  const explainer = new PrismaClient();
+
+  const installed = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { domain: true },
+  });
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { domain: chooseShop(installed, shopArg(process.argv.slice(2))).domain },
+  });
+  const total = await prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } });
+
+  console.log(`${shop.domain}: ${total} variants.`);
+  console.log("\n  Each path is the real service function; every statement it emits is");
+  console.log("  captured from Prisma and run through EXPLAIN (ANALYZE, BUFFERS).");
+
+  const measure = async (label: string, fn: () => Promise<unknown>): Promise<PathResult> => {
+    captured.length = 0;
+    capturing = true;
+    const started = process.hrtime.bigint();
+    await fn();
+    const wallMs = Number(process.hrtime.bigint() - started) / 1e6;
+    capturing = false;
+
+    const plans: Plan[] = [];
+    for (const statement of captured) {
+      const plan = await explain(explainer, statement);
+      if (plan) plans.push(plan);
+    }
+    return { label, wallMs, statements: captured.length, plans };
+  };
+
+  const ast = (...conditions: FilterAst["groups"][number]["conditions"]): FilterAst => ({
+    groups: conditions.length ? [{ conditions }] : [],
+  });
+
+  const everything = ast();
+  const byTag = ast({ field: "tag", value: "sale" });
+
+  const paths: Array<[string, () => Promise<unknown>]> = [
+    // The filter engine, one condition at a time. A merchant combines them, but a
+    // combination is only as fast as its worst leg and the legs are what we can fix.
+    ["scope: whole catalogue", () => previewMatches(shop.id, everything)],
+    ["scope: tag", () => previewMatches(shop.id, byTag)],
+    [
+      "scope: collection",
+      () => previewMatches(shop.id, ast({ field: "collection", value: "anchor-perf-1" })),
+    ],
+    [
+      "scope: vendor",
+      () => previewMatches(shop.id, ast({ field: "vendor", value: "Anchor Supply" })),
+    ],
+    [
+      "scope: product type",
+      () => previewMatches(shop.id, ast({ field: "productType", value: "Boots" })),
+    ],
+    ["scope: title contains", () => previewMatches(shop.id, ast({ field: "title", value: "Alpine" }))],
+    ["scope: sku contains", () => previewMatches(shop.id, ast({ field: "sku", value: "AB-1" }))],
+    ["scope: price floor", () => previewMatches(shop.id, ast({ field: "priceMin", value: 2000 }))],
+
+    // The picker's option lists, which three route loaders await before first paint.
+    ["facets: the scope picker's options", () => facets(shop.id)],
+
+    // Enrolment and planning, the two paths that touch every variant in scope.
+    ["enrol: every gid in scope", () => resolveVariantGids(shop.id, byTag)],
+    ["plan: candidates for a tag", () => loadCandidates(shop.id, byTag)],
+    ["plan: candidates for the whole catalogue", () => loadCandidates(shop.id, everything)],
+  ];
+
+  // Warm the pool and the page cache once, so the first path measured is not also
+  // measuring the connection handshake.
+  await prisma.variantIndex.count({ where: { shopId: shop.id } });
+
+  const results: PathResult[] = [];
+  for (const [label, fn] of paths) results.push(await measure(label, fn));
+
+  for (const result of results) report(result);
+
+  const scanning = results.flatMap((r) =>
+    r.plans.filter((p) => p.scannedRelations.length > 0).map((plan) => ({ path: r.label, plan })),
+  );
+  const planned = results.reduce((n, r) => n + r.plans.length, 0);
+
+  console.log(`\n  ${scanning.length} of ${planned} statements read a whole table:`);
+  for (const { path, plan } of scanning.sort((a, b) => b.plan.executionMs - a.plan.executionMs)) {
+    console.log(
+      `    ${plan.executionMs.toFixed(1).padStart(7)}ms  ` +
+        `${plan.scannedRelations.join(", ").padEnd(22)} ${path}`,
+    );
+  }
+
+  await Promise.all([observed.$disconnect(), explainer.$disconnect()]);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
First half of #160. The blocker on that ticket is "real beta catalogs", which do not
exist yet — but four of its six criteria are answerable against `anchor-perf`'s 102,132
variants today, and this is the instrument the rest need.

## What it adds

`npm run measure:queries -- --shop anchor-perf` runs the real service functions
(`previewMatches`, `facets`, `resolveVariantGids`, `loadCandidates`), captures every
statement Prisma emits from the query event, and runs `EXPLAIN (ANALYZE, BUFFERS)` on
each. Read-only — unlike the other scripts in `scripts/`, it writes nothing.

**Capturing rather than quoting is the whole point.** An EXPLAIN of a hand-copied query
measures the query you believe the ORM builds. Finding 1 below exists because those had
diverged and nothing on the Prisma side said so.

## Baseline: 63 of 70 statements read a whole table

`docs/perf/queries.md` has the table. It separates the three things behind that number,
because only two are defects — `scope: price floor` matches 86% of the catalogue and a
sequential scan is the *correct* plan for it. Driving the scan count to zero would buy
write amplification on a sync path that upserts 102K rows, in exchange for indexes
Postgres declines to use.

### Finding 1 — four conditions cannot use an index, and two indexes cannot be used

`vendor`, `productType`, `title` and `sku` all compile to `ILIKE`. `variant_index` carries
`variant_index_title_lower` (14 MB) and `variant_index_sku_lower` (7.3 MB) — btrees on
`lower(col)`, which `ILIKE` cannot use. Both report **zero scans since creation**, and no
raw SQL in `app/` uses `lower(`, so this is structural, not a sampling artefact.

| Condition | Matches | Seq scan | `gin_trgm_ops` |
|---|---|---|---|
| `sku contains "APF-927"` | 52 | 24.7 ms | **0.6 ms** |
| `title contains "Alpine"` | 8,354 | 38.9 ms | **4.0 ms** |
| `productType = "Boots"` | 12,680 | 27.5 ms | **5.6 ms** |
| `vendor = "Northwind"` | 11,973 | 28.5 ms | 25.9 ms |

The win tracks selectivity. `vendor`/`productType` are deliberately left alone: matching
11% of a table is a scan whatever index exists.

### Finding 2 — `facets()` reads the whole catalogue to fill four dropdowns

330 ms to produce 16 vendors, 15 product types, 18 tags and 10 collections — each then
`.slice(0, 100)`. Three route loaders await it. Only ~44 ms is Postgres; the rest is
materialising 102,132 rows to build four `Set`s.

### Finding 3 — `IN_CHUNK` at 5,000 is measured optimal and stays

| `IN_CHUNK` | Batches | Total |
|---|---|---|
| 250 | 409 | 6,354 ms |
| 1,000 | 103 | 4,493 ms |
| **5,000 (current)** | 21 | **1,740 ms** |
| 20,000 | 6 | 1,577 ms |

250 is 3.7× slower. The 9% above 5,000 is not worth spending headroom that exists for
Postgres's bind-variable ceiling. Findings 1 and 2 get their own tickets; this PR only
records them.

## Testing

22 unit tests on the harness's reading of a plan, all five mutations caught:

| Mutation | Result |
|---|---|
| `walk()` returns only the root | 7 failed |
| rows-removed ignores `Actual Loops` | 1 failed |
| `Parallel Seq Scan` not counted as a scan | 1 failed |
| keyword match loses its `\b` | 1 failed |
| params flattened | 1 failed |

Those guard the failure mode that matters: a harness that finds no scan in a plan that
has one reports a clean bill of health for a catalogue it *did* look at, and that is the
number somebody quotes later.

Full suite 2,772 passing; typecheck, lint and build clean.

Refs #160