### PR TITLE
Give the help index a left edge (#557)

### DIFF
--- a/app/lib/help/nav-layout.test.ts
+++ b/app/lib/help/nav-layout.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The help index reads as a list.
+ *
+ * Each article was a title button followed by its blurb on the same line, and a button is
+ * as wide as its label — so every blurb started at a different x. "and why every campaign
+ * computes from it" began about a hundred and thirty pixels right of "one winner per
+ * product, never stacked", and a reader scanning for the article they want had no column
+ * to scan down.
+ *
+ * Two things this pins, because both are the kind that revert quietly:
+ *
+ * - The rows are grid cells, not inline stacks. An inline stack is exactly what was there
+ *   and it looks reasonable in the source.
+ * - Every article contributes both cells even when it has no blurb. A grid places its
+ *   children in order, so one skipped cell pulls the next title into the blurb column and
+ *   every row after it is one cell out of step — a failure that only appears on a shop
+ *   whose help index happens to have an article without a blurb.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const help = sourceOf(process.cwd(), "app", "routes", "app.help.tsx");
+
+/** The block that renders one section's articles. */
+const start = help.indexOf("section.items.map");
+const list = help.slice(start, help.indexOf("</s-grid>", start));
+
+describe("the article list", () => {
+  it("finds the list, so this cannot pass by checking nothing", () => {
+    expect(list).toContain("item.title");
+    expect(list).toContain("item.blurb");
+  });
+
+  it("lays the articles out in columns rather than on one line each", () => {
+    // What encloses the rows, reading back from where they are rendered: a grid, not the
+    // inline stack that was there — which looks perfectly reasonable in the source, which
+    // is why it needs asserting.
+    const before = help.slice(0, start);
+
+    expect(before.lastIndexOf("<s-grid")).toBeGreaterThan(before.lastIndexOf("<ActionRow"));
+  });
+
+  it("renders a blurb cell even when the article has none", () => {
+    // `{item.blurb ? … : null}` is the natural way to write it and it is the bug: the
+    // row after a blurb-less article is one cell out of step, for ever.
+    // `??` supplies an empty cell; a bare `?` decides whether to render one at all.
+    expect(
+      list,
+      "a conditional cell shifts every row after it into the wrong column",
+    ).not.toMatch(/item\.blurb \?(?!\?)/);
+    expect(list).toMatch(/item\.blurb \?\?/);
+  });
+
+  it("still opens each article in a new tab from a root-relative href", () => {
+    // An absolute URL in the frame takes `host`, `id_token` and `shop` with it and every
+    // nav item goes inert. The note at the top of `app.help.tsx` has the detail.
+    expect(list).toContain('target="_blank"');
+    expect(list).toContain("${HELP_ROUTE}/${item.slug}");
+  });
+});

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -32,6 +32,7 @@
  */
 
 import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { Fragment } from "react";
 import { useLoaderData } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 
@@ -93,9 +94,25 @@ export default function HelpIndex() {
           <s-stack gap={SPACE.section}>
             {section.blurb ? <s-paragraph>{section.blurb}</s-paragraph> : null}
 
-            <s-stack gap={SPACE.item}>
+            {/* A grid, so the list has a left edge.
+
+                Each row was a title button followed by its blurb on the same line, and a
+                button is as wide as its label — so every blurb started at a different x.
+                "and why every campaign computes from it" began a hundred and thirty
+                pixels right of "one winner per product, never stacked", and a reader
+                scanning for the article they want had no column to scan down.
+
+                `auto 1fr` rather than two equal halves: the titles are what is being
+                chosen between, so they take the room they need and the blurbs take what
+                is left. Below 700px the blurb wraps under its title instead, which is a
+                list rather than two cramped columns. */}
+            <s-grid
+              gridTemplateColumns="@container (inline-size <= 700px) 1fr, auto 1fr"
+              gap={SPACE.item}
+              alignItems="center"
+            >
               {section.items.map((item) => (
-                <ActionRow key={item.slug}>
+                <Fragment key={item.slug}>
                   {/* Root-relative and a new tab. Relative because the app document is
                       served from our own origin inside the frame as well as outside it,
                       and a new tab because the destination is not an embedded page — see
@@ -108,10 +125,14 @@ export default function HelpIndex() {
                   >
                     {item.title}
                   </s-button>
-                  {item.blurb ? <s-text color="subdued">{item.blurb}</s-text> : null}
-                </ActionRow>
+                  {/* Always rendered, even when there is no blurb: the grid places
+                      children in order, so a skipped cell would pull the next article's
+                      title into the blurb column and every row after it would be one
+                      cell out of step. */}
+                  <s-text color="subdued">{item.blurb ?? ""}</s-text>
+                </Fragment>
               ))}
-            </s-stack>
+            </s-grid>
           </s-stack>
         </s-section>
       ))}


### PR DESCRIPTION
Each article was a title button followed by its blurb on the same line, and a button is as
wide as its label — so every blurb started at a different x. "and why every campaign
computes from it" began about a hundred and thirty pixels right of "one winner per product,
never stacked", and a reader scanning for the article they want had no column to scan down.

A grid at `auto 1fr` rather than two equal halves: the titles are what is being chosen
between, so they take the room they need and the blurbs take what is left.

**The trap this introduced, and why it ships with a test.** A grid places its children in
order, so `{item.blurb ? … : null}` — the natural way to write it — pulls the next
article's title into the blurb column and leaves every row after it one cell out of step.
It would only show on a help index that happens to have an article without a blurb, which
is not the one in this repo. The cell is always rendered, and `nav-layout.test.ts` refuses
the conditional.

### Checks

- 3438 unit tests, typecheck, lint and build pass.
- Mutation-tested: making the blurb cell conditional fails it, and putting the row back in
  an `ActionRow` fails it.

Part of #543.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)