### PR TITLE
Test the error reference and the audit export

### DIFF
--- a/app/lib/errors/report.test.ts
+++ b/app/lib/errors/report.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The reference a merchant reads out to support.
+ *
+ * `error-id.ts` goes to real trouble over the id — an alphabet with no `O`/`0`, no
+ * `I`/`1`/`L`, no `U` — because a person transcribes it by hand. It has its own test. The
+ * call site that gives each error a *distinct* one did not, and making `reportErrorSync`
+ * return a constant passed all 2,991 tests.
+ *
+ * That failure is quiet and complete: every merchant quotes the same reference, and the
+ * diagnostics page's lookup returns the wrong incident or all of them. Nothing about the
+ * error screen would look different.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { AppError } from "./app-error";
+import { isErrorId } from "./error-id";
+import { reportErrorSync } from "./report";
+
+describe("the reference on the error screen", () => {
+  it("is a well-formed error id", () => {
+    expect(isErrorId(reportErrorSync(new Error("boom")).errorId)).toBe(true);
+  });
+
+  it("is different for every error", () => {
+    // The whole point. One id shared by every incident makes the diagnostics lookup
+    // answer with somebody else's error, which is worse than answering with none.
+    const ids = new Set(
+      Array.from({ length: 50 }, () => reportErrorSync(new Error("boom")).errorId),
+    );
+
+    expect(ids.size).toBe(50);
+  });
+
+  it("is different even for two throws of the same error object", () => {
+    const error = new Error("the same object twice");
+
+    expect(reportErrorSync(error).errorId).not.toBe(reportErrorSync(error).errorId);
+  });
+});
+
+describe("what the boundary is given to render", () => {
+  it("carries an AppError's own merchant-facing message", () => {
+    const reported = reportErrorSync(
+      new AppError({
+        code: "GUARDRAIL_BLOCKED",
+        userMessage: "A guardrail stopped this run before anything was written.",
+      }),
+    );
+
+    expect(reported.userMessage).toBe(
+      "A guardrail stopped this run before anything was written.",
+    );
+    expect(reported.code).toBe("GUARDRAIL_BLOCKED");
+  });
+
+  it("never puts a raw thrown message in front of the merchant", () => {
+    // The assertion that actually distinguishes something. `AppError` sets `message`
+    // *from* `userMessage`, so for an AppError the two can never differ and a test using
+    // one proves nothing — a mutation swapping the fields survived until this case
+    // existed. What can differ is a raw error from Prisma or `fetch`, whose message is
+    // the thing that must not reach a screen.
+    const raw = "PrismaClientKnownRequestError: P2025 An operation failed because it " +
+      "depends on one or more records that were required but not found";
+    const reported = reportErrorSync(Object.assign(new Error(raw), { code: "P2025" }));
+
+    expect(reported.code).toBe("NOT_FOUND");
+    expect(reported.userMessage).not.toContain("Prisma");
+    expect(reported.userMessage).not.toBe(raw);
+    expect(reported.userMessage).toContain("no longer exists");
+  });
+
+  it("carries retryable and status from the classification", () => {
+    // The worker reads `retryable` to decide whether to try again, so dropping it here
+    // turns a transient failure into a permanent one.
+    const reported = reportErrorSync(
+      Object.assign(new Error("pool timeout"), { code: "P2024" }),
+    );
+
+    expect(reported.code).toBe("DB_UNAVAILABLE");
+    expect(reported.retryable).toBe(true);
+    expect(reported.status).toBe(503);
+  });
+
+  it("normalises something that is not an Error at all", () => {
+    // Anything can be thrown. A report that crashed on a thrown string would replace a
+    // handled error with an unhandled one, at the moment the app is already failing.
+    const reported = reportErrorSync("just a string");
+
+    expect(reported.code).toBe("UNKNOWN");
+    expect(reported.userMessage.length).toBeGreaterThan(0);
+    expect(isErrorId(reported.errorId)).toBe(true);
+  });
+
+  it("keeps an AppError's own code rather than reclassifying it", () => {
+    const reported = reportErrorSync(
+      new AppError({ code: "NOT_FOUND", userMessage: "That campaign no longer exists." }),
+    );
+
+    expect(reported.code).toBe("NOT_FOUND");
+    expect(reported.status).toBe(404);
+  });
+});

--- a/app/lib/reporting/activity-csv.test.ts
+++ b/app/lib/reporting/activity-csv.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The activity log as a file.
+ *
+ * The module states the one thing worth pinning and nothing enforced it:
+ *
+ *   "system" rather than blank: an empty cell in an exported audit log reads as missing
+ *    data rather than as unattended work.
+ *
+ * Blanking it passed all 2,991 tests. Someone reconciling an audit trail then cannot tell
+ * "nobody was attributed" from "the scheduler did it" — the difference between an
+ * unexplained change and a routine one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { activityCsv, type ActivityEntry } from "./activity-csv";
+
+const entry = (over: Partial<ActivityEntry> = {}): ActivityEntry => ({
+  id: "a1",
+  at: "2026-08-30T09:00:00.000Z",
+  actor: "staff:42",
+  action: "campaign.applied",
+  entity: "campaign",
+  entityId: "c1",
+  summary: "Applied Summer Sale to 412 variants",
+  ...over,
+});
+
+const lines = (csv: string) => csv.trimEnd().split("\n");
+
+describe("the exported audit log", () => {
+  it("names every column in the header", () => {
+    expect(lines(activityCsv([]))[0]).toBe(
+      '"timestamp","actor","action","entity","entity_id","change"',
+    );
+  });
+
+  it("writes one line per entry", () => {
+    expect(lines(activityCsv([entry(), entry({ id: "a2" })]))).toHaveLength(3);
+  });
+
+  it("carries the actor, the action and the summary", () => {
+    const csv = activityCsv([entry()]);
+
+    expect(csv).toContain('"staff:42"');
+    expect(csv).toContain('"campaign.applied"');
+    expect(csv).toContain('"Applied Summer Sale to 412 variants"');
+  });
+});
+
+describe("unattended work", () => {
+  it('is exported as "system", never as a blank cell', () => {
+    // A blank reads as missing data. The scheduler acting is not missing data — it is the
+    // answer to "who did this", and the export has to be able to say it.
+    expect(activityCsv([entry({ actor: null })])).toContain('"system"');
+  });
+
+  it("does not leave the actor column empty for any entry", () => {
+    const csv = activityCsv([entry({ actor: null }), entry({ actor: "staff:7" })]);
+
+    for (const line of lines(csv).slice(1)) {
+      expect(line.split(",")[1], `blank actor in: ${line}`).not.toBe('""');
+    }
+  });
+});
+
+describe("columns that legitimately have nothing in them", () => {
+  it("writes an empty cell for a missing entity, rather than the word null", () => {
+    // Unlike the actor, an entry with no entity genuinely has none — a settings change
+    // is not about an object. `null` would read as a value the app assigned.
+    const csv = activityCsv([entry({ entity: null, entityId: null })]);
+
+    expect(csv).not.toContain("null");
+    expect(lines(csv)[1]).toContain('"","",');
+  });
+
+  it("survives a summary containing a comma and a quote", () => {
+    // Summaries quote merchant text — campaign names, product titles. A log that
+    // corrupts itself on one is not a record of anything.
+    expect(activityCsv([entry({ summary: 'Renamed to "Winter, Final"' })])).toContain(
+      '"Renamed to ""Winter, Final"""',
+    );
+  });
+
+  it("exports a header-only file when there is no activity", () => {
+    expect(lines(activityCsv([]))).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #533. Refs #527, #531.

Last two from the sweep. Both survived all 2,991 tests.

| Module | Mutation | Before | After |
|---|---|---|---|
| `errors/report.ts` | every error gets the **same** reference id | 2,991 passed | 2 failed ✓ |
| `errors/report.ts` | `retryable` and `status` dropped | — | 2 failed ✓ |
| `reporting/activity-csv.ts` | unattended work exports as a **blank** cell | 2,991 passed | 2 failed ✓ |
| `reporting/activity-csv.ts` | a missing entity exports as the word `null` | — | 1 failed ✓ |

**The error id is the support handoff.** `error-id.ts` goes to real trouble over it — an
alphabet with no `O`/`0`, no `I`/`1`/`L`, no `U`, because a merchant reads it out and
somebody types it back — and it has its own test. The call site giving each error a
*distinct* one did not. A constant would have every merchant quoting the same reference
while the diagnostics lookup returned somebody else's incident, with nothing on the error
screen looking different.

**A blank actor reads as missing data.** The module says so itself: *"'system' rather than
blank: an empty cell in an exported audit log reads as missing data rather than as
unattended work."*

## The mutation that survived, and what it taught

Swapping `userMessage` for `message` changed nothing — because `AppError`'s constructor does
`super(options.userMessage)`, so for an `AppError` the two **can never differ**. My test
built an `AppError` and therefore proved nothing about the distinction it claimed to check.

The assertion that does distinguish uses a raw Prisma error, whose technical message is the
thing that must not reach a screen:

```ts
const reported = reportErrorSync(Object.assign(new Error(raw), { code: "P2025" }));
expect(reported.userMessage).not.toContain("Prisma");
expect(reported.userMessage).toContain("no longer exists");
```

The mutation fails against it. Worth more than the four that were caught first — a test
whose subject cannot vary is a test that passes for the wrong reason.

## Checks

3,007 unit tests (was 2,991), typecheck / lint / build clean.