### PR TITLE
Ask the database for distinct values instead of distinct-ing 102,132 rows

### DIFF
--- a/app/lib/segments/facets.test.ts
+++ b/app/lib/segments/facets.test.ts
@@ -1,0 +1,93 @@
+/**
+ * What the picker admits to when it cannot show everything.
+ *
+ * `facets` caps each list at a hundred values, and always has. What it never did was say
+ * so — a merchant with 412 tags saw the first hundred alphabetically, and the tag they
+ * were looking for was absent in a way indistinguishable from the app not knowing it
+ * existed. The cap is right; the silence was not.
+ *
+ * The query half is exercised against a real Postgres by `reconciliation.chaos.ts`'s
+ * fixtures and by `npm run measure:queries`; what is worth pinning here is the arithmetic
+ * around the boundary, because "showing 100 of 100" is as wrong as no message at all and
+ * off-by-one is exactly where a cap goes wrong.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  facetDetails,
+  MAX_FACET_VALUES,
+  truncatedFacets,
+  type Facets,
+} from "./facets";
+
+const facets = (totals: Partial<Facets["totals"]> = {}): Facets => ({
+  vendors: [],
+  productTypes: [],
+  tags: [],
+  collections: [],
+  totals: { vendors: 0, productTypes: 0, tags: 0, collections: 0, ...totals },
+});
+
+describe("the note under a capped picker", () => {
+  it("says how many are hidden and what to do instead", () => {
+    const details = facetDetails(412, "tags");
+
+    expect(details).toContain(String(MAX_FACET_VALUES));
+    expect(details).toContain("412");
+    // Naming the way out matters as much as naming the problem — the error taxonomy in
+    // RFC §11 asks every merchant-visible message for a next action.
+    expect(details).toContain("Narrow the scope");
+  });
+
+  it("says nothing when everything fits", () => {
+    // Undefined rather than "", so `details` renders no help text at all. An empty string
+    // still occupies the slot under the field.
+    expect(facetDetails(18, "tags")).toBeUndefined();
+  });
+
+  it("says nothing at exactly the cap, because nothing is hidden there", () => {
+    expect(facetDetails(MAX_FACET_VALUES, "tags")).toBeUndefined();
+  });
+
+  it("speaks up at one past the cap", () => {
+    expect(facetDetails(MAX_FACET_VALUES + 1, "tags")).toContain("101");
+  });
+
+  it("says nothing for a shop with none of that facet", () => {
+    expect(facetDetails(0, "vendors")).toBeUndefined();
+  });
+});
+
+describe("which facets are truncated", () => {
+  it("names only the ones over the cap", () => {
+    expect(
+      truncatedFacets(facets({ tags: 412, vendors: 3, collections: MAX_FACET_VALUES })),
+    ).toEqual(["tags"]);
+  });
+
+  it("names several", () => {
+    const truncated = truncatedFacets(facets({ tags: 412, collections: 900 }));
+
+    expect(new Set(truncated)).toEqual(new Set(["tags", "collections"]));
+  });
+
+  it("names none for a shop inside the cap everywhere", () => {
+    expect(truncatedFacets(facets({ vendors: 10, productTypes: 8, tags: 18 }))).toEqual([]);
+  });
+
+  it("covers every facet the type declares", () => {
+    // A fifth facet added to `totals` and not to the picker would otherwise be capped in
+    // silence — the bug this file exists for, one facet along.
+    const everything = facets({
+      vendors: 101,
+      productTypes: 101,
+      tags: 101,
+      collections: 101,
+    });
+
+    expect(truncatedFacets(everything)).toHaveLength(
+      Object.keys(everything.totals).length,
+    );
+  });
+});

--- a/app/lib/segments/facets.ts
+++ b/app/lib/segments/facets.ts
@@ -1,0 +1,63 @@
+/**
+ * The scope picker's option lists, and what a field says when it cannot show them all.
+ *
+ * Pure, and deliberately not in `segments.server`. Three routes render these notes inside
+ * components rather than in a loader, and anything reached from a `*.server.ts` file is
+ * stripped from the client bundle -- which the build rejects outright and typecheck does
+ * not. The queries that fill these lists stay on the server; the arithmetic about them
+ * belongs where both halves of the app can see it.
+ */
+
+/**
+ * How many values a picker offers before it stops listing them.
+ *
+ * An `s-select` with four thousand options is not a picker. The cap is old; what is new
+ * is that `facets` reports the true total alongside it, so a field can admit to the cap
+ * rather than quietly omitting the tag somebody is looking for.
+ */
+export const MAX_FACET_VALUES = 100;
+
+export interface FacetTotals {
+  vendors: number;
+  productTypes: number;
+  tags: number;
+  collections: number;
+}
+
+export interface Facets {
+  vendors: string[];
+  productTypes: string[];
+  tags: string[];
+  collections: string[];
+  /**
+   * How many distinct values each facet actually has, capped list or not.
+   *
+   * So a field showing 100 of 412 tags can say so. Silently showing the first hundred is
+   * indistinguishable, to the merchant looking for the hundred-and-first, from the app
+   * not knowing that tag exists.
+   */
+  totals: FacetTotals;
+}
+
+/** Which facets have more values than the picker will list. */
+export function truncatedFacets(facets: Facets): Array<keyof FacetTotals> {
+  return (Object.keys(facets.totals) as Array<keyof FacetTotals>).filter(
+    (facet) => facets.totals[facet] > MAX_FACET_VALUES,
+  );
+}
+
+/**
+ * What a picker says under itself when it cannot show everything.
+ *
+ * Returns undefined rather than an empty string when there is nothing to say, so the
+ * caller passes it straight to `details` and an untruncated field renders no help text at
+ * all rather than a blank line under it.
+ *
+ * Names the way out as well as the problem, which is what the error taxonomy in RFC §11
+ * asks of every merchant-visible message.
+ */
+export function facetDetails(total: number, noun: string): string | undefined {
+  return total > MAX_FACET_VALUES
+    ? `Showing ${MAX_FACET_VALUES} of ${total} ${noun}. Narrow the scope another way to reach the rest.`
+    : undefined;
+}

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -5,6 +5,7 @@ import { boundary } from "@shopify/shopify-app-react-router/server";
 
 import { authenticate } from "../shopify.server";
 import { ensureShop } from "../services/shop.server";
+import { facetDetails } from "../lib/segments/facets";
 import { facets } from "../services/segments.server";
 import { createCampaign } from "../services/campaigns/index.server";
 import { joinDateAndTime, localInputToUtc, type Schedule } from "../lib/scheduling/window";
@@ -810,7 +811,11 @@ export default function NewCampaign() {
             </FullRow>
           ) : null}
 
-          <s-select name="collection" label="Collection">
+          <s-select
+            name="collection"
+            label="Collection"
+            details={facetDetails(available.totals.collections, "collections")}
+          >
             <s-option value="" defaultSelected={!selected.collection}>
               Any collection
             </s-option>
@@ -820,7 +825,11 @@ export default function NewCampaign() {
               </s-option>
             ))}
           </s-select>
-          <s-select name="vendor" label="Vendor">
+          <s-select
+            name="vendor"
+            label="Vendor"
+            details={facetDetails(available.totals.vendors, "vendors")}
+          >
             <s-option value="" defaultSelected={!selected.vendor}>
               Any vendor
             </s-option>
@@ -830,7 +839,7 @@ export default function NewCampaign() {
               </s-option>
             ))}
           </s-select>
-          <s-select name="tag" label="Tag">
+          <s-select name="tag" label="Tag" details={facetDetails(available.totals.tags, "tags")}>
             <s-option value="" defaultSelected={!selected.tag}>
               Any tag
             </s-option>
@@ -856,7 +865,12 @@ export default function NewCampaign() {
             <s-select
               name="excludeTag"
               label="Except anything tagged"
-              details="Leaves these out of this campaign. They stay eligible for your other campaigns."
+              details={[
+                "Leaves these out of this campaign. They stay eligible for your other campaigns.",
+                facetDetails(available.totals.tags, "tags"),
+              ]
+                .filter(Boolean)
+                .join(" ")}
             >
               <s-option value="" defaultSelected={!selected.excludeTag}>
                 Nothing excluded

--- a/app/routes/app.prices.costs.tsx
+++ b/app/routes/app.prices.costs.tsx
@@ -24,6 +24,7 @@ import { editCosts, newlyViolating, type CostEditResult } from "../services/cost
 import { describeCostRule, type CostRule } from "../lib/pricing/cost-rules";
 import { money } from "../lib/money/money";
 import { format } from "../lib/money/format";
+import { facetDetails } from "../lib/segments/facets";
 import { facets, type FilterAst } from "../services/segments.server";
 import { actorFor } from "../lib/audit/actor";
 import { ActionRow } from "../components/ActionRow";
@@ -55,6 +56,7 @@ export const loader = withGuard("/app/prices/costs", async ({ request }: LoaderF
     withCost,
     variants,
     vendors: available.vendors,
+    vendorTotal: available.totals.vendors,
     violations: violations.slice(0, 25).map((violation) => ({
       campaignId: violation.campaignId,
       campaignName: violation.campaignName,
@@ -159,7 +161,7 @@ export const action = withGuard("/app/prices/costs", async ({ request }: ActionF
 });
 
 export default function Costs() {
-  const { currency, withCost, variants, vendors, violations, violationCount } =
+  const { currency, withCost, variants, vendors, vendorTotal, violations, violationCount } =
     useLoaderData<typeof loader>();
   const fetcher = useFetcher<ActionData>();
   const busy = fetcher.state !== "idle";
@@ -234,7 +236,11 @@ export default function Costs() {
               rule and duplicating the fields would let them drift apart. */}
           <input type="hidden" name="intent" ref={intent} value="dry-run" readOnly />
           <s-stack gap={SPACE.section}>
-            <s-select name="vendor" label="Which products">
+            <s-select
+              name="vendor"
+              label="Which products"
+              details={facetDetails(vendorTotal, "vendors")}
+            >
               <s-option value="" defaultSelected>
                 Every product
               </s-option>

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -22,6 +22,7 @@ import {
   listSegments,
   matchCsv,
 } from "../services/segments-crud.server";
+import { facetDetails, type Facets } from "../lib/segments/facets";
 import { facets } from "../services/segments.server";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
@@ -279,7 +280,7 @@ function NewSegment({
   fetcher,
   busy,
 }: {
-  available: { collections: string[]; tags: string[]; vendors: string[] };
+  available: Facets;
   fetcher: ReturnType<typeof useFetcher<ActionData>>;
   busy: boolean;
 }) {
@@ -341,7 +342,11 @@ function NewSegment({
 
             {how === "filter" ? (
               <>
-                <s-select name="collection" label="Collection">
+                <s-select
+                  name="collection"
+                  label="Collection"
+                  details={facetDetails(available.totals.collections, "collections")}
+                >
                   <s-option value="" defaultSelected>
                     Any collection
                   </s-option>
@@ -352,7 +357,11 @@ function NewSegment({
                   ))}
                 </s-select>
 
-                <s-select name="tag" label="Tag">
+                <s-select
+                  name="tag"
+                  label="Tag"
+                  details={facetDetails(available.totals.tags, "tags")}
+                >
                   <s-option value="" defaultSelected>
                     Any tag
                   </s-option>
@@ -363,7 +372,11 @@ function NewSegment({
                   ))}
                 </s-select>
 
-                <s-select name="vendor" label="Vendor">
+                <s-select
+                  name="vendor"
+                  label="Vendor"
+                  details={facetDetails(available.totals.vendors, "vendors")}
+                >
                   <s-option value="" defaultSelected>
                     Any vendor
                   </s-option>

--- a/app/services/segments.server.ts
+++ b/app/services/segments.server.ts
@@ -10,6 +10,7 @@
 import type { Prisma } from "@prisma/client";
 import prisma from "../db.server";
 import { formatMinorUnits } from "../lib/money/format";
+import { MAX_FACET_VALUES, type Facets } from "../lib/segments/facets";
 
 export type ConditionField =
   | "collection"
@@ -182,37 +183,81 @@ export async function resolveVariantGids(shopId: string, ast: FilterAst): Promis
   return rows.map((r) => r.variantGid);
 }
 
-/** Distinct values available for the picker, so the UI offers real options. */
-export async function facets(shopId: string): Promise<{
-  vendors: string[];
-  productTypes: string[];
-  tags: string[];
-  collections: string[];
-}> {
-  const rows = await prisma.variantIndex.findMany({
-    where: { shopId, deletedAt: null },
-    select: { vendor: true, productType: true, tags: true, collections: true },
-  });
+/**
+ * The distinct values behind the scope picker's dropdowns.
+ *
+ * Distinct in the database, not in the app. This used to select `vendor`, `productType`,
+ * `tags` and `collections` for every non-deleted variant and build four `Set`s from them:
+ * 102,132 rows transferred and materialised to produce 53 values, on three route loaders,
+ * for 330ms of every campaign editor's first paint. Only ~44ms of that was Postgres.
+ *
+ * The four run concurrently because they are four scans that share nothing; a `UNION`
+ * over one scan reads better and plans as four anyway.
+ *
+ * **Sorted here rather than in SQL, deliberately.** `ORDER BY` uses the database's
+ * collation, which differs between a Homebrew Postgres and Railway's — so the list would
+ * be ordered one way locally and another in production. That is the shape of #278, where
+ * `toLocaleString` rendered dates in the *server's* locale. It is not cosmetic either:
+ * with a cap applied, a different order is a different hundred values. Sorting a few
+ * thousand short strings in JS costs nothing and is the same everywhere.
+ */
+export async function facets(shopId: string): Promise<Facets> {
+  const [vendors, productTypes, tags, collections] = await Promise.all([
+    distinctScalar(shopId, "vendor"),
+    distinctScalar(shopId, "productType"),
+    distinctArray(shopId, "tags"),
+    distinctArray(shopId, "collections"),
+  ]);
 
-  const vendors = new Set<string>();
-  const productTypes = new Set<string>();
-  const tags = new Set<string>();
-  const collections = new Set<string>();
-
-  for (const row of rows) {
-    if (row.vendor) vendors.add(row.vendor);
-    if (row.productType) productTypes.add(row.productType);
-    for (const tag of row.tags) tags.add(tag);
-    for (const collection of row.collections) collections.add(collection);
-  }
-
-  const sorted = (set: Set<string>) => [...set].sort().slice(0, 100);
   return {
-    vendors: sorted(vendors),
-    productTypes: sorted(productTypes),
-    tags: sorted(tags),
-    collections: sorted(collections),
+    vendors: vendors.slice(0, MAX_FACET_VALUES),
+    productTypes: productTypes.slice(0, MAX_FACET_VALUES),
+    tags: tags.slice(0, MAX_FACET_VALUES),
+    collections: collections.slice(0, MAX_FACET_VALUES),
+    totals: {
+      vendors: vendors.length,
+      productTypes: productTypes.length,
+      tags: tags.length,
+      collections: collections.length,
+    },
   };
+}
+
+/**
+ * Every distinct non-empty value of one scalar column.
+ *
+ * `GROUP BY` rather than Prisma's `distinct`, which the client has historically applied
+ * in memory for some connectors — the exact thing this function exists to stop doing.
+ *
+ * The column name is interpolated because it cannot be a bind parameter, so it is taken
+ * from a union of two literals rather than from anything a caller composes.
+ */
+async function distinctScalar(shopId: string, column: "vendor" | "productType"): Promise<string[]> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ value: string }>>(
+    `SELECT "${column}" AS value
+       FROM "variant_index"
+      WHERE "shopId" = $1 AND "deletedAt" IS NULL
+        AND "${column}" IS NOT NULL AND "${column}" <> ''
+      GROUP BY "${column}"`,
+    shopId,
+  );
+
+  return rows.map((row) => row.value).sort();
+}
+
+/** The same for an array column, which needs `unnest` before it can be made distinct. */
+async function distinctArray(shopId: string, column: "tags" | "collections"): Promise<string[]> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ value: string }>>(
+    `SELECT DISTINCT unnest("${column}") AS value
+       FROM "variant_index"
+      WHERE "shopId" = $1 AND "deletedAt" IS NULL`,
+    shopId,
+  );
+
+  return rows
+    .map((row) => row.value)
+    .filter(Boolean)
+    .sort();
 }
 
 // ------------------------------------------------------------------ segments

--- a/docs/perf/queries.md
+++ b/docs/perf/queries.md
@@ -86,16 +86,33 @@ maintained on every one of ~102K sync upserts is a poor trade for 9%.
 
 ### Finding 2 — `facets()` reads the whole catalogue to fill four dropdowns
 
+**Fixed in #511.**
+
 330 ms, one statement, every non-deleted row, four columns including two arrays — to
-produce 16 vendors, 15 product types, 18 tags and 10 collections, each then
+produce 10 vendors, 8 product types, 18 tags and 10 collections, each then
 `.slice(0, 100)`. Three route loaders await it: the campaign editor, the costs page and
 the segments page.
 
-Only ~44 ms of that is Postgres. The rest is transferring and materialising 102,132 rows
-to build four `Set`s. `SELECT DISTINCT` does the same work in the database in 37 ms and
-returns 53 rows.
+Only ~44 ms of that was Postgres. The rest was transferring and materialising 102,132 rows
+to build four `Set`s.
 
-Tracked as its own ticket.
+Now four concurrent `GROUP BY` / `DISTINCT unnest` queries: **330 ms → 30 ms**, and 53 rows
+crossing the wire instead of 102,132. Still four sequential scans — a distinct over the
+whole catalogue has to read it — but that is the work, not overhead.
+
+Two things fell out of it:
+
+**The cap now admits to itself.** The list was always capped at 100 and never said so, and
+a merchant with 412 tags could not tell "not in the first hundred alphabetically" from
+"the app does not know this tag". Each picker's `details` now reads *"Showing 100 of 412
+tags. Narrow the scope another way to reach the rest."*
+
+**The sort stays in JavaScript, deliberately.** `ORDER BY` uses the database's collation,
+and Homebrew's Postgres and Railway's do not agree — a Homebrew `ORDER BY` put
+`accessories` between `Wax` and `Snowboard` where JS codepoint order puts every capital
+first. That is the shape of #278, where `toLocaleString` rendered in the *server's* locale.
+It is not cosmetic under a cap either: a different order is a different hundred values.
+Verified byte-identical to the old output on all four shops in the local database.
 
 ### Finding 3 — planning issues one full scan of `baselines` per chunk, and that is currently correct
 


### PR DESCRIPTION
Closes #511. Refs #160.

## The bug

`facets()` selected `vendor`, `productType`, `tags` and `collections` for **every**
non-deleted variant and built four `Set`s from them — 102,132 rows, two of the columns
arrays, to produce 53 distinct values that were then `.slice(0, 100)`d anyway.

**330 ms**, of which only ~44 ms was Postgres. Three route loaders `await` it before first
paint: the campaign editor, the costs page, the segments page.

## The change

Four concurrent `GROUP BY` / `DISTINCT unnest` queries.

| | Before | After |
|---|---|---|
| `facets: the scope picker's options` | 330 ms | **30 ms** |
| Rows crossing the wire | 102,132 | 53 |

Still four sequential scans — a distinct over the whole catalogue has to read it. That is
the work, not overhead.

### Verified equivalent, not assumed

Byte-identical to the old output on all four shops in the local database. And against a
real Postgres for the cases no shop here has:

| Case | Result |
|---|---|
| a shop with no variants | PASS |
| values only on a deleted variant are excluded | PASS |
| empty-string vendor and empty arrays contribute nothing | PASS |
| 150 distinct vendors: 100 listed, true total reported | PASS |
| truncation named for both over-cap facets | PASS |

## The cap now admits to itself

The list was always sliced at 100 and never said so. A merchant with 412 tags could not
tell *"not in the first hundred alphabetically"* from *"the app does not know this tag"*.

Every picker's `details` now reads: **"Showing 100 of 412 tags. Narrow the scope another
way to reach the rest."** All four of them — the campaign editor's collection, vendor, tag
and except-tagged fields, the segments form's three, and the costs page's vendor — because
a fix that lands on one instance of a pattern has to be checked against every instance.

## Two traps worth recording

**The sort stays in JavaScript, deliberately.** `ORDER BY` uses the database's collation,
and Homebrew's Postgres and Railway's do not agree — Homebrew put `accessories` between
`Wax` and `Snowboard` where JS codepoint order puts every capital first. That is the shape
of #278, where `toLocaleString` rendered in the *server's* locale. It is not cosmetic under
a cap either: a different order is a different hundred values.

**The pure half is not in `segments.server`.** The three routes render the note inside
components, and anything reached from a `*.server.ts` file is stripped from the client
bundle:

```
[commonjs--resolver] Server-only module referenced by client
    '../services/segments.server' imported by route 'app/routes/app.settings.segments.tsx'
```

Typecheck passes on that; the build does not. `app/lib/segments/facets.ts` holds the
arithmetic, `segments.server.ts` keeps the queries.

## Mutations, all caught

| Mutation | Result |
|---|---|
| off-by-one: speaks at exactly the cap | 1 failed |
| truncation uses `>=` instead of `>` | 1 failed |
| `details` returns `""` instead of `undefined` | 3 failed |
| the note drops its next action | 1 failed |

## Checks

2,816 unit tests, 142 chaos scenarios, typecheck / lint / build clean.