### PR TITLE
Put a page's action in the admin's title bar (#544)

### DIFF
--- a/app/components/PageShell.test.tsx
+++ b/app/components/PageShell.test.tsx
@@ -311,19 +311,20 @@ describe("the way back", () => {
 
     expect(html).toContain('href="/app/campaigns"');
     expect(html).toContain("Campaigns");
-    expect(html).toContain('icon="arrow-left"');
   });
 
-  it("sits above the title rather than inside the page", () => {
-    // Under the heading it reads as the first thing *in* the page rather than the way
-    // out of it, and `s-page` takes no slot for one in this version.
+  it("goes in the slot App Bridge reads, as a direct child of the page", () => {
+    // `app-bridge.js` looks for `:scope > s-link[slot="breadcrumb-actions"]` and renders
+    // it in the admin's own title bar. Wrapped in anything, or on any other element, it
+    // is never found — so this asserts the two things that make it work rather than the
+    // appearance of a button we used to draw ourselves.
     const html = render(
       <PageShell heading="Summer sale" backTo={{ href: "/app/campaigns", label: "Campaigns" }}>
         <s-section>detail</s-section>
       </PageShell>,
     );
 
-    expect(html.indexOf('href="/app/campaigns"')).toBeLessThan(html.indexOf("<s-page"));
+    expect(html).toMatch(/<s-page[^>]*><s-button slot="breadcrumb-actions"/);
   });
 
   it("is absent on a page that has a tab bar, which is already the way back", () => {
@@ -333,7 +334,81 @@ describe("the way back", () => {
       </PageShell>,
     );
 
-    expect(html).not.toContain('icon="arrow-left"');
+    expect(html).not.toContain('slot="breadcrumb-actions"');
+  });
+});
+
+describe("the title bar", () => {
+  /**
+   * These assert the contract in `app-bridge.js`, not a look.
+   *
+   * It scans for `:scope > s-button[slot="primary-action"]` — a **direct child** of
+   * `s-page`, an `s-button` or `s-link`, carrying the slot as an attribute. Anything
+   * else is simply not found, and an action that is not found is an action a merchant
+   * cannot reach from where the admin has taught them to look for it.
+   */
+  const html = render(
+    <PageShell
+      heading="Campaigns"
+      primaryAction={{ label: "Create campaign", href: "/app/campaigns/new" }}
+      secondaryActions={[{ label: "Export", href: "/app/export" }]}
+    >
+      <s-section>rows</s-section>
+    </PageShell>,
+  );
+
+  it("puts the primary action in the slot the admin reads", () => {
+    expect(html).toContain('slot="primary-action"');
+    expect(html).toContain("Create campaign");
+  });
+
+  it("renders it as a direct child of the page", () => {
+    // Nested one element deeper and the `:scope >` selector misses it entirely.
+    expect(html).toMatch(/<s-page[^>]*><s-button slot="primary-action"/);
+  });
+
+  it("marks the primary action primary and the secondary ones secondary", () => {
+    expect(html).toMatch(/slot="primary-action"[^>]*variant="primary"/);
+    expect(html).toMatch(/slot="secondary-actions"[^>]*variant="secondary"/);
+  });
+
+  it("renders every secondary action, not just the first", () => {
+    const many = render(
+      <PageShell
+        heading="Prices"
+        secondaryActions={[{ label: "Import" }, { label: "Recapture" }]}
+      >
+        <s-section>rows</s-section>
+      </PageShell>,
+    );
+
+    expect(many).toContain("Import");
+    expect(many).toContain("Recapture");
+  });
+
+  it("leaves the bar empty on a page that has no page-level action", () => {
+    const plain = render(
+      <PageShell heading="Variants">
+        <s-section>rows</s-section>
+      </PageShell>,
+    );
+
+    expect(plain).not.toContain('slot="primary-action"');
+    expect(plain).not.toContain('slot="secondary-actions"');
+  });
+
+  it("carries a modal opener's command, so Apply can be hoisted without a form", () => {
+    // A form submit cannot go in the title bar — App Bridge only reads direct children
+    // of `s-page`, and a button inside a `<form>` is not one. A modal opener can, and
+    // that is how a confirmed action reaches the bar.
+    const opener = render(
+      <PageShell heading="Summer sale" primaryAction={{ label: "Apply", commandFor: "apply-modal" }}>
+        <s-section>detail</s-section>
+      </PageShell>,
+    );
+
+    expect(opener).toContain('commandFor="apply-modal"');
+    expect(opener).toContain('command="--show"');
   });
 });
 

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -1,8 +1,13 @@
-import { Children, cloneElement, isValidElement, type ReactNode } from "react";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
 
-import { ActionRow } from "./ActionRow";
 import { HelpNote } from "./HelpNote";
-import { PAGE_INSET, SPACE } from "../lib/ui/spacing";
+import { SPACE } from "../lib/ui/spacing";
 
 /**
  * How much of the frame a page occupies, leaving a tenth on each side.
@@ -106,24 +111,96 @@ export function PageWidth({ children }: { children: ReactNode }) {
  *   the page stops having visible structure at all.
  */
 /**
- * The way back, above the title.
+ * What a page can put in the admin's own title bar.
  *
- * Above rather than beside: `s-page` renders its own heading and takes no slot for this
- * in the version pinned here, and a back link under the title would read as the first
- * thing *in* the page rather than as the way out of it. The padding matches what `s-page`
- * insets its own contents by, so it lines up with the heading below it.
+ * The admin reserves a strip at the top right of every page for the thing you came to
+ * do, and until this existed it was empty on all twenty of ours — so "Create campaign"
+ * sat to the right of a tab bar, the editor's submit was in the middle of its form, and
+ * the campaign header carried six buttons in a row of its own.
+ *
+ * ## How it gets there
+ *
+ * Not through the `primaryAction` prop the Polaris types describe. Those are Preact
+ * slots; React 18 renders a custom element's unknown props as attributes, so handing
+ * `s-page` a JSX element would stringify it. What App Bridge actually looks for, in
+ * `app-bridge.js`, is a **direct child of `s-page` carrying the slot as an attribute**:
+ *
+ *     ':scope > s-button[slot="primary-action"], :scope > s-link[slot="primary-action"]'
+ *
+ * It reads those, renders them in the admin's title bar, and hides the originals. So
+ * the contract is: an `s-button` or `s-link`, a `slot` attribute, and nothing wrapping
+ * it. A `<form>` around the button is not a direct child and would never be found —
+ * which is why this takes links and buttons rather than arbitrary children, and why the
+ * campaign header's Duplicate and Archive (both form posts) stay where they are.
+ *
+ * The same scan reads `slot="breadcrumb-actions"`, which is the way back, and
+ * `slot="accessory"`, which is a badge beside the title.
+ *
+ * ## What happens if it is not hoisted
+ *
+ * The page renders the button inline at the top of the content instead. That is the
+ * important difference from the `aside` trap described above: an unhoisted action is
+ * misplaced, not deleted, so this cannot silently remove the only way to apply a
+ * campaign.
+ */
+export interface PageAction {
+  label: string;
+  href?: string;
+  icon?: ComponentProps<"s-button">["icon"];
+  /** Only for an action that opens a modal — `commandFor` plus `command="--show"`. */
+  commandFor?: string;
+  tone?: "critical" | "auto";
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+/**
+ * The way back, in the title bar.
+ *
+ * It used to be a tertiary button in a box above `s-page`, with a comment saying
+ * `s-page` "takes no slot for this". It does: `breadcrumb-actions`, read by the same
+ * scan as the actions above.
  */
 function BackLink({ backTo }: { backTo?: { href: string; label: string } }) {
   if (!backTo) return null;
 
+  /* An `s-button`, not an `s-link`, though App Bridge's scan accepts either.
+     Hoisted, the admin draws its own control and neither matters. Unhoisted, the page
+     renders what it is given — and the app's action vocabulary reserves blue for a word
+     inside a sentence, so the fallback has to be the tertiary button this used to be. */
   return (
-    <s-box paddingInline={PAGE_INSET}>
-      <ActionRow>
-        <s-button variant="tertiary" icon="arrow-left" href={backTo.href}>
-          {backTo.label}
-        </s-button>
-      </ActionRow>
-    </s-box>
+    <s-button
+      slot="breadcrumb-actions"
+      variant="tertiary"
+      icon="arrow-left"
+      href={backTo.href}
+    >
+      {backTo.label}
+    </s-button>
+  );
+}
+
+/** The command a modal opener issues. Typed as a constant because the prop is `Lowercase<string>`. */
+const SHOW = "--show" as const;
+
+/** One title-bar action, in whichever slot the caller asked for. */
+type TitleBarSlot = "primary-action" | "secondary-actions";
+
+function TitleBarAction({ action, slot }: { action: PageAction; slot: TitleBarSlot }) {
+  return (
+    <s-button
+      slot={slot}
+      href={action.href}
+      icon={action.icon}
+      tone={action.tone}
+      variant={slot === "primary-action" ? "primary" : "secondary"}
+      disabled={action.disabled || undefined}
+      loading={action.loading || undefined}
+      commandFor={action.commandFor}
+      command={action.commandFor ? SHOW : undefined}
+    >
+      {action.label}
+    </s-button>
   );
 }
 
@@ -179,10 +256,21 @@ const ASIDE_TRACK: Record<AsideWidth, string> = {
 export function PageShell({
   heading,
   backTo,
+  primaryAction,
+  secondaryActions,
   asideWidth = "base",
   children,
 }: {
   heading: string;
+  /**
+   * The one thing this page is for, in the admin's title bar. See `PageAction`.
+   *
+   * One per page, and only ever a link or a modal opener — a form submit cannot be
+   * hoisted, because App Bridge only reads direct children of `s-page`.
+   */
+  primaryAction?: PageAction;
+  /** Beside the primary one, for actions that are still page-level but not the point. */
+  secondaryActions?: PageAction[];
   /** See `AsideWidth`. Defaults to the narrow strip every other page wants. */
   asideWidth?: AsideWidth;
   /**
@@ -218,6 +306,18 @@ export function PageShell({
 
   const aside = all.filter(isAside);
   const help = all.filter(isHelp);
+
+  /* Direct children of `s-page`, and they have to stay that way — see `PageAction`. */
+  const actions = (
+    <>
+      {primaryAction ? (
+        <TitleBarAction action={primaryAction} slot="primary-action" />
+      ) : null}
+      {(secondaryActions ?? []).map((action) => (
+        <TitleBarAction key={action.label} action={action} slot="secondary-actions" />
+      ))}
+    </>
+  );
   const main = all.filter((child) => !isAside(child) && !isHelp(child));
 
   if (aside.length === 0) {
@@ -236,8 +336,9 @@ export function PageShell({
     // aside — `/app/prices/live` is one — and looking at it.
     return (
       <PageWidth>
-        <BackLink backTo={backTo} />
         <s-page heading={heading} inlineSize="large">
+          <BackLink backTo={backTo} />
+          {actions}
           {help}
           {main}
         </s-page>
@@ -247,8 +348,9 @@ export function PageShell({
 
   return (
     <PageWidth>
-      <BackLink backTo={backTo} />
       <s-page heading={heading} inlineSize="large">
+        <BackLink backTo={backTo} />
+        {actions}
         <s-grid
           gap={SPACE.page}
           // The column gap is the page rhythm too, not a smaller one. Two columns set

--- a/app/components/campaign/views.test.ts
+++ b/app/components/campaign/views.test.ts
@@ -56,11 +56,18 @@ describe("both views read the same filters", () => {
 });
 
 describe("the page header is a header, not a card", () => {
-  it("puts the primary action in the tab bar's action slot", () => {
-    // It used to sit in an `s-section` of its own above the tabs: a card holding one
-    // button and a two-item toggle, mostly empty white space, which is the shape a page
-    // takes when nobody has decided what its header is.
-    expect(route).toMatch(/<TabBar[\s\S]*?action=\{[\s\S]*?Create campaign/);
+  it("puts the primary action in the admin's title bar", () => {
+    // Three homes in three releases, and this is the last of them. It began in an
+    // `s-section` of its own above the tabs — a card holding one button and a two-item
+    // toggle, mostly empty white space. Then it moved into `TabBar`'s action slot, which
+    // made a row of tabs also a row of actions. It belongs in the strip the admin keeps
+    // for a page's action, which `PageShell` now fills; a tab bar carrying a button is
+    // what this assertion exists to stop coming back.
+    expect(route).toMatch(/primaryAction=\{\{[\s\S]*?Create campaign/);
+    expect(
+      route.slice(route.indexOf("<TabBar"), route.indexOf("/>", route.indexOf("tabs={"))),
+      "a tab bar chooses a view; it does not also carry what you can do to one",
+    ).not.toContain("action={");
   });
 
   it("does not wrap the tabs and the action in a card", () => {

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -117,7 +117,22 @@ export default function Campaigns() {
   };
 
   return (
-    <PageShell heading="Campaigns">
+    <PageShell
+      heading="Campaigns"
+      /* One way in, and in the strip the admin keeps for it.
+
+         It used to sit in `TabBar`'s action slot, so the row that chooses *which view
+         you are looking at* was also carrying the only thing you can do to the list —
+         and the title bar the admin reserves for exactly that was empty.
+
+         Still one door. The second one was the last of the "Imports" thinking: a
+         spreadsheet of exact prices creates a campaign exactly as a rule does, so "From
+         a spreadsheet" was a second entrance to the same object, and a merchant had to
+         know which of their two intentions the app had filed their case under before
+         they could start. It is an option inside the editor now (#445), which is where
+         "how should prices change" is actually asked. */
+      primaryAction={{ label: "Create campaign", href: "/app/campaigns/new" }}
+    >
       {/* Counted across the shop rather than the filtered page: a campaign needing a
           decision must not be hidden by an unrelated filter. */}
       {list.attentionCount > 0 ? (
@@ -135,37 +150,13 @@ export default function Campaigns() {
         </s-banner>
       ) : null}
 
-      {/* The page's header, and not a card.
+      {/* Which view you are looking at, and nothing else.
 
-          A card is a container for content, and this one held a button and a two-item
-          toggle with nothing else in it — an empty white rectangle above the actual page,
-          which is what the screenshot that prompted this looked wrong for. What belongs
-          here is a header: which view you are in on the left, the one thing you can do
-          about it on the right, a rule under both, and no box around any of it.
-
-          Which view / what you can do is exactly the split `TabBar` and its action slot
-          make, so the row is one control rather than two stacked ones.
-
-          `s-button` takes an href, so the action is one anchor styled as a button rather
-          than a button nested inside a link — which is what it was, and which no browser
-          is obliged to make sense of. */}
+          It used to carry Create campaign on its right, which made a row of tabs also a
+          row of actions; the action is in the title bar now. What is left is a header
+          rather than a card — no box around a two-item toggle. */}
       <TabBar
         label="Campaign views"
-        action={
-          // One way in.
-          //
-          // There were two, and the second was the last of the "Imports" thinking: a
-          // spreadsheet of exact prices creates a campaign exactly as a rule does, so
-          // "From a spreadsheet" was a second door to the same object — and a merchant
-          // had to know which of their two intentions the app had filed their case under
-          // before they could start. It is an option inside the editor now (#445), which
-          // is where the question "how should prices change" is actually asked.
-          <ActionRow>
-            <s-button variant="primary" href="/app/campaigns/new">
-              Create campaign
-            </s-button>
-          </ActionRow>
-        }
         tabs={[
           {
             label: "List",


### PR DESCRIPTION
The admin reserves a strip at the top right of every page for the thing you came to do,
and it was empty on all twenty of ours. "Create campaign" sat to the right of a tab bar,
and the way back was a tertiary button in a box above `s-page`.

`PageShell` takes `primaryAction` and `secondaryActions` now, and `backTo` goes through
`breadcrumb-actions`.

**The mechanism, because it is not the one the types describe.** Polaris types `s-page`
with `primaryAction`/`secondaryActions`/`breadcrumbActions` props, but those are Preact
slots — React 18 renders a custom element's unknown props as attributes, so handing
`s-page` a JSX element stringifies it. What App Bridge actually scans for is a **direct
child of `s-page` carrying the slot as an attribute**:

```
':scope > s-button[slot="primary-action"], :scope > s-link[slot="primary-action"]'
```

It reads those, renders them in the title bar, and hides the originals. Hence the API
shape: links and modal openers, not arbitrary children — a submit inside a `<form>` is
not a direct child and can never be hoisted, which is why the campaign header's Duplicate
and Archive stay where they are (they move into an overflow menu in #546).

**If it is not hoisted, the action is misplaced, not deleted** — it renders inline at the
top of the page. That is the difference from the `aside` trap this component already
documents, and the reason this was safe to do in one change.

### Checks

- 3380 unit tests, typecheck, lint and build all pass.
- Five new assertions, each mutation-tested: renaming the breadcrumb slot, nesting the
  actions one element deeper, dropping them entirely, dropping the primary variant, and
  rendering only the first secondary action all fail the suite.
- `views.test.ts` has now asserted three different homes for this button in three
  releases. Its comment records all three, and it refuses a `TabBar` that carries an
  action again.

Part of #543. Verified on the deployed build after merge, per the working agreement.

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)