### PR TITLE
One place, one name, in the prices section (#555)

### DIFF
--- a/app/components/section-tabs.test.ts
+++ b/app/components/section-tabs.test.ts
@@ -93,7 +93,10 @@ describe("drift is countable without being opened", () => {
   });
 
   it("puts the count on the tab", () => {
-    expect(layout).toMatch(/label: "Drift", badge: drifted/);
+    // Matched on the badge rather than on the label: the tab is called "Price drift" now
+    // — the page's own name, see `one-name.test.ts` — and this assertion is about where
+    // the count goes, not about what the tab is called.
+    expect(layout).toMatch(/label: "Price drift", badge: drifted/);
   });
 
   it("shows nothing at zero, since an empty count is noise", () => {

--- a/app/lib/ui/one-name.test.ts
+++ b/app/lib/ui/one-name.test.ts
@@ -1,0 +1,112 @@
+/**
+ * One place, one name.
+ *
+ * The prices section had three words for its first page, read in the order a merchant
+ * meets them: the nav item said **Prices**, its first tab said **Variants**, and the page
+ * that tab opened was headed **Catalogue**. Its fourth tab said "What's live" over a page
+ * headed "What is live, and why", and its fifth said "Drift" over a page headed "Price
+ * drift" that Home linked to as the "Drift queue".
+ *
+ * None of those is wrong on its own, which is exactly why it happened: each was written
+ * where it reads best, by somebody looking at one of them. The cost lands on the merchant
+ * who reads them in sequence and has to decide whether they are the same thing.
+ *
+ * Epic 14 already drew the rule for nav items — a nav item is a noun — and this is its
+ * other half: a tab and the page it opens are the same noun. Checked against the routes
+ * directory rather than a list, so a sixth tab is covered without anybody remembering
+ * this file exists.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+/** `{ href: "…", label: "…" }` entries from a section layout's tab list. */
+function tabs(source: string): Array<{ href: string; label: string }> {
+  return [...source.matchAll(/\{\s*href:\s*"([^"]+)",\s*label:\s*"([^"]+)"/g)].map((match) => ({
+    href: match[1],
+    label: match[2],
+  }));
+}
+
+/** The `heading` a route hands `PageShell`, or null if that file is not the one. */
+function heading(routeFile: string): string | null {
+  try {
+    const source = sourceOf(process.cwd(), "app", "routes", routeFile);
+    return /<PageShell[\s\S]{0,600}?heading="([^"]+)"/.exec(source)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which route file serves a path.
+ *
+ * Flat routes give a section's page two possible shapes, and which one it is depends on
+ * whether the path has children of its own: `/app/prices/baselines` is
+ * `app.prices.baselines._index.tsx` precisely because `/recapture` hangs off it, while
+ * `/app/prices/costs` is `app.prices.costs.tsx`. Both are tried rather than guessed.
+ */
+function routeFilesFor(href: string): string[] {
+  const flat = href.replace(/^\//, "").replace(/\//g, ".");
+  return [`${flat}.tsx`, `${flat}._index.tsx`];
+}
+
+const SECTIONS = [
+  { layout: "app.prices.tsx", index: "app.prices._index.tsx" },
+  { layout: "app.settings.tsx", index: "app.settings._index.tsx" },
+];
+
+describe("a tab and the page it opens are the same noun", () => {
+  for (const section of SECTIONS) {
+    const list = tabs(sourceOf(process.cwd(), "app", "routes", section.layout));
+
+    it(`${section.layout} has tabs to check`, () => {
+      expect(list.length).toBeGreaterThanOrEqual(4);
+    });
+
+    for (const tab of list) {
+      it(`${tab.label} → ${tab.href}`, () => {
+        const candidates = tab.href.endsWith("/prices") || tab.href.endsWith("/settings")
+          ? [section.index]
+          : routeFilesFor(tab.href);
+
+        const title = candidates.map(heading).find((found) => found !== null) ?? null;
+
+        expect(title, `no route file found for ${tab.href}`).not.toBeNull();
+
+        // The one deliberate exception, and it names itself: settings' first tab is a
+        // page of three subjects — "Guardrails, rounding & alerts" — and the page under
+        // it is "Settings". A label listing what a page holds is not a second name for
+        // it, and #352 records why those three live together.
+        if (tab.label.includes(",")) return;
+
+        expect(
+          title,
+          `the tab says "${tab.label}" and the page it opens says "${title}"`,
+        ).toBe(tab.label);
+      });
+    }
+  }
+});
+
+describe("Home links to a page by the page's own name", () => {
+  const home = sourceOf(process.cwd(), "app", "routes", "app._index.tsx");
+
+  it("does not invent a fourth name for the drift page", () => {
+    // It called it the "Drift queue" while the tab said "Drift" and the page said "Price
+    // drift".
+    const links = [...home.matchAll(/href="\/app\/prices\/drift">([^<]+)</g)].map((m) => m[1]);
+
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    for (const label of links) {
+      // The page's own name has to appear in the label. A button inside a banner is a
+      // sentence and a tab is a noun, so they need not match word for word — but
+      // "Drift queue" is a name the merchant will not find anywhere they land.
+      expect(
+        label.toLowerCase(),
+        `"${label}" is a name for this page that the page does not use`,
+      ).toContain("price drift");
+    }
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -421,7 +421,7 @@ export default function Dashboard() {
             overwritten — each is waiting on your decision.
           </s-paragraph>
           <ActionRow>
-            <s-button href="/app/prices/drift">Open the drift queue</s-button>
+            <s-button href="/app/prices/drift">Review price drift</s-button>
           </ActionRow>
         </s-banner>
       ) : null}
@@ -510,7 +510,7 @@ export default function Dashboard() {
               Create campaign
             </s-button>
             <s-button variant="tertiary" href="/app/campaigns">Campaigns</s-button>
-            <s-button variant="tertiary" href="/app/prices/drift">Drift queue</s-button>
+            <s-button variant="tertiary" href="/app/prices/drift">Price drift</s-button>
             <s-button variant="tertiary" href="/app/activity">Activity log</s-button>
           </ActionRow>
         </s-section>

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -104,7 +104,16 @@ export default function Catalog() {
   const [params] = useSearchParams();
 
   return (
-    <PageShell heading="Catalogue">
+    /* "Variants", the same word as the tab that opens this page.
+
+        It was headed "Catalogue" while its tab said "Variants" and the nav item above
+        both said "Prices" — three words for one place, read in that order. The tab bar is
+        the set this belongs to (Variants · Baselines · Costs · What's live · Drift), and
+        every other name in it is the column it lists. This one lists variants.
+
+        "Catalogue" stays in the prose, where it means the mirror of the shop rather than
+        this page: syncing the catalogue is what fills this table. */
+    <PageShell heading="Variants">
       <s-section>
         <VariantSearch fields={CATALOGUE_FIELDS} query={query} />
 

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -96,7 +96,10 @@ export default function Reconciliation() {
   const busy = fetcher.state !== "idle";
 
   return (
-    <PageShell heading="What is live, and why">
+    /* The tab's own words. It read "What is live, and why" under a tab saying "What's
+        live" — the heading was answering a second question the tab had not asked, and the
+        sentence below already answers it better than a title can. */
+    <PageShell heading="What's live">
       <s-section>
         <s-paragraph>
           <s-text>

--- a/app/routes/app.prices.tsx
+++ b/app/routes/app.prices.tsx
@@ -44,7 +44,10 @@ export default function PricesSection() {
           { href: "/app/prices/baselines", label: "Baselines" },
           { href: "/app/prices/costs", label: "Costs" },
           { href: "/app/prices/live", label: "What's live" },
-          { href: "/app/prices/drift", label: "Drift", badge: drifted },
+          // "Price drift", the page's own heading. It said "Drift" while the page said
+          // "Price drift" and Home linked to it as the "Drift queue" — three names for
+          // one destination, which is the thing this section was already worst at.
+          { href: "/app/prices/drift", label: "Price drift", badge: drifted },
         ]}
       />
       <Outlet />


### PR DESCRIPTION
Read in the order a merchant meets them, the first page of this section had three names:
the nav item said **Prices**, its first tab said **Variants**, and the page that tab
opened was headed **Catalogue**.

| where | before | after |
| --- | --- | --- |
| first tab / its page | Variants / Catalogue | Variants / Variants |
| fourth tab / its page | What's live / What is live, and why | What's live / What's live |
| fifth tab / its page / Home's links | Drift / Price drift / "Drift queue", "Open the drift queue" | Price drift throughout |

None of those is wrong on its own, which is exactly how it happened: each was written where
it reads best, by somebody looking at one of them. The cost lands on the merchant reading
them in sequence, deciding whether they are the same thing.

"Catalogue" stays in the prose, where it means the mirror of the shop rather than this
page — syncing the catalogue is what fills the table.

Epic 14 drew the rule for nav items: *a nav item is a noun*. `one-name.test.ts` is its
other half — a tab and the page it opens are the same noun — walked from the section
layouts rather than a list, so a sixth tab is covered without anyone remembering the file
exists. Settings' first tab is the one exception and it names itself: a label listing three
subjects ("Guardrails, rounding & alerts") is not a second name for a page, and #352
records why those three live together.

### Checks

- 3457 unit tests, typecheck, lint and build pass.
- Mutation-tested all four renames: restoring any one of them fails the guard.

Part of #543.

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)