### PR TITLE
Cover the two modules the suite could not see being broken

### DIFF
--- a/app/lib/errors/guard.test.ts
+++ b/app/lib/errors/guard.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The wrapper around twenty loaders and actions.
+ *
+ * Everything here is a property the module's own header or a comment beside the code
+ * says must hold, and every one of them could be broken with the whole suite green:
+ * the Response pass-through, reporting before throwing, the status, the route, and
+ * `shopContext` being unable to throw.
+ *
+ * Two of them are not cosmetic. Swallowing a thrown Response replaces Shopify's silent
+ * re-authentication with an error screen. Throwing before `reportError` finishes hands
+ * the merchant an id that is not in `error_events` — which the header calls the one
+ * answer a diagnostics page must never give, and which is the reason this module exists
+ * rather than the boundary doing the work.
+ *
+ * `reportError` is mocked rather than exercised: it needs Prisma, and what is under test
+ * here is the wrapper's contract with it — that it is called, called first, and that its
+ * result is what shapes the thrown response.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReportedError } from "./report";
+
+const reportError = vi.fn();
+
+vi.mock("../../services/error-report.server", () => ({
+  reportError: (...args: unknown[]) => reportError(...args),
+}));
+
+const { withGuard, ANCHOR_ERROR } = await import("./guard.server");
+
+const reported: ReportedError = {
+  errorId: "err_abc123",
+  code: "NOT_FOUND",
+  userMessage: "That campaign no longer exists.",
+  retryable: false,
+  status: 404,
+};
+
+beforeEach(() => {
+  reportError.mockReset();
+  reportError.mockResolvedValue(reported);
+});
+
+const args = (url = "https://x.test/app/campaigns?shop=demo.myshopify.com") => ({
+  request: new Request(url, { method: "POST" }),
+});
+
+/** The thrown value from a guarded handler that failed. */
+async function thrownBy(handler: () => Promise<unknown>, at = "/app/campaigns") {
+  try {
+    await withGuard(at, handler)(args());
+    throw new Error("the guard did not throw");
+  } catch (error) {
+    return error as { init?: { status?: number }; data?: Record<string, ReportedError> };
+  }
+}
+
+describe("the happy path is left alone", () => {
+  it("returns what the handler returned", async () => {
+    await expect(withGuard("/app", async () => ({ ok: true }))(args())).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("reports nothing when nothing failed", async () => {
+    await withGuard("/app", async () => null)(args());
+
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});
+
+describe("a thrown Response passes straight through", () => {
+  /**
+   * Not an optimisation. `authenticate.admin` signals "redirect this embedded app to
+   * re-authenticate" *by throwing a Response*, so catching it turns a silent sign-in
+   * into an error screen — and the merchant is then stuck, because the thing that would
+   * have signed them in is the thing being swallowed.
+   */
+  it("rethrows the redirect rather than reporting it", async () => {
+    const redirect = new Response(null, { status: 302, headers: { location: "/auth" } });
+
+    const thrown = await thrownBy(async () => {
+      throw redirect;
+    });
+
+    expect(thrown, "the auth redirect was replaced by an error screen").toBe(redirect);
+    expect(reportError, "an auth redirect was recorded as a failure").not.toHaveBeenCalled();
+  });
+
+  it("passes a non-redirect Response through too", async () => {
+    const notFound = new Response("nope", { status: 404 });
+
+    expect(await thrownBy(async () => {
+      throw notFound;
+    })).toBe(notFound);
+  });
+});
+
+describe("a real failure is recorded before it is thrown", () => {
+  /**
+   * The reason this module exists. An id minted without a row behind it means a merchant
+   * quoting it gets "no error stored under that reference".
+   */
+  it("awaits reportError, so the row exists before the id is shown", async () => {
+    let settled = false;
+    reportError.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      settled = true;
+      return reported;
+    });
+
+    await thrownBy(async () => {
+      throw new Error("boom");
+    });
+
+    expect(settled, "the id reached the merchant before the row was written").toBe(true);
+  });
+
+  it("throws the id and message the report produced", async () => {
+    const thrown = await thrownBy(async () => {
+      throw new Error("boom");
+    });
+
+    expect(thrown.data?.[ANCHOR_ERROR]).toEqual(reported);
+  });
+
+  /**
+   * The status drives the boundary's copy and whether the failure reads as retryable.
+   * Hardcoding 500 renders a missing campaign as a server outage.
+   */
+  it("takes the status from the report rather than assuming a server error", async () => {
+    const thrown = await thrownBy(async () => {
+      throw new Error("boom");
+    });
+
+    expect(thrown.init?.status).toBe(404);
+  });
+
+  it("passes the handler's own error to the reporter, not a replacement", async () => {
+    const original = new Error("the real cause");
+
+    await thrownBy(async () => {
+      throw original;
+    });
+
+    expect(reportError.mock.calls[0][0]).toBe(original);
+  });
+});
+
+describe("the context a failure is filed under", () => {
+  /**
+   * What makes "is this one merchant or all of them" a query rather than a grep. A
+   * constant here files every error in the app under one route.
+   */
+  it("records the route it was given", async () => {
+    await thrownBy(async () => {
+      throw new Error("boom");
+    }, "/app/prices/baselines");
+
+    expect(reportError.mock.calls[0][1]).toMatchObject({ route: "/app/prices/baselines" });
+  });
+
+  it("distinguishes two routes rather than reporting a fixed one", async () => {
+    // The subject has to be able to vary, or the assertion above proves nothing — the
+    // trap from #533, where two fields could never differ.
+    await thrownBy(async () => {
+      throw new Error("a");
+    }, "/app/one");
+    await thrownBy(async () => {
+      throw new Error("b");
+    }, "/app/two");
+
+    expect([
+      reportError.mock.calls[0][1].route,
+      reportError.mock.calls[1][1].route,
+    ]).toEqual(["/app/one", "/app/two"]);
+  });
+
+  it("records the method, so a failed action is not read as a failed page load", async () => {
+    await thrownBy(async () => {
+      throw new Error("boom");
+    });
+
+    expect(reportError.mock.calls[0][1]).toMatchObject({ method: "POST" });
+  });
+
+  it("takes the shop off the request rather than looking it up", async () => {
+    await thrownBy(async () => {
+      throw new Error("boom");
+    });
+
+    expect(reportError.mock.calls[0][1]).toMatchObject({ shop: "demo.myshopify.com" });
+  });
+});
+
+describe("enriching the context cannot make things worse", () => {
+  /**
+   * Best-effort by design: this runs while something is already failing, so a throw here
+   * turns one error into two and loses the original — the merchant gets a crash instead
+   * of the message and the id that were already computed for them.
+   */
+  it("still reports when there is no request to read", async () => {
+    await withGuard("/app", async () => {
+      throw new Error("boom");
+    })({} as never).catch(() => {});
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports when the request URL cannot be parsed", async () => {
+    const unparseable = { request: { url: "not a url", method: "GET" } as Request };
+
+    await withGuard("/app", async () => {
+      throw new Error("boom");
+    })(unparseable as never).catch(() => {});
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the shop rather than inventing one when the URL carries none", async () => {
+    await withGuard("/app", async () => {
+      throw new Error("boom");
+    })({ request: new Request("https://x.test/app") } as never).catch(() => {});
+
+    expect(reportError.mock.calls[0][1].shop).toBeUndefined();
+  });
+});

--- a/app/lib/reporting/baseline-errors.test.ts
+++ b/app/lib/reporting/baseline-errors.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The file a merchant fixes their import from.
+ *
+ * The point of the download is that the rows get corrected and re-uploaded, so the
+ * failure that matters is not a crash — it is the file arriving *incomplete* and looking
+ * finished. A merchant fixes what the file lists, re-uploads, and the same rows fail
+ * again with nothing to explain why.
+ *
+ * That is the same shape as the `ledger-csv.ts` finding in #531: failed rows filtered out
+ * of the export whose own comment calls it "the specific dishonesty this whole product is
+ * built against". Before this file, dropping a whole category from the report passed the
+ * entire suite.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { importErrorCsv, type ProblemReport } from "./baseline-errors";
+
+const report: ProblemReport = {
+  invalid: [{ line: 7, identifier: "SKU-INVALID", reason: "price is not a number" }],
+  unmatched: [{ line: 2, identifier: "SKU-UNMATCHED", reason: "no variant with that SKU" }],
+  ambiguous: [{ line: 5, identifier: "SKU-AMBIGUOUS", reason: "matches 3 variants" }],
+};
+
+/** The data rows, without the header. */
+function rows(csv: string): string[] {
+  return csv.trim().split("\n").slice(1);
+}
+
+/** The line column, unquoted — `toCsv` quotes every cell, including the numeric ones. */
+function lineNumbers(csv: string): number[] {
+  return rows(csv).map((row) => Number(row.split(",")[0].replace(/"/g, "")));
+}
+
+describe("every problem reaches the file", () => {
+  it.each([
+    ["invalid", "SKU-INVALID"],
+    ["unmatched", "SKU-UNMATCHED"],
+    ["ambiguous", "SKU-AMBIGUOUS"],
+  ])("includes the %s rows", (_kind, identifier) => {
+    expect(
+      importErrorCsv(report),
+      `a category missing from the download is a merchant re-uploading rows that will ` +
+        `fail again, with nothing in the file to say why`,
+    ).toContain(identifier);
+  });
+
+  it("writes one row per problem and no more", () => {
+    expect(rows(importErrorCsv(report))).toHaveLength(3);
+  });
+
+  it("names which kind of problem each row is", () => {
+    const csv = importErrorCsv(report);
+
+    // Not just "the word appears somewhere": it has to be on the row it describes,
+    // otherwise every row says something is wrong and none says what.
+    expect(csv).toMatch(/SKU-INVALID.*invalid/);
+    expect(csv).toMatch(/SKU-UNMATCHED.*unmatched/);
+    expect(csv).toMatch(/SKU-AMBIGUOUS.*ambiguous/);
+  });
+
+  it("carries the reason, which is the only actionable column", () => {
+    expect(importErrorCsv(report)).toContain("matches 3 variants");
+  });
+
+  it("has a header, so the file opens as a spreadsheet rather than as data", () => {
+    expect(importErrorCsv(report).split("\n")[0]).toContain("line");
+  });
+});
+
+describe("ordering", () => {
+  /**
+   * The merchant reads this file beside the spreadsheet they uploaded. Grouped by
+   * category — which is the order the categories are concatenated in — the lines jump
+   * 7, 2, 5 and the file stops being usable against the original.
+   */
+  it("follows the merchant's file, not our category order", () => {
+    expect(lineNumbers(importErrorCsv(report))).toEqual([2, 5, 7]);
+  });
+
+  it("sorts numerically, not as text", () => {
+    // The bug a string sort produces: 10 before 9, which looks almost right and is
+    // wrong exactly where a file is long enough for it to matter.
+    const csv = importErrorCsv({
+      invalid: [
+        { line: 10, identifier: "TEN", reason: "r" },
+        { line: 9, identifier: "NINE", reason: "r" },
+        { line: 100, identifier: "HUNDRED", reason: "r" },
+      ],
+      unmatched: [],
+      ambiguous: [],
+    });
+
+    expect(lineNumbers(csv)).toEqual([9, 10, 100]);
+  });
+});
+
+describe("edges", () => {
+  it("returns a header and nothing else when there is nothing wrong", () => {
+    const csv = importErrorCsv({ invalid: [], unmatched: [], ambiguous: [] });
+
+    expect(rows(csv)).toEqual([]);
+    expect(csv).toContain("line");
+  });
+
+  /**
+   * These identifiers are SKUs, which arrive from Shopify — which accepts them from
+   * suppliers, feeds and other apps. `toCsv` neutralises a leading formula character;
+   * this is here so that protection cannot be lost by this export building its rows
+   * some other way.
+   */
+  it("does not let an identifier become a formula", () => {
+    const csv = importErrorCsv({
+      invalid: [{ line: 1, identifier: "=1+1", reason: "r" }],
+      unmatched: [],
+      ambiguous: [],
+    });
+
+    expect(csv).not.toMatch(/(^|,)"?=1\+1/);
+  });
+});


### PR DESCRIPTION
Closes #541. The mutation-survival sweep from #527/#531/#533, re-run over `app/lib`.

Two modules were left with no test naming their exports, and the gap was total: **eight
mutations, all eight surviving the full 3348-test suite**, every one breaking something
the module's own comment says must hold.

## `guard.server.ts` — wrapped around 20 loaders and actions

| mutation | what it does to a merchant |
|---|---|
| drop the `error instanceof Response` pass-through | `authenticate.admin` signals "re-authenticate this embedded app" **by throwing a Response**. Swallowing it replaces a silent sign-in with an error screen — and the merchant is stuck, because the thing that would have signed them in is the thing being caught. |
| throw before `reportError` settles | The merchant is shown an id with no row behind it, so quoting it returns *"no error stored under that reference"* — which the header calls the one answer a diagnostics page must never give. **This module exists because that already happened**; the id used to be minted in the boundary, which never wrote it. |
| hardcode the status to 500 | A missing campaign renders as a server outage; the boundary's copy and the retryable hint both follow the status. |
| replace `route` with a constant | Every error in the app files under one route, and "is this one merchant or all of them" stops being a query. |
| unguard `shopContext` | Its comment says best-effort: it runs *while something is already failing*, so a throw turns one error into two and loses the original — the merchant gets a crash instead of the message and id already computed for them. |

## `baseline-errors.ts` — the file a merchant fixes their import from

The point of the download is that rows get corrected and re-uploaded, so the failure that
matters is not a crash. It is the file arriving **incomplete and looking finished**: the
merchant fixes what it lists, re-uploads, and the same rows fail again with nothing to
explain why.

| mutation | what it does |
|---|---|
| drop `ambiguous` from the loop | a whole category silently missing |
| remove the sort | rows no longer follow the spreadsheet they came from |
| blank the `problem` column | every row says something is wrong, none says what |

Same shape as the `ledger-csv.ts` finding in #531 — failed rows filtered out of the export
whose own comment calls that *"the specific dishonesty this whole product is built
against"*.

## Avoiding the trap from #533

*A test whose subject cannot vary passes for the wrong reason.* The route test asserts
that **two different routes** come through as two different values, rather than that one
route matches one string — a constant would satisfy the second.

`reportError` is mocked rather than exercised: it needs Prisma, and what is under test is
the wrapper's contract with it — that it is called, called *first*, and that its result is
what shapes the thrown response.

## Verification

All eight mutations re-applied against the new tests. Each now fails, by its intended test:

| mutation | caught by |
|---|---|
| Response pass-through dropped | `rethrows the redirect rather than reporting it` |
| thrown before the report is awaited | `awaits reportError, so the row exists before the id is shown` |
| status hardcoded | `takes the status from the report rather than assuming a server error` |
| route replaced by a constant | `records the route it was given` |
| `shopContext` unguarded | `still reports when the request URL cannot be parsed` |
| ambiguous category dropped | `includes the ambiguous rows` |
| rows unsorted | `follows the merchant's file, not our category order` |
| problem column blanked | `names which kind of problem each row is` |

3374 tests pass; typecheck, lint and build clean.

`app/lib` now has no module without a test naming its exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)