### PR TITLE
Make the editor's selects readable at the width they get (#548)

### DIFF
--- a/app/lib/money/rounding-choices.test.ts
+++ b/app/lib/money/rounding-choices.test.ts
@@ -1,0 +1,116 @@
+/**
+ * A select option a merchant can read once it is chosen.
+ *
+ * A native select shows every option in full while the list is open, and only as much of
+ * the chosen one as the closed control is wide. So option text is not a typography
+ * question — it decides whether the merchant can see which rounding they picked without
+ * opening the list again.
+ *
+ * The campaign editor is where this bit. Its form column is about 470px, and its field
+ * grid halves that, so a select gets roughly 220px — about twenty-eight characters. The
+ * options read `Leave prices exactly as calculated · $2,347.62 → $2,347.62`, fifty-eight
+ * of them, and arrived as "Leave prices exactly as calc…".
+ *
+ * The fix was to stop repeating the starting price in all six. It is identical in every
+ * option, so it is said once in the select's `details` and each option shows only what it
+ * does to it. What that preserves is the reason the examples are in the options at all:
+ * six explaining themselves while the merchant compares them, rather than one line
+ * describing whichever is already chosen.
+ *
+ * These budgets are characters because that is what the source can count. They are not a
+ * substitute for looking at the page — the whole ticket exists because nobody had.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+import { roundingChoices, sampleLine } from "./rounding-example";
+
+/**
+ * What fits in a select given a full row of the campaign editor's form column.
+ *
+ * ~470px, less the chevron and the control's own padding, at the admin's body size.
+ * Deliberately not the 220px of a half row: the editor puts this select in a `FullRow`
+ * precisely because these six are the longest text in the form.
+ */
+const FULL_ROW = 50;
+
+/** The same select on a half row, which every other option list in the editor gets. */
+const HALF_ROW = 28;
+
+const CURRENCIES = ["USD", "JPY"];
+
+describe("rounding options fit the control that shows them", () => {
+  it.each(CURRENCIES)("%s", (currency) => {
+    const tooLong = roundingChoices(currency)
+      .map((choice) => `${choice.label} · ${choice.example}`)
+      .filter((line) => line.length > FULL_ROW);
+
+    expect(
+      tooLong,
+      "a chosen option longer than the closed select is one the merchant cannot read back",
+    ).toEqual([]);
+  });
+
+  it("does not repeat the starting price in every option", () => {
+    // The starting price is the same in all six. Repeating it is what made the longest
+    // option twice as long as the control, and it is the first thing that would come
+    // back if somebody reinstated the "before becomes after" sentence.
+    const lines = roundingChoices("USD").map((choice) => choice.example);
+    const sample = sampleLine("USD");
+
+    for (const line of lines) {
+      expect(sample).toContain("$2,347.62");
+      expect(line, `"${line}" restates the starting price`).not.toContain(" → ");
+      expect(line).not.toContain(" becomes ");
+    }
+  });
+
+  it("says once what the examples start from", () => {
+    // Without this the options are bare numbers with no question attached.
+    expect(sampleLine("USD")).toContain("$2,347.62");
+    expect(sampleLine("JPY")).toContain("¥234,762");
+  });
+});
+
+describe("the pages that show them", () => {
+  const editor = sourceOf(process.cwd(), "app", "routes", "app.campaigns.new.tsx");
+  const settings = sourceOf(process.cwd(), "app", "routes", "app.settings._index.tsx");
+
+  it("both name the sample beside the select", () => {
+    expect(editor).toContain("sample");
+    expect(settings).toContain("details={sample}");
+  });
+
+  it("the editor gives the rounding select a whole row", () => {
+    // Half a row is 28 characters and the longest option is well past that, so this is
+    // the difference between the fix working and not.
+    const select = editor.indexOf('name="rounding.default"');
+    const fullRow = editor.lastIndexOf("<FullRow>", select);
+    const closes = editor.lastIndexOf("</FullRow>", select);
+
+    expect(fullRow).toBeGreaterThan(-1);
+    expect(fullRow, "the rounding select is not inside the FullRow").toBeGreaterThan(closes);
+  });
+
+  it("keeps the compare-at options short enough for a half row", () => {
+    // "Set to baseline (shows a strike-through)" was forty characters in a
+    // twenty-eight character control; what it *does* is a note, and notes go in details.
+    const block = editor.slice(
+      editor.indexOf('name="compareAt"'),
+      editor.indexOf("</s-select>", editor.indexOf('name="compareAt"')),
+    );
+
+    const options = [...block.matchAll(/<s-option[^>]*>([\s\S]*?)<\/s-option>/g)].map((match) =>
+      match[1].replace(/\s+/g, " ").trim(),
+    );
+
+    expect(options.length).toBeGreaterThanOrEqual(3);
+    for (const option of options) {
+      expect(option.length, `"${option}" will be cut off in a half-row select`).toBeLessThanOrEqual(
+        HALF_ROW,
+      );
+    }
+  });
+});

--- a/app/lib/money/rounding-example.ts
+++ b/app/lib/money/rounding-example.ts
@@ -89,9 +89,36 @@ export function roundingExample(
 }
 
 /** The one-line example a select's help text shows. */
+/**
+ * The result only, for a select option that has to fit inside a closed control.
+ *
+ * It used to be the whole sentence — "$2,347.62 becomes $2,347.99" — repeated in every
+ * option, which made the longest of the six read `Leave prices exactly as calculated ·
+ * $2,347.62 → $2,347.62`: fifty-eight characters in a control the campaign editor gives
+ * about half a column. What a merchant saw was "Leave prices exactly as calc…".
+ *
+ * The starting price is identical in all six, so saying it once above the select and
+ * showing only what each does to it loses nothing and halves the line. The comparison is
+ * the point of putting examples in the options at all — all six explaining themselves
+ * while the merchant chooses between them, rather than one line describing whichever is
+ * already chosen — and that survives.
+ *
+ * `sampleLine` is the sentence that has to accompany this. An option reading "$2,347.99"
+ * with nothing saying what it started from is a number with no question attached.
+ */
 export function roundingExampleLine(name: RoundingProfileName, currency: string): string {
   const example = roundingExample(name, currency);
-  return example.unavailable ?? `${example.before} becomes ${example.after}`;
+  return example.unavailable ?? example.after ?? example.before;
+}
+
+/**
+ * What the examples above start from, said once.
+ *
+ * Belongs in the `details` of any select whose options are built by `roundingChoices` —
+ * see `rounding-choices.test.ts`, which refuses one that omits it.
+ */
+export function sampleLine(currency: string): string {
+  return `Examples show what ${formatMoneyForDisplay(money(samplePrice(), currency))} becomes.`;
 }
 
 /**

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -19,7 +19,7 @@ import {
   readRoundingPolicy,
   roundingLabel,
 } from "../lib/money/rounding-policy";
-import { roundingChoices } from "../lib/money/rounding-example";
+import { roundingChoices, sampleLine } from "../lib/money/rounding-example";
 import { ActionRow } from "../components/ActionRow";
 import { CampaignNameField } from "../components/campaign/CampaignNameField";
 import { RouteBoundary } from "../components/RouteBoundary";
@@ -186,6 +186,7 @@ export const loader = withGuard("/app/campaigns/new", async ({ request }: Loader
     // what "Nearest 10" means and knowing — see `rounding-example.ts`, and #489 for what
     // the examples turned out to reveal about two of the labels.
     roundingOptions: roundingChoices(currency),
+    sample: sampleLine(currency),
     facets: available,
     segments,
     usingSegment: segment ? { id: segment.id, name: segment.name, kind: segment.kind } : null,
@@ -319,6 +320,7 @@ export default function NewCampaign() {
     currencies,
     storeRounding,
     roundingOptions,
+    sample,
     presetStart,
     gates,
     planName,
@@ -505,18 +507,40 @@ export default function NewCampaign() {
                   confusion having two pages caused. */}
               {fromFile ? null : (
                 <>
-              <s-select name="compareAt" label="Compare-at price">
+              {/* The parenthetical moved into `details`.
+
+                  "Set to baseline (shows a strike-through)" is forty characters, and a
+                  select in this column shows about twenty-eight before it clips — so the
+                  merchant read "Set to baseline (shows a strik…", which is the label plus
+                  a promise that gets cut off half way through. What the option *is* is
+                  three words; what it *does* is a note, and a note has a place. */}
+              <s-select
+                name="compareAt"
+                label="Compare-at price"
+                details="Setting it to the baseline is what shows a customer the old price struck through."
+              >
                 <s-option value="set-to-baseline" defaultSelected>
-                  Set to baseline (shows a strike-through)
+                  Set to baseline
                 </s-option>
                 <s-option value="leave">Leave unchanged</s-option>
                 <s-option value="clear">Clear it</s-option>
               </s-select>
 
+              {/* The whole row, because these six options are the longest text in the
+                  form: `label · example` puts "Leave prices exactly as calculated ·
+                  $2,347.62 → $2,347.62" in a control that gets half a column otherwise,
+                  and a rounding rule a merchant cannot read is a rounding rule they will
+                  not check.
+
+                  The examples stay in the options rather than moving to a line under the
+                  select. A single line describes whichever is already chosen; the point
+                  of putting them in the options is that all six explain themselves while
+                  the merchant is still comparing them. */}
+              <FullRow>
               <s-select
                 name="rounding.default"
                 label="Rounding"
-                details="Starts from your store setting. Change it here to round this campaign differently."
+                details={`Starts from your store setting. Change it here to round this campaign differently. ${sample}`}
               >
                 {roundingOptions.map((option) => (
                   <s-option
@@ -532,6 +556,7 @@ export default function NewCampaign() {
                   </s-option>
                 ))}
               </s-select>
+              </FullRow>
                 </>
               )}
             </FieldGrid>

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -16,7 +16,7 @@ import {
   readRoundingPolicy,
   roundingLabel,
 } from "../lib/money/rounding-policy";
-import { roundingChoices } from "../lib/money/rounding-example";
+import { roundingChoices, sampleLine } from "../lib/money/rounding-example";
 import { PageSections, PageShell } from "../components/PageShell";
 import { SettingsSaveBar } from "../components/SettingsSaveBar";
 import { Field, FieldGrid, FullRow } from "../components/FieldGrid";
@@ -55,6 +55,7 @@ export const loader = withGuard("/app/settings", async ({ request }: LoaderFunct
     // Currency-aware: a step is in minor units, so "Nearest 10" means ten cents on a USD
     // store and ten yen on a JPY one, and the option list itself differs (#489).
     roundingOptions: roundingChoices(currency),
+    sample: sampleLine(currency),
     withCost,
     variants,
     notifications,
@@ -124,6 +125,7 @@ export default function Settings() {
     currency,
     currencies,
     roundingOptions,
+    sample,
     withCost,
     variants,
     notifications,
@@ -247,7 +249,14 @@ export default function Settings() {
               {/* A rounding rule is half a dozen words. Unbounded it was a 970px bar, and
                   the per-currency selects below it were five more. */}
               <Field width="medium">
-                <s-select name="rounding.default" label="Everywhere, unless overridden">
+                <s-select
+                  name="rounding.default"
+                  label="Everywhere, unless overridden"
+                  /* Said once, above six options that each show only their own result.
+                     Repeating "$2,347.62 becomes" in all six is what made the longest of
+                     them too long to read inside a closed select. */
+                  details={sample}
+                >
                   {roundingOptions.map((option) => (
                     <s-option
                       key={option.value}


### PR DESCRIPTION
Second attempt. The first (#560, reverted in #561) was right about *why* the container
queries never match and wrong about the fix — `s-query-container` made them match and
produced a 10px column on the deployed page. This one does not depend on them.

**The reframe that made it tractable.** A native select shows every option in full while
the list is open, and only as much of the chosen one as the closed control is wide. So the
problem was never the option list; it was that the chosen value could not be read back.
The editor's form column is ~470px and its field grid halves that, so a select gets roughly
220px — about twenty-eight characters — against options of forty and fifty-eight.

**Compare-at.** "Set to baseline (shows a strike-through)" is forty characters, and the
merchant read "Set to baseline (shows a strik…" — the label plus a promise cut off half way
through. What the option *is* is three words; what it *does* is a note, and notes go in
`details`.

**Rounding.** The six options read `label · example`, and the example repeated a starting
price identical in all six:

```
before  Leave prices exactly as calculated · $2,347.62 → $2,347.62   (58)
after   Leave prices exactly as calculated · $2,347.62               (46)
        + "Examples show what $2,347.62 becomes." in the select's details
```

Plus a whole row for that select, because these are the longest text in the form.

What this preserves is the reason the examples are in the options at all — six explaining
themselves while the merchant compares them, rather than one line describing whichever is
already chosen. #455 put them there for that reason and it still holds.

### Checks

- 3430 unit tests, typecheck, lint and build pass.
- `rounding-choices.test.ts` budgets option text against the width of the control that
  shows it — 50 characters for a full row, 28 for a half. Mutation-tested three ways:
  restoring the restated starting price, taking the rounding select out of its `FullRow`,
  and growing the compare-at option back to forty characters each fail it.
- Character counts because that is what the source can count. They are not a substitute
  for opening the page, which is the whole reason this ticket exists — verified in the
  admin after merge.

Part of #543.

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)