### PR TITLE
Route the last ten console calls in app/ through the logger

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -7,6 +7,7 @@ import { isbot } from "isbot";
 import { addDocumentResponseHeaders } from "./shopify.server";
 import { initSentry } from "./lib/observability/sentry.server";
 import { initOtel } from "./lib/observability/otel.server";
+import { logger } from "./lib/logging/logger";
 
 // Once per process, at import time, before any request is handled. Initialising lazily
 // on the first error would miss the errors that happen during startup, which are the ones
@@ -55,7 +56,11 @@ export default async function handleRequest(
         },
         onError(error) {
           responseStatusCode = 500;
-          console.error(error);
+          // Through the logger, not `console.error(error)`. This prints a render
+          // failure's message and stack, and a render below a loader that touched a
+          // price is exactly where one appears — stdout ships to the aggregator, so it
+          // goes through the same two passes as every other line.
+          logger.error("render failed", { route: new URL(request.url).pathname, error });
         },
       }
     );

--- a/app/lib/logging/no-console.test.ts
+++ b/app/lib/logging/no-console.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Nothing in `app/` writes to the console except the logger's own sink.
+ *
+ * `logger.emit` is the enforcement point for two rules that the codebase deliberately
+ * moved off call sites: prices are stripped by `telemetry/redact`, secrets by
+ * `logging/redact`, and since #535 the shop, run and job ids are attached from the
+ * ambient context. A direct `console.log` gets none of the three, and stdout in the
+ * deployed web process ships to the aggregator — the destination `telemetry/redact.ts`
+ * names in its own header.
+ *
+ * Ten call sites had drifted past it, and the two that mattered were both in
+ * price-adjacent paths: the render `onError` handing a whole Error to `console.error`,
+ * and the products webhook logging a failure out of `enrollNewVariants`, which is the
+ * path that captures baselines. This is the guard that stops the eleventh.
+ *
+ * **`scripts/` is exempt on purpose.** Those are operator tools a human runs at a
+ * terminal, and several print live prices because reading the price *is* the check —
+ * `test-pricing-rules.ts` exists to do exactly that. The telemetry rule is about
+ * third-party pipelines with their own retention and access lists, not about a
+ * developer's own screen, and enforcing it there would break the live-script half of
+ * this repo's testing convention.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceFiles, sourceOf } from "../testing/source";
+
+/**
+ * The one file allowed to call it: the logger writes the line somewhere in the end, and
+ * `console` is that somewhere.
+ */
+const SINK = "app/lib/logging/logger.ts";
+
+/**
+ * Any reference to a console method, not only a call of one.
+ *
+ * Requiring a trailing `(` was the first version and it was wrong in both directions.
+ * It missed the sink — `logger.ts` picks its output with
+ * `const sink = level === "error" ? console.error : …` and never writes `console.error(`
+ * at all — and by the same token it would have missed anyone else taking the method as a
+ * value and calling it a line later.
+ */
+const CONSOLE_USE = /\bconsole\s*\.\s*(log|info|warn|error|debug|trace|dir|table)\b/g;
+
+describe("the console is the logger's, not everyone's", () => {
+  // `sourceFiles` leaves out test files, which assert *about* these strings and are the
+  // other half of the trap the comment stripping exists for.
+  const files = sourceFiles("app").filter((file) => file !== SINK);
+
+  it("found the tree, so this is not passing over an empty list", () => {
+    expect(files.length).toBeGreaterThan(50);
+    expect(files).toContain("app/entry.server.tsx");
+    expect(files).toContain("app/routes/webhooks.products.tsx");
+  });
+
+  it.each(files)("%s goes through the logger", (file) => {
+    // Comments stripped, so the note beside a converted call site — which necessarily
+    // says the words `console.error` to explain what it replaced — cannot trip this.
+    // That trap has caught this repo seven times.
+    const offenders = [...sourceOf(file).matchAll(CONSOLE_USE)].map(([, method]) => method);
+
+    expect(
+      offenders,
+      `${file} reaches console.${offenders[0]} directly, so that line reaches the ` +
+        `aggregator without the price and secret passes and without the shop or run id`,
+    ).toEqual([]);
+  });
+
+  it("still lets the logger write the line", () => {
+    // The rule is "one sink", not "no output". A guard that also forbade the sink would
+    // be satisfied by an app that logs nothing at all.
+    expect(sourceOf(SINK)).toMatch(/console\s*\.\s*(log|warn|error)/);
+  });
+});

--- a/app/routes/webhooks.app.scopes_update.tsx
+++ b/app/routes/webhooks.app.scopes_update.tsx
@@ -1,10 +1,11 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import db from "../db.server";
+import { logger } from "../lib/logging/logger";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
     const { payload, session, topic, shop } = await authenticate.webhook(request);
-    console.log(`Received ${topic} webhook for ${shop}`);
+    logger.info("webhook received", { topic, shop });
 
     const current = payload.current as string[];
     if (session) {

--- a/app/routes/webhooks.app.uninstalled.tsx
+++ b/app/routes/webhooks.app.uninstalled.tsx
@@ -1,11 +1,12 @@
 import type { ActionFunctionArgs } from "react-router";
 import { authenticate } from "../shopify.server";
 import db from "../db.server";
+import { logger } from "../lib/logging/logger";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const { shop, session, topic } = await authenticate.webhook(request);
 
-  console.log(`Received ${topic} webhook for ${shop}`);
+  logger.info("webhook received", { topic, shop });
 
   // Webhook requests can trigger multiple times and after an app has already been uninstalled.
   // If this webhook already ran, the session may have been deleted previously.

--- a/app/routes/webhooks.compliance.tsx
+++ b/app/routes/webhooks.compliance.tsx
@@ -13,6 +13,7 @@
 import type { ActionFunctionArgs } from "react-router";
 
 import { authenticate } from "../shopify.server";
+import { logger } from "../lib/logging/logger";
 import prisma from "../db.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -30,13 +31,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     case "CUSTOMERS_DATA_REQUEST":
       // We store no customer-specific data, so there is nothing to hand over.
       // Acknowledging is the complete and honest response.
-      console.log(`[compliance] ${topic} for ${shop}: no customer data held`);
+      logger.info("compliance webhook: no customer data held", { topic, shop });
       break;
 
     case "CUSTOMERS_REDACT":
       // Nothing to erase, for the same reason. Logged so the acknowledgement is
       // auditable if a merchant ever asks what happened to a request.
-      console.log(`[compliance] ${topic} for ${shop}: no customer data to redact`);
+      logger.info("compliance webhook: no customer data to redact", { topic, shop });
       break;
 
     case "SHOP_REDACT": {
@@ -45,14 +46,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       // entries with it.
       const deleted = await prisma.shop.deleteMany({ where: { domain: shop } });
       await prisma.session.deleteMany({ where: { shop } });
-      console.log(`[compliance] ${topic} for ${shop}: purged ${deleted.count} shop record(s)`);
+      logger.info("compliance webhook: shop purged", { topic, shop, purged: deleted.count });
       break;
     }
 
     default:
       // An unexpected topic on this endpoint means the app config and this handler
       // have drifted apart. Surface it rather than returning a silent 200.
-      console.error(`[compliance] Unhandled topic ${topic} for ${shop}`);
+      logger.error("compliance webhook: unhandled topic", { topic, shop });
       return new Response(`Unhandled topic ${topic}`, { status: 422 });
   }
 

--- a/app/routes/webhooks.products.tsx
+++ b/app/routes/webhooks.products.tsx
@@ -25,6 +25,7 @@ import type { ActionFunctionArgs } from "react-router";
 
 import { authenticate } from "../shopify.server";
 import prisma from "../db.server";
+import { logger } from "../lib/logging/logger";
 import { parseMoney } from "../lib/money/money";
 import { checkForDrift } from "../services/drift.server";
 import { enrollNewVariants } from "../services/auto-enroll.server";
@@ -182,9 +183,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     });
 
     if (removed.count > 0) {
-      console.log(
-        `[webhook] ${productGid}: tombstoned ${removed.count} variant(s) no longer on the product`,
-      );
+      logger.info("tombstoned variants no longer on the product", {
+        shop: shop.domain,
+        productGid,
+        tombstoned: removed.count,
+      });
     }
   }
 
@@ -197,10 +200,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   try {
     await enrollNewVariants(shop.id, seenVariantGids);
   } catch (error) {
-    console.error(
-      `[webhook] auto-enroll failed for ${productGid}:`,
-      error instanceof Error ? error.message : error,
-    );
+    // Through the logger: this is the enrolment path, which captures baselines, so
+    // its failures are the ones in this file most likely to name a price.
+    logger.error("auto-enroll failed", { shop: shop.domain, productGid, error });
   }
 
   return new Response();


### PR DESCRIPTION
Closes #539. Third and last part of the #45 review — *"Log/metric review confirms no price
values are emitted anywhere"* — done as a sweep over every sink rather than a reading of
the redactors. #537 was the trace sink; this is the console one.

## What the sweep found

`logger.emit` is the enforcement point: price pass, then secret pass, then the ambient
shop/run/job ids from #535. Ten call sites in `app/` skipped it entirely.

| file | wrote |
|---|---|
| `entry.server.tsx` | `console.error(error)` — a **raw Error object** |
| `webhooks.products.tsx` | the failure out of `enrollNewVariants`; a gid and a count |
| `webhooks.compliance.tsx` ×4 | topic, shop, purge counts |
| `webhooks.app.uninstalled.tsx`, `webhooks.app.scopes_update.tsx` | topic and shop |

Stdout in the deployed web process ships to the aggregator — the destination
`telemetry/redact.ts` names in its own header — so all ten were on the same wire as
everything the logger protects, without the protection.

Most were fine on content. Two were not: the render handler prints an Error's message and
stack, and a render below a loader that touched a price is where one appears; and the
products webhook logs the failure from `enrollNewVariants`, the path that **captures
baselines**.

Interpolated strings become structured fields on the way, so they are queryable and carry
a shop.

## The guard

`app/` may not reach `console.*` outside the logger's own sink.

It matches any **reference** to a console method, not a call of one. The first version
required a trailing `(` and was wrong in both directions — and the test caught it:
`logger.ts` picks its output with

```ts
const sink = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
```

and never writes `console.error(` at all, so the guard both failed to find its own sink
and would have missed anyone else taking the method as a value and calling it a line
later.

Comments are stripped by `sourceOf`, so the note beside a converted call site — which has
to say `console.error` to explain what it replaced — cannot trip it. That trap has caught
this repo seven times.

**`scripts/` is exempt, with the reason recorded beside the guard.** Those are operator
tools a human runs at a terminal, and several print live prices deliberately —
`test-pricing-rules.ts` exists to read the price off the storefront. The telemetry rule is
about third-party pipelines with their own retention and access lists, not a developer's
screen, and enforcing it there would break the live-script half of this repo's testing
convention.

## Verification

| mutation | result |
|---|---|
| **the original**: raw Error to `console.error` in the render handler | caught |
| **the original**: enrolment failure logged raw | caught |
| evasion: console method taken as a value, called later | caught |
| a comment naming `console.log` | correctly **not** caught |

3348 tests pass; typecheck, lint and build clean.

## With this, the #45 review is complete

Every sink reviewed: logger, `metric()`, OTel metric attributes, OTel span attributes
(#537), OTel recorded exceptions (#537), Sentry `beforeSend`, Sentry `captureError`,
`setShopContext`, and direct console (here). Two genuine gaps found, both closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)