### PR TITLE
Make the on-call page say what will actually wake somebody

### DIFF
--- a/app/lib/observability/metrics-contract.test.ts
+++ b/app/lib/observability/metrics-contract.test.ts
@@ -58,7 +58,12 @@ function promised(): Set<string> {
     [...runbook.matchAll(/`([a-z0-9_]+\.[a-z0-9_]+)`/g)]
       .map(([, name]) => name)
       // Table and column names also arrive in backticks and are not metrics.
-      .filter((name) => !/^(scheduler_heartbeat|variant_changes|error_events|webhook_events)\./.test(name)),
+      .filter((name) => !/^(scheduler_heartbeat|variant_changes|error_events|webhook_events)\./.test(name))
+      // Neither are filenames. A runbook that names the module deciding a severity is
+      // being helpful, and `alerts.ts` matching "word.word" would otherwise be read as a
+      // metric nothing emits. A source-file suffix cannot be a metric name here: metrics
+      // are `domain.measure`, and no domain is called "ts".
+      .filter((name) => !/\.(ts|tsx|md|json|sql|yml|yaml|toml)$/.test(name)),
   );
 }
 

--- a/app/lib/observability/runbook-coverage.test.ts
+++ b/app/lib/observability/runbook-coverage.test.ts
@@ -21,6 +21,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { PRICES_MAY_BE_LIVE } from "../lifecycle/transitions";
+import { evaluate, type AlertSeverity, type SignalWindow } from "./alerts";
 
 const runbooks = readFileSync(join(process.cwd(), "docs", "runbooks.md"), "utf8");
 const section = runbooks.slice(
@@ -63,5 +64,97 @@ describe("stuck run recovery", () => {
   it("warns against the fix that looks obvious and is wrong", () => {
     // Moving the campaign out of APPLYING by hand, while a run may be writing prices.
     expect(section).toMatch(/Do not.*UPDATE|UPDATE.*Do not/is);
+  });
+});
+
+/**
+ * The on-call summary and the severities it summarises.
+ *
+ * Two halves of a contract validated by nobody, and they had drifted in three directions
+ * at once. Four of the six alerts that page were absent from the document telling somebody
+ * what pages them — including `unpriceable-variants`, which the code's own comment calls
+ * "how a whole catalogue was once importable and unpriceable at the same time". The one
+ * condition the doc *did* call page-worthy was the single one deliberately made a notice.
+ * And its "next business day" list named conditions from `NOT_ALERTS`, which never fire, so
+ * somebody was told to expect notifications that cannot arrive.
+ *
+ * Keyed by alert id rather than matched against prose. A bijection over sentences is a
+ * bijection over spelling, and the spelling is what changes.
+ */
+describe("on-call expectations", () => {
+  const section = runbooks.slice(runbooks.indexOf("## On-call expectations"));
+
+  /**
+   * Every alert the app can raise.
+   *
+   * Derived by tripping all of them at once rather than restated here. A list written out
+   * in the test is a third copy of the contract, and it would drift from the other two the
+   * same way they drifted from each other.
+   */
+  const everythingWrong: SignalWindow = {
+    secondsSinceTick: 10_000,
+    webhookLagMs: 10 * 60_000,
+    errors: 100,
+    requests: 100,
+    divergenceRate: 0.5,
+    executionQueueDepth: 5_000,
+    unpriceableVariants: 400,
+    shopRates: [{ shopId: "shop-1", errors: 40, requests: 100 }],
+  };
+
+  const raisable = evaluate(everythingWrong);
+
+  /** The `id` of every alert named in a table row, with the response beside it. */
+  const documented = new Map<string, string>(
+    [...section.matchAll(/^\|\s*`([a-z-]+)`\s*\|\s*\*\*(\w+)\*\*\s*\|/gm)].map(
+      (row) => [row[1], row[2].toLowerCase()],
+    ),
+  );
+
+  it("finds the alerts it is protecting", () => {
+    // A floor, so this cannot pass by parsing nothing — the failure mode of every census
+    // check, and the reason the others in this repo carry a number.
+    expect(raisable.length).toBeGreaterThanOrEqual(7);
+    expect(documented.size).toBeGreaterThanOrEqual(7);
+  });
+
+  it("documents every alert the app can raise", () => {
+    const missing = raisable.map((alert) => alert.id).filter((id) => !documented.has(id));
+
+    expect(
+      missing,
+      "an alert nobody documented will wake somebody who has never heard of it",
+    ).toEqual([]);
+  });
+
+  it("documents no alert the app cannot raise", () => {
+    // The other direction, and the one a one-way check misses: a stale row left beside a
+    // correct one reads as coverage. Somebody waits for a page that will never come.
+    const ids = new Set(raisable.map((alert) => alert.id));
+    const phantom = [...documented.keys()].filter((id) => !ids.has(id));
+
+    expect(phantom, "documented as an alert but nothing raises it").toEqual([]);
+  });
+
+  it("gives each one the response its severity says it deserves", () => {
+    const expected: Record<AlertSeverity, string> = { page: "page", notice: "notice" };
+    const wrong = raisable
+      .filter((alert) => documented.get(alert.id) !== expected[alert.severity])
+      .map((alert) => `${alert.id}: code says ${alert.severity}, runbook says ${documented.get(alert.id)}`);
+
+    expect(
+      wrong,
+      "being woken by something the runbook called routine is how people stop reading it",
+    ).toEqual([]);
+  });
+
+  it("does not promise a notification for anything that never fires", () => {
+    // `NOT_ALERTS` records conditions deliberately left un-alerted. Listing one under
+    // "next business day" tells somebody to watch a channel that will stay empty.
+    const notUrgent = section.slice(section.indexOf("Look at these next working day"));
+    const rows = [...notUrgent.matchAll(/^\|\s*`([a-z-]+)`/gm)].map((row) => row[1]);
+    const ids = new Set(raisable.map((alert) => alert.id));
+
+    for (const id of rows) expect(ids, `${id} is documented but never raised`).toContain(id);
   });
 });

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -375,6 +375,29 @@ on every run rather than letting three PASS lines read as "the objective is met"
 
 ## On-call expectations
 
-- **Page-worthy:** scheduler tick stopped, execution queue depth rising for over an hour, mirror divergence above 0.5%. All three mean merchant prices are wrong or about to be.
-- **Next business day:** audit queue backlog, budget saturation, individual run failures. The app is designed so these are visible and resumable rather than urgent.
-- **Never page for:** a single failed variant, a guardrail block, a drift hold. Those are the product working.
+Every alert the app can raise, and what to do when it arrives. Kept in step with
+`app/lib/observability/alerts.ts` by `runbook-coverage.test.ts`: a new alert, a removed one,
+or a changed severity fails CI until this table matches.
+
+**Wake up for these.** All six mean merchant prices are wrong or about to be, which is the
+line `alerts.ts` draws between a page and a graph.
+
+| Alert | Response | Why it cannot wait |
+|---|---|---|
+| `scheduler-stopped` | **Page** | Nothing is running. Scheduled campaigns are not starting and running ones are not finishing. |
+| `mirror-divergence` | **Page** | The app's picture of the store is systematically wrong, so every campaign planned from now on plans against fiction. |
+| `webhook-lag` | **Page** | Price edits are not reaching the mirror, which widens the window in which the app can be wrong about a store. |
+| `error-spike` | **Page** | Something is broken across shops. |
+| `shop-error-spike` | **Page** | One merchant's every campaign is failing inside a healthy global rate — the incident the overall error rate cannot see. |
+| `unpriceable-variants` | **Page** | Variants are mirrored, counted and shown, with no baseline — so campaigns silently skip them and the merchant is told nothing. |
+
+**Look at these next working day.**
+
+| Alert | Response | Why it can wait |
+|---|---|---|
+| `execution-backlog` | **Notice** | Campaigns are queued rather than running. Not urgent on its own; what matters is whether the floor rises over hours. |
+
+**Never page for** a single failed variant, a guardrail block, a drift hold, a saturated
+rate-limit budget, or an audit queue backlog. Those are the product working, and none of
+them raises an alert at all — see `NOT_ALERTS` in `alerts.ts` for the reasoning on each.
+Expect no notification for them, because none will come.


### PR DESCRIPTION
Closes #522. Refs #161.

## The defect

`docs/runbooks.md` § *On-call expectations* is what somebody reads before their first
rotation. It did not match `app/lib/observability/alerts.ts` in **three directions at
once**.

| Alert | Severity in code | Was in the doc |
|---|---|---|
| `scheduler-stopped` | page | page-worthy ✓ |
| `mirror-divergence` | page | page-worthy ✓ |
| `webhook-lag` | page | **absent** |
| `error-spike` | page | **absent** |
| `shop-error-spike` | page | **absent** |
| `unpriceable-variants` | page | **absent** |
| `execution-backlog` | **notice** | listed as **page-worthy** |

1. **Four of the six things that page were missing** — including `unpriceable-variants`,
   whose comment in the code calls it *"how a whole catalogue was once importable and
   unpriceable at the same time"*.
2. **The one condition the doc called page-worthy is the single one deliberately made a
   notice.**
3. Its "next business day" list named *budget saturation* and *individual run failures* —
   both in `NOT_ALERTS`, so they **never fire at all**. Somebody was told to watch a channel
   that stays empty, while being woken by four things the document never mentions.

Being woken by something the runbook called routine is how people stop reading the runbook.

## Why nothing caught it

Prose and a `severity:` field are two halves of a contract validated by nobody.
`alerts.test.ts` checks every alert has a runbook link; `runbook-coverage.test.ts` checked
the stuck-run section. Neither compared the *summary* against the severities — the same
shape as the alerts that once linked to a runbook page about a different incident.

## The fix

The section is a table keyed by alert id, so the bijection is exact rather than fuzzy prose
matching — a bijection over sentences is a bijection over spelling, and the spelling is what
changes.

`runbook-coverage.test.ts` asserts **set equality in both directions** against what
`evaluate()` can emit, plus severity agreement per row. The expected set is derived by
tripping every alert at once rather than listed in the test: a third copy of the contract
would drift like the other two did.

The reverse direction matters as much as the forward one. A stale row left beside a correct
one reads as coverage and leaves somebody waiting for a page that will never come.

### Mutations, all caught

| Mutation | Result |
|---|---|
| a page is removed from the table | 3 failed |
| a stale row for an alert nothing raises | 2 failed |
| the code changes a severity | 1 failed |
| the table demotes a page to a notice | 1 failed |

## A guard that fired on the fix, and the narrowing it needed

`metrics-contract.test.ts` reads any `` `word.word` `` in the runbook as a metric a runbook
promises, so naming `` `alerts.ts` `` made it hunt for a metric nothing emits.

A source-file suffix cannot be a metric name here — metrics are `domain.measure` and no
domain is called `ts`. The filter now excludes file extensions, joining the exclusion for
table names that was already there.

**Verified the narrowing did not weaken the rule**: pointing the runbook at
`queue.nonexistent` still fails, and adding `mirror.imaginary` beside a real metric still
fails.

## Checks

2,860 unit tests, 146 chaos scenarios, typecheck / lint / build clean.