### PR TITLE
Give every container query something to measure (#548)

### DIFF
--- a/app/components/CountsRow.tsx
+++ b/app/components/CountsRow.tsx
@@ -1,4 +1,5 @@
 import { formatCount } from "../lib/format/display";
+import { QueryContainer } from "./QueryContainer";
 import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
 
 /**
@@ -59,6 +60,9 @@ export function CountsRow({ items }: { items: CountItem[] }) {
   const columns = items.map(() => "1fr").join(" ") || "1fr";
 
   return (
+    // The container the query below is measured against. Without one it resolved
+    // against nothing and the tiles never went two up, whatever the card's width.
+    <QueryContainer>
     <s-grid
       // Two up when the card gets narrow. Four tiles in a 400px column would be four
       // slivers, and a figure that wraps mid-number is worse than a second row.
@@ -83,6 +87,7 @@ export function CountsRow({ items }: { items: CountItem[] }) {
         ),
       )}
     </s-grid>
+    </QueryContainer>
   );
 }
 

--- a/app/components/FieldGrid.tsx
+++ b/app/components/FieldGrid.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { QueryContainer } from "./QueryContainer";
 import { SPACE } from "../lib/ui/spacing";
 
 /**
@@ -81,6 +82,7 @@ export function Field({
  */
 export function FieldGrid({ children }: { children: ReactNode }) {
   return (
+    <QueryContainer>
     <s-grid
       gap={SPACE.section}
       // Capped, for the reason `FIELD` exists. Two equal columns of a 970px card are
@@ -97,6 +99,7 @@ export function FieldGrid({ children }: { children: ReactNode }) {
     >
       {children}
     </s-grid>
+    </QueryContainer>
   );
 }
 

--- a/app/components/LastRunSummary.tsx
+++ b/app/components/LastRunSummary.tsx
@@ -1,4 +1,5 @@
 import { formatAgo, formatCount } from "../lib/format/display";
+import { QueryContainer } from "./QueryContainer";
 import { HAIRLINE, PAD, SPACE } from "../lib/ui/spacing";
 import { RUN_TONE, toneFor } from "./tone";
 
@@ -43,6 +44,7 @@ export function LastRunSummary({
       borderColor={HAIRLINE.borderColor}
       borderRadius="base"
     >
+      <QueryContainer>
       <s-grid
         // One comma only: Polaris reads the comma as the separator between the responsive
         // value and the default, so a second one anywhere stops the value parsing.
@@ -65,6 +67,7 @@ export function LastRunSummary({
           View campaign
         </s-button>
       </s-grid>
+      </QueryContainer>
     </s-box>
   );
 }

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { QueryContainer } from "./QueryContainer";
 
 import type { OnboardingState, OnboardingStep } from "../lib/onboarding/steps";
 import { SPACE } from "../lib/ui/spacing";
@@ -100,6 +101,7 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
 
   return (
     <s-stack gap={SPACE.tight}>
+      <QueryContainer>
       <s-grid
         // Three columns, collapsing to two. `auto 1fr auto` keeps the status glyph and
         // the action tight to their content and gives the title everything left over,
@@ -148,6 +150,7 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
           ) : null}
         </ActionRow>
       </s-grid>
+      </QueryContainer>
 
       {/* Progressive disclosure, not a link away. The reasoning belongs next to the step
           it explains — sending a merchant to a docs page to find out why they are being

--- a/app/components/PageShell.tsx
+++ b/app/components/PageShell.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 
 import { HelpNote } from "./HelpNote";
+import { QueryContainer } from "./QueryContainer";
 import { SPACE } from "../lib/ui/spacing";
 
 /**
@@ -351,6 +352,10 @@ export function PageShell({
       <s-page heading={heading} inlineSize="large">
         <BackLink backTo={backTo} />
         {actions}
+        {/* The page is what this grid's `@container` value is measured against. Without
+            one it was measured against nothing, so the aside never fell below the
+            content however narrow the admin got. See `QueryContainer`. */}
+        <QueryContainer>
         <s-grid
           gap={SPACE.page}
           // The column gap is the page rhythm too, not a smaller one. Two columns set
@@ -380,6 +385,7 @@ export function PageShell({
             )}
           </s-stack>
         </s-grid>
+        </QueryContainer>
       </s-page>
     </PageWidth>
   );

--- a/app/components/QueryContainer.tsx
+++ b/app/components/QueryContainer.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+/**
+ * The thing a `@container` value is measured against.
+ *
+ * Seven layouts in this app choose their columns with a Polaris responsive value —
+ * `"@container (inline-size <= 700px) 1fr, 1fr 1fr"` — and every one of them was being
+ * measured against nothing.
+ *
+ * A CSS container query resolves against the **nearest ancestor container**, and an
+ * element only becomes one if something sets `container-type` on it. Polaris sets it in
+ * exactly one place, which its own types spell out: "We place the container name of
+ * `s-default` on every container… @implementation You must always have a CSS
+ * `container-name` of `s-default` for this component" — the component being
+ * `s-query-container`, which this app had never used. No container, no match, so the
+ * value silently fell through to its unmatched branch on every screen.
+ *
+ * ## How it showed
+ *
+ * The campaign editor. `FieldGrid` says it becomes one column at 700px, and the editor's
+ * form column is about 470px — so its four selects should have been full width there.
+ * They rendered as two columns of roughly 220px, which is why "Set to baseline (shows a
+ * strike-through)" and "Leave prices exactly as calculated · $12.34" arrived as "Set to
+ * baseline (shows a strik…" and "Leave prices exactly as calc…". Three of the four
+ * selects in the create flow could not be read at the width they were given, on the
+ * page where a trial is won or lost.
+ *
+ * The same grid on the settings page, in a 970px card, renders two columns and looks
+ * right. That is what made this invisible for so long: the unmatched branch is the
+ * correct layout for the widest place the component is used, so the bug only appears
+ * where the container is narrow — and the narrower the space, the more it matters.
+ *
+ * ## What it does not fix
+ *
+ * A container established here measures the space this component was given. It does not
+ * make anything responsive to the window, and it must not be hoisted to the page to
+ * "cover" several grids at once — a grid measured against the page rather than against
+ * its own column is exactly the state this replaces.
+ */
+export function QueryContainer({ children }: { children: ReactNode }) {
+  return <s-query-container>{children}</s-query-container>;
+}

--- a/app/components/UpcomingCampaigns.tsx
+++ b/app/components/UpcomingCampaigns.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from "react";
+import { QueryContainer } from "./QueryContainer";
 
 import { formatAgo } from "../lib/format/display";
 import { humanise } from "../lib/format/label";
@@ -33,6 +34,7 @@ export function UpcomingCampaigns({
     //
     // One comma only: Polaris reads it as the separator between the responsive value and
     // the default, so a second one stops the value parsing.
+    <QueryContainer>
     <s-grid
       gridTemplateColumns="@container (inline-size <= 520px) auto 1fr, auto 1fr auto"
       gap={SPACE.item}
@@ -56,5 +58,6 @@ export function UpcomingCampaigns({
         </Fragment>
       ))}
     </s-grid>
+    </QueryContainer>
   );
 }

--- a/app/components/prices/VariantSearch.tsx
+++ b/app/components/prices/VariantSearch.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { FilterForm } from "../FilterForm";
+import { QueryContainer } from "../QueryContainer";
 import { SPACE } from "../../lib/ui/spacing";
 
 /**
@@ -86,6 +87,7 @@ export function VariantSearch({
         // `1fr 1fr 1fr`, never `repeat(3, 1fr)`: Polaris splits a responsive value on
         // the comma to separate the two branches, so a comma inside a value makes the
         // whole thing unparseable and it silently falls back to `none`.
+        <QueryContainer>
         <s-stack gap={SPACE.section}>
           <s-grid
             gap={SPACE.section}
@@ -108,6 +110,7 @@ export function VariantSearch({
             <s-button type="submit">Search</s-button>
           </s-stack>
         </s-stack>
+        </QueryContainer>
       )}
     </FilterForm>
   );

--- a/app/components/query-container.test.tsx
+++ b/app/components/query-container.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Every `@container` value is measured against something.
+ *
+ * A CSS container query resolves against the nearest ancestor container, and an element
+ * only becomes one if something sets `container-type` on it. Polaris does that in
+ * exactly one place — `s-query-container` — and this app had never used it, so all seven
+ * responsive layouts silently took their unmatched branch on every screen.
+ *
+ * The failure is invisible in two directions at once, which is why it needs a test
+ * rather than a habit. Nothing errors, nothing is missing, and the unmatched branch is
+ * the *correct* layout for the widest place each component is used — so the page you
+ * would look at to check is the page where it looks right. It shows up only where the
+ * space is narrow, which is exactly where the collapse was written for.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../lib/testing/source";
+
+import { FieldGrid } from "./FieldGrid";
+import { PageShell } from "./PageShell";
+
+const COMPONENTS = join(process.cwd(), "app", "components");
+
+/** Every `.tsx` under `app/components`, tests excluded. */
+function componentFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return componentFiles(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [path];
+  });
+}
+
+describe("a container query has a container", () => {
+  const files = componentFiles(COMPONENTS);
+
+  it("finds the components, so this cannot pass by checking nothing", () => {
+    expect(files.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("every component with a responsive value renders one", () => {
+    // Written as a list of offenders rather than a per-file case so the failure names
+    // all of them at once — this arrived as seven at a time, and would again if the
+    // wrapper were ever refactored out of a shared component.
+    const offenders = files
+      .filter((path) => {
+        const source = sourceOf(path);
+        return source.includes("@container (") && !source.includes("<QueryContainer>");
+      })
+      .map((path) => path.replace(`${COMPONENTS}/`, ""));
+
+    expect(
+      offenders,
+      "a `@container` value with no container resolves against nothing and always takes its unmatched branch",
+    ).toEqual([]);
+  });
+
+  it("renders the element Polaris measures", () => {
+    // `s-query-container`, not a `div` with `container-type` — Polaris' types require the
+    // container name `s-default` on it, which is what a bare `@container (…)` query
+    // resolves against.
+    expect(sourceOf(join(COMPONENTS, "QueryContainer.tsx"))).toContain("<s-query-container>");
+  });
+});
+
+describe("the two layouts it changes most", () => {
+  it("wraps the field grid, so a narrow column gets one column of fields", () => {
+    // The campaign editor's form column is about 470px and `FieldGrid` says it collapses
+    // at 700px. It never did, so four selects rendered at roughly 220px each and three
+    // of the four truncated their own value.
+    const html = renderToStaticMarkup(
+      <FieldGrid>
+        <s-select label="Rounding" />
+      </FieldGrid>,
+    );
+
+    expect(html.indexOf("<s-query-container>")).toBeLessThan(html.indexOf("<s-grid"));
+  });
+
+  it("wraps the page's two columns, so the aside can fall below the content", () => {
+    const html = renderToStaticMarkup(
+      <PageShell heading="Campaign">
+        <s-section>main</s-section>
+        <s-section slot="aside">facts</s-section>
+      </PageShell>,
+    );
+
+    const container = html.indexOf("<s-query-container>");
+    expect(container).toBeGreaterThan(-1);
+    expect(container).toBeLessThan(html.indexOf('gridTemplateColumns="@container'));
+  });
+});


### PR DESCRIPTION
The reported bug was three of the four selects in the campaign editor truncating their own
value — "Set to baseline (shows a strik…", "Leave prices exactly as calc…". The cause is
not the labels.

**Seven layouts in this app pick their columns with a Polaris responsive value, and every
one was being measured against nothing.**

A CSS container query resolves against the nearest ancestor container, and an element only
becomes one if something sets `container-type` on it. Polaris does that in exactly one
place, and its own types spell it out:

> We place the container name of `s-default` on every container… **@implementation** You
> must always have a CSS `container-name` of `s-default` for this component.

The component is `s-query-container`, and this app had never used it. No container, no
match, so all seven values silently took their unmatched branch on every screen.

`FieldGrid` says it becomes one column at 700px. The editor's form column is about 470px,
so its four selects should have been full width there; they rendered as two columns of
roughly 220px. Same failure, unnoticed, in six other places: the page's aside never fell
below the content however narrow the admin got, the count tiles never went two up, the
checklist rows never collapsed.

### Why this stayed invisible

The unmatched branch is the *correct* layout for the widest place each component is used —
so the page you would open to check is the page where it looks right. The same `FieldGrid`
in a 970px settings card renders two columns and is fine. It only shows where the space is
narrow, which is exactly what the collapse was written for.

That is why this ships with a guard rather than a note. `query-container.test.tsx` fails on
any component with a `@container` value and no container, and reports all offenders at
once, because that is how they arrived.

### Checks

- 3433 unit tests, typecheck, lint and build pass.
- Mutation-tested: unwrapping `FieldGrid`, `PageShell`, `CountsRow` or `OnboardingCard`
  fails the guard, and so does replacing `s-query-container` with an `s-box` that does not
  establish one.

Part of #543.

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)