### PR TITLE
Two control rows before the first campaign, not four (#554)

### DIFF
--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -91,7 +91,13 @@ export function CampaignListView({
           }))}
         />
 
-        {/* FilterForm rather than a native form element: a plain GET submit replaces the
+        {/* Search and the archive on one row.
+
+            They were two, stacked, so the card opened with a tab bar, a search bar and a
+            lone tertiary button on a line of its own before the first campaign. Both are
+            ways of narrowing what the list shows, and neither needed a row of its own.
+
+            FilterForm rather than a native form element: a plain GET submit replaces the
             whole query string, including the `host` and `id_token` App Bridge put there,
             and the merchant gets a blank page with nothing in the console. It also merges
             rather than replaces, so the view and status already in the URL survive a
@@ -100,8 +106,8 @@ export function CampaignListView({
           {/* A grid, not an inline stack. The stack put the button *after* a field that
               takes the full width, so it wrapped onto its own line and sat under the
               field's left edge looking like an orphan. Here the field takes what is left
-              and the button takes what it needs, on one baseline. */}
-          <s-grid gridTemplateColumns="1fr auto" gap={SPACE.item} alignItems="center">
+              and the two buttons take what they need, on one baseline. */}
+          <s-grid gridTemplateColumns="1fr auto auto" gap={SPACE.item} alignItems="center">
             <s-search-field
               name="q"
               label="Search campaigns"
@@ -115,23 +121,21 @@ export function CampaignListView({
             <s-button type="submit" icon="search">
               Search
             </s-button>
+            {/* Not a seventh status tab. Archiving is a filing decision and the tabs are
+                the lifecycle; folding them together would mean giving up the status
+                filter to look in the archive, and "archived" would have to claim to be a
+                state a campaign can be in. A merchant looking for an archived campaign is
+                usually looking for a finished one, so both controls have to work at
+                once. */}
+            <s-button
+              variant="tertiary"
+              icon="archive"
+              href={linkTo({ archived: filters.archived ? "" : "1" })}
+            >
+              {filters.archived ? "Show active" : "Show archived"}
+            </s-button>
           </s-grid>
         </FilterForm>
-
-        {/* Not a seventh status tab. Archiving is a filing decision and the tabs are the
-            lifecycle; folding them together would mean giving up the status filter to
-            look in the archive, and "archived" would have to claim to be a state a
-            campaign can be in. A merchant looking for an archived campaign is usually
-            looking for a finished one, so both controls have to work at once. */}
-        <ActionRow>
-          <s-button
-            variant="tertiary"
-            icon="archive"
-            href={linkTo({ archived: filters.archived ? "" : "1" })}
-          >
-            {filters.archived ? "Show active campaigns" : "Show archived"}
-          </s-button>
-        </ActionRow>
 
         {list.campaigns.length === 0 ? (
           filters.archived ? (

--- a/app/components/campaign/campaign-list-view.test.tsx
+++ b/app/components/campaign/campaign-list-view.test.tsx
@@ -17,6 +17,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { StaticRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 
+import { sourceOf } from "../../lib/testing/source";
+
 import { CampaignListView } from "./CampaignListView";
 import { describeState } from "../../lib/lifecycle/transitions";
 import { describeRule, describeScope } from "../../lib/campaigns/describe";
@@ -129,5 +131,45 @@ describe("when there is nothing to list", () => {
 
     expect(html).toContain("No campaigns match those filters");
     expect(html).toContain("Clear filters");
+  });
+});
+
+describe("what a merchant reads before the first campaign", () => {
+  /**
+   * Two control rows, and only one of them looks like tabs.
+   *
+   * The page opened with four: List/Calendar tabs, then All/Needs a decision/Draft/… tabs,
+   * then a search bar, then a lone tertiary "Show archived" on a line of its own. Two of
+   * those were tab bars answering different questions — one picks a *shape* of view, the
+   * other filters what is in it — and nothing in their appearance said so.
+   *
+   * The status filter keeps the tabs, because it is the one a merchant uses. The view
+   * switch is a button in the page's title bar, which is also the only place it can live:
+   * the calendar replaces this card entirely, so a switch inside it would vanish in one
+   * of its two views.
+   */
+  const view = sourceOf(process.cwd(), "app", "components", "campaign", "CampaignListView.tsx");
+  const route = sourceOf(process.cwd(), "app", "routes", "app.campaigns._index.tsx");
+
+  it("renders one tab bar, not two", () => {
+    expect((view.match(/<TabBar/g) ?? []).length).toBe(1);
+    expect(
+      route,
+      "a second bar above this one is the arrangement that made the page unreadable",
+    ).not.toContain("<TabBar");
+  });
+
+  it("puts search and the archive toggle on the same row", () => {
+    const row = view.slice(view.indexOf("<FilterForm"), view.indexOf("</FilterForm>"));
+
+    expect(row).toContain("<s-search-field");
+    expect(row, "the archive toggle is back on a row of its own").toContain('icon="archive"');
+  });
+
+  it("keeps the view switch reachable from the calendar", () => {
+    // It is in the title bar rather than in this card precisely so that it survives the
+    // calendar replacing the card.
+    expect(route).toContain("secondaryActions");
+    expect(route).toContain('view === "calendar"');
   });
 });

--- a/app/components/tab-bar.test.tsx
+++ b/app/components/tab-bar.test.tsx
@@ -67,7 +67,11 @@ describe("every set of tabs uses the shared bar", () => {
   it.each([
     "app/components/SectionTabs.tsx",
     "app/components/campaign/CampaignTabs.tsx",
-    "app/routes/app.campaigns._index.tsx",
+    // The campaigns *index* no longer appears here, and its list view does instead. The
+    // page used to render two bars stacked — List/Calendar, then the status filter — and
+    // the top one is a view switch in the title bar now. One question per control: the
+    // tabs filter what is in the list, and a button swaps which shape the list takes.
+    "app/components/campaign/CampaignListView.tsx",
   ])("%s renders TabBar rather than its own row", (path) => {
     const source = files.find((file) => file.path === path)?.source ?? "";
     expect(source, `${path} should be a known tab surface`).not.toBe("");

--- a/app/routes/app.campaigns._index.tsx
+++ b/app/routes/app.campaigns._index.tsx
@@ -8,7 +8,6 @@ import { ActionRow } from "../components/ActionRow";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
-import { TabBar } from "../components/TabBar";
 import { CampaignCalendar } from "../components/campaign/CampaignCalendar";
 import { CampaignListView } from "../components/campaign/CampaignListView";
 import { HelpNote } from "../components/HelpNote";
@@ -132,6 +131,21 @@ export default function Campaigns() {
          they could start. It is an option inside the editor now (#445), which is where
          "how should prices change" is actually asked. */
       primaryAction={{ label: "Create campaign", href: "/app/campaigns/new" }}
+      /* The view switch, beside the action rather than as a second tab bar.
+
+         The page used to open with two tab bars stacked: List/Calendar, then All/Needs a
+         decision/Draft/… Both looked like tabs and they were answering different
+         questions — one picks a *shape* of view, the other filters what is in it — so the
+         merchant had to read both before the first campaign. The status filter is the one
+         a merchant uses, so it keeps the tabs; this is one button that swaps.
+
+         It has to sit outside the list card because the calendar replaces that card
+         entirely, and a view switch that disappears in one of its two views is a trap. */
+      secondaryActions={[
+        view === "calendar"
+          ? { label: "List", icon: "list-bulleted", href: linkTo({ view: "list" }) }
+          : { label: "Calendar", icon: "calendar", href: linkTo({ view: "calendar" }) },
+      ]}
     >
       {/* Counted across the shop rather than the filtered page: a campaign needing a
           decision must not be hidden by an unrelated filter. */}
@@ -150,30 +164,7 @@ export default function Campaigns() {
         </s-banner>
       ) : null}
 
-      {/* Which view you are looking at, and nothing else.
 
-          It used to carry Create campaign on its right, which made a row of tabs also a
-          row of actions; the action is in the title bar now. What is left is a header
-          rather than a card — no box around a two-item toggle. */}
-      <TabBar
-        label="Campaign views"
-        tabs={[
-          {
-            label: "List",
-            // A glyph each, because these two name a *shape* of view rather than a
-            // subject, and the shape is the thing being chosen between.
-            icon: "list-bulleted",
-            href: linkTo({ view: "list" }),
-            current: view === "list",
-          },
-          {
-            label: "Calendar",
-            icon: "calendar",
-            href: linkTo({ view: "calendar" }),
-            current: view === "calendar",
-          },
-        ]}
-      />
 
       {view === "calendar" && calendar ? (
         <CampaignCalendar {...calendar} />


### PR DESCRIPTION
The index opened with four stacked rows before a merchant reached a campaign:

1. List / Calendar tabs
2. All / Needs a decision / Draft / Scheduled / Active / Completed tabs
3. a search bar
4. a lone tertiary "Show archived" on a line of its own

Two of those were tab bars, one under the other, answering different questions — one picks
a *shape* of view, the other filters what is in it — and nothing in their appearance said
so.

- The **status filter keeps the tabs**, because it is the one a merchant uses.
- The **view switch is one button in the title bar**, beside Create campaign. That is also
  the only place it can live: the calendar replaces the list card entirely, so a switch
  inside the card would vanish in one of its two views.
- **Search and the archive toggle share a row.** Both narrow what the list shows.

`tab-bar.test.tsx`'s inventory of tab surfaces moves the campaigns-index entry onto its
list view, which is where the one remaining bar now is.

### Checks

- 3460 unit tests, typecheck, lint and build pass.
- Mutation-tested three ways: removing the title-bar view switch, putting the archive
  toggle back on its own row, and restoring a second tab bar above the card each fail.

Part of #543.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)