### PR TITLE
Notice when a recorded perf number stops being true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ chaos/artefacts/
 # are what typechecking reads.
 app/types/admin-*.schema.json
 perf-baseline-*.json
+
+# Except the admin baseline, which is a record rather than a run artefact. The others are
+# written to the repo root by a one-off measurement; this one is what `measure:admin`
+# compares against on every run and what `readme-parity.test.ts` checks the published table
+# against. A record that is not in version control is not a record, and a guard that reads
+# a file CI does not have is a guard that can never fail.
+!docs/perf/perf-baseline-admin.json

--- a/app/lib/perf/drift.test.ts
+++ b/app/lib/perf/drift.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Noticing that a recorded perf number stopped being true.
+ *
+ * `docs/perf/README.md` said reconciliation took 7ms. It took 1,006ms, and had done for
+ * days, and it was found by accident while measuring something else. Nothing compared the
+ * two, so a document recorded a number and then had no further relationship with reality.
+ *
+ * The failure mode of a check like this is reporting "held" for something it never
+ * compared — which is why the empty case, the renamed case and the one-sided cases all have
+ * assertions here rather than being left to the happy path.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  comparable,
+  compare,
+  passed,
+  REGRESSION_FLOOR_MS,
+  REGRESSION_RATIO,
+  verdict,
+  type Timing,
+} from "./drift";
+
+const at = (label: string, p50: number): Timing => ({ label, p50, max: p50 + 5 });
+
+const movementOf = (label: string, before: number, after: number) =>
+  compare([at(label, before)], [at(label, after)])[0].movement;
+
+describe("what counts as a regression", () => {
+  it("catches the one that actually happened", () => {
+    // 7ms to 1,006ms, undetected for days.
+    expect(movementOf("reconciliation, first page", 7, 1006)).toBe("regressed");
+  });
+
+  it("ignores a fast query wobbling, however large the ratio", () => {
+    // 5ms to 12ms is 2.4x and means nothing — timer granularity, a cold cache, an
+    // autovacuum passing through. Crying wolf here is how a check stops being read.
+    expect(movementOf("catalogue, first page", 5, 12)).toBe("held");
+  });
+
+  it("catches a slow query getting slower, on a ratio that looks mild", () => {
+    // 1.75x, which a ratio-only rule set higher would miss and an absolute-only rule
+    // would drown in noise from the fast queries.
+    expect(movementOf("catalogue, last page", 400, 700)).toBe("regressed");
+  });
+
+  it("needs both tests, not either", () => {
+    // Proportionally large, absolutely tiny.
+    expect(movementOf("q", 2, 20)).toBe("held");
+    // Absolutely large, proportionally tiny.
+    expect(movementOf("q", 1000, 1030)).toBe("held");
+  });
+
+  it("does not fire at exactly the thresholds", () => {
+    const before = 100;
+    const after = Math.max(before * REGRESSION_RATIO, before + REGRESSION_FLOOR_MS);
+
+    expect(movementOf("q", before, after - 1)).toBe("held");
+    expect(movementOf("q", before, after)).toBe("regressed");
+  });
+
+  it("reports a real improvement, so somebody re-records it", () => {
+    // A query that got faster and was never re-recorded leaves the next comparison
+    // measuring against a number the app has already beaten — so a later regression back
+    // to the old figure reads as "held".
+    expect(movementOf("reconciliation, first page", 1006, 59)).toBe("improved");
+  });
+});
+
+describe("queries on only one side", () => {
+  it("names one that is measured but not on record", () => {
+    const [only] = compare([], [at("barcode contains", 2)]);
+
+    expect(only.movement).toBe("new");
+    expect(only.after).toBe(2);
+  });
+
+  it("names one that is on record but no longer measured", () => {
+    // A rename would otherwise drop a query's history silently: the old label keeps a
+    // number nobody compares again, and the new one starts with no baseline — so a
+    // regression can hide inside a rename.
+    const [only] = compare([at("reconciliation, deep page", 5)], []);
+
+    expect(only.movement).toBe("missing");
+    expect(only.before).toBe(5);
+  });
+
+  it("reports both sides of a rename", () => {
+    const movements = compare([at("old name", 10)], [at("new name", 900)]).map((c) => c.movement);
+
+    expect(new Set(movements)).toEqual(new Set(["missing", "new"]));
+  });
+});
+
+describe("the verdict", () => {
+  const held = [at("a", 10), at("b", 300)];
+
+  it("passes when nothing regressed", () => {
+    expect(verdict(compare(held, held))[0]).toMatch(/^PASS/);
+  });
+
+  it("fails on a regression, naming the query and both numbers", () => {
+    const line = verdict(compare([at("reconciliation, first page", 7)], [at("reconciliation, first page", 1006)]))[0];
+
+    expect(line).toMatch(/^FAIL/);
+    expect(line).toContain("reconciliation, first page");
+    expect(line).toContain("7ms");
+    expect(line).toContain("1006ms");
+  });
+
+  it("fails when it compared nothing at all", () => {
+    // The failure this file exists for. An empty list contains no regression, and would
+    // otherwise print a pass for an observation never made.
+    const line = verdict([])[0];
+
+    expect(line).toMatch(/^FAIL/);
+    expect(line).toContain("compared nothing");
+  });
+
+  it("warns about a missing query without failing over it", () => {
+    // Deleting a page legitimately deletes its measurement. Silence would hide a rename;
+    // failing would make removing a feature a perf failure.
+    const lines = verdict(compare([at("gone", 5)], [at("a", 10)]));
+
+    expect(lines.some((line) => line.startsWith("WARN"))).toBe(true);
+    expect(passed(lines)).toBe(true);
+  });
+
+  it("mentions an improvement so it gets re-recorded", () => {
+    expect(verdict(compare([at("a", 1000)], [at("a", 50)])).join(" ")).toContain("--record");
+  });
+});
+
+describe("whether two runs are comparable", () => {
+  const base = { shop: "anchor-perf.myshopify.com", variants: 102_132 };
+
+  it("accepts the same store at the same size", () => {
+    expect(comparable(base, base)).toBeNull();
+  });
+
+  it("refuses a different store", () => {
+    // Numbers from another store are a different measurement wearing the same labels.
+    const other = comparable(base, { ...base, shop: "boltify-apps.myshopify.com" });
+
+    expect(other).toContain("boltify-apps");
+  });
+
+  it("refuses the same store after the catalogue changed size", () => {
+    expect(comparable(base, { ...base, variants: 200_000 })).toContain("200000");
+  });
+
+  it("tolerates the catalogue drifting slightly, as a live store does", () => {
+    // A merchant adding a few products must not invalidate the baseline — the first
+    // false alarm is what teaches somebody to pass --record without reading.
+    expect(comparable(base, { ...base, variants: 102_132 + 4_000 })).toBeNull();
+  });
+
+  it("does not divide by zero on an empty catalogue", () => {
+    expect(comparable({ shop: "a", variants: 0 }, { shop: "a", variants: 0 })).toBeNull();
+  });
+});

--- a/app/lib/perf/drift.ts
+++ b/app/lib/perf/drift.ts
@@ -1,0 +1,188 @@
+/**
+ * Comparing a perf measurement against the one on record.
+ *
+ * `docs/perf/README.md` said reconciliation took 7ms. It took 1,006ms, and had done for
+ * days. Nothing noticed, because nothing compared the two — the document recorded a number
+ * and then had no further relationship with reality.
+ *
+ * It was found by accident while measuring something else, and it was invisible by design:
+ * the regression grew with *ledger* size rather than catalogue size, so every
+ * catalogue-scaled measurement stayed flat throughout.
+ *
+ * **A stale perf number is worse than no perf number**, because it is the one somebody
+ * quotes — `docs/built-for-shopify.md` cites this directory, and a Built for Shopify review
+ * is where it would be quoted.
+ *
+ * ## Why a ratio *and* an absolute floor
+ *
+ * A 5ms query becoming 12ms is 2.4x and means nothing: timer granularity, a cold cache, an
+ * autovacuum passing through. Ratio alone would cry wolf on every fast query until somebody
+ * stopped reading the output, which is how a check stops working.
+ *
+ * A 400ms query becoming 700ms is 1.75x and matters. Absolute alone would miss it while
+ * catching every trivial wobble on the slow ones.
+ *
+ * So: a regression has to be **both** proportionally large and absolutely noticeable. The
+ * 7ms → 1,006ms case clears both by two orders of magnitude, which is the point — the check
+ * exists for the regression nobody was looking for, not for tuning noise.
+ */
+
+/** One timing, as measured or as recorded. */
+export interface Timing {
+  label: string;
+  p50: number;
+  max: number;
+}
+
+export interface PerfBaseline {
+  /** When these numbers were accepted, so an old record reads as old. */
+  recordedAt: string;
+  /** The store they came from. Numbers from a different store are not comparable. */
+  shop: string;
+  /** Catalogue size, for the same reason. */
+  variants: number;
+  timings: Timing[];
+}
+
+/** How much slower a query may get before it counts as a regression. */
+export const REGRESSION_RATIO = 1.5;
+
+/**
+ * And by how many milliseconds, so a fast query wobbling cannot trip it.
+ *
+ * Set above the noise a warm p50 shows between runs on the same data — the catalogue's
+ * first page has been seen at 26ms and 35ms on consecutive runs with nothing changed.
+ */
+export const REGRESSION_FLOOR_MS = 25;
+
+export type Movement = "regressed" | "improved" | "held" | "new" | "missing";
+
+export interface Comparison {
+  label: string;
+  movement: Movement;
+  /** Absent for a query with no counterpart on the other side. */
+  before?: number;
+  after?: number;
+}
+
+function movementOf(before: number, after: number): Movement {
+  const slower = after - before;
+
+  // Both tests, deliberately. See the note above on why either alone is useless.
+  if (slower >= REGRESSION_FLOOR_MS && after >= before * REGRESSION_RATIO) return "regressed";
+
+  // Improvement uses the same two tests mirrored, so "improved" means the same size of
+  // move that "regressed" would. A query reported as improved is one somebody should
+  // re-record, and a trivial wobble is not worth that.
+  if (-slower >= REGRESSION_FLOOR_MS && before >= after * REGRESSION_RATIO) return "improved";
+
+  return "held";
+}
+
+/**
+ * Every query, and what happened to it since the record.
+ *
+ * Queries present on only one side are reported rather than skipped. A renamed measurement
+ * silently drops its own history otherwise — the record keeps a number nobody will ever
+ * compare again, and the new name starts with no baseline, so a regression can hide in a
+ * rename.
+ */
+export function compare(
+  recorded: readonly Timing[],
+  measured: readonly Timing[],
+): Comparison[] {
+  const before = new Map(recorded.map((timing) => [timing.label, timing]));
+  const after = new Map(measured.map((timing) => [timing.label, timing]));
+
+  const comparisons: Comparison[] = measured.map((timing) => {
+    const was = before.get(timing.label);
+    return was
+      ? {
+          label: timing.label,
+          movement: movementOf(was.p50, timing.p50),
+          before: was.p50,
+          after: timing.p50,
+        }
+      : { label: timing.label, movement: "new" as const, after: timing.p50 };
+  });
+
+  for (const timing of recorded) {
+    if (!after.has(timing.label)) {
+      comparisons.push({ label: timing.label, movement: "missing", before: timing.p50 });
+    }
+  }
+
+  return comparisons;
+}
+
+/** What the comparison proved, in the shape the other drills print. */
+export function verdict(comparisons: readonly Comparison[]): string[] {
+  const lines: string[] = [];
+  const of = (movement: Movement) => comparisons.filter((c) => c.movement === movement);
+
+  const regressed = of("regressed");
+  lines.push(
+    comparisons.length === 0
+      ? "FAIL  compared nothing, so no drift was observed"
+      : regressed.length === 0
+        ? `PASS  ${comparisons.length} queries checked, none slower than the record`
+        : `FAIL  ${regressed
+            .map((c) => `${c.label} ${c.before}ms → ${c.after}ms`)
+            .join(", ")}`,
+  );
+
+  const missing = of("missing");
+  if (missing.length > 0) {
+    // Not a failure — deleting a page deletes its measurement, legitimately. But silence
+    // would let a *rename* drop a query's history, and a regression can hide in a rename.
+    lines.push(
+      `WARN  on record but not measured: ${missing.map((c) => c.label).join(", ")}`,
+    );
+  }
+
+  const added = of("new");
+  if (added.length > 0) {
+    lines.push(`      not yet on record: ${added.map((c) => c.label).join(", ")}`);
+  }
+
+  const improved = of("improved");
+  if (improved.length > 0) {
+    // Worth saying out loud rather than passing quietly. An improvement nobody records
+    // leaves the next comparison measuring against a number the app has already beaten,
+    // which is how a later regression back to the old figure reads as "held".
+    lines.push(
+      `      faster than the record, re-record with --record: ` +
+        improved.map((c) => `${c.label} ${c.before}ms → ${c.after}ms`).join(", "),
+    );
+  }
+
+  return lines;
+}
+
+export const passed = (lines: readonly string[]): boolean =>
+  !lines.some((line) => line.startsWith("FAIL"));
+
+/**
+ * Whether two runs are comparable at all.
+ *
+ * A baseline from a different store, or from the same store at a different size, is not a
+ * baseline — it is a different measurement wearing the same labels. Comparing them would
+ * report a regression that is only a change of subject, and the first such false alarm is
+ * what teaches people to pass `--record` without reading.
+ */
+export function comparable(
+  recorded: Pick<PerfBaseline, "shop" | "variants">,
+  measured: Pick<PerfBaseline, "shop" | "variants">,
+  tolerance = 0.05,
+): string | null {
+  if (recorded.shop !== measured.shop) {
+    return `recorded against ${recorded.shop}, measured against ${measured.shop}`;
+  }
+
+  const drift = Math.abs(measured.variants - recorded.variants);
+  if (recorded.variants > 0 && drift > recorded.variants * tolerance) {
+    return `catalogue changed from ${recorded.variants} to ${measured.variants} variants`;
+  }
+
+  return null;
+}

--- a/app/lib/perf/readme-parity.test.ts
+++ b/app/lib/perf/readme-parity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The perf table people read and the baseline the script compares against say the same
+ * thing.
+ *
+ * `measure:admin` now compares its timings to `perf-baseline-admin.json`, which closes the
+ * gap that let reconciliation sit at 7ms in a document while measuring 1,006ms. It closes
+ * one gap and opens another: the numbers a person actually reads are in a markdown table,
+ * hand-copied from that file. Two copies, and only one of them has a script keeping it
+ * honest.
+ *
+ * That is the same drift one step along, and this repo has been bitten by it repeatedly —
+ * an alert linked to a runbook page about a different incident, an on-call summary naming
+ * two of six pages, a comment describing an index the code could not use.
+ *
+ * ## Not exact equality
+ *
+ * A re-record moving a p50 from 27ms to 28ms should not fail a build until somebody edits
+ * prose. What must fail is the table being *stale* — materially different from what the
+ * script measured. So the same rule the drift check uses decides it: proportionally large
+ * and absolutely noticeable, both. 7ms against 1,006ms clears it by two orders of
+ * magnitude; 27 against 28 is not a disagreement.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { rawSource } from "../testing/source";
+import { compare, type PerfBaseline, type Timing } from "./drift";
+
+const baseline = JSON.parse(
+  rawSource("docs", "perf", "perf-baseline-admin.json"),
+) as PerfBaseline;
+
+/**
+ * The admin table's rows, from the markdown.
+ *
+ * Read raw rather than through `sourceOf`: this is markdown, where the prose *is* the
+ * subject. Only the section under its own heading, so a number in another table cannot
+ * satisfy the check for this one.
+ */
+function tableRows(): Timing[] {
+  const readme = rawSource("docs", "perf", "README.md");
+  const start = readme.indexOf("## Admin queries");
+  const section = readme.slice(start, readme.indexOf("\n## ", start + 1));
+
+  return [...section.matchAll(/^\|\s*([^|]+?)\s*\|\s*(\d+) ms\s*\|\s*(\d+) ms\s*\|/gm)].map(
+    (row) => ({ label: row[1], p50: Number(row[2]), max: Number(row[3]) }),
+  );
+}
+
+/** Table headings to baseline labels. The table titles a row for a reader, not a script. */
+const HEADING_TO_LABEL: Record<string, string> = {
+  "Catalogue, first page": "catalogue, first page",
+  "Catalogue, last page (offset 101,100)": "catalogue, last page",
+  "Catalogue, text search": "catalogue, text search",
+  "Reconciliation, first page": "reconciliation, first page",
+  "Reconciliation, deep page": "reconciliation, deep page",
+};
+
+describe("the perf README and the recorded baseline", () => {
+  const rows = tableRows();
+
+  it("finds the table it is protecting", () => {
+    // A floor, so this cannot pass by parsing nothing.
+    expect(rows.length).toBeGreaterThanOrEqual(5);
+    expect(baseline.timings.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("gives every row in the table a row in the baseline", () => {
+    const recorded = new Set(baseline.timings.map((timing) => timing.label));
+    const orphans = rows
+      .map((row) => HEADING_TO_LABEL[row.label])
+      .filter((label) => !label || !recorded.has(label));
+
+    expect(orphans, "a table row nothing measures cannot go stale visibly").toEqual([]);
+  });
+
+  it("gives every measured query a row in the table", () => {
+    // The other direction. A query measured and never published is a number nobody sees
+    // move — which is how reconciliation's regression stayed invisible for days.
+    const published = new Set(rows.map((row) => HEADING_TO_LABEL[row.label]));
+    const unpublished = baseline.timings
+      .map((timing) => timing.label)
+      .filter((label) => !published.has(label));
+
+    expect(unpublished, "measured but absent from the table people read").toEqual([]);
+  });
+
+  it("quotes numbers that have not gone stale", () => {
+    const quoted: Timing[] = rows.map((row) => ({ ...row, label: HEADING_TO_LABEL[row.label] }));
+    const drifted = compare(baseline.timings, quoted)
+      .filter((c) => c.movement === "regressed" || c.movement === "improved")
+      .map((c) => `${c.label}: baseline ${c.before}ms, README says ${c.after}ms`);
+
+    expect(
+      drifted,
+      "the table and the measurement disagree — a stale perf number is the one somebody quotes",
+    ).toEqual([]);
+  });
+
+  it("says which store and how many variants the numbers came from", () => {
+    // Timings without a subject are not comparable to anything, and the heading claims a
+    // catalogue size that has to be the one measured.
+    expect(baseline.shop.length).toBeGreaterThan(0);
+    expect(baseline.variants).toBeGreaterThan(0);
+
+    // The *heading*, not the file. "102,132" appears in the intro too, so searching the
+    // whole document passes on a different occurrence — a check satisfied by the wrong
+    // instance is the shape that has slipped through here before.
+    const readme = rawSource("docs", "perf", "README.md");
+    const heading = /^## Admin queries.*$/m.exec(readme)?.[0] ?? "";
+
+    expect(heading, "the admin table has no heading to carry a catalogue size").not.toBe("");
+    expect(
+      heading,
+      "the table's heading claims a catalogue size the baseline did not measure",
+    ).toContain(baseline.variants.toLocaleString("en-US"));
+  });
+});

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -30,14 +30,21 @@ had a product bigger than one page until this one existed.
 
 | Query | p50 | max |
 |---|---|---|
-| Catalogue, first page | 26 ms | 26 ms |
-| Catalogue, last page (offset 101,100) | 292 ms | 360 ms |
-| Catalogue, text search | 19 ms | 21 ms |
-| Reconciliation, first page | 61 ms | 61 ms |
-| Reconciliation, deep page | 59 ms | 62 ms |
+| Catalogue, first page | 27 ms | 35 ms |
+| Catalogue, last page (offset 101,100) | 296 ms | 332 ms |
+| Catalogue, text search | 18 ms | 19 ms |
+| Reconciliation, first page | 59 ms | 70 ms |
+| Reconciliation, deep page | 53 ms | 60 ms |
+
+Recorded in [`perf-baseline-admin.json`](perf-baseline-admin.json), which
+`npm run measure:admin` compares against on every run — the table above and that file are
+checked against each other by `app/lib/perf/readme-parity.test.ts`, so neither can go stale
+while the other is right. Accept new numbers deliberately with `--record`.
 
 Text search was 74 ms until #510 replaced two unusable `lower()` btrees with trigram GIN
-indexes.
+indexes — **while the planner's statistics are current**. On stale statistics the same query
+seq-scans at ~50 ms; `ANALYZE variant_index` restores it. See [`queries.md`](queries.md),
+which records how that nearly got written up as the index not working.
 
 The reconciliation rows read 7 ms and 5 ms until #513. They were taken against a store
 with an empty ledger; at 125,070 verified rows both had become **~1,000 ms**, because the

--- a/docs/perf/perf-baseline-admin.json
+++ b/docs/perf/perf-baseline-admin.json
@@ -1,0 +1,32 @@
+{
+  "recordedAt": "2026-08-29T20:47:36.941Z",
+  "shop": "anchor-perf.myshopify.com",
+  "variants": 102132,
+  "timings": [
+    {
+      "label": "catalogue, first page",
+      "p50": 27,
+      "max": 35
+    },
+    {
+      "label": "catalogue, last page",
+      "p50": 296,
+      "max": 332
+    },
+    {
+      "label": "catalogue, text search",
+      "p50": 18,
+      "max": 19
+    },
+    {
+      "label": "reconciliation, first page",
+      "p50": 59,
+      "max": 70
+    },
+    {
+      "label": "reconciliation, deep page",
+      "p50": 53,
+      "max": 60
+    }
+  ]
+}

--- a/docs/perf/queries.md
+++ b/docs/perf/queries.md
@@ -161,13 +161,41 @@ rather than guessed at.
 The statement count fell from 63 of 70 reading a whole table to **59 of 72** — 72 because
 `barcode` is now measured too. Nothing else in the report moved.
 
-The merchant-visible one is the catalogue search box, which `measure:admin` times. Run
-twice in each index state on the same warm database:
+The merchant-visible one is the catalogue search box, which `measure:admin` times:
 
 | | `lower()` btrees | Trigram GIN |
 |---|---|---|
-| Catalogue, text search (p50) | 55 ms, 49 ms | **20 ms, 19 ms** |
+| Catalogue, text search (p50) | 49, 51, 52 ms | **18, 19, 18, 18 ms** |
 | Catalogue, first page (p50) | 29 ms | 29 ms |
+
+### The caveat that nearly became a wrong correction
+
+Between those two measurements this query was observed at **48–70 ms with the trigram
+indexes in place**, seq-scanning. It looked like the index did not help, and the obvious
+reading — "the 19 ms was a warm cache right after `CREATE INDEX`" — was wrong.
+
+`ANALYZE variant_index` restored it. The plan, on identical data:
+
+```
+stale statistics:  Parallel Seq Scan on variant_index    42 ms
+after ANALYZE:     Bitmap Heap Scan → BitmapOr           35 ms
+                     Bitmap Index Scan on variant_index_title_trgm
+                     Bitmap Index Scan on variant_index_sku_trgm
+```
+
+`"jacket"` matches 14,624 of 105,869 rows — 14%, and a two-column `OR` at that selectivity
+with `ORDER BY title LIMIT 50` sits close to the point where the planner's choice flips. The
+chaos suite and the restore drills had churned the table enough to move the estimate onto
+the wrong side of it.
+
+**So the index's benefit is conditional on the statistics being current**, and that is an
+operational fact rather than a footnote: after a large catalogue import, search can be ~3×
+slower until autovacuum analyses the table. Worth knowing before somebody debugs it as a
+regression.
+
+**And the method matters more than the number.** Two wall-clock measurements taken in good
+faith supported opposite conclusions. The plan did not: it says which index is used and why,
+and it is the same answer whatever is in cache. Take the plan first.
 
 Index bytes on `variant_index`: 21.3 MB removed (`title_lower` 14 MB, `sku_lower` 7.3 MB),
 11.4 MB added (`title_trgm` 6.5 MB, `sku_trgm` 2.5 MB, `barcode_trgm` 2.4 MB). Net

--- a/scripts/measure-admin.ts
+++ b/scripts/measure-admin.ts
@@ -15,15 +15,38 @@
  * catalogue grows.
  */
 
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 import prisma from "../app/db.server";
+import {
+  compare,
+  comparable,
+  passed,
+  verdict,
+  type PerfBaseline,
+  type Timing,
+} from "../app/lib/perf/drift";
 import { chooseShop, shopArg } from "../app/lib/seed/target-shop";
 import { reconcile } from "../app/services/reconciliation.server";
 
 const PAGE_SIZE = 50;
 const RUNS = 5;
 
-/** p50 and max of a warm run, because a cold first call measures the connection. */
-async function time(label: string, fn: () => Promise<unknown>): Promise<void> {
+/** Where the accepted numbers live, so a later run has something to disagree with. */
+const BASELINE_PATH = join(process.cwd(), "docs", "perf", "perf-baseline-admin.json");
+
+/** Everything measured this run, in the order it was measured. */
+const measured: Timing[] = [];
+
+/**
+ * p50 and max of a warm run, because a cold first call measures the connection.
+ *
+ * `record` is false for the offset-scaling sweep, whose labels carry the page number and
+ * therefore change with the catalogue. A baseline keyed on those would report every row as
+ * new after any import, which is a comparison that can never fail.
+ */
+async function time(label: string, fn: () => Promise<unknown>, record = true): Promise<void> {
   await fn();
 
   const runs: number[] = [];
@@ -36,10 +59,13 @@ async function time(label: string, fn: () => Promise<unknown>): Promise<void> {
 
   const p50 = runs[Math.floor(runs.length / 2)];
   const max = runs[runs.length - 1];
+  if (record) measured.push({ label: label.trim(), p50, max });
   console.log(`  ${label.padEnd(44)} p50 ${String(p50).padStart(5)}ms   max ${String(max).padStart(5)}ms`);
 }
 
 async function main() {
+  const args = process.argv.slice(2);
+
   // Name the store or be told which exist. These scripts write real prices to a real
   // storefront, so guessing is the one behaviour not on offer — the same rule the seeder
   // and the perf scripts already follow.
@@ -48,7 +74,7 @@ async function main() {
     select: { domain: true },
   });
   const shop = await prisma.shop.findUniqueOrThrow({
-    where: { domain: chooseShop(installed, shopArg(process.argv.slice(2))).domain },
+    where: { domain: chooseShop(installed, shopArg(args)).domain },
   });
   const total = await prisma.variantIndex.count({ where: { shopId: shop.id, deletedAt: null } });
   const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -106,10 +132,58 @@ async function main() {
   console.log("\n  offset scaling");
   for (const fraction of [0, 0.15, 0.4, 0.7, 0.99]) {
     const page = Math.max(1, Math.round(lastPage * fraction));
-    await time(`    page ${page} (offset ${(page - 1) * PAGE_SIZE})`, () => catalogue(page));
+    await time(`    page ${page} (offset ${(page - 1) * PAGE_SIZE})`, () => catalogue(page), false);
   }
 
+  await reportDrift(shop.domain, total, args.includes("--record"));
+
   await prisma.$disconnect();
+}
+
+/**
+ * What moved since the numbers on record, and whether that is acceptable.
+ *
+ * The whole point of the file this reads. `docs/perf/README.md` said reconciliation took
+ * 7ms while it took 1,006ms, for days, because a recorded number and a measured one had no
+ * relationship — and the regression was invisible to every other check, having grown with
+ * ledger size rather than catalogue size.
+ */
+async function reportDrift(shop: string, variants: number, record: boolean): Promise<void> {
+  const now: PerfBaseline = {
+    recordedAt: new Date().toISOString(),
+    shop,
+    variants,
+    timings: measured,
+  };
+
+  if (record) {
+    writeFileSync(BASELINE_PATH, `${JSON.stringify(now, null, 2)}\n`);
+    console.log(`\n  recorded ${measured.length} timings to ${BASELINE_PATH}`);
+    return;
+  }
+
+  if (!existsSync(BASELINE_PATH)) {
+    console.log(`\n  no baseline on record — run again with --record to accept these numbers`);
+    return;
+  }
+
+  const recorded = JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as PerfBaseline;
+
+  const incomparable = comparable(recorded, now);
+  if (incomparable) {
+    // Not a failure. A different store or a resized catalogue is a change of subject, and
+    // reporting it as a regression is the first false alarm that teaches somebody to pass
+    // --record without reading.
+    console.log(`\n  not comparable: ${incomparable}`);
+    console.log(`  the numbers above stand on their own; --record to make them the baseline`);
+    return;
+  }
+
+  console.log(`\n  against ${recorded.recordedAt}:`);
+  const lines = verdict(compare(recorded.timings, measured));
+  for (const line of lines) console.log(`  ${line}`);
+
+  if (!passed(lines)) process.exitCode = 1;
 }
 
 main().catch(async (error) => {


### PR DESCRIPTION
Closes #525. Refs #160, #513.

## The problem, which already happened

`docs/perf/README.md` said reconciliation took **7 ms**. It took **1,006 ms**, and had done
for days. Nothing compared the two — the document recorded a number and then had no further
relationship with reality — and it was found by accident while measuring something else.

A stale perf number is worse than no perf number, because it is the one somebody quotes.
`docs/built-for-shopify.md` cites this directory.

## The change

`measure:admin` writes `perf-baseline-admin.json` and, on later runs, compares against it:
**held**, **improved**, **regressed**, or one-sided. A regression exits non-zero. `--record`
accepts new numbers, so improving a query is a decision rather than a silent overwrite.

**A regression has to be both proportionally large and absolutely noticeable.** Ratio alone
cries wolf on every 5 ms query until nobody reads the output; absolute alone misses a 400 ms
query becoming 700 ms. The 7 ms → 1,006 ms case clears both by two orders of magnitude —
this is for the regression nobody was looking for, not for tuning noise.

It also refuses to compare a different store, or the same store after the catalogue changed
size. Those are a change of subject, and the first false alarm is what teaches somebody to
pass `--record` without reading.

## Closing one gap opens another

The numbers a person reads are in a markdown table, hand-copied from that file. Two copies,
one script. `readme-parity.test.ts` checks them against each other **in both directions** —
a table row nothing measures, and a measured query absent from the table, both fail. Not
exact equality: 27 ms against 28 ms is not a disagreement, but the same staleness rule
applies.

The baseline is now tracked. `.gitignore` had `perf-baseline-*.json`, so **none** of the
perf baselines were in version control — a record that is not in version control is not a
record, and a guard reading a file CI does not have is a guard that can never fail. Verified
with a clean clone.

## The guard earned itself immediately, on me

Re-measuring showed the catalogue search box at **48–70 ms** against the **19 ms** I had
recorded hours earlier in #512. The obvious reading was that my 19 ms had been a warm cache
right after `CREATE INDEX`, and I had written that correction into both docs before checking
the plan.

It was wrong. `ANALYZE variant_index` restored it:

```
stale statistics:  Parallel Seq Scan on variant_index    42 ms
after ANALYZE:     Bitmap Heap Scan → BitmapOr           35 ms
                     Bitmap Index Scan on variant_index_title_trgm
```

`"jacket"` matches 14,624 of 105,869 rows — 14%, close enough to the flip point that a day
of chaos runs and restore drills moved the planner's estimate across it.

**Two wall-clock measurements taken in good faith supported opposite conclusions.** The plan
did not: it says which index is used whatever is in cache. Both docs now carry the caveat,
because it is an operational fact rather than a footnote — after a large catalogue import,
search is ~3× slower until autovacuum analyses the table, and somebody will otherwise debug
that as a regression.

## Mutations

**Drift logic — all 7 caught:** ratio without the absolute floor · absolute without the ratio
· an empty comparison passing · missing queries dropped silently · a missing query failing
rather than warning · different stores compared anyway · catalogue size change ignored.

**Parity guard — all 5 behaved correctly:** the 7 ms-vs-1,006 ms case fails · a table row
nothing measures fails · a measured query missing from the table fails · a 1 ms rounding
difference does *not* fail · a changed catalogue size in the heading fails.

That last one passed on the first attempt because `102,132` appears in the intro as well as
the heading — a check satisfied by the wrong instance. It now reads the heading only.

## Checks

2,884 unit tests, 146 chaos scenarios, typecheck / lint / build clean.