### PR TITLE
Rehearse the data restore instead of stating an objective

### DIFF
--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -347,8 +347,29 @@ What actually needs restoring, in order of how badly it hurts to lose:
 4. Run the reconciliation spot check at a large sample *before* starting the worker. If the mirror disagrees with Shopify, sync before scheduling anything — a campaign planned against a stale mirror prices the wrong products.
 5. Start the worker. Reclaim happens on the first tick.
 
-**Rehearse this, do not assume it.** The numbers above are objectives until somebody has
-timed them against a real snapshot.
+**Rehearsed.** `npm run drill:restore` performs the procedure — dump, restore into a fresh
+database, `prisma migrate deploy` — and times each phase, then checks the restore is
+*complete* rather than merely successful: row counts per critical table against the source,
+plus the extensions and indexes a row count cannot see.
+
+Measured 30 Aug 2026 against `anchor_dev` — 105,869 variants, 125,070 ledger rows, 116,000
+surface entries, a 17 MB dump:
+
+| Phase | Elapsed |
+|---|---|
+| `pg_dump` | 2.1 s |
+| `pg_restore` | 7.4 s |
+| `prisma migrate deploy` | 0.7 s |
+| **Total** | **~10 s against a 60 min RTO** |
+
+All six critical tables came back whole; `pg_trgm` and the four indexes added this week
+survived the round trip.
+
+**Two things that number is not.** It is a *floor*: local Postgres on one machine, no
+network, no Railway, and 17 MB rather than a production snapshot. And it says nothing about
+**RPO** — five minutes of maximum data loss depends on Railway's backup cadence and
+point-in-time recovery, which needs the Railway console. The drill prints `RPO NOT MEASURED`
+on every run rather than letting three PASS lines read as "the objective is met".
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "measure:import": "tsx scripts/measure-import.ts",
     "drill:mirror": "tsx scripts/drill-mirror.ts",
     "measure:queries": "tsx scripts/measure-queries.ts",
-    "measure:concurrency": "tsx scripts/measure-concurrency.ts"
+    "measure:concurrency": "tsx scripts/measure-concurrency.ts",
+    "drill:restore": "tsx scripts/drill-restore.ts"
   },
   "type": "module",
   "engines": {

--- a/scripts/drill-restore.test.ts
+++ b/scripts/drill-restore.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The verdict a restore drill prints.
+ *
+ * The numbers need a real Postgres and 17 MB of real data; what they *mean* does not. And
+ * the meaning is where a drill like this fails silently — by reporting a pass for something
+ * it never observed. A restore that says "every critical table came back whole" having
+ * compared no tables is worse than no drill at all, because it is the line somebody quotes
+ * in the hour they most need it to be true.
+ *
+ * `docs/runbooks.md` asked for exactly this and had been waiting: *"Rehearse this, do not
+ * assume it. The numbers above are objectives until somebody has timed them against a real
+ * snapshot."*
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CRITICAL_TABLES,
+  passed,
+  REQUIRED_OBJECTS,
+  RTO_BUDGET_MS,
+  verdict,
+  type RestoreDrill,
+} from "./drill-restore";
+
+const whole = CRITICAL_TABLES.map((table) => ({ table, source: 1_000, restored: 1_000 }));
+
+const drill = (over: Partial<RestoreDrill> = {}): RestoreDrill => ({
+  dumpMs: 2_100,
+  restoreMs: 7_400,
+  migrateMs: 700,
+  dumpBytes: 17 * 1024 * 1024,
+  rows: whole,
+  missingExtensions: [],
+  missingIndexes: [],
+  cleanedUp: true,
+  ...over,
+});
+
+describe("the RTO budget", () => {
+  it("passes a restore inside the hour", () => {
+    expect(verdict(drill())[0]).toMatch(/^PASS/);
+  });
+
+  it("fails one that runs over, and says by how much", () => {
+    const line = verdict(drill({ restoreMs: RTO_BUDGET_MS + 60_000 }))[0];
+
+    expect(line).toMatch(/^FAIL/);
+    expect(line).toContain("61.0 min");
+  });
+
+  it("treats exactly the budget as inside it", () => {
+    expect(verdict(drill({ dumpMs: RTO_BUDGET_MS, restoreMs: 0, migrateMs: 0 }))[0]).toMatch(/^PASS/);
+  });
+
+  it("counts all three phases, not just the restore", () => {
+    // Dump and migrate are part of the hour a merchant is down. Timing only the restore
+    // would report a comfortable pass for a procedure that misses the objective.
+    const line = verdict(drill({ dumpMs: 40 * 60_000, restoreMs: 30 * 60_000, migrateMs: 0 }))[0];
+
+    expect(line).toMatch(/^FAIL/);
+  });
+});
+
+describe("completeness", () => {
+  it("passes when every critical table matches", () => {
+    expect(verdict(drill())[1]).toMatch(/^PASS/);
+  });
+
+  it("fails when a table came back short, naming it and both counts", () => {
+    const line = verdict(
+      drill({ rows: [...whole.slice(1), { table: "baselines", source: 1_000, restored: 998 }] }),
+    )[1];
+
+    expect(line).toMatch(/^FAIL/);
+    expect(line).toContain("baselines 998 of 1000");
+  });
+
+  it("fails when it compared nothing at all", () => {
+    // The failure this file exists for. An empty list satisfies "no table came back
+    // short" and would otherwise print a pass for an observation never made.
+    const line = verdict(drill({ rows: [] }))[1];
+
+    expect(line).toMatch(/^FAIL/);
+    expect(line).toContain("compared no tables");
+  });
+
+  it("fails when a table could not be counted in either database", () => {
+    // Two unreadable counts are equal, so an equality check alone reads a table missing
+    // from *both* copies as matching.
+    const line = verdict(
+      drill({ rows: [{ table: "variant_changes", source: -1, restored: -1 }] }),
+    )[1];
+
+    expect(line).toMatch(/^FAIL/);
+    expect(line).toContain("could not be counted");
+  });
+
+  it("covers the ledger and the baselines, which are the two that cannot be rebuilt", () => {
+    // The runbook orders the tables by how badly it hurts to lose them. The mirror is
+    // rebuildable from Shopify; these two are not, and a drill omitting them would be
+    // measuring the recoverable half.
+    expect(CRITICAL_TABLES).toContain("baselines");
+    expect(CRITICAL_TABLES).toContain("variant_changes");
+  });
+});
+
+describe("the objects a row count cannot see", () => {
+  it("passes when the extensions and indexes are present", () => {
+    expect(verdict(drill())[2]).toMatch(/^PASS/);
+  });
+
+  it("fails on a missing extension, naming it", () => {
+    const line = verdict(drill({ missingExtensions: ["pg_trgm"] }))[2];
+
+    expect(line).toMatch(/^FAIL/);
+    expect(line).toContain("pg_trgm");
+  });
+
+  it("fails on a missing index", () => {
+    // A restore returning every row and none of the indexes is a working app that
+    // searches forty times slower — which reads as a successful restore.
+    expect(verdict(drill({ missingIndexes: ["variant_index_sku_trgm"] }))[2]).toMatch(/^FAIL/);
+  });
+
+  it("checks the extension the schema gained most recently", () => {
+    // pg_trgm arrived in #512. A dump carries CREATE EXTENSION only if the target
+    // cluster has it available, and mid-restore is the wrong time to find out.
+    expect(REQUIRED_OBJECTS.extensions).toContain("pg_trgm");
+  });
+});
+
+describe("what the drill admits to", () => {
+  it("reports the target database being dropped", () => {
+    expect(verdict(drill()).join(" ")).toContain("target database dropped");
+  });
+
+  it("warns when it could not drop it", () => {
+    const lines = verdict(drill({ cleanedUp: false }));
+
+    expect(lines.some((line) => line.startsWith("WARN"))).toBe(true);
+    // A leftover database is not a failed restore. Warning without failing keeps the
+    // verdict about the procedure rather than about the housekeeping.
+    expect(passed(lines)).toBe(true);
+  });
+
+  it("says on every run that RPO was not measured", () => {
+    // Three PASS lines would otherwise read as "the objective is met", and half the
+    // objective — five minutes of data loss — depends on Railway's backup cadence, which
+    // this drill cannot reach. Stated always, not only when something fails.
+    expect(verdict(drill()).join(" ")).toContain("RPO NOT MEASURED");
+  });
+
+  it("prints the phase breakdown, so a slow restore says which phase was slow", () => {
+    expect(verdict(drill()).join(" ")).toMatch(/dump .* restore .* migrate /);
+  });
+});
+
+describe("passed()", () => {
+  it("is true when nothing failed", () => {
+    expect(passed(verdict(drill()))).toBe(true);
+  });
+
+  it("is false when anything did", () => {
+    expect(passed(verdict(drill({ missingExtensions: ["pg_trgm"] })))).toBe(false);
+  });
+});

--- a/scripts/drill-restore.ts
+++ b/scripts/drill-restore.ts
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * The data-restore procedure, executed and timed.
+ *
+ *   npm run drill:restore
+ *
+ * `docs/runbooks.md` § Data restore states an objective and then says what this script
+ * exists to fix:
+ *
+ *   "Rehearse this, do not assume it. The numbers above are objectives until somebody
+ *    has timed them against a real snapshot."
+ *
+ * Until now nobody had, so all five steps were hypotheses — including `npm run setup`,
+ * which has to apply migrations to a snapshot that predates them, and which nothing had
+ * ever asked to do.
+ *
+ * ## What it proves and what it does not
+ *
+ * **RTO — measured here.** Dump, restore and migrate against real data volumes.
+ *
+ * **RPO — not measurable here, and deliberately not implied.** Five minutes depends on
+ * Railway's backup cadence and point-in-time recovery, which needs the Railway console.
+ * The verdict says so rather than staying quiet about it, because a drill that reports
+ * PASS on everything it looked at, having not looked at half the objective, is the exact
+ * dishonesty the chaos suite exists to catch the engine doing.
+ *
+ * ## Safety
+ *
+ * Reads the source database and writes only to a target it creates. The target name
+ * carries a fixed prefix and the script refuses to touch anything else, because "drop the
+ * database" is the one instruction here that cannot be taken back.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** RTO from the runbook. One hour, in milliseconds. */
+export const RTO_BUDGET_MS = 60 * 60_000;
+
+/**
+ * Tables whose row counts must match exactly for a restore to count as complete.
+ *
+ * The runbook orders them by how badly it hurts to lose them, and the first two are the
+ * reason this is a product rather than a spreadsheet: baselines are what every campaign
+ * computes from, and the ledger is what makes a revert trustworthy. A restore that came
+ * back "successful" while silently short on either is the failure worth catching.
+ */
+export const CRITICAL_TABLES = [
+  "baselines",
+  "variant_changes",
+  "campaigns",
+  "campaign_runs",
+  "variant_index",
+  "price_surface_entries",
+] as const;
+
+/**
+ * Database objects the app stops working without, which a plain row count cannot see.
+ *
+ * `pg_trgm` earns its place here: it arrived in #512, a dump carries `CREATE EXTENSION`
+ * only if the target cluster has the extension available, and the first time anybody
+ * would discover otherwise is mid-restore. The trigram indexes are named for the same
+ * reason — a restore that returns every row and none of the indexes is a working app that
+ * takes forty times longer to search, which reads as "the restore worked".
+ */
+export const REQUIRED_OBJECTS = {
+  extensions: ["pg_trgm"],
+  indexes: [
+    "variant_index_title_trgm",
+    "variant_index_sku_trgm",
+    "variant_index_barcode_trgm",
+    "variant_changes_drift_lookup",
+  ],
+} as const;
+
+export interface RestoreDrill {
+  dumpMs: number;
+  restoreMs: number;
+  migrateMs: number;
+  dumpBytes: number;
+  /** Row counts before and after, per table. */
+  rows: Array<{ table: string; source: number; restored: number }>;
+  missingExtensions: string[];
+  missingIndexes: string[];
+  /** Whether the target database was removed afterwards. */
+  cleanedUp: boolean;
+}
+
+export const totalMs = (drill: RestoreDrill): number =>
+  drill.dumpMs + drill.restoreMs + drill.migrateMs;
+
+/** What the drill proved, or did not. */
+export function verdict(drill: RestoreDrill): string[] {
+  const lines: string[] = [];
+  const elapsed = totalMs(drill);
+  const minutes = (ms: number) => (ms / 60_000).toFixed(1);
+
+  lines.push(
+    elapsed <= RTO_BUDGET_MS
+      ? `PASS  restored in ${minutes(elapsed)} min, inside the 60.0 min RTO`
+      : `FAIL  restore took ${minutes(elapsed)} min against a 60.0 min RTO`,
+  );
+
+  // A negative count means the table could not be read at all. Equality alone would let
+  // a table missing from *both* databases pass as "matching" -- two unreadable counts are
+  // equal, and a drill that reports a whole restore because it could not find either copy
+  // is worse than one that crashes.
+  const unreadable = drill.rows.filter((row) => row.source < 0 || row.restored < 0);
+  const short = drill.rows.filter((row) => row.restored !== row.source);
+  const wrong = [...new Set([...unreadable, ...short])];
+
+  lines.push(
+    drill.rows.length === 0
+      ? `FAIL  compared no tables, so nothing about completeness was observed`
+      : wrong.length === 0
+        ? `PASS  every one of ${drill.rows.length} critical tables came back whole`
+        : `FAIL  ${wrong
+            .map((row) =>
+              row.source < 0 || row.restored < 0
+                ? `${row.table} could not be counted`
+                : `${row.table} ${row.restored} of ${row.source}`,
+            )
+            .join(", ")}`,
+  );
+
+  lines.push(
+    drill.missingExtensions.length === 0 && drill.missingIndexes.length === 0
+      ? `PASS  extensions and indexes the app depends on are present`
+      : `FAIL  missing ${[...drill.missingExtensions, ...drill.missingIndexes].join(", ")}`,
+  );
+
+  lines.push(
+    `      dump ${minutes(drill.dumpMs)} min · restore ${minutes(drill.restoreMs)} min · ` +
+      `migrate ${minutes(drill.migrateMs)} min · ` +
+      `${(drill.dumpBytes / 1024 / 1024).toFixed(0)} MB`,
+  );
+
+  // Always reported, because a drill that leaves a database behind is worse than no drill.
+  lines.push(
+    drill.cleanedUp
+      ? `      target database dropped`
+      : `WARN  target database left behind — drop it by hand`,
+  );
+
+  // Stated on every run rather than only when it matters. Half the runbook's objective is
+  // not measured here, and a verdict that mentioned it only in a footnote would let three
+  // PASS lines read as "the objective is met".
+  lines.push(
+    `      RPO NOT MEASURED — the 5 min objective depends on Railway's backup cadence ` +
+      `and point-in-time recovery, which this drill cannot reach`,
+  );
+
+  return lines;
+}
+
+export const passed = (lines: readonly string[]): boolean =>
+  !lines.some((line) => line.startsWith("FAIL"));
+
+// ------------------------------------------------------------------ execution
+
+/** Target databases this drill may create, and the only ones it may drop. */
+const TARGET_PREFIX = "anchor_restore_drill_";
+
+function psqlEnv(url: URL): NodeJS.ProcessEnv {
+  return { ...process.env, PGPASSWORD: decodeURIComponent(url.password) };
+}
+
+function connection(url: URL): string[] {
+  return ["-h", url.hostname, "-p", url.port || "5432", "-U", decodeURIComponent(url.username)];
+}
+
+function run(command: string, args: string[], env: NodeJS.ProcessEnv): string {
+  return execFileSync(command, args, { env, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+function timed<T>(fn: () => T): [T, number] {
+  const started = process.hrtime.bigint();
+  const value = fn();
+  return [value, Number(process.hrtime.bigint() - started) / 1e6];
+}
+
+function countRows(url: URL, database: string, table: string): number {
+  try {
+    const out = run(
+      "psql",
+      [...connection(url), "-d", database, "-X", "-t", "-A", "-c", `SELECT count(*) FROM "${table}"`],
+      psqlEnv(url),
+    );
+    return Number(out.trim());
+  } catch {
+    // A table missing from the restore is a count of nothing, which is what the verdict
+    // should compare against — not a crash that hides which table it was.
+    return -1;
+  }
+}
+
+function present(url: URL, database: string, query: string): Set<string> {
+  const out = run(
+    "psql",
+    [...connection(url), "-d", database, "-X", "-t", "-A", "-c", query],
+    psqlEnv(url),
+  );
+  return new Set(out.split("\n").map((line) => line.trim()).filter(Boolean));
+}
+
+async function main(): Promise<void> {
+  // The other scripts here reach the database through `app/db.server`, which is what
+  // loads `.env`. This one talks to `pg_dump` directly and never imports it, so it has
+  // to do the same itself — as the chaos harness does, for the same reason.
+  if (!process.env.DATABASE_URL) {
+    try {
+      process.loadEnvFile(".env");
+    } catch {
+      // No .env is fine as long as the variable is set some other way, as in CI.
+    }
+  }
+
+  const raw = process.env.DATABASE_URL;
+  if (!raw) {
+    throw new Error("This drill needs a real Postgres. Set DATABASE_URL (or put it in .env).");
+  }
+
+  const url = new URL(raw);
+  const source = url.pathname.replace(/^\//, "");
+  const target = `${TARGET_PREFIX}${process.pid}`;
+  const workDir = mkdtempSync(join(tmpdir(), "anchor-restore-"));
+  const dumpPath = join(workDir, "source.dump");
+
+  console.log(`Rehearsing docs/runbooks.md § Data restore.`);
+  console.log(`  source ${source} → target ${target}\n`);
+
+  // Step 1 of the runbook is "stop the worker first". Not simulated: this reads the
+  // source and writes only to a database it creates, so there is nothing for a running
+  // worker to half-write. Said out loud because a drill that silently skips a step is
+  // rehearsing a procedure nobody will follow.
+  console.log("  (runbook step 1, stop the worker, does not apply — this drill writes to a copy)");
+
+  const [, dumpMs] = timed(() =>
+    run(
+      "pg_dump",
+      [...connection(url), "-d", source, "-Fc", "--no-owner", "--no-acl", "-f", dumpPath],
+      psqlEnv(url),
+    ),
+  );
+  const dumpBytes = statSync(dumpPath).size;
+  console.log(`  dumped ${(dumpBytes / 1024 / 1024).toFixed(0)} MB in ${(dumpMs / 1000).toFixed(1)}s`);
+
+  let cleanedUp = false;
+  try {
+    run("createdb", [...connection(url), target], psqlEnv(url));
+
+    const [, restoreMs] = timed(() => {
+      try {
+        run(
+          "pg_restore",
+          [...connection(url), "-d", target, "--no-owner", "--no-acl", "-j", "4", dumpPath],
+          psqlEnv(url),
+        );
+      } catch (error) {
+        // pg_restore exits non-zero on warnings it also recovers from. Whether the
+        // restore is *complete* is decided by the row counts below, not by this code.
+        console.log(`  pg_restore reported: ${(error as Error).message.split("\n")[0]}`);
+      }
+      return null;
+    });
+    console.log(`  restored in ${(restoreMs / 1000).toFixed(1)}s`);
+
+    // Runbook step 3. The step nothing had ever executed: a restored snapshot can predate
+    // migrations, and `migrate deploy` has to be a no-op on a current one.
+    const targetUrl = new URL(raw);
+    targetUrl.pathname = `/${target}`;
+    const [, migrateMs] = timed(() =>
+      run("npx", ["prisma", "migrate", "deploy"], {
+        ...process.env,
+        DATABASE_URL: targetUrl.toString(),
+      }),
+    );
+    console.log(`  migrations applied in ${(migrateMs / 1000).toFixed(1)}s`);
+
+    const rows = CRITICAL_TABLES.map((table) => ({
+      table,
+      source: countRows(url, source, table),
+      restored: countRows(url, target, table),
+    }));
+
+    const extensions = present(url, target, "SELECT extname FROM pg_extension");
+    const indexes = present(url, target, "SELECT indexname FROM pg_indexes WHERE schemaname='public'");
+
+    const drill: RestoreDrill = {
+      dumpMs,
+      restoreMs,
+      migrateMs,
+      dumpBytes,
+      rows,
+      missingExtensions: REQUIRED_OBJECTS.extensions.filter((name) => !extensions.has(name)),
+      missingIndexes: REQUIRED_OBJECTS.indexes.filter((name) => !indexes.has(name)),
+      cleanedUp: false,
+    };
+
+    // Dropped before the verdict is printed, so the verdict can report whether it worked.
+    if (target.startsWith(TARGET_PREFIX)) {
+      try {
+        run("dropdb", [...connection(url), target], psqlEnv(url));
+        cleanedUp = true;
+      } catch {
+        cleanedUp = false;
+      }
+    }
+    drill.cleanedUp = cleanedUp;
+
+    console.log("");
+    const lines = verdict(drill);
+    for (const line of lines) console.log(`  ${line}`);
+
+    if (!passed(lines)) process.exitCode = 1;
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+    if (!cleanedUp) {
+      try {
+        run("dropdb", [...connection(url), "--if-exists", target], psqlEnv(url));
+      } catch {
+        console.error(`  could not drop ${target} — drop it by hand`);
+      }
+    }
+  }
+}
+
+// Only when run as a script. Importing this module — which the test beside it does, for
+// the verdict logic — must not perform the drill: `main()` at import time races the test
+// runner, and the race it usually wins is the one where nothing happens. `drill-mirror`
+// already guards itself this way.
+if (process.argv[1]?.includes("drill-restore")) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/measure-concurrency.ts
+++ b/scripts/measure-concurrency.ts
@@ -270,7 +270,13 @@ async function main(): Promise<void> {
   await Promise.all([observed.$disconnect()]);
 }
 
-main().catch((error: unknown) => {
-  console.error(error);
-  process.exit(1);
-});
+// Only when run as a script. Importing this module — which the test beside it does, for
+// the verdict logic — must not perform the drill: `main()` at import time races the test
+// runner, and the race it usually wins is the one where nothing happens. `drill-mirror`
+// already guards itself this way.
+if (process.argv[1]?.includes("measure-concurrency")) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/measure-queries.ts
+++ b/scripts/measure-queries.ts
@@ -331,7 +331,13 @@ async function main(): Promise<void> {
   await Promise.all([observed.$disconnect(), explainer.$disconnect()]);
 }
 
-main().catch((error: unknown) => {
-  console.error(error);
-  process.exit(1);
-});
+// Only when run as a script. Importing this module — which the test beside it does, for
+// the verdict logic — must not perform the drill: `main()` at import time races the test
+// runner, and the race it usually wins is the one where nothing happens. `drill-mirror`
+// already guards itself this way.
+if (process.argv[1]?.includes("measure-queries")) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #520. Refs #161.

## The gap

`docs/runbooks.md` § *Data restore* has said this since it was written:

> **Rehearse this, do not assume it.** The numbers above are objectives until somebody has
> timed them against a real snapshot.

Nobody had. All five steps were hypotheses — including step 3, `npm run setup`, which has
to apply migrations to a snapshot that predates them and which nothing had ever asked it to
do.

**Why now:** #512 added `CREATE EXTENSION pg_trgm` this week. A dump carries
`CREATE EXTENSION` only if the target cluster has it available, and mid-restore is the wrong
time to find out.

## What the drill does

`npm run drill:restore` performs the procedure against a real database and times each
phase, then checks the restore is **complete** rather than merely successful:

- row counts per critical table against the source
- the extensions and indexes a row count cannot see — a restore returning every row and
  none of the trigram indexes is a working app that searches 40× slower, which reads as
  success

Measured against `anchor_dev` (105,869 variants, 125,070 ledger rows, 17 MB dump):

| Phase | Elapsed |
|---|---|
| `pg_dump` | 2.1 s |
| `pg_restore` | 7.4 s |
| `prisma migrate deploy` | 0.7 s |
| **Total** | **~10 s against a 60 min RTO** |

Six critical tables whole. **`pg_trgm` and all four indexes added this week survive the
round trip.**

## What it refuses to claim

The verdict prints `RPO NOT MEASURED` on **every** run, not only on failure. Five minutes of
maximum data loss depends on Railway's backup cadence and point-in-time recovery, which this
cannot reach — and three PASS lines would otherwise read as "the objective is met".

The RTO number is also stated as a floor in the runbook: local Postgres, one machine, no
network, 17 MB rather than a production snapshot.

## A hole found while testing the verdict

Comparing source and restored counts for equality passes a table missing from **both**
databases, because two unreadable counts are equal — a drill reporting a whole restore
because it could not find either copy. A negative count now fails, naming the table.

## And a latent flake, fixed

`drill-restore.test.ts` took **6.3 s** and loaded `.env` on import: `main()` runs at module
load, so importing the module to test its verdict logic was *performing the drill*.

`measure-queries.ts` (merged earlier today) has the same shape. Its test passes only because
it wins the race against vitest teardown — the kind of green that turns red in CI on a
slower runner, with a `process.exit(1)` inside it.

All three scripts now use the `process.argv[1]?.includes(...)` guard `drill-mirror.ts`
already had. Verified both ways: the tests import in 107 ms and print nothing, and both
scripts still run correctly when invoked.

## Mutations, all caught

| Mutation | Result |
|---|---|
| an empty table list reads as a pass | 1 failed |
| unreadable counts treated as equal | 1 failed |
| only the restore phase is timed | 1 failed |
| missing indexes ignored | 1 failed |
| the RPO caveat is dropped | 1 failed |
| a leftover database fails rather than warns | 1 failed |

## Checks

2,855 unit tests, 146 chaos scenarios, typecheck / lint / build clean.