### PR TITLE
Stop sorting the whole ledger to ask whether anything drifted

### DIFF
--- a/app/services/reconciliation-counts.test.ts
+++ b/app/services/reconciliation-counts.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The badge counts what the table would show, and is not capped by the filter's bound.
+ *
+ * `counts()` used to be `driftedCells(shopId).length`, and `driftedCells` ends in
+ * `LIMIT 5000` — so a store with 8,000 drifted prices was told it had **5,000**. Not an
+ * error, not a "5,000+", just a specific plausible number that happened to be the cap.
+ * `reconcile`'s own doc comment explains why that is the worst available failure:
+ *
+ *   "12 products have drifted" is the number a merchant needs; "0 on this page" tells
+ *   them nothing and quietly implies everything is fine.
+ *
+ * A capped count fails that test in a way "0 on this page" does not, because 5,000 does
+ * not read as a ceiling.
+ *
+ * The cap itself is right where it is. The cells list feeds a `WHERE … IN`, and bounding
+ * how many variants that names is deliberate. It was only ever wrong as an answer to
+ * "how many".
+ *
+ * These assert on the composed SQL rather than on results, because the property is about
+ * how the two questions are built: they must share one definition of what "drifted"
+ * means, and only one of them may carry the bound. Whether the numbers are then right is
+ * `reconciliation.chaos.ts`'s job, against a real engine and a real ledger.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  cellsQuery,
+  countQuery,
+  driftedFrom,
+  MAX_FILTER_CELLS,
+  offBaselineFrom,
+} from "./reconciliation.server";
+
+/** The statement as Postgres receives it, parameter placeholders and all. */
+const text = (sql: { sql: string }): string => sql.sql.replace(/\s+/g, " ").trim();
+
+describe("counting is not listing", () => {
+  it("counts without the filter's row bound", () => {
+    const sql = text(countQuery(driftedFrom("shop_1")));
+
+    expect(sql).toContain("COUNT(*)");
+    expect(sql).not.toContain("LIMIT");
+  });
+
+  it("lists with it", () => {
+    expect(text(cellsQuery(driftedFrom("shop_1")))).toContain("LIMIT");
+  });
+
+  it("binds the bound rather than interpolating it", () => {
+    // A cap spliced into the string would make every page a distinct statement and lose
+    // the prepared-statement cache. It is also how a value reaches SQL unescaped.
+    expect(cellsQuery(driftedFrom("shop_1")).values).toContain(MAX_FILTER_CELLS);
+  });
+});
+
+describe("one definition of what has drifted", () => {
+  it("asks the count and the list the same question", () => {
+    // The two queries differ only in their projection and the bound. If they could drift
+    // apart, the page would say "3 drifted" above a table showing four — which is the
+    // failure this page exists to prevent, arriving through the page itself.
+    const predicate = text(driftedFrom("shop_1"));
+
+    expect(text(countQuery(driftedFrom("shop_1")))).toContain(predicate);
+    expect(text(cellsQuery(driftedFrom("shop_1")))).toContain(predicate);
+  });
+
+  it("does the same for off-baseline", () => {
+    const predicate = text(offBaselineFrom("shop_1"));
+
+    expect(text(countQuery(offBaselineFrom("shop_1")))).toContain(predicate);
+    expect(text(cellsQuery(offBaselineFrom("shop_1")))).toContain(predicate);
+  });
+});
+
+describe("the shop is a parameter", () => {
+  it.each([
+    ["drifted", driftedFrom],
+    ["off-baseline", offBaselineFrom],
+  ])("binds the shop id in the %s predicate", (_name, build) => {
+    const sql = build("shop_1");
+
+    expect(sql.values).toContain("shop_1");
+    expect(text(sql)).not.toContain("shop_1");
+  });
+});
+
+describe("the drift predicate still describes drift", () => {
+  const sql = text(driftedFrom("shop_1"));
+
+  it("reads the newest verified write per cell", () => {
+    // `DISTINCT ON` with this ordering is what `variant_changes_drift_lookup` was built
+    // to serve. Reordering the sort keys silently returns Postgres to sorting the whole
+    // ledger — a 14x regression that no result-level assertion would notice.
+    expect(sql).toContain('DISTINCT ON (c."variantGid", c."priceListGid")');
+    expect(sql).toContain('ORDER BY c."variantGid", c."priceListGid", c."verifiedAt" DESC');
+  });
+
+  it("considers only cells a campaign has written", () => {
+    // An inner join, not a left join: a cell nothing ever promised a price for cannot
+    // have drifted from that promise.
+    expect(sql).toContain("JOIN (");
+    expect(sql).not.toContain("LEFT JOIN");
+  });
+
+  it("compares live against intended", () => {
+    expect(sql).toContain('e."livePrice" <> w."intendedPrice"');
+  });
+});

--- a/app/services/reconciliation.server.ts
+++ b/app/services/reconciliation.server.ts
@@ -23,6 +23,8 @@
  * is the difference between a feature and a timeout.
  */
 
+import { Prisma } from "@prisma/client";
+
 import prisma from "../db.server";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { formatMinorUnits } from "../lib/money/format";
@@ -249,19 +251,24 @@ export async function reconcile(
 }
 
 /**
- * Cells where the live price disagrees with what we last verified writing.
+ * The cells where the live price disagrees with what we last verified writing.
  *
  * This is drift in the strict sense: somebody changed the price behind us. A cell no
- * campaign has ever written cannot drift, because nothing was promised about it — hence
+ * campaign has ever written cannot drift, because nothing was promised about it -- hence
  * the join rather than a left join.
  *
  * `DISTINCT ON` picks the newest verified write per cell, which is the one that explains
  * the price now. Postgres-specific and deliberately so: the alternative is a correlated
- * subquery per row.
+ * subquery per row. `variant_changes_drift_lookup` exists to serve that ordering; without
+ * it Postgres sorts the shop's whole verified ledger and spills to disk.
+ *
+ * A fragment rather than a whole query, because two callers ask about the same set and
+ * must not be able to disagree about what it contains -- one lists the cells to filter a
+ * page by, the other counts them for the badge. Definitions that get restated are how a
+ * page ends up saying "3 drifted" above a table showing four.
  */
-async function driftedCells(shopId: string) {
-  return prisma.$queryRaw<Array<{ variantGid: string; priceListGid: string }>>`
-    SELECT e."variantGid", e."priceListGid"
+export function driftedFrom(shopId: string): Prisma.Sql {
+  return Prisma.sql`
     FROM "price_surface_entries" e
     JOIN (
       SELECT DISTINCT ON (c."variantGid", c."priceListGid")
@@ -274,14 +281,12 @@ async function driftedCells(shopId: string) {
       AND e."livePrice" IS NOT NULL
       AND w."intendedPrice" IS NOT NULL
       AND e."livePrice" <> w."intendedPrice"
-    LIMIT 5000
   `;
 }
 
-/** Cells whose live price differs from their baseline — what a sale looks like. */
-async function offBaselineCells(shopId: string) {
-  return prisma.$queryRaw<Array<{ variantGid: string; priceListGid: string }>>`
-    SELECT e."variantGid", e."priceListGid"
+/** The same for cells whose live price differs from their baseline -- what a sale looks like. */
+export function offBaselineFrom(shopId: string): Prisma.Sql {
+  return Prisma.sql`
     FROM "price_surface_entries" e
     JOIN "baselines" b
       ON b."variantGid" = e."variantGid"
@@ -291,9 +296,47 @@ async function offBaselineCells(shopId: string) {
     WHERE e."shopId" = ${shopId}
       AND e."livePrice" IS NOT NULL
       AND e."livePrice" <> b."basePrice"
-    LIMIT 5000
   `;
 }
+
+/**
+ * How many cells a `WHERE ... IN` may name.
+ *
+ * A bound on the filter, not on the truth. The count below deliberately does not use it.
+ */
+export const MAX_FILTER_CELLS = 5_000;
+
+/** The statement listing matching cells, bounded so it can be named in a `WHERE ... IN`. */
+export function cellsQuery(where: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`SELECT e."variantGid", e."priceListGid" ${where} LIMIT ${MAX_FILTER_CELLS}`;
+}
+
+async function cells(where: Prisma.Sql) {
+  return prisma.$queryRaw<Array<{ variantGid: string; priceListGid: string }>>(cellsQuery(where));
+}
+
+/**
+ * How many cells match, counted in the database.
+ *
+ * Not `cells(...).length`. That is what it used to be, and because `cells` is capped a
+ * store with 8,000 drifted prices was told it had **5,000** -- a specific, plausible,
+ * wrong number with nothing about it that reads as a ceiling. The cap belongs on the
+ * filter, where naming 5,000 variants in a `WHERE ... IN` is a deliberate bound; on the
+ * badge it silently replaced the answer.
+ *
+ * It also stops shipping up to 10,000 rows to Node so their length can be taken.
+ */
+export function countQuery(where: Prisma.Sql): Prisma.Sql {
+  return Prisma.sql`SELECT COUNT(*)::bigint AS count ${where}`;
+}
+
+async function countCells(where: Prisma.Sql): Promise<number> {
+  const [row] = await prisma.$queryRaw<Array<{ count: bigint }>>(countQuery(where));
+  return Number(row?.count ?? 0);
+}
+
+const driftedCells = (shopId: string) => cells(driftedFrom(shopId));
+const offBaselineCells = (shopId: string) => cells(offBaselineFrom(shopId));
 
 /**
  * Store-wide totals, not page totals.
@@ -303,11 +346,11 @@ async function offBaselineCells(shopId: string) {
  */
 async function counts(shopId: string) {
   const [drifted, offBaseline] = await Promise.all([
-    driftedCells(shopId),
-    offBaselineCells(shopId),
+    countCells(driftedFrom(shopId)),
+    countCells(offBaselineFrom(shopId)),
   ]);
 
-  return { drifted: drifted.length, offBaseline: offBaseline.length };
+  return { drifted, offBaseline };
 }
 
 const key = (variantGid: string, priceListGid: string) => `${variantGid}@${priceListGid}`;

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -33,13 +33,20 @@ had a product bigger than one page until this one existed.
 | Catalogue, first page | 26 ms | 26 ms |
 | Catalogue, last page (offset 101,100) | 292 ms | 360 ms |
 | Catalogue, text search | 19 ms | 21 ms |
-| Reconciliation, first page | 7 ms | 9 ms |
-| Reconciliation, deep page | 5 ms | 6 ms |
+| Reconciliation, first page | 61 ms | 61 ms |
+| Reconciliation, deep page | 59 ms | 62 ms |
 
 Text search was 74 ms until #510 replaced two unusable `lower()` btrees with trigram GIN
-indexes. The two reconciliation rows are **stale**: both now measure ~1,000 ms against the
-same store, which grew 21 campaign runs and 125,579 ledger rows after these were taken.
-Tracked separately — see [`queries.md`](queries.md).
+indexes.
+
+The reconciliation rows read 7 ms and 5 ms until #513. They were taken against a store
+with an empty ledger; at 125,070 verified rows both had become **~1,000 ms**, because the
+drift query sorted the whole ledger and spilled to disk. An index in the `DISTINCT ON`
+order removed the sort. See [`queries.md`](queries.md).
+
+**These two are the reason to re-measure rather than trust the table.** They degraded with
+*use*, not with catalogue size, so nothing about a bigger seed would have found it — and a
+stale perf number is the one somebody quotes.
 
 ### Offset scaling
 

--- a/docs/perf/queries.md
+++ b/docs/perf/queries.md
@@ -163,15 +163,55 @@ reason. It reads the index list out of `schema.prisma` rather than restating it,
 field list is a `Record<ConditionField, …>` so a new condition fails typecheck until it is
 classified.
 
-## Unrelated, found while measuring: reconciliation is 140× its recorded baseline
+## Reconciliation: a sort that spilled to disk (#513)
 
-`docs/perf/README.md` records reconciliation at 7 ms first page and 5 ms deep page. It now
-measures **~1,000 ms** for both.
+Found while measuring #510, and not caused by it — confirmed by restoring the old indexes
+and re-measuring. `docs/perf/README.md` recorded 7 ms first page and 5 ms deep page; both
+had become **~1,000 ms**.
 
-Not caused by #510 — confirmed by dropping the trigram indexes, restoring the `lower()`
-ones and re-measuring, which gives ~1,000 ms as well. The store has since grown 21 campaign
-runs and 125,579 ledger rows where the original baseline was taken against a store with
-none. Filed separately.
+`driftedCells` picks the newest verified write per cell with `DISTINCT ON (variantGid,
+priceListGid) … ORDER BY …, verifiedAt DESC`. With no index in that order:
+
+```
+Sort (actual time=880.447..983.412 rows=125070)
+  Sort Method: external merge  Disk: 9072kB
+Execution Time: 1017.951 ms
+```
+
+983 ms of the 1,018 ms was one sort spilling out of the default 4 MB `work_mem` — for a
+query returning **zero rows**. `variant_changes_drift_lookup`, partial on `VERIFIED` and
+ordered to match, removes the sort entirely:
+
+```
+Index Scan using variant_changes_drift_lookup (actual time=0.017..30.704 rows=125070)
+Execution Time: 71.776 ms
+```
+
+| | Before | After |
+|---|---|---|
+| Reconciliation, first page (p50) | 1,006 ms | **61 ms** |
+| Reconciliation, deep page (p50) | 1,006 ms | **59 ms** |
+
+**This degraded with use, not with catalogue size.** One ledger row per variant × surface
+× run, retained indefinitely because unlimited history is a deliberate free-tier feature;
+#183 puts an active store at ~7.8M rows a year, and this was at 125K. No larger seed would
+have found it — only a store that had *run campaigns*.
+
+Two things worth carrying:
+
+**`counts()` was silently capped.** It was `driftedCells(shopId).length`, and that helper
+ends in `LIMIT 5000` — so a store with 8,000 drifted prices was told it had 5,000. The cap
+is right for the cells list, which feeds a `WHERE … IN`; it was only ever wrong as an
+answer to "how many". Both questions now compose the same predicate fragment, so they
+cannot disagree about what "drifted" means.
+
+**An intermittent 1 s outlier during this measurement was autovacuum**, not the query —
+`pg_stat_user_tables` showed autovacuum and autoanalyze running on all three tables inside
+the measurement window. Twelve consecutive calls afterwards ran 55–73 ms with no statement
+over 200 ms. Worth checking before attributing a spike to the change under test.
+
+`offBaselineCells` is left alone at 185 ms. It is already a merge join over two index
+scans; comparing every surface entry to its baseline *is* the work.
 
 ## What this does not cover
 

--- a/prisma/migrations/20260830130000_drift_lookup_index/migration.sql
+++ b/prisma/migrations/20260830130000_drift_lookup_index/migration.sql
@@ -1,0 +1,31 @@
+-- The drift query's sort, removed.
+--
+-- `driftedCells` picks the newest verified write per cell with
+-- `DISTINCT ON (variantGid, priceListGid) ... ORDER BY ..., verifiedAt DESC`. With no
+-- index in that order Postgres sorts the shop's entire verified ledger to produce it,
+-- and on anchor-perf's 125,070 rows that sort does not fit in the default 4MB work_mem:
+--
+--   Sort (actual time=880.447..983.412 rows=125070)
+--     Sort Method: external merge  Disk: 9072kB
+--   Execution Time: 1017.951 ms
+--
+-- 983ms of the 1,018ms was one sort spilling to disk, for a query returning zero rows.
+-- With this index the sort disappears -- Unique reads the index in order:
+--
+--   Index Scan using variant_changes_drift_lookup (actual time=0.017..30.704 rows=125070)
+--   Execution Time: 71.776 ms
+--
+-- This degrades with *use*, not with catalogue size: one ledger row per variant x surface
+-- x run, retained indefinitely because unlimited history is a deliberate free-tier
+-- feature. #183 puts an active store at ~7.8M rows a year. `reconcile` calls `counts()`
+-- on every page load, so every merchant paid this on every visit to the live-prices page.
+--
+-- Partial on VERIFIED for the same reason `variant_changes_unverified` is partial the
+-- other way: the drift path reads only verified rows, and an index over the whole ledger
+-- would carry history this query never looks at.
+--
+-- Expand only -- an index changes no rows, and the previous release simply does not
+-- benefit from it.
+CREATE INDEX "variant_changes_drift_lookup"
+  ON "variant_changes" ("shopId", "variantGid", "priceListGid", "verifiedAt" DESC)
+  WHERE "status" = 'VERIFIED';

--- a/scripts/measure-queries.test.ts
+++ b/scripts/measure-queries.test.ts
@@ -123,6 +123,72 @@ describe("rows discarded", () => {
   });
 });
 
+describe("sorts that spill to disk", () => {
+  it("reports the kilobytes a disk sort wrote", () => {
+    // The finding that a timing alone cannot give you. A spilling sort is a cliff, not a
+    // slope — fast until the data outgrows work_mem, then not — and the plan node is a
+    // `Sort` either way. Only `Sort Space Type` distinguishes them.
+    const plan = summarise(
+      "select 1",
+      node("Unique", {
+        Plans: [
+          node("Sort", {
+            "Sort Method": "external merge",
+            "Sort Space Used": 9072,
+            "Sort Space Type": "Disk",
+          }),
+        ],
+      }),
+      1018,
+    );
+
+    expect(plan.diskSortKb).toEqual([9072]);
+  });
+
+  it("says nothing about a sort that fit in memory", () => {
+    const plan = summarise(
+      "select 1",
+      node("Sort", {
+        "Sort Method": "quicksort",
+        "Sort Space Used": 5887,
+        "Sort Space Type": "Memory",
+      }),
+      3,
+    );
+
+    expect(plan.diskSortKb).toEqual([]);
+  });
+
+  it("multiplies a spill inside a loop by its iterations", () => {
+    const plan = summarise(
+      "select 1",
+      node("Nested Loop", {
+        Plans: [
+          node("Sort", { "Sort Space Used": 100, "Sort Space Type": "Disk", "Actual Loops": 21 }),
+        ],
+      }),
+      1,
+    );
+
+    expect(plan.diskSortKb).toEqual([2100]);
+  });
+
+  it("reports each spilling sort separately", () => {
+    const plan = summarise(
+      "select 1",
+      node("Merge Join", {
+        Plans: [
+          node("Sort", { "Sort Space Used": 10, "Sort Space Type": "Disk" }),
+          node("Sort", { "Sort Space Used": 20, "Sort Space Type": "Disk" }),
+        ],
+      }),
+      1,
+    );
+
+    expect(plan.diskSortKb).toEqual([10, 20]);
+  });
+});
+
 describe("buffers", () => {
   it("adds cache hits and disk reads across the tree", () => {
     const plan = summarise(

--- a/scripts/measure-queries.ts
+++ b/scripts/measure-queries.ts
@@ -38,6 +38,8 @@ export interface Plan {
   rowsRemovedByFilter: number;
   executionMs: number;
   sharedBlocks: number;
+  /** Kilobytes each sort had to write to disk, one entry per spilling sort. */
+  diskSortKb: number[];
 }
 
 /**
@@ -92,6 +94,14 @@ export function summarise(sql: string, root: Record<string, unknown>, executionM
         total + Number(n["Rows Removed by Filter"] ?? 0) * Number(n["Actual Loops"] ?? 1),
       0,
     ),
+    // A sort that does not fit in `work_mem` writes to disk, and the difference is not
+    // marginal: the reconciliation drift query spent 983ms of 1,018ms in one 9MB external
+    // merge, for a result of zero rows. It is invisible in a timing -- the query is
+    // simply slow -- and invisible in the plan shape, because the node is a Sort either
+    // way. Only `Sort Space Type` says which.
+    diskSortKb: nodes
+      .filter((n) => String(n["Sort Space Type"]) === "Disk")
+      .map((n) => Number(n["Sort Space Used"] ?? 0) * Number(n["Actual Loops"] ?? 1)),
     executionMs,
     sharedBlocks: nodes.reduce(
       (total, n) =>
@@ -152,9 +162,12 @@ function report(result: PathResult): void {
   );
 
   for (const plan of [...result.plans].sort((a, b) => b.executionMs - a.executionMs).slice(0, 3)) {
-    const how = plan.scannedRelations.length
-      ? `SEQ SCAN ${plan.scannedRelations.join(", ")}`
-      : "indexed";
+    const spill = plan.diskSortKb.length
+      ? `  SORT SPILLED ${plan.diskSortKb.reduce((a, b) => a + b, 0)}kB TO DISK`
+      : "";
+    const how =
+      (plan.scannedRelations.length ? `SEQ SCAN ${plan.scannedRelations.join(", ")}` : "indexed") +
+      spill;
     console.log(
       `      ${plan.executionMs.toFixed(1).padStart(7)}ms  ` +
         `${String(plan.sharedBlocks).padStart(6)} blocks  ` +
@@ -187,6 +200,7 @@ async function main(): Promise<void> {
   }
 
   const { loadCandidates } = await import("../app/services/campaigns/candidates.server");
+  const { reconcile } = await import("../app/services/reconciliation.server");
   const segments = await import("../app/services/segments.server");
   const { facets, previewMatches, resolveVariantGids } = segments;
   type FilterAst = import("../app/services/segments.server").FilterAst;
@@ -263,6 +277,12 @@ async function main(): Promise<void> {
     ["enrol: every gid in scope", () => resolveVariantGids(shop.id, byTag)],
     ["plan: candidates for a tag", () => loadCandidates(shop.id, byTag)],
     ["plan: candidates for the whole catalogue", () => loadCandidates(shop.id, everything)],
+
+    // The trust view. Its drift query grows with the ledger rather than the catalogue,
+    // which is why it degraded unnoticed while every catalogue-sized measurement stayed
+    // flat -- see #513.
+    ["reconcile: first page", () => reconcile(shop.id, shop.domain, {}, 1)],
+    ["reconcile: deep page", () => reconcile(shop.id, shop.domain, {}, 20)],
   ];
 
   // Warm the pool and the page cache once, so the first path measured is not also
@@ -285,6 +305,27 @@ async function main(): Promise<void> {
       `    ${plan.executionMs.toFixed(1).padStart(7)}ms  ` +
         `${plan.scannedRelations.join(", ").padEnd(22)} ${path}`,
     );
+  }
+
+  // Reported separately and last, because it is the finding most worth acting on and the
+  // one least visible in a timing. A spilling sort is a cliff, not a slope: it is fast
+  // until the data outgrows work_mem, and then it is not.
+  const spilling = results.flatMap((r) =>
+    r.plans.filter((p) => p.diskSortKb.length > 0).map((plan) => ({ path: r.label, plan })),
+  );
+
+  if (spilling.length === 0) {
+    console.log("\n  No sort spilled to disk.");
+  } else {
+    console.log(`\n  ${spilling.length} statements sorted to disk — raise work_mem or index the order:`);
+    for (const { path, plan } of spilling.sort(
+      (a, b) => b.plan.executionMs - a.plan.executionMs,
+    )) {
+      const kb = plan.diskSortKb.reduce((a, b) => a + b, 0);
+      console.log(
+        `    ${plan.executionMs.toFixed(1).padStart(7)}ms  ${String(kb).padStart(7)}kB  ${path}`,
+      );
+    }
   }
 
   await Promise.all([observed.$disconnect(), explainer.$disconnect()]);


### PR DESCRIPTION
Closes #513. Refs #160.

## The bug

Reconciliation measured **1,006 ms** on both first and deep page, against a recorded
baseline of 7 ms and 5 ms. Found while measuring #510, and not caused by it — confirmed by
restoring the old indexes and re-measuring.

```
 Limit (actual time=1017.435..1017.438 rows=0 loops=1)
   ->  Hash Join (actual time=1017.435..1017.436 rows=0 loops=1)
         ->  Seq Scan on price_surface_entries e (rows=102132)
         ->  Hash (actual time=997.807..997.808 rows=62535)
               ->  Unique (actual time=880.449..990.278 rows=62535)
                     ->  Sort (actual time=880.447..983.412 rows=125070)
                           Sort Key: c."variantGid", c."priceListGid", c."verifiedAt" DESC
                           Sort Method: external merge  Disk: 9072kB
 Execution Time: 1017.951 ms
```

**983 ms of the 1,018 ms was one sort spilling to disk — for a query returning zero rows.**
`driftedCells` needs the newest verified write per cell, and with no index in the
`DISTINCT ON` order Postgres sorts every verified row the shop has. 9 MB does not fit in
the default 4 MB `work_mem`.

**It degraded with use, not with catalogue size.** One ledger row per variant × surface ×
run, retained indefinitely because unlimited history is a deliberate free-tier feature.
Every catalogue-sized measurement we have stayed flat while this got 17× worse. `reconcile`
calls `counts()` on every page load, so every merchant paid it on every visit to the
live-prices page.

## The fix

`variant_changes_drift_lookup`, partial on `VERIFIED` and ordered to match. The `Sort` node
disappears — `Unique` reads the index in order:

```
Index Scan using variant_changes_drift_lookup (actual time=0.017..30.704 rows=125070)
Execution Time: 71.776 ms
```

| | Before | After |
|---|---|---|
| Reconciliation, first page (p50) | 1,006 ms | **61 ms** |
| Reconciliation, deep page (p50) | 1,006 ms | **59 ms** |

Partial on `VERIFIED` for the same reason `variant_changes_unverified` is partial the other
way. `offBaselineCells` (185 ms) is left alone — already a merge join over two index scans;
comparing every surface entry to its baseline *is* the work.

## Second bug in the same function: the badge was silently capped

```ts
return { drifted: drifted.length, offBaseline: offBaseline.length };
```

Both helpers end in `LIMIT 5000`. A store with 8,000 drifted prices was told **"5,000"** —
a specific, plausible, wrong number with nothing about it that reads as a ceiling.
`reconcile`'s own doc comment says why that is the worst available failure:

> "12 products have drifted" is the number a merchant needs; "0 on this page" tells them
> nothing and quietly implies everything is fine.

Rendered to merchants at `app/routes/app.prices.live.tsx:110`.

The cap is right where it is — the cells list feeds a `WHERE … IN`, and bounding that is
deliberate. It was only ever wrong as an answer to "how many". Both questions now compose
**one** `Prisma.Sql` predicate fragment, so they cannot drift apart into a page that says
"3 drifted" above a table showing four.

## The guard is the spill, not this query

`measure:queries` now reports disk-spilling sorts. That is the class: a spill is a cliff,
not a slope — fast until the data outgrows `work_mem`, then not — and the plan node is a
`Sort` either way. Only `Sort Space Type` distinguishes them, which is why a timing alone
never showed it.

Verified end to end by dropping the index and watching it fire, then restoring it:

```
  2 statements sorted to disk — raise work_mem or index the order:
      977.2ms     9072kB  reconcile: deep page
      973.6ms     9072kB  reconcile: first page
   ↓ index restored
  No sort spilled to disk.
```

The two reconciliation paths are now measured by the harness too.

## Mutations, all caught

| Mutation | Result |
|---|---|
| count reverts to `.length` of a capped list | 1 failed |
| cells loses its bound | 2 failed |
| `DISTINCT ON` sort keys reordered | 1 failed |
| inner join becomes a left join | 1 failed |
| shop id interpolated instead of bound | 1 failed |
| spill matched on `Sort Method` not `Sort Space Type` | 1 failed |
| spill ignores loop count | 1 failed |

## One measurement trap worth recording

An intermittent 1 s outlier during this work was **autovacuum**, not the query —
`pg_stat_user_tables` showed autovacuum and autoanalyze running on all three tables inside
the measurement window. Twelve consecutive calls afterwards ran 55–73 ms with no statement
over 200 ms. Recorded in `docs/perf/queries.md`, because attributing that spike to the
change under test would have been the easy mistake.

## Checks

2,807 unit tests, 142 chaos scenarios, typecheck / lint / build clean. Migration is expand
only.