### PR TITLE
Index the search columns in a way ILIKE can use

### DIFF
--- a/app/services/segments-index-coverage.test.ts
+++ b/app/services/segments-index-coverage.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Every case-insensitive scope condition has an index Postgres can actually use.
+ *
+ * `mode: "insensitive"` compiles to `ILIKE`, and *no btree serves ILIKE* — not even one
+ * on `lower(col)`. The original data model created exactly that pair for `title` and
+ * `sku`, described them in a comment as "case-insensitive prefix search", and they
+ * recorded zero scans for the eighteen days they existed on a 102,132-variant store.
+ * The comment was not wrong about btrees: `lower(sku) LIKE 'abc%'` would have used it.
+ * The code simply never issued that query, and nothing connected the two halves.
+ *
+ * That is the failure this file exists to prevent, and the reason it checks the *class*
+ * rather than the two columns that were wrong. Adding a condition is one line in
+ * `conditionToWhere`; noticing that the line commits the mirror to a sequential scan of
+ * every merchant's catalogue is not something the diff shows.
+ *
+ * Two properties keep it honest as the engine grows:
+ *
+ *   The field list is a `Record<ConditionField, …>`, so adding a member to the union
+ *   fails the *typecheck* until it is classified here. An enumeration that can silently
+ *   fall behind the thing it enumerates is the same bug in a different place.
+ *
+ *   The indexed columns are read out of `schema.prisma` rather than restated, so this
+ *   cannot agree with a list that no longer matches the database.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
+import { astToWhere, type Condition, type ConditionField } from "./segments.server";
+
+/**
+ * Columns on `variant_index` carrying a trigram GIN index, from the schema itself.
+ *
+ * Scoped to the model block: `@@index` lines elsewhere in the file describe other
+ * tables, and a trigram index on some unrelated model must not satisfy a scan here.
+ *
+ * Read through `sourceOf`, so the doc comment above those very `@@index` lines — which
+ * explains what a trigram index is for, in the same words — cannot be what satisfies
+ * this. That is the repo's oldest recurring trap and it applies to a schema as readily
+ * as to a route.
+ */
+function trigramIndexedColumns(): Set<string> {
+  const schema = sourceOf("prisma", "schema.prisma");
+
+  const model = /model VariantIndex \{([\s\S]*?)\n\}/.exec(schema);
+  if (!model) throw new Error("VariantIndex model not found in schema.prisma");
+
+  return new Set(
+    [...model[1].matchAll(/@@index\(\[(\w+)\(ops: raw\("gin_trgm_ops"\)\)\]/g)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+/**
+ * The columns a Prisma filter matches case-insensitively.
+ *
+ * Walks the object the filter engine produced rather than the source that produced it.
+ * A grep for `mode: "insensitive"` would pass the day somebody extracts a helper, and
+ * would say nothing about what the query actually asks for.
+ */
+function insensitiveColumns(where: unknown, column: string | null = null): string[] {
+  if (!where || typeof where !== "object") return [];
+
+  const entries = Object.entries(where as Record<string, unknown>);
+
+  if (entries.some(([key, value]) => key === "mode" && value === "insensitive")) {
+    return column ? [column] : [];
+  }
+
+  return entries.flatMap(([key, value]) =>
+    Array.isArray(value)
+      ? value.flatMap((item) => insensitiveColumns(item, key))
+      : // AND/OR/NOT are combinators, not columns — keep whatever column we are inside
+        // so a condition nested under `NOT` is still attributed to its own column.
+        insensitiveColumns(value, key === "AND" || key === "OR" || key === "NOT" ? column : key),
+  );
+}
+
+/**
+ * A value each field will accept, so `conditionToWhere` returns a clause rather than the
+ * null it uses for "nothing to filter on".
+ */
+const SAMPLE: Record<ConditionField, Condition["value"]> = {
+  collection: "summer",
+  tag: "sale",
+  excludeTag: "clearance",
+  vendor: "Northwind",
+  productType: "Boots",
+  status: "active",
+  title: "Alpine",
+  sku: "APF-927",
+  barcode: "0123456789012",
+  priceMin: 1000,
+  priceMax: 9000,
+  inventoryMin: 1,
+  inventoryMax: 100,
+  hasCompareAt: true,
+  hasCost: true,
+  variantGid: ["gid://shopify/ProductVariant/1"],
+};
+
+/**
+ * Columns matched case-insensitively that are deliberately left to a sequential scan.
+ *
+ * Both are low-cardinality equality. "Northwind" matches 11% of anchor-perf's catalogue,
+ * and reading 11% of a heap costs what it costs however the rows are reached — measured
+ * at 28.5ms scanning against 25.9ms through a trigram index, which does not pay for a
+ * GIN index maintained on every one of ~102K sync upserts.
+ *
+ * The entry is the point: an accepted scan is a decision with a number behind it, and
+ * anything not listed here has to earn its index or be added with a reason.
+ */
+const ACCEPTED_SCANS = new Set(["vendor", "productType"]);
+
+const FIELDS = Object.keys(SAMPLE) as ConditionField[];
+
+describe("case-insensitive conditions", () => {
+  const indexed = trigramIndexedColumns();
+
+  it.each(FIELDS)("%s matches through an index, or is an accepted scan", (field) => {
+    const where = astToWhere("shop_1", {
+      groups: [{ conditions: [{ field, value: SAMPLE[field] }] }],
+    });
+
+    for (const column of insensitiveColumns(where)) {
+      expect(
+        indexed.has(column) || ACCEPTED_SCANS.has(column),
+        `\`${field}\` matches \`${column}\` with mode: "insensitive", which Prisma ` +
+          `compiles to ILIKE. No btree serves ILIKE, so this reads every variant the ` +
+          `shop has. Add a trigram GIN index on \`${column}\` in schema.prisma and a ` +
+          `migration, or add it to ACCEPTED_SCANS with the measurement that justifies it.`,
+      ).toBe(true);
+    }
+  });
+
+  it("finds the insensitive matches at all", () => {
+    // Guards the guard. If `insensitiveColumns` ever returned nothing — a Prisma
+    // upgrade renaming the key, a walk that stops one level too early — every
+    // assertion above would pass vacuously and this file would protect nothing.
+    const found = FIELDS.flatMap((field) =>
+      insensitiveColumns(
+        astToWhere("shop_1", { groups: [{ conditions: [{ field, value: SAMPLE[field] }] }] }),
+      ),
+    );
+
+    expect(new Set(found)).toEqual(new Set(["vendor", "productType", "title", "sku", "barcode"]));
+  });
+
+  it("reads real index declarations out of the schema", () => {
+    // Guards the other half: an empty set would make `indexed.has` always false, which
+    // fails loudly, but a regex matching the wrong thing could just as easily return a
+    // set that happens to contain the names.
+    expect(trigramIndexedColumns()).toEqual(new Set(["title", "sku", "barcode"]));
+  });
+});
+
+describe("attributing a match to its column", () => {
+  it("looks through the NOT that excludeTag wraps its condition in", () => {
+    expect(insensitiveColumns({ NOT: { vendor: { contains: "x", mode: "insensitive" } } })).toEqual(
+      ["vendor"],
+    );
+  });
+
+  it("looks through the OR of groups an AST compiles to", () => {
+    const columns = insensitiveColumns({
+      OR: [
+        { AND: [{ title: { contains: "a", mode: "insensitive" } }] },
+        { AND: [{ sku: { contains: "b", mode: "insensitive" } }] },
+      ],
+    });
+
+    expect(new Set(columns)).toEqual(new Set(["title", "sku"]));
+  });
+
+  it("says nothing about a case-sensitive match", () => {
+    expect(insensitiveColumns({ status: "ACTIVE", price: { gte: 100n } })).toEqual([]);
+  });
+});

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -32,9 +32,14 @@ had a product bigger than one page until this one existed.
 |---|---|---|
 | Catalogue, first page | 26 ms | 26 ms |
 | Catalogue, last page (offset 101,100) | 292 ms | 360 ms |
-| Catalogue, text search | 74 ms | 75 ms |
+| Catalogue, text search | 19 ms | 21 ms |
 | Reconciliation, first page | 7 ms | 9 ms |
 | Reconciliation, deep page | 5 ms | 6 ms |
+
+Text search was 74 ms until #510 replaced two unusable `lower()` btrees with trigram GIN
+indexes. The two reconciliation rows are **stale**: both now measure ~1,000 ms against the
+same store, which grew 21 campaign runs and 125,579 ledger rows after these were taken.
+Tracked separately — see [`queries.md`](queries.md).
 
 ### Offset scaling
 

--- a/docs/perf/queries.md
+++ b/docs/perf/queries.md
@@ -52,9 +52,12 @@ The distinction matters because the obvious response to a scan count is to add i
 until it reaches zero, which buys write amplification on the sync path in exchange for
 plans Postgres will decline to use.
 
-### Finding 1 — four filter conditions cannot use an index, and two indexes cannot be used
+### Finding 1 — five filter conditions cannot use an index, and two indexes cannot be used
 
-`vendor`, `productType`, `title` and `sku` all compile to `ILIKE`. `variant_index` carries
+**Fixed in #510.** The before/after is recorded under "After #510" below.
+
+
+`vendor`, `productType`, `title`, `sku` and `barcode` all compile to `ILIKE`. `variant_index` carries
 `variant_index_title_lower` (14 MB) and `variant_index_sku_lower` (7.3 MB), both btrees on
 `lower(col)`, and Postgres cannot serve `ILIKE` from either. Both report **zero scans**
 since creation, and no raw SQL in `app/` uses `lower(` — so this is structural, not a
@@ -74,10 +77,12 @@ rows gets 42× and a filter that matches 11% of the catalogue gets nothing worth
 The trigram indexes are also *smaller* than the dead ones they replace — 6.5 MB for
 `title` against 14 MB, 2.5 MB for `sku` against 7.3 MB.
 
-Tracked as its own ticket. `vendor` and `productType` are deliberately left scanning:
-low-cardinality equality over a large fraction of the table is a scan whatever index
-exists, and two more GIN indexes maintained on every one of 102K sync upserts is a poor
-trade for 9%.
+`barcode` had no index at all — not even an unusable one — and is the most selective
+column of the five: 81,649 distinct values across 102,132 variants.
+
+`vendor` and `productType` are deliberately left scanning. Low-cardinality equality over a
+large fraction of the table is a heap read whatever index exists, and two more GIN indexes
+maintained on every one of ~102K sync upserts is a poor trade for 9%.
 
 ### Finding 2 — `facets()` reads the whole catalogue to fill four dropdowns
 
@@ -122,6 +127,51 @@ the *scope* and each scan costs the size of the *table*, so total work is O(scop
 At 102K variants that product is small enough that the scan wins. It is not obvious that
 it still wins at ten times the ledger, and this catalogue cannot answer that. Recorded
 rather than guessed at.
+
+## After #510 — trigram indexes for the ILIKE conditions
+
+`pg_trgm` enabled; `gin_trgm_ops` GIN indexes on `title`, `sku` and `barcode`; the two
+`lower()` btrees dropped. Same store, same method.
+
+| Path | Before | After |
+|---|---|---|
+| scope: title contains | 54 ms, 2 scans | **10 ms, 0 scans** |
+| scope: sku contains | 29 ms, 2 scans | **2 ms, 0 scans** |
+| scope: barcode contains | (unmeasured, 2 scans) | **2 ms, 0 scans** |
+| scope: vendor | 31 ms, 2 scans | 34 ms, 2 scans — accepted |
+| scope: product type | 35 ms, 2 scans | 35 ms, 2 scans — accepted |
+
+The statement count fell from 63 of 70 reading a whole table to **59 of 72** — 72 because
+`barcode` is now measured too. Nothing else in the report moved.
+
+The merchant-visible one is the catalogue search box, which `measure:admin` times. Run
+twice in each index state on the same warm database:
+
+| | `lower()` btrees | Trigram GIN |
+|---|---|---|
+| Catalogue, text search (p50) | 55 ms, 49 ms | **20 ms, 19 ms** |
+| Catalogue, first page (p50) | 29 ms | 29 ms |
+
+Index bytes on `variant_index`: 21.3 MB removed (`title_lower` 14 MB, `sku_lower` 7.3 MB),
+11.4 MB added (`title_trgm` 6.5 MB, `sku_trgm` 2.5 MB, `barcode_trgm` 2.4 MB). Net
+−9.9 MB, and one fewer index maintained per row on the sync path despite covering one
+more column.
+
+`app/services/segments-index-coverage.test.ts` now fails the build if a condition is
+matched with `mode: "insensitive"` on a column with no trigram index and no recorded
+reason. It reads the index list out of `schema.prisma` rather than restating it, and its
+field list is a `Record<ConditionField, …>` so a new condition fails typecheck until it is
+classified.
+
+## Unrelated, found while measuring: reconciliation is 140× its recorded baseline
+
+`docs/perf/README.md` records reconciliation at 7 ms first page and 5 ms deep page. It now
+measures **~1,000 ms** for both.
+
+Not caused by #510 — confirmed by dropping the trigram indexes, restoring the `lower()`
+ones and re-measuring, which gives ~1,000 ms as well. The store has since grown 21 campaign
+runs and 125,579 ledger rows where the original baseline was taken against a store with
+none. Filed separately.
 
 ## What this does not cover
 

--- a/prisma/migrations/20260830120000_trigram_search_indexes/migration.sql
+++ b/prisma/migrations/20260830120000_trigram_search_indexes/migration.sql
@@ -1,0 +1,45 @@
+-- Search indexes that the search queries can actually use.
+--
+-- `astToWhere` matches `title` and `sku` with `contains` + `mode: "insensitive"`, and
+-- Prisma compiles that to `ILIKE '%text%'`. The catalogue and reconciliation search
+-- boxes do the same. No btree serves ILIKE -- including a btree on `lower(title)`,
+-- which is exactly what the original data model created for this purpose:
+--
+--   -- Case-insensitive prefix search on SKU and title for the picker and filter builder.
+--   CREATE INDEX "variant_index_sku_lower" ON "variant_index" (LOWER("sku"));
+--   CREATE INDEX "variant_index_title_lower" ON "variant_index" (LOWER("title"));
+--
+-- A btree on `lower(sku)` does serve `lower(sku) LIKE 'abc%'`, so the comment describes
+-- a query that would have worked. The code never issued it. Both indexes reported zero
+-- scans since creation on a store with 102,132 variants, and no raw SQL in app/ uses
+-- `lower(` -- so this is structural, not a sampling artefact.
+--
+-- Measured on anchor-perf (#160, docs/perf/queries.md):
+--
+--   sku contains "APF-927"    52 matches   24.7ms -> 0.6ms
+--   title contains "Alpine" 8,354 matches  38.9ms -> 4.0ms
+--
+-- The replacements are smaller than what they replace: 6.5MB against 14MB for title,
+-- 2.5MB against 7.3MB for sku. Net -12MB, and 21MB less index maintenance on every one
+-- of the ~102K upserts a catalogue sync performs.
+--
+-- Deliberately NOT indexed: `vendor` and `productType`. They compile to ILIKE too, but
+-- they are low-cardinality equality -- "Northwind" matches 11% of the catalogue, and
+-- reading 11% of a heap costs the same however it is reached. Measured at 28.5ms
+-- scanning against 25.9ms with a trigram index, which does not pay for a GIN index
+-- maintained on every sync write.
+--
+-- pg_trgm is a trusted extension from PG13, so this needs no superuser on Railway.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX "variant_index_title_trgm" ON "variant_index" USING GIN ("title" gin_trgm_ops);
+CREATE INDEX "variant_index_sku_trgm" ON "variant_index" USING GIN ("sku" gin_trgm_ops);
+CREATE INDEX "variant_index_barcode_trgm" ON "variant_index" USING GIN ("barcode" gin_trgm_ops);
+
+-- Contract in the same migration as the expand, which the expand/contract rule normally
+-- forbids. It is safe here for a specific reason rather than by exception: rolling back
+-- one version returns to code that never issued a query either index could serve, so
+-- there is no version of this app that runs slower without them. An index with zero
+-- scans has no rollback risk to trade against.
+DROP INDEX IF EXISTS "variant_index_sku_lower";
+DROP INDEX IF EXISTS "variant_index_title_lower";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,12 @@ model VariantIndex {
   /// because a btree on an array column cannot serve containment.
   @@index([tags], type: Gin)
   @@index([collections], type: Gin)
+  /// Trigram GIN, because `astToWhere` matches these two with `mode: "insensitive"`
+  /// and Prisma compiles that to `ILIKE '%text%'`. No btree serves ILIKE -- including
+  /// one on `lower(title)`, which is what these replace. See #510.
+  @@index([title(ops: raw("gin_trgm_ops"))], type: Gin, map: "variant_index_title_trgm")
+  @@index([sku(ops: raw("gin_trgm_ops"))], type: Gin, map: "variant_index_sku_trgm")
+  @@index([barcode(ops: raw("gin_trgm_ops"))], type: Gin, map: "variant_index_barcode_trgm")
   @@map("variant_index")
 }
 

--- a/scripts/measure-queries.ts
+++ b/scripts/measure-queries.ts
@@ -249,7 +249,11 @@ async function main(): Promise<void> {
       () => previewMatches(shop.id, ast({ field: "productType", value: "Boots" })),
     ],
     ["scope: title contains", () => previewMatches(shop.id, ast({ field: "title", value: "Alpine" }))],
-    ["scope: sku contains", () => previewMatches(shop.id, ast({ field: "sku", value: "AB-1" }))],
+    ["scope: sku contains", () => previewMatches(shop.id, ast({ field: "sku", value: "APF-927" }))],
+    [
+      "scope: barcode contains",
+      () => previewMatches(shop.id, ast({ field: "barcode", value: "555000" })),
+    ],
     ["scope: price floor", () => previewMatches(shop.id, ast({ field: "priceMin", value: 2000 }))],
 
     // The picker's option lists, which three route loaders await before first paint.


### PR DESCRIPTION
Closes #510. Refs #160.

## The bug

`astToWhere` matches `title`, `sku`, `barcode`, `vendor` and `productType` with
`mode: "insensitive"`. Prisma compiles that to `ILIKE`. **No btree serves `ILIKE`** —
including one on `lower(col)`, which is exactly what the original data model built:

```sql
-- Case-insensitive prefix search on SKU and title for the picker and filter builder.
CREATE INDEX "variant_index_sku_lower" ON "variant_index" (LOWER("sku"));
CREATE INDEX "variant_index_title_lower" ON "variant_index" (LOWER("title"));
```

The comment is not wrong about btrees — `lower(sku) LIKE 'abc%'` would have used it. The
code never issued that query. Contract drift between an index and the query it was built
for, with neither half validating the other.

Evidence it is structural rather than a sampling artefact: **zero scans** on both since
creation against a 102,132-variant store, and no raw SQL in `app/` uses `lower(`.

`barcode` had no index at all, and is the most selective of the five — 81,649 distinct
values across 102,132 variants.

## The change

`pg_trgm` (a trusted extension since PG13, so no superuser needed on Railway), trigram GIN
on `title`/`sku`/`barcode`, both `lower()` btrees dropped.

**The merchant-visible number** is the catalogue search box. `measure:admin`, run twice in
each index state on the same warm database:

| | `lower()` btrees | Trigram GIN |
|---|---|---|
| Catalogue, text search (p50) | 55 ms, 49 ms | **20 ms, 19 ms** |
| Catalogue, first page (p50) | 29 ms | 29 ms |

Scope conditions, via `measure:queries`:

| Path | Before | After |
|---|---|---|
| scope: title contains | 54 ms, 2 scans | **10 ms, 0 scans** |
| scope: sku contains | 29 ms, 2 scans | **2 ms, 0 scans** |
| scope: barcode contains | (2 scans) | **2 ms, 0 scans** |

Index bytes: −21.3 MB removed, +11.4 MB added. **Net −9.9 MB and one fewer index
maintained per sync upsert, despite covering one more column.**

`vendor` and `productType` are deliberately left scanning — "Northwind" matches 11% of the
catalogue, and reading 11% of a heap costs what it costs however it is reached (28.5 ms
scanning vs 25.9 ms indexed). Recorded in `ACCEPTED_SCANS` with the measurement, so the
omission reads as a decision.

## The guard is the point, not the two columns

`app/services/segments-index-coverage.test.ts` fails the build if any condition matches
`mode: "insensitive"` on a column with no trigram index and no recorded reason.

- It walks what `astToWhere` **actually produces**, not the source that produces it — a
  grep for `mode: "insensitive"` would pass the day somebody extracts a helper.
- Its field list is a `Record<ConditionField, …>`, so adding a member to the union **fails
  typecheck** until it is classified.
- Index names are read out of `schema.prisma` through `sourceOf`, so a comment describing
  an index cannot be what satisfies the check for it. (`source-guard.test.ts` caught the
  first draft reaching for `readFileSync` — the guard worked.)

### Mutations, all caught

| Mutation | Result |
|---|---|
| drop the barcode index from the schema | 2 failed |
| the walk stops recursing into arrays | 2 failed |
| a new unindexed insensitive condition (`status`) | 2 failed |
| the `gin_trgm_ops` match finds nothing | 4 failed |
| comment out the barcode index, leaving the text | 2 failed |
| remove a field from the `Record<ConditionField, …>` | **typecheck fails** |

## Migration safety

Expand and contract land together, which the rule normally forbids. Safe here for a
specific reason rather than by exception: rolling back one version returns to code that
never issued a query either dropped index could serve, so there is no version of this app
that runs slower without them. `prisma migrate diff` confirms schema and migration agree —
no trigram or `lower()` drift.

## Checks

2,793 unit tests, 142 chaos scenarios, typecheck / lint / build clean.

## Found while measuring, not fixed here

Reconciliation is **~1,000 ms** against a recorded baseline of 7 ms. Not caused by this PR
— confirmed by restoring the old indexes and re-measuring. `driftedCells` sorts all
125,070 ledger rows for its `DISTINCT ON` and spills to disk (`external merge, 9072kB`);
983 ms of the 1,017 ms is that sort. Filed separately.