### PR TITLE
Bind shop, run and job ids to every log line inside a unit of work

### DIFF
--- a/app/lib/logging/context.server.ts
+++ b/app/lib/logging/context.server.ts
@@ -1,0 +1,85 @@
+/**
+ * The ids every log line inside a unit of work should carry, without every call site
+ * being asked to remember them.
+ *
+ * `logger` already moved two rules off call sites and into `emit` — secrets and prices —
+ * for the reason written there: a rule kept by everyone remembering lasts until somebody
+ * adds a field in a hurry. Correlation is the same kind of rule and had not been moved.
+ * Before this, one log line in the whole tree carried a `jobId`, so a failed job's own
+ * handler output could not be filtered back to it.
+ *
+ * **Bound at the unit of work, not at the HTTP request.** Per CLAUDE.md rule 2 the web
+ * process writes prices and does so inline, so a boundary around the request would cover
+ * an inline Apply and miss the queued one that runs the identical code. `runCampaign` and
+ * the job wrapper are the two places where a shop, a campaign, a run and a job are all
+ * actually known, and binding there gives both processes the same fields.
+ *
+ * **This file is server-only and the logger does not import it.** `logger.ts` is
+ * reachable from the browser through `lib/errors/report.ts`, so it holds a registration
+ * slot instead and `node:async_hooks` never enters the client bundle. Installation
+ * happens at import, and nothing can bind a context without importing this module — so
+ * the slot cannot still be empty at the moment it is needed.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { installLogContext, type LogFields } from "./logger";
+
+/** Ids only. Anything a call site would rather say once than on every line. */
+export type LogContext = Pick<
+  LogFields,
+  "shop" | "shopId" | "campaignId" | "runId" | "jobId" | "route"
+>;
+
+const storage = new AsyncLocalStorage<LogContext>();
+
+/**
+ * Runs `work` with these ids on every line it logs, directly or indirectly.
+ *
+ * Nesting **merges** with whatever is already bound rather than replacing it. A run
+ * starting inside a job has to keep the job id: losing it there would break the exact
+ * correlation this exists to provide, and the inner scope is the one that knows least
+ * about how it was reached.
+ */
+export function withLogContext<T>(fields: LogContext, work: () => Promise<T>): Promise<T> {
+  return storage.run({ ...storage.getStore(), ...defined(fields) }, work);
+}
+
+/**
+ * Adds ids to the scope already running.
+ *
+ * For the id that is not known at the boundary. `runCampaign` binds the shop and the
+ * campaign on entry, but the run id does not exist until the `campaign_runs` row is
+ * created some way in — and everything logged after that point should carry it.
+ *
+ * Safe to mutate because `withLogContext` stores a fresh object per scope, so this
+ * reaches that scope and its children and nothing else. A no-op when no scope is
+ * running, rather than an error: a caller that gained an id is not the right place to
+ * discover that nobody bound a context.
+ */
+export function addLogContext(fields: LogContext): void {
+  const store = storage.getStore();
+  if (!store) return;
+  Object.assign(store, defined(fields));
+}
+
+/** What is bound right now. Empty outside any scope. */
+export function currentLogContext(): LogContext {
+  return storage.getStore() ?? {};
+}
+
+/**
+ * Drops undefined values before they are merged.
+ *
+ * Without this, a boundary passing an optional id it does not have — `runId: ref.runId`
+ * on a job that carries no run — would spread `runId: undefined` over an id an outer
+ * scope had correctly bound, and erase it. Passing a key you have no value for should
+ * mean "I have nothing to add", never "forget what you knew".
+ */
+function defined(fields: LogContext): LogContext {
+  return Object.fromEntries(
+    Object.entries(fields).filter(([, value]) => value !== undefined),
+  ) as LogContext;
+}
+
+installLogContext(currentLogContext);

--- a/app/lib/logging/context.test.ts
+++ b/app/lib/logging/context.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Ambient log context.
+ *
+ * The properties worth protecting are the ones that fail silently. A context that
+ * replaced instead of merging, or that let an absent optional id erase a bound one,
+ * still produces log lines — just log lines missing the id somebody will filter on
+ * during an incident, which is the moment nobody is in a position to notice.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { addLogContext, currentLogContext, withLogContext } from "./context.server";
+import { installLogContext, logger, resetLogContextForTests } from "./logger";
+
+/** Captures one JSON log line. Production format, which is the one that gets queried. */
+async function lineFrom(work: () => Promise<void>): Promise<Record<string, unknown>> {
+  const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.stubEnv("NODE_ENV", "production");
+  try {
+    await work();
+    const last = spy.mock.calls.at(-1)?.[0];
+    return JSON.parse(String(last)) as Record<string, unknown>;
+  } finally {
+    vi.unstubAllEnvs();
+    spy.mockRestore();
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("binding", () => {
+  it("puts the bound ids on a line that passed none of them", async () => {
+    const line = await lineFrom(() =>
+      withLogContext({ shopId: "shop_1", runId: "run_1", jobId: "job_1" }, async () => {
+        logger.info("planned");
+      }),
+    );
+
+    expect(line).toMatchObject({
+      message: "planned",
+      shopId: "shop_1",
+      runId: "run_1",
+      jobId: "job_1",
+    });
+  });
+
+  it("adds nothing when no context is bound", async () => {
+    const line = await lineFrom(async () => {
+      logger.info("planned");
+    });
+
+    expect(line.shopId).toBeUndefined();
+    expect(line.jobId).toBeUndefined();
+  });
+
+  it("does not leak out of the scope that bound it", async () => {
+    await withLogContext({ shopId: "shop_1" }, async () => {});
+    expect(currentLogContext()).toEqual({});
+  });
+
+  it("keeps concurrent scopes apart", async () => {
+    const seen: Array<string | undefined> = [];
+
+    const one = withLogContext({ jobId: "job_1" }, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      seen.push(currentLogContext().jobId);
+    });
+    const two = withLogContext({ jobId: "job_2" }, async () => {
+      seen.push(currentLogContext().jobId);
+    });
+
+    await Promise.all([one, two]);
+    expect(seen.sort()).toEqual(["job_1", "job_2"]);
+  });
+});
+
+describe("nesting", () => {
+  /**
+   * The property the whole design rests on. A run binds inside a job, and the run knows
+   * nothing about how it was reached — so replacing rather than merging would drop the
+   * job id on exactly the lines a failed job is investigated through.
+   */
+  it("merges with the enclosing scope rather than replacing it", async () => {
+    const line = await lineFrom(() =>
+      withLogContext({ shopId: "shop_1", jobId: "job_1" }, () =>
+        withLogContext({ campaignId: "camp_1", runId: "run_1" }, async () => {
+          logger.info("executing");
+        }),
+      ),
+    );
+
+    expect(line).toMatchObject({
+      shopId: "shop_1",
+      jobId: "job_1",
+      campaignId: "camp_1",
+      runId: "run_1",
+    });
+  });
+
+  it("lets an inner scope override an id the outer one bound", async () => {
+    const line = await lineFrom(() =>
+      withLogContext({ runId: "run_outer" }, () =>
+        withLogContext({ runId: "run_inner" }, async () => {
+          logger.info("executing");
+        }),
+      ),
+    );
+
+    expect(line.runId).toBe("run_inner");
+  });
+
+  /**
+   * `traced()` passes `runId: ref.runId` for every job class, and most job classes carry
+   * no run. Spreading that `undefined` over a bound id would erase it.
+   */
+  it("does not let an absent optional id erase one already bound", async () => {
+    const line = await lineFrom(() =>
+      withLogContext({ shopId: "shop_1", runId: "run_1" }, () =>
+        withLogContext({ runId: undefined, campaignId: "camp_1" }, async () => {
+          logger.info("executing");
+        }),
+      ),
+    );
+
+    expect(line.runId).toBe("run_1");
+    expect(line.campaignId).toBe("camp_1");
+  });
+
+  it("restores the outer scope when the inner one ends", async () => {
+    await withLogContext({ jobId: "job_1" }, async () => {
+      await withLogContext({ jobId: "job_2" }, async () => {});
+      expect(currentLogContext().jobId).toBe("job_1");
+    });
+  });
+});
+
+describe("addLogContext", () => {
+  /** The run id does not exist until the `campaign_runs` row does. */
+  it("reaches lines logged after it, in the scope already running", async () => {
+    const line = await lineFrom(() =>
+      withLogContext({ shopId: "shop_1" }, async () => {
+        addLogContext({ runId: "run_1" });
+        logger.info("executing");
+      }),
+    );
+
+    expect(line).toMatchObject({ shopId: "shop_1", runId: "run_1" });
+  });
+
+  it("does not reach lines logged before it", async () => {
+    const lines: Array<Record<string, unknown>> = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(JSON.parse(String(args[0])) as Record<string, unknown>);
+    });
+    vi.stubEnv("NODE_ENV", "production");
+
+    await withLogContext({ shopId: "shop_1" }, async () => {
+      logger.info("planning");
+      addLogContext({ runId: "run_1" });
+      logger.info("executing");
+    });
+
+    vi.unstubAllEnvs();
+    spy.mockRestore();
+
+    expect(lines[0].runId).toBeUndefined();
+    expect(lines[1].runId).toBe("run_1");
+  });
+
+  it("does not escape into a sibling scope", async () => {
+    await withLogContext({ shopId: "shop_1" }, async () => {
+      addLogContext({ runId: "run_1" });
+    });
+
+    await withLogContext({ shopId: "shop_2" }, async () => {
+      expect(currentLogContext().runId).toBeUndefined();
+    });
+  });
+
+  it("is a no-op outside any scope rather than throwing", () => {
+    expect(() => addLogContext({ runId: "run_1" })).not.toThrow();
+    expect(currentLogContext()).toEqual({});
+  });
+});
+
+describe("the logger's side of the seam", () => {
+  /**
+   * An id bound at a boundary is no more trustworthy than a field passed at a call site.
+   * Redaction runs over the merged object, not around the ambient half of it.
+   */
+  it("redacts ambient fields, not only the ones passed at the call site", async () => {
+    const line = await lineFrom(() =>
+      // `shop` is a domain in real use; the point is that whatever is bound goes through
+      // the same passes. A money-shaped value must not survive because it arrived here.
+      withLogContext({ shop: "19.99" } as never, async () => {
+        logger.info("executing");
+      }),
+    );
+
+    expect(line.shop).toBe("[redacted:price]");
+  });
+
+  it("lets an explicit field at the call site win over the bound one", async () => {
+    const line = await lineFrom(() =>
+      withLogContext({ runId: "run_ambient" }, async () => {
+        logger.info("verifying a different run", { runId: "run_explicit" });
+      }),
+    );
+
+    expect(line.runId).toBe("run_explicit");
+  });
+
+  it("still logs when reading the context throws", async () => {
+    try {
+      installLogContext(() => {
+        throw new Error("async context is broken");
+      });
+
+      const line = await lineFrom(async () => {
+        logger.info("executing");
+      });
+
+      expect(line.message).toBe("executing");
+      expect(line.shopId).toBeUndefined();
+    } finally {
+      // Re-register by hand. `context.server.ts` installs itself at import and ESM
+      // caches the module, so re-importing it would not run that line again and every
+      // later test in this worker would see an empty context.
+      installLogContext(currentLogContext);
+    }
+  });
+
+  it("behaves as it did before when nothing is registered", async () => {
+    try {
+      resetLogContextForTests();
+
+      const line = await lineFrom(() =>
+        withLogContext({ shopId: "shop_1" }, async () => {
+          logger.info("executing", { route: "/app/campaigns" });
+        }),
+      );
+
+      expect(line).toMatchObject({ message: "executing", route: "/app/campaigns" });
+      expect(line.shopId).toBeUndefined();
+    } finally {
+      installLogContext(currentLogContext);
+    }
+  });
+});

--- a/app/lib/logging/logger.ts
+++ b/app/lib/logging/logger.ts
@@ -25,11 +25,52 @@ export interface LogFields {
   errorId?: string;
   code?: string;
   shop?: string;
+  /** The internal id. `shop` is the myshopify domain; both get logged, they are not the same key. */
+  shopId?: string;
   route?: string;
   campaignId?: string;
   runId?: string;
+  /** BullMQ's id for the job this line happened inside. Absent when the work ran inline. */
+  jobId?: string;
   durationMs?: number;
   [key: string]: unknown;
+}
+
+/**
+ * Where the ambient fields come from, when anything is providing them.
+ *
+ * A seam rather than a direct import, because this module is reachable from the browser:
+ * `lib/errors/report.ts` is the isomorphic half of error reporting, renders inside the
+ * ErrorBoundary on both sides, and imports the logger. `node:async_hooks` in this file
+ * would put it in the client bundle, which is the same class of mistake as the `process`
+ * guard below.
+ *
+ * The default returns nothing, so a logger with nothing registered — every browser
+ * render, every test that does not opt in — behaves exactly as it did before.
+ */
+export type LogContextSource = () => LogFields;
+
+let contextSource: LogContextSource = () => ({});
+
+/** Called once by `context.server.ts` at import. Server-only by construction. */
+export function installLogContext(source: LogContextSource): void {
+  contextSource = source;
+}
+
+/** Test seam: puts the logger back to reading no ambient context. */
+export function resetLogContextForTests(): void {
+  contextSource = () => ({});
+}
+
+function ambient(): LogFields {
+  try {
+    return contextSource();
+  } catch {
+    // A logger that throws while assembling a line loses the line, and the lines most
+    // likely to be assembled during a broken async context are the ones explaining why
+    // it broke. Missing ids are a worse log; no log is a worse incident.
+    return {};
+  }
 }
 
 const LEVELS: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
@@ -58,11 +99,21 @@ function isPretty(): boolean {
 function emit(level: LogLevel, message: string, fields: LogFields = {}): void {
   if (LEVELS[level] < threshold()) return;
 
+  // Ambient first, so an explicit field at the call site wins. A caller naming a runId
+  // means *that* run — most often when it is reporting on a run other than the one it is
+  // currently inside, which is exactly when being overwritten would mislead.
+  //
+  // Merged before redaction rather than after, so context goes through the same two
+  // passes as everything else. An id bound at a boundary is no more trustworthy than a
+  // field passed at a call site; `shop` is already a domain and nothing stops a future
+  // binding carrying something money-shaped.
+  const merged = { ...ambient(), ...fields };
+
   // Prices first, then secrets. The order matters: the secret pass renders a bigint as
   // "8000n", and a price that has already become a string slips past a money-shaped
   // check. Every price in this codebase is a bigint, so catching it while it still is
   // one is the only reliable pass.
-  const safe = redact(redactPrices(fields)) as LogFields;
+  const safe = redact(redactPrices(merged)) as LogFields;
   const sink = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
 
   if (isPretty()) {

--- a/app/services/campaigns/run-context.test.ts
+++ b/app/services/campaigns/run-context.test.ts
@@ -1,0 +1,86 @@
+/**
+ * That a run's log lines say which run they belong to.
+ *
+ * `runCampaign` is the function both writers share. A queued apply reaches it through the
+ * job wrapper, and an inline Apply or Revert reaches it straight from a route — and per
+ * CLAUDE.md rule 2 both genuinely write prices. So this is the one place that gives both
+ * processes the same fields; binding only in the worker would have left the web half, the
+ * half a merchant is watching while it happens, with nothing to correlate on.
+ *
+ * Checked as source because the alternative is a Postgres, an Admin client and a
+ * campaign, and none of that would make the assertion stronger — what is being asserted
+ * is that two calls exist and are in the right order relative to a third. `sourceOf`
+ * strips comments, so the notes beside these calls cannot satisfy the checks on their own.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../../lib/testing/source";
+
+const source = sourceOf("app/services/campaigns/run.server.ts");
+
+describe("the run boundary binds its ids", () => {
+  it("wraps the run in the shop and campaign", () => {
+    expect(
+      source,
+      "runCampaign no longer binds a log context, so an inline apply logs without a shop",
+    ).toMatch(/withLogContext\(\s*\{\s*shopId,\s*campaignId\s*\}/);
+  });
+
+  it("adds the run id, which does not exist until the run row does", () => {
+    expect(
+      source,
+      "nothing binds the run id, so every line after the claim is unattributable",
+    ).toMatch(/addLogContext\(\{\s*runId:\s*run\.id\s*\}\)/);
+  });
+
+  /**
+   * The half worth guarding. `addLogContext` before the `campaign_runs` row exists has
+   * no id to add and would bind nothing — and it would still look correct in review,
+   * because the call is there.
+   */
+  it("adds it after the row is created, not before", () => {
+    const created = source.indexOf("prisma.campaignRun.create");
+    const bound = source.indexOf("addLogContext(");
+
+    expect(created, "the run row is no longer created here").toBeGreaterThan(-1);
+    expect(bound, "the run id is no longer bound here").toBeGreaterThan(-1);
+    expect(
+      bound,
+      "the run id is bound before the row that mints it, so it binds nothing",
+    ).toBeGreaterThan(created);
+  });
+
+  /**
+   * `withLogContext` has to enclose the work, not sit beside it. A binding that wrapped
+   * nothing would pass both checks above and produce no ids at all.
+   *
+   * Asserted as "the callback *is* the call" rather than "the two appear near each
+   * other". The proximity version was written first and a deliberately broken copy —
+   * `withLogContext(…, async () => {})` on the line above an unwrapped run — passed it,
+   * because the two tokens were still 60 characters apart.
+   */
+  it("binds around the run rather than beside it", () => {
+    expect(
+      source,
+      "the context is bound but does not enclose executeCampaignRun, so the run logs " +
+        "without ids while the binding still looks present",
+    ).toMatch(
+      /withLogContext\(\s*\{\s*shopId,\s*campaignId\s*\},\s*\(\)\s*=>\s*executeCampaignRun\(/,
+    );
+  });
+
+  /**
+   * The other way to lose it: leave the wrapped path alone and add a second, unwrapped
+   * caller beside it. Every check above still passes.
+   */
+  it("has no second path into the run that skips the binding", () => {
+    const calls = [...source.matchAll(/(?<!function\s)\bexecuteCampaignRun\(/g)].length;
+
+    expect(
+      calls,
+      "executeCampaignRun is called from more than one place, so at least one path into " +
+        "a run is not inside a log context",
+    ).toBe(1);
+  });
+});

--- a/app/services/campaigns/run.server.ts
+++ b/app/services/campaigns/run.server.ts
@@ -35,6 +35,7 @@ import {
 } from "./market-surfaces.server";
 import { notify } from "../notifications.server";
 import { metric } from "../../lib/telemetry/metrics";
+import { addLogContext, withLogContext } from "../../lib/logging/context.server";
 
 export interface RunOptions {
   revert?: boolean;
@@ -134,7 +135,17 @@ export async function runCampaign(
   const releaseTo = (options.claimedFrom ?? before?.status) as CampaignState | undefined;
 
   try {
-    return await executeCampaignRun(shopId, campaignId, client, options);
+    // Every line this run produces carries the shop and the campaign, and the run id
+    // from the moment there is one. Bound here rather than in the worker because this is
+    // the function both callers share: a queued apply arrives through the job wrapper,
+    // an inline Apply or Revert arrives straight from a route, and per CLAUDE.md rule 2
+    // both genuinely write. Binding at the job alone would have left the web half — the
+    // half a merchant is watching — with no ids at all.
+    //
+    // Merges with the job's context when there is one, so a queued run keeps its job id.
+    return await withLogContext({ shopId, campaignId }, () =>
+      executeCampaignRun(shopId, campaignId, client, options),
+    );
   } catch (error) {
     // Only release to a state that is not itself a claim. A campaign that was already
     // APPLYING when this was called -- a resume, a second worker -- has nowhere to be
@@ -362,6 +373,11 @@ async function executeCampaignRun(
       },
       select: { id: true },
     });
+
+    // The one id that cannot be bound at the boundary: it does not exist until this row
+    // does. Everything after this point — planning results, execution, verification,
+    // tags, markets — logs with the run it belongs to.
+    addLogContext({ runId: run.id });
   } catch (error) {
     if (!isOccurrenceTaken(error)) throw error;
 

--- a/app/worker/queue-runtime.server.ts
+++ b/app/worker/queue-runtime.server.ts
@@ -22,6 +22,7 @@ import { Queue, Worker, type Job } from "bullmq";
 import { logger } from "../lib/logging/logger";
 import { metric } from "../lib/telemetry/metrics";
 import { span } from "../lib/observability/otel.server";
+import { withLogContext } from "../lib/logging/context.server";
 import {
   jobOptionsFor,
   QUEUE_NAMES,
@@ -83,7 +84,7 @@ export function redisRuntime(handler: Handler, options: RedisRuntimeOptions): Qu
       const worker = new Worker(
         name,
         async (job: Job<JobRef>) => {
-          await traced(name, job.data, () => handler(name, job.data));
+          await traced(name, job.data, () => handler(name, job.data), job.id);
         },
         { connection, concurrency: policy.concurrency },
       );
@@ -93,7 +94,9 @@ export function redisRuntime(handler: Handler, options: RedisRuntimeOptions): Qu
       worker.on("failed", (job, error) => {
         logger.error("job failed", {
           queue: name,
-          jobId: job?.id ?? null,
+          // Explicit, because a `failed` listener fires outside the job's own async
+          // context — the ambient binding in `traced` is long gone by then.
+          jobId: job?.id ?? undefined,
           attempts: job?.attemptsMade ?? 0,
           error: error?.message ?? String(error),
         });
@@ -203,16 +206,36 @@ export async function reportDepths(runtime: QueueRuntime): Promise<void> {
  * deployment running inline looks the same as one from a deployment with a queue. A
  * degraded mode that is invisible in tracing is a degraded mode nobody notices.
  */
-async function traced(name: QueueName, ref: JobRef, work: () => Promise<void>): Promise<void> {
-  await span(
-    `job ${name}`,
+async function traced(
+  name: QueueName,
+  ref: JobRef,
+  work: () => Promise<void>,
+  jobId?: string,
+): Promise<void> {
+  // The same ids on the log lines as on the span. They were on the span from the day it
+  // was written and on exactly one log line — `job failed` — so a failing job could be
+  // seen but the handler output explaining it could not be filtered back to it.
+  //
+  // Outside the span rather than inside, so a handler that throws still logs with its
+  // ids while `span()` is recording the exception.
+  await withLogContext(
     {
-      "queue.name": name,
-      "shop.id": ref.shopId,
-      ...(ref.campaignId ? { "campaign.id": ref.campaignId } : {}),
-      ...(ref.runId ? { "run.id": ref.runId } : {}),
-      ...(ref.revert === undefined ? {} : { "job.revert": ref.revert }),
+      shopId: ref.shopId,
+      campaignId: ref.campaignId,
+      runId: ref.runId,
+      jobId,
     },
-    work,
+    () =>
+      span(
+        `job ${name}`,
+        {
+          "queue.name": name,
+          "shop.id": ref.shopId,
+          ...(ref.campaignId ? { "campaign.id": ref.campaignId } : {}),
+          ...(ref.runId ? { "run.id": ref.runId } : {}),
+          ...(ref.revert === undefined ? {} : { "job.revert": ref.revert }),
+        },
+        work,
+      ),
   );
 }

--- a/app/worker/queue-runtime.test.ts
+++ b/app/worker/queue-runtime.test.ts
@@ -7,9 +7,10 @@
  */
 
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { sourceOf } from "../lib/testing/source";
+import { logger } from "../lib/logging/logger";
 
 import { inlineRuntime, runtimeFor } from "./queue-runtime.server";
 import type { JobRef, QueueName } from "./queues";
@@ -106,5 +107,65 @@ describe("both ends of a job's life are traced", () => {
       const uses = source.split(attribute).length - 1;
       expect(uses, `${attribute} appears on only one of the two spans`).toBeGreaterThanOrEqual(2);
     }
+  });
+});
+
+describe("a job's log lines carry the ids the job was asked for", () => {
+  /**
+   * Before this, `job failed` was the only line in the tree with a `jobId` on it. The
+   * handler output that would explain *why* it failed carried nothing to filter on, so
+   * reconstructing a failed run meant ordering by timestamp and guessing.
+   *
+   * Asserted through `inlineRuntime` because that runs the real wrapper — the same
+   * `traced()` the Redis worker goes through — rather than a copy of it.
+   */
+  async function lineFrom(ref: JobRef): Promise<Record<string, unknown>> {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubEnv("NODE_ENV", "production");
+    try {
+      const runtime = inlineRuntime(async () => {
+        // A handler logging exactly as handlers do: no ids passed.
+        logger.info("handling");
+      });
+      await runtime.enqueue("execution", ref);
+      return JSON.parse(String(spy.mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+    } finally {
+      vi.unstubAllEnvs();
+      spy.mockRestore();
+    }
+  }
+
+  it("binds the shop, campaign and run onto a line that passed none of them", async () => {
+    const line = await lineFrom({ shopId: "s1", campaignId: "c1", runId: "r1" });
+
+    expect(line).toMatchObject({
+      message: "handling",
+      shopId: "s1",
+      campaignId: "c1",
+      runId: "r1",
+    });
+  });
+
+  it("omits the ids the job does not carry rather than binding them empty", async () => {
+    const line = await lineFrom({ shopId: "s1" });
+
+    expect(line.shopId).toBe("s1");
+    expect(line.campaignId).toBeUndefined();
+    expect(line.runId).toBeUndefined();
+  });
+
+  /**
+   * The one id `inlineRuntime` cannot exercise: it exists only where BullMQ minted it,
+   * so the check that the Redis worker hands it over is over the source. Comments are
+   * stripped by `sourceOf`, so the note beside the call cannot satisfy this on its own.
+   */
+  it("hands the queue worker's job id to the same wrapper", () => {
+    const source = sourceOf("app/worker/queue-runtime.server.ts");
+
+    expect(
+      source,
+      "the Redis worker runs traced() without the BullMQ job id, so a queued job's log " +
+        "lines cannot be filtered back to the job",
+    ).toMatch(/traced\(name, job\.data, \(\) => handler\(name, job\.data\), job\.id\)/);
   });
 });

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -9,6 +9,14 @@ holds one row per variant per surface per run, written *before* the API call and
 after it. If you want to know what is live and why, that table and the reconciliation view
 over it are the answer — not the logs, and not a guess from the campaign's status.
 
+The logs are the second question: *why* did it do that. Every line emitted inside a job or
+a run carries the ids to filter on — shopId, campaignId, runId, and jobId where the work
+came off a queue — bound at the boundary rather than passed by each call site, so a
+handler's own output can be narrowed to the run it belongs to. Filter by runId to get one
+run's whole story; by jobId to get everything a failing job did before it failed. Lines
+outside a run or job (route handlers, startup, the nightly audit) carry whatever their
+call site passes, which is usually a shop and a route.
+
 ---
 
 ## Alert: mirror divergence above 0.5%


### PR DESCRIPTION
Closes #535. The last unchecked code criterion on #45 (P0.6).

## The problem

`logger` took its fields from the call site and nowhere else:

| | |
|---|---|
| `logger.*` call sites in `app` + `scripts` | 67 |
| that passed any shop identifier | 15 |
| that passed `jobId` | **1** — the `job failed` line |

So a failing job could be *seen* but the four lines its handler emitted just before
could not be filtered back to it. Reconstructing a failed run meant ordering by
timestamp and guessing.

The ids were already at the boundary and already in use — `traced()` has put
`shop.id`, `campaign.id` and `run.id` on the **span** since it was written. The logs
were the half that missed out.

## The approach

Ambient context bound once at the boundary, the same shape as the two redaction passes
`logger.ts` already moved off call sites, for the reason it states itself: *a rule kept
by everyone remembering lasts until somebody adds a field in a hurry.*

**Bound at the unit of work, not the HTTP request.** React Router 7.18 has middleware
only behind `future.v8_middleware`, which retypes `context` across every loader and
action — far too broad for a logging change. It is also the wrong boundary: per
CLAUDE.md rule 2 the web process writes prices and does so inline, so `runCampaign`
covers an inline Apply *and* a queued one from one place, where an HTTP boundary would
cover the first and miss the second.

Two bindings:
- `traced()` — shop, campaign, run, and the BullMQ job id where there is one
- `runCampaign` — shop and campaign on entry, run id via `addLogContext` the moment the
  `campaign_runs` row exists

## The browser constraint

`logger.ts` must never import `node:async_hooks`: it is reachable from the browser
through `lib/errors/report.ts`, the isomorphic half of error reporting that renders in
the ErrorBoundary on both sides. So the storage lives in `context.server.ts` and
registers itself through a slot on the logger.

Verified against the built output — neither `async_hooks` nor `withLogContext` appears
in `build/client/`. With nothing registered the logger behaves exactly as before, which
is its own test.

## The subtleties, each with a test

- Nesting **merges** rather than replaces — a run inside a job keeps its job id
- `undefined` is dropped before merging, so `runId: ref.runId` on a job class that
  carries no run cannot erase one an outer scope bound
- An explicit field at a call site still wins over the ambient one — a caller naming a
  runId usually means a run other than the one it is inside
- Ambient fields go through the price and secret passes, not around them
- Reading the context can never throw into `emit`

`jobId: job?.id ?? null` became `?? undefined` in the `failed` listener: it now
conflicts with the typed field, and the listener fires outside the job's async context
so it rightly still passes the id explicitly.

## Verification

- 3031 tests pass; typecheck and lint clean (6 pre-existing warnings, none in these files)
- **Every assertion mutation-checked.** Nine mutations, each caught by its intended test.
  One survived first time — `binds around the run rather than beside it` was a proximity
  regex, and `withLogContext(…, async () => {})` on the line above an unwrapped run still
  satisfied it. Now structural: the callback must *be* the call, plus a check that no
  second unwrapped path into the run exists.
- Chaos suite not run locally (no Docker on this machine) — it runs in CI.

`docs/runbooks.md` gains a short paragraph on what is now filterable, since the runbook
is what somebody reads at 3am.

🤖 Generated with [Claude Code](https://claude.com/claude-code)