### PR TITLE
Redact span attributes and recorded exceptions before they leave the process

### DIFF
--- a/app/lib/observability/otel.server.ts
+++ b/app/lib/observability/otel.server.ts
@@ -19,8 +19,8 @@
 import { metrics, trace, type Counter, type Histogram, type Span, type Tracer } from "@opentelemetry/api";
 
 import { logger } from "../logging/logger";
-import { redactPrices } from "../telemetry/redact";
-import { redact } from "../logging/redact";
+import { redactPrices, redactPricesInText } from "../telemetry/redact";
+import { redact, redactText } from "../logging/redact";
 import type { Metric, MetricLabels } from "../telemetry/metrics";
 
 const SERVICE = "anchor";
@@ -211,18 +211,47 @@ export async function span<T>(
 
   const tracer: Tracer = trace.getTracer(SERVICE);
 
-  return tracer.startActiveSpan(name, { attributes }, async (active) => {
+  // Redacted on the way in, exactly as `record()` does for a metric label. A span
+  // attribute reaches the same collector by the same wire; nothing about the rule
+  // changes because this one describes a duration rather than a measurement.
+  return tracer.startActiveSpan(name, { attributes: attributesFrom(attributes) }, async (active) => {
     try {
       const result = await work(active);
       active.end();
       return result;
     } catch (error) {
-      active.recordException(error as Error);
+      active.recordException(safeException(error));
       active.setStatus({ code: 2 });
       active.end();
       throw error;
     }
   });
+}
+
+/**
+ * An exception with the price and the secrets taken out of its text.
+ *
+ * `recordException` writes the message *and* the stacktrace onto the span, and both
+ * carry whatever the thrown message said. That matters here more than it looks: every
+ * Admin API call is wrapped in `span("shopify.graphql", …)`, and `admin-client` throws
+ * Shopify's own error text for the mutation that just ran — which for a price mutation
+ * is the single most likely string in the system to contain a price.
+ *
+ * Sentry has guarded this shape since it was written. Until this, the trace path did
+ * not, so one thrown error was scrubbed on its way to Sentry and exported intact to the
+ * collector. Same two passes, same order, same reason as `logger`.
+ */
+function safeException(error: unknown): { name: string; message: string; stack?: string } {
+  const thrown = error instanceof Error ? error : new Error(String(error));
+  const scrub = (text: string) => redactText(redactPricesInText(text));
+
+  return {
+    name: thrown.name,
+    message: scrub(thrown.message),
+    // The stacktrace repeats the message on its first line, so leaving it alone would
+    // have redacted the field somebody reads and kept the value beside it.
+    ...(thrown.stack ? { stack: scrub(thrown.stack) } : {}),
+  };
 }
 
 export async function shutdownOtel(): Promise<void> {

--- a/app/lib/observability/sentry.server.ts
+++ b/app/lib/observability/sentry.server.ts
@@ -20,7 +20,7 @@
 import * as Sentry from "@sentry/node";
 
 import { redact, redactText } from "../logging/redact";
-import { redactPrices } from "../telemetry/redact";
+import { redactPrices, redactPricesInText } from "../telemetry/redact";
 import { logger } from "../logging/logger";
 
 let started = false;
@@ -107,30 +107,6 @@ export function scrub(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
   return event;
 }
 
-/**
- * Money-shaped substrings inside free text.
- *
- * The structured redactor works on keys and values; an exception message is one string,
- * and "cannot set price 19.99 on variant 12345" carries a price in the middle of a
- * sentence. Numbers with exactly two decimals are the shape worth catching — variant ids
- * and counts do not look like that.
- *
- * The lookbehind and lookahead are load-bearing rather than tidiness. Without them
- * "API version 2025.10" matched its own tail as "5.10" and became "API version 2[price]",
- * which is both a corrupted message and a false sense that something was protected. And
- * without them the leading space was consumed, so every redaction ran the previous word
- * into the placeholder.
- *
- * Over-matching costs more than it looks: a log full of unreadable messages is a log
- * people stop reading, which is worse than the leak it was guarding against.
- */
-export function redactPricesInText(text: string): string {
-  return text.replace(
-    /(?<![\d.])[$£€¥]?\d{1,3}(?:[,\s]\d{3})*\.\d{2}(?!\d)/g,
-    "[price]",
-  );
-}
-
 /** Attaches shop context. Never prices — see the note at the top. */
 export function setShopContext(shopId: string | null, shop?: string | null): void {
   if (!started) return;
@@ -160,3 +136,7 @@ export function captureError(error: unknown, context: Record<string, unknown> = 
 export function resetSentryForTests(): void {
   started = false;
 }
+
+// Re-exported so the callers and tests that knew it here keep working; it now lives
+// beside the structured price redactor, which is where the trace path can reach it too.
+export { redactPricesInText };

--- a/app/lib/observability/span-redaction.test.ts
+++ b/app/lib/observability/span-redaction.test.ts
@@ -1,0 +1,154 @@
+/**
+ * What a collector actually receives from a span.
+ *
+ * Asserted against a real `BasicTracerProvider` and an in-memory exporter rather than
+ * against the redactor in isolation, because the bug this covers was not a redactor that
+ * got something wrong — it was a redactor that was never called on this path. A test over
+ * `redactPricesInText` passed the whole time the price was going out on the wire.
+ *
+ * Two leaks, and the second had two halves. `span()` passed its attributes straight into
+ * `startActiveSpan`, and `recordException` wrote the thrown message onto the span in both
+ * `exception.message` and `exception.stacktrace` — so redacting only the message would
+ * have cleaned the field somebody reads and left the value beside it.
+ */
+
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { trace } from "@opentelemetry/api";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { otelEnabledForTests, span } from "./otel.server";
+
+const exporter = new InMemorySpanExporter();
+
+beforeAll(() => {
+  // Once per process — OTel ignores a second registration, which is itself worth knowing:
+  // a per-test provider silently sends every span after the first to the first exporter.
+  trace.setGlobalTracerProvider(
+    new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] }),
+  );
+  otelEnabledForTests(true);
+});
+
+afterAll(() => otelEnabledForTests(false));
+beforeEach(() => exporter.reset());
+
+/** The one span the work produced, as the exporter received it. */
+async function exported(
+  attributes: Record<string, string | number | boolean>,
+  work: () => Promise<void> = async () => {},
+) {
+  await span("write", attributes, work).catch(() => {});
+  return exporter.getFinishedSpans()[0];
+}
+
+describe("span attributes", () => {
+  it("redacts a price the same way a metric label is redacted", async () => {
+    const recorded = await exported({ "variant.price": "19.99", "shop.id": "s1" });
+
+    expect(
+      recorded.attributes["variant.price"],
+      "a span attribute reaches the collector by the same wire as a metric label",
+    ).not.toBe("19.99");
+    expect(String(recorded.attributes["variant.price"])).not.toMatch(/19\.99/);
+  });
+
+  it("redacts by key as well as by shape", async () => {
+    const recorded = await exported({ price: 1999, amount: 2500 });
+
+    expect(recorded.attributes.price).not.toBe(1999);
+    expect(recorded.attributes.amount).not.toBe(2500);
+  });
+
+  /**
+   * The other half of the trade. Over-redaction is not free: the ids and cost points on
+   * these spans are the whole reason they exist, and a trace that has redacted its own
+   * queue name is a trace nobody can use.
+   */
+  it("leaves the attributes a span exists to carry", async () => {
+    const recorded = await exported({
+      "queue.name": "execution",
+      "shop.id": "s1",
+      "campaign.id": "c1",
+      "run.id": "r1",
+      "graphql.operation": "productVariantsBulkUpdate",
+      "shopify.cost.actual": 12,
+      "shopify.throttle.available": 987,
+      "job.revert": true,
+    });
+
+    expect(recorded.attributes).toMatchObject({
+      "queue.name": "execution",
+      "shop.id": "s1",
+      "campaign.id": "c1",
+      "run.id": "r1",
+      "graphql.operation": "productVariantsBulkUpdate",
+      "shopify.cost.actual": 12,
+      "shopify.throttle.available": 987,
+      "job.revert": true,
+    });
+  });
+});
+
+describe("recorded exceptions", () => {
+  /**
+   * The realistic path, not a contrived one. Every Admin API call runs inside
+   * `span("shopify.graphql", …)`, and `admin-client` throws Shopify's own error text for
+   * the mutation that just ran.
+   */
+  const shopifySaid = "Price must be greater than 19.99 for variant 12345";
+
+  it("scrubs the price out of the exception message", async () => {
+    const recorded = await exported({ "shop.id": "s1" }, async () => {
+      throw new Error(shopifySaid);
+    });
+
+    const event = recorded.events.find((e) => e.name === "exception");
+    expect(event, "no exception was recorded, so this proves nothing").toBeDefined();
+    expect(String(event!.attributes!["exception.message"])).not.toMatch(/19\.99/);
+  });
+
+  it("scrubs the stacktrace too, which repeats the message on its first line", async () => {
+    const recorded = await exported({ "shop.id": "s1" }, async () => {
+      throw new Error(shopifySaid);
+    });
+
+    const event = recorded.events.find((e) => e.name === "exception");
+    expect(String(event!.attributes!["exception.stacktrace"] ?? "")).not.toMatch(/19\.99/);
+  });
+
+  it("keeps the exception useful — the type, and the part that is not a price", async () => {
+    const recorded = await exported({ "shop.id": "s1" }, async () => {
+      throw new TypeError(shopifySaid);
+    });
+
+    const event = recorded.events.find((e) => e.name === "exception");
+    expect(event!.attributes!["exception.type"]).toBe("TypeError");
+    expect(String(event!.attributes!["exception.message"])).toMatch(/variant 12345/);
+  });
+
+  it("records something thrown that is not an Error at all", async () => {
+    const recorded = await exported({ "shop.id": "s1" }, async () => {
+      throw "refused at 19.99";
+    });
+
+    const event = recorded.events.find((e) => e.name === "exception");
+    expect(event, "a non-Error throw recorded nothing").toBeDefined();
+    expect(String(event!.attributes!["exception.message"])).not.toMatch(/19\.99/);
+  });
+
+  it("still marks the span failed and rethrows", async () => {
+    const boom = new Error("plain failure");
+
+    await expect(span("write", { "shop.id": "s1" }, async () => {
+      throw boom;
+    })).rejects.toThrow("plain failure");
+
+    // 2 is ERROR. A span that scrubbed its exception and forgot to fail would be worse
+    // than one that leaked, because the trace would read as healthy.
+    expect(exporter.getFinishedSpans()[0].status.code).toBe(2);
+  });
+});

--- a/app/lib/telemetry/redact.ts
+++ b/app/lib/telemetry/redact.ts
@@ -66,3 +66,33 @@ export function containsPrice(value: unknown): boolean {
 function stringifySafe(value: unknown): unknown {
   return JSON.parse(JSON.stringify(value, (_key, entry) => (typeof entry === "bigint" ? `${entry}` : entry)));
 }
+
+/**
+ * Money-shaped substrings inside free text.
+ *
+ * Shared by both sinks that export free text: Sentry's `beforeSend` and the span
+ * recorder in `otel.server`. It lived in `sentry.server.ts` while Sentry was the only
+ * caller, which meant the trace path had no equivalent at all and the same thrown
+ * error was scrubbed on its way to Sentry and exported intact to the collector.
+ * One definition, so the two cannot drift about what a price looks like.
+ *
+ * `redactPrices` above works on keys and values; an exception message is one string,
+ * and "cannot set price 19.99 on variant 12345" carries a price in the middle of a
+ * sentence. Numbers with exactly two decimals are the shape worth catching — variant ids
+ * and counts do not look like that.
+ *
+ * The lookbehind and lookahead are load-bearing rather than tidiness. Without them
+ * "API version 2025.10" matched its own tail as "5.10" and became "API version 2[price]",
+ * which is both a corrupted message and a false sense that something was protected. And
+ * without them the leading space was consumed, so every redaction ran the previous word
+ * into the placeholder.
+ *
+ * Over-matching costs more than it looks: a log full of unreadable messages is a log
+ * people stop reading, which is worse than the leak it was guarding against.
+ */
+export function redactPricesInText(text: string): string {
+  return text.replace(
+    /(?<![\d.])[$£€¥]?\d{1,3}(?:[,\s]\d{3})*\.\d{2}(?!\d)/g,
+    "[price]",
+  );
+}


### PR DESCRIPTION
Closes #537. Found while doing the last unchecked criterion on #45 — *"Log/metric review
confirms no price values are emitted anywhere"* — as an actual review of every sink
rather than a reading of the redactors.

## The gap

`otel.server.ts` redacted on the **metrics** path and not on the **traces** path. Both go
to the same collector by the same wire.

`record()` routes labels through `attributesFrom`, and its own comment says why:

> An attribute is exported verbatim to whoever is collecting, and the rule about prices
> does not change because the destination is a metrics backend rather than an error tracker.

`span()` passed `attributes` straight into `startActiveSpan` and called
`recordException(error)` raw.

## Measured, not reasoned

Captured from a real `BasicTracerProvider` with an in-memory exporter — what a collector
would actually receive:

```
ATTRS:  {"variant.price":"19.99","shop.id":"s1"}

EVENTS: [{"name":"exception","attributes":{
           "exception.type":"Error",
           "exception.message":"cannot set price 19.99 on variant 12345",
           "exception.stacktrace":"Error: cannot set price 19.99 on variant 12345\n    at …"}}]
```

The exception leaked **twice**. Redacting only the message would have cleaned the field
somebody reads and left the value on the line beside it.

## Why it was reachable

Every Admin API call runs inside `span("shopify.graphql", …)`, and `admin-client` does:

```ts
const message = formatGraphQLErrors(body.errors);
if (message) throw new Error(message);
```

That is Shopify's own error text for the mutation that just ran — for a price mutation,
the likeliest string in the system to contain a price. Sentry's `scrub()` has guarded
exactly this shape since it was written, so **the same thrown error was scrubbed on its
way to Sentry and exported intact on its way to the collector.**

No span *attribute* carries a price today — the three call sites pass queue names, ids,
an operation name and cost integers, and `admin-client` is explicitly careful. So this
closes a latent hole in a rule CLAUDE.md states without exception; the exception path was
live.

## The change

- `span()` redacts attributes through the same `attributesFrom` a metric label uses
- `recordException` receives a scrubbed name/message/stack
- `redactPricesInText` moves from `sentry.server.ts` to `telemetry/redact.ts`, beside the
  structured redactor, so both sinks share one definition instead of drifting about what
  a price looks like. Re-exported from its old home, so callers and tests are untouched.

## Verification

Tests assert on **what the exporter received**, not on the redactor — because the bug was
a redactor that was never called on this path, and every existing `redactPricesInText`
test passed the whole time it was leaking.

Six mutations, each caught by its intended test:

| mutation | caught by |
|---|---|
| **the original bug**: attributes passed raw | `redacts a price the same way a metric label is redacted` |
| **the original bug**: exception recorded raw | `scrubs the price out of the exception message` |
| message scrubbed, stacktrace left alone | `scrubs the stacktrace too` |
| key-based redaction removed | `redacts by key as well as by shape` |
| over-redacts everything | `keeps the exception useful` |
| span stops marking the failure | `still marks the span failed and rethrows` |

3039 tests pass; typecheck, lint and build clean. Chaos suite runs in CI (no Docker
locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)