### PR TITLE
Stop the support card and its own field saying the same words (#556)

### DIFF
--- a/app/lib/support/heading.test.ts
+++ b/app/lib/support/heading.test.ts
@@ -1,0 +1,49 @@
+/**
+ * A card is not named after one of the things inside it.
+ *
+ * The support form was headed "What happened" and its third field was labelled "What
+ * happened" — the same three words twice on one card, with an email address and a
+ * subject line between them. A merchant reading down the card met the heading, two
+ * unrelated fields, and then the heading again as a label, which reads as a form that
+ * has lost its place rather than as a form.
+ *
+ * Checked rather than remembered because it is the kind of collision that comes back:
+ * both strings are the natural name for their own job, and nothing but reading the two
+ * together shows the problem.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const support = sourceOf(process.cwd(), "app", "routes", "app.support.tsx");
+
+/** Every `heading="…"` on a section, and every `label="…"` on a field. */
+function strings(source: string, attribute: string): string[] {
+  return [...source.matchAll(new RegExp(`${attribute}="([^"]+)"`, "g"))].map((match) => match[1]);
+}
+
+describe("the support form", () => {
+  const headings = strings(support, "heading");
+  const labels = strings(support, "label");
+
+  it("finds both, so this cannot pass by checking nothing", () => {
+    expect(headings.length).toBeGreaterThanOrEqual(2);
+    expect(labels.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("does not label a field with the name of the card it is in", () => {
+    const collisions = headings.filter((heading) => labels.includes(heading));
+
+    expect(
+      collisions,
+      "the card and one of its fields are saying the same words to the same reader",
+    ).toEqual([]);
+  });
+
+  it("still asks for an account of the problem", () => {
+    // The fix must not be to rename the field: what happened is the question, and the
+    // heading is what moved.
+    expect(labels).toContain("What happened");
+  });
+});

--- a/app/routes/app.support.tsx
+++ b/app/routes/app.support.tsx
@@ -107,7 +107,14 @@ export default function Support() {
         </s-banner>
       ) : null}
 
-      <s-section heading="What happened">
+      {/* "Your message", not "What happened".
+
+          The card was headed "What happened" and its third field was labelled "What
+          happened" — the same three words twice, four hundred pixels apart, with an
+          email address and a subject line in between. The card holds the whole message;
+          the field holds the account of the problem. Naming the container after one of
+          its contents is how a form stops being legible as a form. */}
+      <s-section heading="Your message">
         <fetcher.Form method="post">
           {/* Each field at the width of what it holds. An email address and a subject
               line rendered the full width of the card, which is a message box's worth of


### PR DESCRIPTION
The form was headed **What happened** and its third field was labelled **What happened** —
the same three words twice on one card, four hundred pixels apart, with an email address
and a subject line in between. Reading down the card you met the heading, two unrelated
fields, and then the heading again as a label.

The card holds the whole message; the field holds the account of the problem. So the card
is "Your message" and the field keeps its question, which is the half that was right.

`heading.test.ts` refuses any field labelled with the name of the card it is in — checked
rather than remembered, because both strings are the natural name for their own job and
nothing but reading the two together shows the collision. It also refuses the other way
out: renaming the field, which would lose the question.

### Checks

- 3437 unit tests and typecheck pass.
- Mutation-tested both directions: restoring the heading collision fails it, and "fixing"
  it by renaming the field fails it too.

Part of #543.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)