### PR TITLE
One sync on Home, and it is the one that works (#551)

### DIFF
--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -18,8 +18,19 @@ import { describe, expect, it } from "vitest";
 import { OnboardingCard } from "./OnboardingCard";
 import { onboarding } from "../lib/onboarding/steps";
 
+/**
+ * The sync step's control comes from the page, not from the step.
+ *
+ * Capturing baselines is a `POST` from the page the checklist is already on. It used to
+ * be written as a link to `/app` — on Home, a button that reloads the page you are
+ * looking at and changes nothing, directly above a second black button that did the work
+ * under a different name. So the card takes the real control and the step carries no
+ * href of its own.
+ */
+const SYNC = <s-button type="submit">Sync catalogue</s-button>;
+
 const render = (facts: Parameters<typeof onboarding>[0]) =>
-  renderToStaticMarkup(<OnboardingCard state={onboarding(facts)} />);
+  renderToStaticMarkup(<OnboardingCard state={onboarding(facts)} actions={{ sync: SYNC }} />);
 
 const fresh = {
   hasBaselines: false,
@@ -51,6 +62,17 @@ describe("a brand new shop", () => {
 
   it("leads with the next action", () => {
     expect(html).toContain("Sync catalogue");
+  });
+
+  it("has no action for that step unless the page supplies one", () => {
+    // The step offers no href of its own, so a card rendered without the page's control
+    // shows the step and no button — rather than a link back to the page it is on.
+    const bare = renderToStaticMarkup(<OnboardingCard state={onboarding(fresh)} />);
+
+    expect(bare).toContain("Capture your baselines");
+    expect(bare, "a link to /app is a button that reloads the page you are on").not.toContain(
+      'href="/app"',
+    );
   });
 
   it("keeps each step's Why with its own step, not the one below", () => {

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
-import type { OnboardingState, OnboardingStep } from "../lib/onboarding/steps";
+import type { OnboardingState, OnboardingStep, StepId } from "../lib/onboarding/steps";
 import { SPACE } from "../lib/ui/spacing";
 import { ActionRow } from "./ActionRow";
 
@@ -43,7 +43,28 @@ import { ActionRow } from "./ActionRow";
  * separated by hairlines rather than each being drawn as its own card, and the eye can
  * run down the status column to see where it is up to.
  */
-export function OnboardingCard({ state }: { state: OnboardingState }) {
+/**
+ * A step's action, where a link cannot be one.
+ *
+ * Two of the three steps go somewhere — the editor, in practice or guided mode — and a
+ * link is the right control for those. The first does not: capturing baselines is a
+ * `POST` from the page the checklist is already on, and it was written as a link to
+ * `/app`. On Home that is a button that reloads the page you are looking at and changes
+ * nothing, sitting directly above a second, black button that actually does the work
+ * under a different name.
+ *
+ * So a page can hand the card the real control for a step, and the checklist stops being
+ * a set of links that mostly work.
+ */
+export type StepActions = Partial<Record<StepId, ReactNode>>;
+
+export function OnboardingCard({
+  state,
+  actions,
+}: {
+  state: OnboardingState;
+  actions?: StepActions;
+}) {
   if (state.complete) return null;
 
   const done = state.steps.filter((step) => step.done).length;
@@ -68,7 +89,11 @@ export function OnboardingCard({ state }: { state: OnboardingState }) {
                   the same information as the box — where one step stops — at a fraction
                   of the ink, and it does not nest a card inside a card. */}
               {index > 0 ? <s-divider /> : null}
-              <Step step={step} isNext={step.id === state.next?.id} />
+              <Step
+                step={step}
+                isNext={step.id === state.next?.id}
+                action={actions?.[step.id]}
+              />
             </s-stack>
           ))}
         </s-stack>
@@ -95,7 +120,15 @@ function StatusIcon({ done, isNext }: { done: boolean; isNext: boolean }) {
   return <s-icon type="circle-dashed" color="subdued" />;
 }
 
-function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
+function Step({
+  step,
+  isNext,
+  action,
+}: {
+  step: OnboardingStep;
+  isNext: boolean;
+  action?: ReactNode;
+}) {
   const [why, setWhy] = useState(false);
 
   return (
@@ -141,7 +174,12 @@ function Step({ step, isNext }: { step: OnboardingStep; isNext: boolean }) {
               checklist whose every row shouts equally is a checklist that has not said
               what to do next — which is the only thing it is for. See `ActionRow` for
               the vocabulary. */}
-          {step.href && step.cta ? (
+          {/* The page's own control wins where it supplied one. A finished step keeps
+              none either way: `onboarding()` drops the href and the label once a step is
+              done, and a page that hands over a form has to do the same or the checklist
+              would offer to redo work it has just ticked off. */}
+          {step.done ? null : action}
+          {!action && step.href && step.cta ? (
             <s-button href={step.href} variant={isNext ? "primary" : "secondary"}>
               {step.cta}
             </s-button>

--- a/app/lib/dashboard/home-actions.test.ts
+++ b/app/lib/dashboard/home-actions.test.ts
@@ -77,3 +77,41 @@ describe("one sync, however many places offer it", () => {
     expect(new Set(syncs).size, `two spellings of one operation: ${[...new Set(syncs)]}`).toBe(1);
   });
 });
+
+describe("one thing to do at a time", () => {
+  /**
+   * At most one primary button on the page, in every state a shop can be in.
+   *
+   * A first run rendered two: the checklist's "Sync catalogue" and, directly below it,
+   * "Sync catalogue and capture baselines". The same operation under two names, in two
+   * black buttons — and the louder-looking half of the pair was an anchor to `/app`, so
+   * it reloaded the page the merchant was already on and did nothing.
+   *
+   * `action-row.test.tsx` already refuses two primaries inside one `s-section`. This is
+   * the same rule read at the level a merchant reads it: two black buttons in two cards
+   * are still two things being demanded at once.
+   */
+  const primaries = [...home.matchAll(/variant="primary"/g)].length;
+
+  it("renders at most one unconditional primary button", () => {
+    expect(
+      primaries,
+      "two black buttons is the page failing to say which one thing to do",
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it("does not offer the same operation under two names", () => {
+    // "Sync catalogue" and "Sync catalogue and capture baselines" were one POST.
+    const labels = [...home.matchAll(/busy \? "Syncing…" : "([^"]+)"/g)].map((match) => match[1]);
+
+    // Two are allowed and two is the ceiling: a first sync and a re-sync are different
+    // requests to make of a merchant even though they post the same intent. What is not
+    // allowed is a third name, or the pair that started this — "Sync catalogue" and
+    // "Sync catalogue and capture baselines" side by side on a first run.
+    expect(labels.length).toBeGreaterThanOrEqual(1);
+    expect(
+      new Set(labels).size,
+      `${[...new Set(labels)].join(" / ")} name one operation`,
+    ).toBeLessThanOrEqual(2);
+  });
+});

--- a/app/lib/onboarding/steps.ts
+++ b/app/lib/onboarding/steps.ts
@@ -56,8 +56,10 @@ export function onboarding(facts: OnboardingFacts): OnboardingState {
         "harmless, and what makes ending one exact. Syncing records today's prices as those " +
         "baselines and changes nothing on your storefront.",
       done: facts.hasBaselines,
-      href: facts.hasBaselines ? undefined : "/app",
-      cta: facts.hasBaselines ? undefined : "Sync catalogue",
+      // No href, and that is the point. Capturing baselines is a POST from the page the
+      // checklist is already on; this used to link to `/app`, which on Home is a button
+      // that reloads the page you are looking at and changes nothing. The page hands the
+      // card the real control instead — see `StepActions` in `OnboardingCard`.
     },
     {
       id: "practice",

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -429,28 +429,37 @@ export default function Dashboard() {
       {/* Before the numbers while it is unfinished, and gone once it is. The card
           retires itself, so this ordering says "your next step first" to a new shop and
           "your storefront first" to an established one without a conditional. */}
-      <OnboardingCard state={guide} />
+      {/* The card is handed the real sync, not a link to this page.
 
-      {neverSynced ? (
-        <s-section heading="Start by capturing your baselines">
-          <s-paragraph>
-            Anchor computes every price change from a <strong>baseline</strong> — a
-            stored reference price for each variant — rather than from whatever price
-            happens to be live. That is what makes running a campaign twice safe, and
-            what makes reverting exact.
-          </s-paragraph>
-          <s-paragraph>
-            Syncing reads your catalogue and records today&rsquo;s prices as those
-            baselines. Nothing on your storefront is changed.
-          </s-paragraph>
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="sync" />
-            <s-button type="submit" variant="primary" loading={busy || undefined}>
-              {busy ? "Syncing…" : "Sync catalogue and capture baselines"}
-            </s-button>
-          </fetcher.Form>
-        </s-section>
-      ) : null}
+          Its first step used to render `Sync catalogue` as an anchor to `/app` while the
+          section below it rendered `Sync catalogue and capture baselines` as the form
+          that does the work — two black buttons on one screen, one of them inert, naming
+          the same operation two ways. The checklist is the spine of a first run, so the
+          working control belongs on it. */}
+      <OnboardingCard
+        state={guide}
+        actions={{
+          sync: (
+            <fetcher.Form method="post">
+              <input type="hidden" name="intent" value="sync" />
+              <s-button
+                type="submit"
+                variant={guide.next?.id === "sync" ? "primary" : "secondary"}
+                loading={busy || undefined}
+              >
+                {busy ? "Syncing…" : "Sync catalogue"}
+              </s-button>
+            </fetcher.Form>
+          ),
+        }}
+      />
+
+      {/* The "Start by capturing your baselines" section that used to sit here is gone.
+
+          It explained what a baseline is and offered a black button to capture them —
+          both of which the checklist above already had: the same explanation, almost
+          word for word, behind that step's "Why?", and the same operation behind its
+          action. What is left is one place to read it and one button to press. */}
 
       {/* Only when there is something live to report.
 
@@ -578,8 +587,17 @@ export default function Dashboard() {
               nothing the second time, and ending it puts prices back exactly.
             </s-text>
           </s-paragraph>
+          {/* Secondary, not black. This card and the quick-create card below it always
+              render together — `emptyState` is a strict subset of `quickCreate` — so a
+              black button here is the second one on the page, pointing at the long way
+              round to what the card underneath does in one number.
+
+              `home.test` already made the same call for the live section's Create
+              campaign, in the same words: quick create *is* creating a campaign, for
+              the case that covers most of them. This card is the teaching, not the
+              action. */}
           <ActionRow>
-            <s-button variant="primary" href="/app/campaigns/new">
+            <s-button variant="secondary" href="/app/campaigns/new">
               Create a campaign
             </s-button>
           </ActionRow>


### PR DESCRIPTION
A first run rendered two black buttons: **"Sync catalogue"** in the Getting started
checklist, and **"Sync catalogue and capture baselines"** in a section directly below it.
The same operation under two names.

The worse half is which one worked. The checklist's step was written with `href: "/app"` —
on Home, an anchor to the page the merchant is already looking at. So the button that reads
as the first step of the product reloaded the page and did nothing, and the one that
actually captured baselines was the second, differently-named one underneath.

- `OnboardingCard` takes `actions`, so a page can hand a step the real control. Two of the
  three steps go somewhere and a link is right for those; capturing baselines is a `POST`
  from the page the checklist is already on, and there was never an href that could express
  it.
- The sync step carries no href of its own now, so a card rendered without a page's control
  shows the step and no button rather than a link back to where you are.
- The "Start by capturing your baselines" section is gone — it was that step's "Why?"
  almost word for word, plus a second copy of its button.

### One more, found while writing the guard

`emptyState` is a strict subset of `quickCreate`, so the "Nothing is running" card and the
"Put everything on sale" card **always render together**, and both had a primary button
pointing at campaign creation. `home.test.ts` had already made this call for the live
section's Create campaign, in these words — *quick create is creating a campaign, for the
case that covers most of them* — so the empty state's is secondary now. That card is the
teaching; the action is the one below it.

`home-actions.test.ts` holds both rules across the whole page rather than per card:
`action-row.test.tsx` already refuses two primaries inside one `s-section`, and two black
buttons in two cards are still two things demanded at once.

### Checks

- 3437 unit tests, typecheck, lint and build pass.
- Mutation-tested: restoring the second primary fails the guard, and restoring
  `href: "/app"` on the sync step fails the checklist's.

Part of #543.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)