### PR TITLE
Test the four modules that could corrupt an export or the audit trail

### DIFF
--- a/app/lib/audit/actor.test.ts
+++ b/app/lib/audit/actor.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Who the audit log says did it.
+ *
+ * The module exists because every entry used to be attributed to the shop domain or to
+ * "system", which answers nothing on a store where four people have admin access. Its own
+ * comment states the point: *"The audit log is only worth keeping if it can answer 'who
+ * turned the cost floor off?'"*
+ *
+ * `actorFor` could be made to return the shop domain for every request — exactly the state
+ * it was written to replace — and all 2,948 tests passed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { actorFor, describeActor, SCHEDULER_ACTOR } from "./actor";
+
+const token = (sub: unknown) => ({ sub }) as never;
+
+describe("attributing an admin request", () => {
+  it("records the staff id from the session token", () => {
+    expect(actorFor(token("gid://shopify/StaffMember/42"), "shop.myshopify.com")).toBe(
+      "staff:gid://shopify/StaffMember/42",
+    );
+  });
+
+  it("falls back to the shop domain when the token has no subject", () => {
+    // Deliberately not the scheduler. An action that definitely had a person behind it
+    // must not be recorded as if nobody did it, even when the token is shaped oddly.
+    expect(actorFor(undefined, "shop.myshopify.com")).toBe("shop.myshopify.com");
+    expect(actorFor(token(undefined), "shop.myshopify.com")).toBe("shop.myshopify.com");
+  });
+
+  it.each([[""], [42], [null], [{}]])(
+    "falls back rather than recording %j as a staff id",
+    (sub) => {
+      expect(actorFor(token(sub), "shop.myshopify.com")).toBe("shop.myshopify.com");
+    },
+  );
+
+  it("never attributes a person's action to the scheduler", () => {
+    // The failure that would matter: an audit entry reading "Scheduler" for something a
+    // person did is worse than one reading the shop domain, because it is confidently
+    // wrong rather than vague.
+    expect(actorFor(token(undefined), "shop.myshopify.com")).not.toBe(SCHEDULER_ACTOR);
+  });
+
+  it("prefixes the id, so a staff actor cannot be mistaken for a domain", () => {
+    expect(actorFor(token("7"), "shop.myshopify.com").startsWith("staff:")).toBe(true);
+  });
+});
+
+describe("rendering an actor", () => {
+  it("shows an unattended action as the scheduler", () => {
+    expect(describeActor(SCHEDULER_ACTOR)).toBe("Scheduler");
+  });
+
+  it.each([[null], [""], ["system"]])("shows %j as the scheduler too", (actor) => {
+    // "system" is what older entries carry. They still have to render as something a
+    // person can read rather than as a raw token from a previous schema.
+    expect(describeActor(actor)).toBe("Scheduler");
+  });
+
+  it("names the drift detector, which is neither a person nor the scheduler", () => {
+    expect(describeActor("drift-detector")).toBe("Drift detector");
+  });
+
+  it("renders a staff actor as an id, without pretending it is a name", () => {
+    // The module deliberately does not fetch names — that would need online tokens and a
+    // reinstall. So the display says "Staff <id>", which is honest about what it knows.
+    expect(describeActor("staff:42")).toBe("Staff 42");
+  });
+
+  it("keeps the whole id, including one that contains a colon", () => {
+    // Shopify staff ids are gids, which are full of colons and slashes. Splitting on the
+    // separator rather than trimming the prefix would truncate every real one.
+    expect(describeActor("staff:gid://shopify/StaffMember/42")).toBe(
+      "Staff gid://shopify/StaffMember/42",
+    );
+  });
+
+  it("passes an unrecognised actor through rather than hiding it", () => {
+    // A shop domain, or something a future release writes. Rendering it as "Scheduler"
+    // would attribute a person's action to nobody.
+    expect(describeActor("shop.myshopify.com")).toBe("shop.myshopify.com");
+  });
+
+  it("round-trips what actorFor produces", () => {
+    // The two halves are used by different processes and had no test tying them
+    // together, which is how a prefix change breaks display without failing anything.
+    expect(describeActor(actorFor(token("99"), "shop.myshopify.com"))).toBe("Staff 99");
+  });
+});

--- a/app/lib/reporting/cost-errors.test.ts
+++ b/app/lib/reporting/cost-errors.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The rows a cost import could not use, as a file to fix and re-upload.
+ *
+ * The module's point is the line number: *"37 rows failed" sends a merchant scrolling
+ * through a spreadsheet; "line 412, SKU-9931, cost is not a plain number" is something
+ * they can act on in seconds.*
+ *
+ * The ordering that makes that usable — errors in the order they appear in the merchant's
+ * file — could be removed with all 2,948 tests passing. A merchant would then work through
+ * a list that jumps between line 412, line 9 and line 88, which is the scrolling the file
+ * exists to replace.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { CostImportResult } from "../../services/cost-import.server";
+import { costErrorCsv } from "./cost-errors";
+
+const problem = (line: number, identifier: string, reason = "cost is not a plain number") => ({
+  line,
+  identifier,
+  reason,
+});
+
+const result = (over: Partial<CostImportResult> = {}): CostImportResult => ({
+  total: 0,
+  ready: 0,
+  written: 0,
+  unchanged: 0,
+  invalid: [],
+  unmatched: [],
+  ambiguous: [],
+  dryRun: true,
+  ...over,
+});
+
+const lines = (csv: string) => csv.trimEnd().split("\n");
+
+describe("the error report", () => {
+  it("names the four things a merchant needs to fix a row", () => {
+    expect(lines(costErrorCsv(result()))[0]).toBe(
+      '"Line","Identifier","Problem","What to do"',
+    );
+  });
+
+  it("carries the line number, the identifier and the reason", () => {
+    const csv = costErrorCsv(result({ invalid: [problem(412, "SKU-9931")] }));
+
+    expect(csv).toContain('"412"');
+    expect(csv).toContain('"SKU-9931"');
+    expect(csv).toContain('"cost is not a plain number"');
+  });
+
+  it("includes all three kinds of problem, each labelled", () => {
+    // A merchant fixes an invalid cost differently from an unmatched SKU, and an
+    // ambiguous one differently again. Merging them into "failed" loses the instruction.
+    const csv = costErrorCsv(
+      result({
+        invalid: [problem(2, "A")],
+        unmatched: [problem(3, "B")],
+        ambiguous: [problem(4, "C")],
+      }),
+    );
+
+    expect(csv).toContain('"invalid"');
+    expect(csv).toContain('"unmatched"');
+    expect(csv).toContain('"ambiguous"');
+  });
+});
+
+describe("ordering, which is what makes the file usable", () => {
+  it("sorts by line number across all three kinds", () => {
+    // The kinds arrive in three separate lists. Concatenating without sorting gives a
+    // merchant a list that jumps between line 412, line 9 and line 88 — the scrolling
+    // this file exists to replace.
+    const csv = costErrorCsv(
+      result({
+        invalid: [problem(412, "late")],
+        unmatched: [problem(9, "early")],
+        ambiguous: [problem(88, "middle")],
+      }),
+    );
+
+    expect(lines(csv).slice(1).map((line) => line.split(",")[0])).toEqual(['"9"', '"88"', '"412"'],
+    );
+  });
+
+  it("orders numerically, not as text", () => {
+    // Sorted as strings, line 100 comes before line 9 — which is exactly the case a
+    // real import hits, and exactly the one a small fixture would miss.
+    const csv = costErrorCsv(
+      result({ invalid: [problem(100, "a"), problem(9, "b"), problem(20, "c")] }),
+    );
+
+    expect(lines(csv).slice(1).map((line) => line.split(",")[0])).toEqual(
+      ['"9"', '"20"', '"100"'],
+    );
+  });
+});
+
+describe("an import with nothing wrong", () => {
+  it("exports a header-only file rather than nothing", () => {
+    // A clean import still offers the download. An empty file would look like a failed
+    // one; a header with no rows says "nothing failed" unambiguously.
+    expect(lines(costErrorCsv(result()))).toHaveLength(1);
+  });
+});

--- a/app/lib/reporting/ledger-csv.test.ts
+++ b/app/lib/reporting/ledger-csv.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The record of what the app did to a merchant's storefront, as a file.
+ *
+ * `ledger-csv.ts` states its own invariant and nothing enforced it:
+ *
+ *   "So a failed row keeps its reason in the file. An export that dropped the failures
+ *    would show a clean run that was not clean, which is the specific dishonesty this
+ *    whole product is built against."
+ *
+ * Both halves of that sentence could be broken — the reason blanked, and failed rows
+ * filtered out entirely — with all 2,948 tests passing. This is the file attached to a
+ * support ticket and handed to a finance team when a price on an invoice does not match.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { LedgerRow } from "../../services/campaigns/types";
+import { ledgerCsv } from "./ledger-csv";
+
+const row = (over: Partial<LedgerRow> = {}): LedgerRow => ({
+  variantGid: "gid://shopify/ProductVariant/1",
+  title: "Alpine Jacket / L",
+  before: "19.99",
+  intended: "15.99",
+  status: "VERIFIED",
+  failureReason: null,
+  ...over,
+});
+
+const lines = (csv: string) => csv.trimEnd().split("\n");
+
+describe("what the ledger export contains", () => {
+  it("has a header naming every column", () => {
+    expect(lines(ledgerCsv([]))[0]).toBe(
+      '"Variant","Title","Before","We wrote","Status","Why not"',
+    );
+  });
+
+  it("writes one line per ledger row", () => {
+    expect(lines(ledgerCsv([row(), row({ variantGid: "gid://v/2" })]))).toHaveLength(3);
+  });
+
+  it("carries the before and intended prices, which are what a dispute is about", () => {
+    const csv = ledgerCsv([row({ before: "19.99", intended: "15.99" })]);
+
+    expect(csv).toContain('"19.99"');
+    expect(csv).toContain('"15.99"');
+  });
+});
+
+describe("a run that was not clean must not export as if it were", () => {
+  const failed = row({
+    status: "FAILED",
+    intended: "15.99",
+    failureReason: "Shopify rejected the price: compare-at must exceed price",
+  });
+
+  it("includes a failed row rather than filtering it out", () => {
+    // Filtering failures produces a file showing only successes — a clean run that was
+    // not clean. That is the exact dishonesty the product exists to prevent, arriving
+    // through the product's own report.
+    expect(ledgerCsv([row(), failed])).toContain("gid://shopify/ProductVariant/1");
+    expect(lines(ledgerCsv([row(), failed]))).toHaveLength(3);
+  });
+
+  it("keeps the reason a row failed", () => {
+    // A failed row with the reason blanked is worse than no export: it names a variant
+    // as a problem and gives nothing to act on.
+    expect(ledgerCsv([failed])).toContain("Shopify rejected the price");
+  });
+
+  it("shows the status, so a reader can sort by it", () => {
+    expect(ledgerCsv([failed])).toContain('"FAILED"');
+  });
+
+  it("exports every status, not only the interesting ones", () => {
+    const csv = ledgerCsv([
+      row({ status: "VERIFIED" }),
+      row({ status: "FAILED", failureReason: "throttled" }),
+      row({ status: "SKIPPED", failureReason: "below floor" }),
+      row({ status: "PENDING" }),
+    ]);
+
+    for (const status of ["VERIFIED", "FAILED", "SKIPPED", "PENDING"]) {
+      expect(csv, `${status} rows must appear`).toContain(`"${status}"`);
+    }
+  });
+});
+
+describe("rows with nothing to report in a column", () => {
+  it("writes an empty cell rather than the word null", () => {
+    // `null` in a spreadsheet reads as a value the app assigned. An empty cell reads as
+    // "there was nothing here", which is what it means.
+    const csv = ledgerCsv([row({ before: null, intended: null, failureReason: null })]);
+
+    expect(csv).not.toContain("null");
+    expect(lines(csv)[1]).toBe(
+      '"gid://shopify/ProductVariant/1","Alpine Jacket / L","","","VERIFIED",""',
+    );
+  });
+
+  it("survives a title with a comma and a quote in it", () => {
+    // Ordinary catalogue data. A ledger that corrupts itself on a product name is not a
+    // record of anything.
+    const csv = ledgerCsv([row({ title: 'Monitor, 24"' })]);
+
+    expect(csv).toContain('"Monitor, 24"""');
+  });
+
+  it("exports a header-only file for a run with no rows", () => {
+    // A campaign that planned nothing is a legitimate outcome, and a file with no header
+    // is one a merchant cannot tell from a failed download.
+    expect(lines(ledgerCsv([]))).toHaveLength(1);
+  });
+});

--- a/app/lib/reporting/lines.test.ts
+++ b/app/lib/reporting/lines.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Splitting a pasted file into lines.
+ *
+ * Both importers share this, so a mistake here is wrong prices or wrong costs on whatever
+ * the merchant pasted — and it had no test. Two deliberate breakages passed all 2,948:
+ * dropping the carriage-return strip, and dropping the final line when the paste has no
+ * trailing newline.
+ *
+ * Neither is an edge case. A spreadsheet saved on Windows ends every line with `\r`, which
+ * unstripped becomes part of the last column's value; and a paste without a trailing
+ * newline is what a text box gives you when somebody does not press return at the end.
+ * Both fail silently: the import succeeds, the numbers are just wrong.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { linesOf } from "./lines";
+
+const collect = async (text: string): Promise<string[]> => {
+  const lines: string[] = [];
+  for await (const line of linesOf(text)) lines.push(line);
+  return lines;
+};
+
+describe("splitting a paste into lines", () => {
+  it("splits on newlines", async () => {
+    expect(await collect("a\nb\nc\n")).toEqual(["a", "b", "c"]);
+  });
+
+  it("keeps the last line when there is no trailing newline", async () => {
+    // What a textarea gives you when the merchant does not press return at the end. An
+    // import of 500 prices would write 499 and report success.
+    expect(await collect("a\nb\nc")).toEqual(["a", "b", "c"]);
+  });
+
+  it("strips the carriage return a Windows spreadsheet leaves on every line", async () => {
+    // Unstripped, `\r` becomes part of the last column's value — so every price in the
+    // file parses as something else, or fails to parse, for a reason nothing names.
+    expect(await collect("a,1\r\nb,2\r\n")).toEqual(["a,1", "b,2"]);
+  });
+
+  it("strips it from the final line too, newline or not", async () => {
+    expect(await collect("a\r\nb\r")).toEqual(["a", "b"]);
+  });
+
+  it("strips only the trailing carriage return, not one inside a value", async () => {
+    // A quoted CSV field can legitimately contain one. Removing every `\r` would edit
+    // the merchant's data rather than the line ending.
+    expect(await collect("a\rb\n")).toEqual(["a\rb"]);
+  });
+
+  it("yields nothing for empty input", async () => {
+    expect(await collect("")).toEqual([]);
+  });
+
+  it("keeps blank lines, so the line numbers an error report quotes still match", async () => {
+    // The importers count lines to say "line 412". Silently skipping blanks would shift
+    // every number after the first one, and the merchant would look at the wrong row.
+    expect(await collect("a\n\nb\n")).toEqual(["a", "", "b"]);
+  });
+
+  it("handles a file that is one line with no newline at all", async () => {
+    expect(await collect("only")).toEqual(["only"]);
+  });
+
+  it("does not invent a line after a trailing newline", async () => {
+    expect(await collect("a\n")).toEqual(["a"]);
+  });
+
+  it("streams rather than materialising the whole split", async () => {
+    // The reason it is a generator: splitting a 500K-row paste doubles the memory at
+    // exactly the moment it is already large. Taking one line must not require the rest.
+    const iterator = linesOf("first\nsecond\nthird\n")[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value).toBe("first");
+  });
+});

--- a/app/lib/reporting/lines.ts
+++ b/app/lib/reporting/lines.ts
@@ -5,6 +5,9 @@
  * splitting would double the memory for a 500K-row paste at exactly the moment it is
  * already large. Shared by both importers so they cannot drift on how a line ends.
  */
+/** Only the line ending, never a carriage return inside a quoted value. */
+const stripCarriageReturn = (line: string): string => line.replace(/\r$/, "");
+
 export async function* linesOf(text: string): AsyncGenerator<string> {
   let start = 0;
   for (;;) {
@@ -12,8 +15,12 @@ export async function* linesOf(text: string): AsyncGenerator<string> {
     if (next === -1) break;
     // Trailing carriage return, because a spreadsheet saved on Windows ends every line
     // with one and it would otherwise become part of the last column's value.
-    yield text.slice(start, next).replace(/\r$/, "");
+    yield stripCarriageReturn(text.slice(start, next));
     start = next + 1;
   }
-  if (start < text.length) yield text.slice(start);
+  // The same strip on the final line, which was missing. A paste ending `...\r` with no
+  // closing newline kept the carriage return on its last column -- so a cost of "12.50\r"
+  // failed to parse and the row came back "invalid" for a reason the merchant could not
+  // see in their spreadsheet. Two branches yielding lines had to agree on what a line is.
+  if (start < text.length) yield stripCarriageReturn(text.slice(start));
 }


### PR DESCRIPTION
Closes #531. Refs #527.

## The method, again

Mutate a module with no direct test, run the full suite, see what survives. Six did, across
four modules — and each was the module's own stated purpose.

| Module | Mutation | Before | After |
|---|---|---|---|
| `lines.ts` | Windows `\r` no longer stripped | 2,948 passed | 2 failed ✓ |
| `lines.ts` | a final line with no trailing newline dropped | 2,948 passed | 3 failed ✓ |
| `lines.ts` | *every* `\r` removed, editing merchant data | — | 1 failed ✓ |
| `ledger-csv.ts` | the failure reason dropped | 2,948 passed | 1 failed ✓ |
| `ledger-csv.ts` | failed rows omitted, so a run exports clean | 2,948 passed | 4 failed ✓ |
| `actor.ts` | staff identity never recorded | 2,948 passed | 3 failed ✓ |
| `actor.ts` | a person's action attributed to the scheduler | — | 6 failed ✓ |
| `cost-errors.ts` | ordering by line lost | 2,948 passed | 2 failed ✓ |
| `cost-errors.ts` | sorted as text, so line 100 precedes line 9 | — | 2 failed ✓ |

### `lines.ts` feeds both importers

Its two failures are ordinary merchant behaviour. A spreadsheet saved on Windows ends every
line with `\r`, which unstripped becomes part of the last column's value — every price in
the file silently wrong. A paste without a trailing newline loses its last row, so an import
of 500 prices writes 499 and reports success.

### `ledger-csv.ts` contradicted its own comment, in both halves

> So a failed row keeps its reason in the file. An export that dropped the failures would
> show a clean run that was not clean, **which is the specific dishonesty this whole product
> is built against.**

### `actor.ts` is the audit trail

It exists because entries used to be attributed to the shop domain. `actorFor` could be made
to return the shop domain for every request again — the exact state it replaced.

## Writing the tests found a real bug

`linesOf` stripped the trailing carriage return in the loop branch and **not** in the
final-line branch. A paste ending `...\r` with no closing newline kept it on the last
column, so a cost of `"12.50\r"` fails to parse and the row comes back `invalid` — for a
reason the merchant cannot see anywhere in their spreadsheet.

Two branches yielding lines now agree on what a line is. The strip stays anchored to the end
so a carriage return *inside* a quoted value is left alone: removing every `\r` would edit
the merchant's data rather than the line ending, and that mutation is covered too.

## Checks

2,991 unit tests (was 2,948), 146 chaos scenarios, typecheck / lint / build clean.