### PR TITLE
Choose the connection pool size instead of inheriting it from a CPU count

### DIFF
--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -1,16 +1,29 @@
 import { PrismaClient } from "@prisma/client";
 
+import { poolUrl } from "./lib/db/pool";
+
 declare global {
   // eslint-disable-next-line no-var
   var prismaGlobal: PrismaClient;
 }
 
+/**
+ * One client, with a pool size this app chose rather than inherited.
+ *
+ * See `lib/db/pool.ts` for where the number comes from and why leaving it to Prisma's
+ * CPU-derived default is a risk rather than a convenience.
+ */
+function client(): PrismaClient {
+  const url = poolUrl(process.env.DATABASE_URL, process.env.DATABASE_POOL_SIZE);
+  return url ? new PrismaClient({ datasources: { db: { url } } }) : new PrismaClient();
+}
+
 if (process.env.NODE_ENV !== "production") {
   if (!global.prismaGlobal) {
-    global.prismaGlobal = new PrismaClient();
+    global.prismaGlobal = client();
   }
 }
 
-const prisma = global.prismaGlobal ?? new PrismaClient();
+const prisma = global.prismaGlobal ?? client();
 
 export default prisma;

--- a/app/lib/db/pool.test.ts
+++ b/app/lib/db/pool.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The pool size is a number this app chose, and says so in the connection string.
+ *
+ * Prisma's default is `num_physical_cpus * 2 + 1`, read from whichever container the
+ * process lands on — so the web service and the worker would each pick their own, and
+ * nothing would account for their sum against `max_connections`. Exhaustion then surfaces
+ * wherever the next query happened to be, including part way through writing prices.
+ *
+ * What is worth pinning here is the *precedence*, because every failure mode of this
+ * helper is silent: an override that gets replaced makes the Railway dashboard lie about
+ * what the process is doing, and a malformed value that throws turns a typo in a tuning
+ * knob into a service that will not boot.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_POOL_SIZE, poolUrl } from "./pool";
+
+const BASE = "postgresql://anchor:anchor@localhost:5432/anchor_dev";
+
+const limitOf = (url: string | undefined): string | null =>
+  url ? new URL(url).searchParams.get("connection_limit") : null;
+
+describe("choosing the pool size", () => {
+  it("applies the default when nothing asks for anything", () => {
+    expect(limitOf(poolUrl(BASE))).toBe(String(DEFAULT_POOL_SIZE));
+  });
+
+  it("takes an override from the environment", () => {
+    expect(limitOf(poolUrl(BASE, "5"))).toBe("5");
+  });
+
+  it("leaves a limit already in the URL alone", () => {
+    // Whoever set `connection_limit` on the Railway variable meant it. A default quietly
+    // replacing it would make the dashboard describe a process that is not running.
+    const explicit = `${BASE}?connection_limit=3`;
+
+    expect(limitOf(poolUrl(explicit, "5"))).toBe("3");
+  });
+
+  it.each(["", "  ", "many", "0", "-1", "2.5", "NaN"])(
+    "falls back to the default for %o rather than refusing to boot",
+    (override) => {
+      expect(limitOf(poolUrl(BASE, override))).toBe(String(DEFAULT_POOL_SIZE));
+    },
+  );
+});
+
+describe("what it does not damage", () => {
+  it("keeps the parameters already on the connection string", () => {
+    // Railway's URL carries sslmode. Rebuilding the string without it would silently
+    // change how the process connects.
+    const withSsl = `${BASE}?sslmode=require&schema=public`;
+    const result = new URL(poolUrl(withSsl) ?? "");
+
+    expect(result.searchParams.get("sslmode")).toBe("require");
+    expect(result.searchParams.get("schema")).toBe("public");
+    expect(result.searchParams.get("connection_limit")).toBe(String(DEFAULT_POOL_SIZE));
+  });
+
+  it("keeps credentials, host, port and database", () => {
+    const result = new URL(poolUrl(BASE) ?? "");
+
+    expect(result.username).toBe("anchor");
+    expect(result.hostname).toBe("localhost");
+    expect(result.port).toBe("5432");
+    expect(result.pathname).toBe("/anchor_dev");
+  });
+
+  it("hands back an unparseable string untouched", () => {
+    // Deciding a connection string is invalid is Prisma's job, and its message names the
+    // problem. Throwing here would replace that with a stack trace from a tuning helper.
+    expect(poolUrl("not a url")).toBe("not a url");
+  });
+
+  it("hands back a missing string as missing", () => {
+    // So the caller can fall through to `new PrismaClient()` and let Prisma raise the
+    // "DATABASE_URL is not set" error it already has good wording for.
+    expect(poolUrl(undefined)).toBeUndefined();
+  });
+});

--- a/app/lib/db/pool.ts
+++ b/app/lib/db/pool.ts
@@ -1,0 +1,78 @@
+/**
+ * How many database connections a process may hold.
+ *
+ * Prisma's default is `num_physical_cpus * 2 + 1`, read from whatever container the
+ * process lands on. That is a poor thing to leave implicit here for two reasons.
+ *
+ * **There are two pools, not one.** The web service and the worker each construct a
+ * client, and each would size itself from its own container's CPU count with nothing
+ * accounting for their sum against Postgres's `max_connections`. The number nobody chose
+ * is the one that has to fit.
+ *
+ * **Exhaustion does not fail cleanly.** Postgres refuses the connection and the failure
+ * surfaces wherever the next query happened to be — including inside a run that is part
+ * way through writing prices. `MAX_INLINE_ROWS` exists because a request that outlives
+ * its dyno leaves writes in flight with nobody reading the result; a pool that runs out
+ * mid-apply is the same failure reached a different way.
+ *
+ * ## Where 10 comes from
+ *
+ * Measured, not guessed — `npm run measure:concurrency` against 102,132 variants. Twenty
+ * merchants paging the catalogue at once, which is the traffic that actually wants
+ * connections:
+ *
+ *   pool  1 → 200 pages, p50 691ms
+ *   pool  2 → 220 pages, p50 571ms
+ *   pool 10 → 290 pages, p50 347ms
+ *   pool 21 → 316 pages, p50 301ms
+ *   pool 40 → 318 pages, p50 290ms
+ *
+ * Ten buys 91% of the throughput available at 40, for a quarter of the connections. The
+ * curve is flat enough past it that the remaining 9% is not worth spending the budget
+ * that a second web replica, the boot-time `migrate deploy`, and somebody with `psql`
+ * all draw from.
+ *
+ * Campaign planning wants far less. The scheduler walks due campaigns in a `for` loop
+ * with an `await` in it, inside a worker holding a cluster lock, so a worker plans one
+ * campaign at a time — and under four concurrent whole-catalogue plans, admin p95 was the
+ * same at pool 2 as at pool 40. The same ten therefore covers the worker with room to
+ * spare, and one number is easier to reason about than two.
+ */
+
+/** Connections per process, absent an explicit override. */
+export const DEFAULT_POOL_SIZE = 10;
+
+/**
+ * The connection string with an explicit pool size.
+ *
+ * An override already present in the URL wins: whoever set `connection_limit` on the
+ * Railway variable meant it, and a default silently replacing it would make the
+ * dashboard lie about what the process is doing.
+ *
+ * A malformed `DATABASE_POOL_SIZE` falls back to the default rather than throwing.
+ * Refusing to boot over a typo in a tuning knob trades a slow page for an outage.
+ */
+export function poolUrl(
+  databaseUrl: string | undefined,
+  override?: string,
+  fallback: number = DEFAULT_POOL_SIZE,
+): string | undefined {
+  if (!databaseUrl) return databaseUrl;
+
+  let url: URL;
+  try {
+    url = new URL(databaseUrl);
+  } catch {
+    // Not a URL we can edit. Hand it back untouched and let Prisma report it — this
+    // helper is not the right place to decide a connection string is invalid.
+    return databaseUrl;
+  }
+
+  if (url.searchParams.has("connection_limit")) return databaseUrl;
+
+  const asked = Number(override);
+  const limit = Number.isInteger(asked) && asked > 0 ? asked : fallback;
+  url.searchParams.set("connection_limit", String(limit));
+
+  return url.toString();
+}

--- a/app/lib/errors/app-error.test.ts
+++ b/app/lib/errors/app-error.test.ts
@@ -131,3 +131,41 @@ describe("error ids", () => {
     expect(ids.size).toBeGreaterThan(4_990);
   });
 });
+
+describe("the database being busy is not the merchant's fault", () => {
+  // `P20` is Prisma's prefix for the query engine, not for "your input was invalid", and
+  // the catch-all that read it that way misfiled every transient code the engine emits.
+  // The consequences compounded: a 400 instead of a 503, `retryable` false so the worker
+  // gave up on something that would have succeeded on the next attempt, and a merchant
+  // whose apply hit a saturated pool told that "some of the values on this form need
+  // fixing before it can be saved".
+  it.each([
+    ["P2024", "timed out fetching a new connection from the connection pool"],
+    ["P2034", "transaction failed due to a write conflict or a deadlock"],
+  ])("classifies %s as the database being unavailable, and retryable", (code, message) => {
+    const error = toAppError(Object.assign(new Error(message), { code }));
+
+    expect(error.code).toBe("DB_UNAVAILABLE");
+    expect(error.retryable).toBe(true);
+    expect(error.status).toBe(503);
+  });
+
+  it("still treats a genuine constraint violation as validation", () => {
+    // The fix must not swing the other way: P2002 is the data being wrong, and a 503 on
+    // a duplicate would have the worker retry something that can never succeed.
+    const error = toAppError(Object.assign(new Error("Unique constraint failed"), { code: "P2002" }));
+
+    expect(error.code).toBe("VALIDATION");
+    expect(error.retryable).toBe(false);
+  });
+
+  it("says the database may be under load, not only that it is down", () => {
+    // "not responding" alone reads as an outage. Pool exhaustion is the opposite —
+    // everything is up and busy — and a message that names only one of the two sends
+    // whoever is on call looking for the wrong thing.
+    const error = toAppError(Object.assign(new Error("pool timeout"), { code: "P2024" }));
+
+    expect(error.userMessage).toContain("heavy load");
+    expect(error.userMessage).toContain("Nothing was changed in your store");
+  });
+});

--- a/app/lib/errors/app-error.ts
+++ b/app/lib/errors/app-error.ts
@@ -112,10 +112,19 @@ const USER_MESSAGE: Record<ErrorCode, string> = {
   NOT_FOUND: "That campaign or record no longer exists. It may have been deleted.",
   VALIDATION: "Some of the values on this form need fixing before it can be saved.",
   DB_UNAVAILABLE:
-    "The app's own database is not responding. Nothing was changed in your store. Try again shortly.",
+    "The app's own database is not responding — it may be briefly down or under heavy load. Nothing was changed in your store. Try again shortly.",
   UNKNOWN:
     "Something went wrong on our side. Nothing was changed in your store unless a run reported otherwise.",
 };
+
+/**
+ * P20xx codes that describe the database being busy rather than the data being wrong.
+ *
+ * A named set rather than another `startsWith`, because that is what put them in the
+ * wrong bucket: `P20` is Prisma's prefix for "query engine", not for "your input was
+ * invalid", and treating the prefix as the latter misfiles anything transient it emits.
+ */
+const TRANSIENT_PRISMA_CODES: ReadonlySet<string> = new Set(["P2024", "P2034"]);
 
 function classify(error: unknown, message: string): ErrorCode {
   const prismaCode = (error as { code?: unknown })?.code;
@@ -123,6 +132,18 @@ function classify(error: unknown, message: string): ErrorCode {
   if (typeof prismaCode === "string") {
     // Prisma's own codes are far more reliable than its messages.
     if (prismaCode === "P2025") return "NOT_FOUND";
+
+    // Two P20xx codes that are not about the data at all, checked before the catch-all
+    // below claims them. Both are the database saying "not now", both clear on their
+    // own, and both were being reported as VALIDATION -- a 400, marked *not retryable*,
+    // telling a merchant that "some of the values on this form need fixing" when the
+    // real cause was load. The worker reads `retryable` to decide whether to try again,
+    // so the misclassification also turned a transient blip into a failed run.
+    //
+    //   P2024  timed out waiting for a connection from the pool
+    //   P2034  transaction rolled back by a write conflict or deadlock
+    if (TRANSIENT_PRISMA_CODES.has(prismaCode)) return "DB_UNAVAILABLE";
+
     if (prismaCode === "P2002" || prismaCode.startsWith("P20")) return "VALIDATION";
     if (prismaCode.startsWith("P1")) return "DB_UNAVAILABLE";
     if (prismaCode === "ECONNREFUSED" || prismaCode === "ENOTFOUND") {

--- a/docs/deploying-to-railway.md
+++ b/docs/deploying-to-railway.md
@@ -112,6 +112,7 @@ not after.
 | `HELP_BASE_URL` | Help links point at this deploy's own `/help`. Set it only to move the docs onto hosting that survives an outage of this app — `failures/app-unavailable` is otherwise served by the app it describes. |
 | `SCHEDULER_TICK_MS` | Defaults to 30s. |
 | `RUN_STALE_AFTER_MS` | Defaults to 5min — how long before the reaper treats a silent run as abandoned and makes it resumable. Raise it only if a legitimate run can go that long without a heartbeat. |
+| `DATABASE_POOL_SIZE` | Defaults to 10 database connections **per process**, so web plus worker is 20. Measured in `docs/perf/README.md`: ten buys 91% of the throughput available at 40 for a quarter of the connections. Raise it only against a known `max_connections`, remembering that every service and every replica draws from the same budget, as does the `migrate deploy` each container runs at boot. A `connection_limit` already present in `DATABASE_URL` wins over this. |
 
 ---
 

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -103,14 +103,65 @@ that corrupted twenty rows out of 102,132 and sampled twenty found nothing — w
 like a broken audit and was a broken drill. It corrupts a *fraction* instead, chosen well
 over the alert threshold so the alert must fire rather than might.
 
+## Concurrency, and the pool size (#516)
+
+```shell
+npx tsx scripts/measure-concurrency.ts --shop anchor-perf
+```
+
+Every other number on this page is one statement at a time against an idle database. This
+is the one that is not.
+
+**Twenty merchants paging the catalogue at once**, no campaigns — the traffic that sizes
+the web process's pool:
+
+| `connection_limit` | Pages in 6s | p50 | p95 |
+|---|---|---|---|
+| 1 | 200 | 691 ms | 964 ms |
+| 2 | 220 | 571 ms | 588 ms |
+| **10** | **290** | **347 ms** | **775 ms** |
+| 21 (the old default) | 316 | 301 ms | 683 ms |
+| 40 | 318 | 290 ms | 709 ms |
+
+**Four campaigns planning the whole catalogue, one merchant browsing:**
+
+| `connection_limit` | admin p50 | admin p95 |
+|---|---|---|
+| 1 | 123 ms | 519 ms |
+| 2 | 88 ms | 243 ms |
+| 10 | 103 ms | 265 ms |
+| 40 | 102 ms | 300 ms |
+
+Idle floor: p50 25 ms, p95 44 ms. **A merchant paging the catalogue while campaigns plan
+against the same tables waits about 5× longer than one on an idle store**, and no pool size
+changes that much — past two connections the curve is flat. Zero pool timeouts at any size.
+
+At sixteen concurrent whole-catalogue plans, admin p95 reaches 1–3 s and a *bigger* pool is
+worse (pool 1: 1,048 ms; pool 10: 2,985 ms) — the pool acts as admission control, and
+removing it just lets more heavy queries contend. Sixteen is well past anything the app
+permits: the scheduler walks due campaigns in a `for` loop with an `await` in it, inside a
+worker holding a cluster lock, so a worker plans one at a time.
+
+**`connection_limit` is now 10, set explicitly** (`app/lib/db/pool.ts`, override with
+`DATABASE_POOL_SIZE`). It was previously Prisma's `num_physical_cpus * 2 + 1`, read from
+whatever container the process landed on — verified as 21 here against `pg_stat_activity`,
+and it was 21 twice, once for web and once for the worker, with nothing accounting for
+their sum against `max_connections`. Ten buys 91% of the throughput available at 40 for a
+quarter of the connections.
+
+Verified end to end rather than assumed — peak client backends observed while 40 concurrent
+reads were in flight:
+
+| `DATABASE_POOL_SIZE` | Backends |
+|---|---|
+| before this change | 21 |
+| unset (default 10) | 10 |
+| 3 | 3 |
+| 25 | 25 |
+
 ## What these numbers do not cover
 
-Concurrency. Every measurement here is one request at a time against an otherwise idle
-store, so they are a floor rather than a forecast. A merchant paging the catalogue while a
-100K campaign runs is a different question, and the honest answer is that it has not been
-measured.
-
-Webhook lag under load, likewise. Twenty sequential edits on an idle store is the best
+Webhook lag under load. Twenty sequential edits on an idle store is the best
 case; the number that would matter during an incident is lag while a bulk import is
 draining the same queue. `webhook.lag_ms` is emitted every tick now, so the panel will
 answer that once there is traffic to look at.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "measure:admin": "tsx scripts/measure-admin.ts",
     "measure:import": "tsx scripts/measure-import.ts",
     "drill:mirror": "tsx scripts/drill-mirror.ts",
-    "measure:queries": "tsx scripts/measure-queries.ts"
+    "measure:queries": "tsx scripts/measure-queries.ts",
+    "measure:concurrency": "tsx scripts/measure-concurrency.ts"
   },
   "type": "module",
   "engines": {

--- a/scripts/measure-concurrency.ts
+++ b/scripts/measure-concurrency.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * What a merchant's admin feels like while campaigns are planning against the same tables.
+ *
+ *   npm run measure:concurrency -- --shop anchor-perf
+ *
+ * Every other number in `docs/perf/` is one statement at a time against an idle database.
+ * That has been written down as a known gap since the first baseline:
+ *
+ *   "A merchant paging the catalogue while a 100K campaign runs is a different question,
+ *    and the honest answer is that it has not been measured."
+ *
+ * This measures it, and the pool size it depends on. `db.server.ts` constructs
+ * `new PrismaClient()` with no `connection_limit`, so Prisma sizes the pool from the CPU
+ * count of whichever container it lands on -- once for the web process and again for the
+ * worker, with nothing accounting for their sum against `max_connections`.
+ *
+ * Read-only. It plans campaigns rather than applying them, so nothing is written.
+ *
+ * ## Reading the output
+ *
+ * The interesting column is admin p95 *under load*, not planner throughput. A pricing app
+ * that plans faster by making the catalogue page unusable has made the wrong trade: the
+ * planner is a background job that can take another second, and the page is somebody
+ * waiting.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+import { chooseShop, shopArg } from "../app/lib/seed/target-shop";
+
+/** Pool sizes to sweep, spanning the default that nobody chose. */
+const POOL_SIZES = [1, 2, 5, 10, 21, 40];
+
+/**
+ * Concurrent campaigns planning at once.
+ *
+ * Four rather than one, but the app's own design permits fewer: the scheduler walks due
+ * campaigns in a `for` loop with an `await` in it, inside a worker holding a cluster
+ * lock, so a worker runs exactly one campaign at a time. Four is a deliberate overshoot
+ * -- a worker, a merchant who pressed Apply, and headroom.
+ */
+const DEFAULT_CAMPAIGNS = 4;
+
+/** Merchants paging the catalogue at once. What actually sizes the web process's pool. */
+const DEFAULT_MERCHANTS = 1;
+
+/** How long each pool size is held under load. */
+const WINDOW_MS = 6_000;
+
+export interface Latencies {
+  count: number;
+  p50: number;
+  p95: number;
+  max: number;
+}
+
+/** p50/p95/max of a sample, or zeroes for an empty one. */
+export function summarise(samples: readonly number[]): Latencies {
+  if (samples.length === 0) return { count: 0, p50: 0, p95: 0, max: 0 };
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const at = (fraction: number) =>
+    sorted[Math.min(sorted.length - 1, Math.floor(fraction * sorted.length))];
+
+  return {
+    count: sorted.length,
+    p50: at(0.5),
+    p95: at(0.95),
+    max: sorted[sorted.length - 1],
+  };
+}
+
+/**
+ * A connection string with an explicit pool size.
+ *
+ * Appended as a query parameter rather than passed to the client, because
+ * `connection_limit` is a property of the URL in Prisma and there is no constructor
+ * option for it. Existing parameters are preserved -- Railway's URL carries `sslmode`,
+ * and dropping it would measure a connection nobody makes.
+ */
+export function urlWithPool(base: string, limit: number): string {
+  const url = new URL(base);
+  url.searchParams.set("connection_limit", String(limit));
+  return url.toString();
+}
+
+/**
+ * Whether an error is the pool refusing to hand out a connection.
+ *
+ * Worth separating from any other failure: a pool timeout is the finding, and counting it
+ * as a generic error would report the run as broken rather than as saturated.
+ */
+export function isPoolTimeout(error: unknown): boolean {
+  const code = (error as { code?: string } | null)?.code;
+  const message = error instanceof Error ? error.message : String(error);
+  return code === "P2024" || /connection pool/i.test(message);
+}
+
+interface Result {
+  pool: number;
+  admin: Latencies;
+  plannerRuns: number;
+  poolTimeouts: number;
+  otherErrors: number;
+}
+
+async function measurePool(
+  shopId: string,
+  pool: number,
+  campaigns: number,
+  merchants: number,
+  loadCandidates: (shopId: string, ast: { groups: [] }) => Promise<unknown>,
+  catalogue: (client: PrismaClient, shopId: string) => Promise<unknown>,
+): Promise<Result> {
+  const client = new PrismaClient({
+    datasources: { db: { url: urlWithPool(process.env.DATABASE_URL ?? "", pool) } },
+  });
+
+  // The services take the module-level client, so the pool under test has to be the one
+  // `db.server` handed out. Assigning the global before its first import is what makes
+  // that work; here the module is already loaded, so the client is swapped on the object
+  // the services are holding a reference to.
+  const previous = globalThis.prismaGlobal;
+  globalThis.prismaGlobal = client;
+
+  const adminSamples: number[] = [];
+  let plannerRuns = 0;
+  let poolTimeouts = 0;
+  let otherErrors = 0;
+  let running = true;
+
+  const count = (error: unknown) => {
+    if (isPoolTimeout(error)) poolTimeouts++;
+    else otherErrors++;
+  };
+
+  // Campaign planners, looping for the window. Each is the real `loadCandidates` over the
+  // whole catalogue -- the heaviest read path the app has, and the one that holds a
+  // connection for twenty-odd chunked statements in a row.
+  const planners = Array.from({ length: campaigns }, async () => {
+    while (running) {
+      try {
+        await loadCandidates(shopId, { groups: [] });
+        plannerRuns++;
+      } catch (error) {
+        count(error);
+      }
+    }
+  });
+
+  // Merchants paging the catalogue throughout. Each page load is one sample, so the
+  // percentiles below are what a person waits, not what the process averages.
+  const browsing = Array.from({ length: merchants }, async () => {
+    while (running) {
+      const started = process.hrtime.bigint();
+      try {
+        await catalogue(client, shopId);
+        adminSamples.push(Number(process.hrtime.bigint() - started) / 1e6);
+      } catch (error) {
+        count(error);
+      }
+    }
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, WINDOW_MS));
+  running = false;
+  await Promise.all([...planners, ...browsing]);
+
+  globalThis.prismaGlobal = previous;
+  await client.$disconnect();
+
+  return { pool, admin: summarise(adminSamples), plannerRuns, poolTimeouts, otherErrors };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const numeric = (flag: string, fallback: number) => {
+    const at = args.indexOf(flag);
+    return at === -1 ? fallback : Number(args[at + 1]);
+  };
+  const campaigns = numeric("--campaigns", DEFAULT_CAMPAIGNS);
+  const merchants = numeric("--merchants", DEFAULT_MERCHANTS);
+
+  const observed = new PrismaClient();
+  globalThis.prismaGlobal = observed;
+
+  const { default: prisma } = await import("../app/db.server");
+  const { loadCandidates } = await import("../app/services/campaigns/candidates.server");
+  const { ROWS_PER_VIEW } = await import("../app/lib/ui/table-budget");
+
+  const installed = await prisma.shop.findMany({
+    where: { uninstalledAt: null },
+    select: { domain: true },
+  });
+  const shop = await prisma.shop.findUniqueOrThrow({
+    where: { domain: chooseShop(installed, shopArg(args)).domain },
+  });
+  const total = await prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } });
+
+  /** One page of the catalogue, the way its loader asks for it. */
+  const catalogue = async (client: PrismaClient, shopId: string) => {
+    const variants = await client.variantIndex.findMany({
+      where: { shopId, deletedAt: null },
+      orderBy: [{ title: "asc" }, { variantGid: "asc" }],
+      take: ROWS_PER_VIEW,
+    });
+    await client.baseline.findMany({
+      where: {
+        shopId,
+        supersededAt: null,
+        surfaceKind: "BASE",
+        variantGid: { in: variants.map((v) => v.variantGid) },
+      },
+      select: { variantGid: true, basePrice: true },
+    });
+  };
+
+  console.log(`${shop.domain}: ${total} variants.`);
+  console.log(`\n  ${campaigns} campaigns planning the whole catalogue continuously, while`);
+  console.log(
+    `  ${merchants} merchant${merchants === 1 ? "" : "s"} page the catalogue. ` +
+      `${WINDOW_MS / 1000}s per pool size.\n`,
+  );
+  console.log("   pool   admin p50   admin p95   admin max   pages   plans   pool timeouts");
+
+  const results: Result[] = [];
+  for (const pool of POOL_SIZES) {
+    const result = await measurePool(
+      shop.id,
+      pool,
+      campaigns,
+      merchants,
+      loadCandidates,
+      catalogue,
+    );
+    results.push(result);
+    console.log(
+      `  ${String(result.pool).padStart(5)}   ` +
+        `${result.admin.p50.toFixed(0).padStart(7)}ms   ` +
+        `${result.admin.p95.toFixed(0).padStart(7)}ms   ` +
+        `${result.admin.max.toFixed(0).padStart(7)}ms   ` +
+        `${String(result.admin.count).padStart(5)}   ` +
+        `${String(result.plannerRuns).padStart(5)}   ` +
+        `${String(result.poolTimeouts).padStart(13)}` +
+        (result.otherErrors > 0 ? `   (${result.otherErrors} other errors)` : ""),
+    );
+  }
+
+  // The idle floor, for comparison. Taken last so it is not the run that warms the cache
+  // for everything else.
+  const idle: number[] = [];
+  for (let i = 0; i < 20; i++) {
+    const started = process.hrtime.bigint();
+    await catalogue(observed, shop.id);
+    idle.push(Number(process.hrtime.bigint() - started) / 1e6);
+  }
+  const floor = summarise(idle);
+  console.log(
+    `\n  idle floor: p50 ${floor.p50.toFixed(0)}ms   p95 ${floor.p95.toFixed(0)}ms` +
+      `   max ${floor.max.toFixed(0)}ms`,
+  );
+
+  const best = results.reduce((a, b) => (b.admin.p95 < a.admin.p95 ? b : a));
+  console.log(
+    `\n  Lowest admin p95 under load: pool ${best.pool} at ${best.admin.p95.toFixed(0)}ms ` +
+      `(${(best.admin.p95 / Math.max(1, floor.p95)).toFixed(1)}x the idle floor).`,
+  );
+
+  await Promise.all([observed.$disconnect()]);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #516. The last buildable criterion on #160.

## The pool

`db.server.ts` constructed `new PrismaClient()` with no `connection_limit`, so Prisma sized
the pool at `num_physical_cpus * 2 + 1` — read from whatever container the process landed
on. **Twice**: once for web, once for the worker, with nothing accounting for their sum
against `max_connections`. Confirmed as 21 here by counting client backends.

Now **10**, explicitly, overridable with `DATABASE_POOL_SIZE`. A `connection_limit` already
in `DATABASE_URL` still wins — whoever set that on the Railway variable meant it.

### Where 10 comes from

Twenty merchants paging the catalogue at once, which is the traffic that actually wants
connections:

| `connection_limit` | Pages in 6s | p50 | p95 |
|---|---|---|---|
| 1 | 200 | 691 ms | 964 ms |
| 2 | 220 | 571 ms | 588 ms |
| **10** | **290** | **347 ms** | **775 ms** |
| 21 (the old default) | 316 | 301 ms | 683 ms |
| 40 | 318 | 290 ms | 709 ms |

91% of the throughput available at 40, for a quarter of the connections — leaving budget
for a second replica, the `migrate deploy` each container runs at boot, and somebody with
`psql`.

### Verified end to end, not assumed

Peak client backends observed against `pg_stat_activity` with 40 concurrent reads in
flight:

| `DATABASE_POOL_SIZE` | Backends |
|---|---|
| before this change | **21** |
| unset (default 10) | **10** |
| 3 | 3 |
| 25 | 25 |

## The concurrency gap, finally measured

`docs/perf/README.md` has admitted this since the first baseline:

> A merchant paging the catalogue while a 100K campaign runs is a different question, and
> the honest answer is that it has not been measured.

`npm run measure:concurrency` measures it. Four campaigns planning the whole catalogue with
one merchant browsing: **admin p95 goes from a 44 ms idle floor to ~243–300 ms**, about 5×,
and no pool size changes that much — past two connections the curve is flat. Zero pool
timeouts at any size.

At sixteen concurrent plans, admin p95 reaches 1–3 s and a **bigger pool is worse**
(pool 1: 1,048 ms; pool 10: 2,985 ms) — the pool is acting as admission control, and
removing it just lets more heavy queries contend. Sixteen is well past what the app
permits: the scheduler walks due campaigns in a `for` loop with an `await` in it, inside a
worker holding a cluster lock, so a worker plans one at a time.

## The bug that mattered most was in the taxonomy, not the pool

`classify` treated **every** P20xx code as `VALIDATION`:

```ts
if (prismaCode === "P2002" || prismaCode.startsWith("P20")) return "VALIDATION";
```

`P20` is Prisma's prefix for the *query engine*, not for "your input was invalid". So:

| Code | Means | Was classified | Consequence |
|---|---|---|---|
| `P2024` | timed out waiting for a pool connection | `VALIDATION` | 400, **not retryable** |
| `P2034` | write conflict or deadlock | `VALIDATION` | 400, **not retryable** |

A merchant whose apply hit a saturated pool was told *"Some of the values on this form need
fixing before it can be saved."* And because the worker reads `retryable` to decide whether
to try again, the misclassification turned a transient blip into a **failed run** — on
exactly the two codes Prisma emits to mean "retry me".

Both are `DB_UNAVAILABLE` now: 503, retryable, checked before the catch-all. A named set
rather than another prefix match, since the prefix match is what caused it.

`DB_UNAVAILABLE`'s message now names load as well as an outage — "not responding" alone
sends whoever is on call looking for a database that is up and busy.

## Mutations, all caught

| Mutation | Result |
|---|---|
| an existing `connection_limit` gets overwritten | 1 failed |
| a non-integer override is accepted | 5 failed |
| zero and negatives are accepted | 4 failed |
| an unparseable URL throws instead of passing through | 1 failed |
| a missing URL becomes `""` | 1 failed |
| revert to the original catch-all ordering | 3 failed |
| only `P2024` handled, `P2034` forgotten | 1 failed |
| the fix swings too far and claims all `P20` | 1 failed |
| the message drops the load half | 1 failed |

`deploy-config.test.ts` caught the new env var missing from the Railway runbook before I
did — it is documented there now.

## Checks

2,835 unit tests, 142 chaos scenarios, typecheck / lint / build clean.