### PR TITLE
An overflow for what files a campaign, never for what prices one (#546)

### DIFF
--- a/app/components/campaign/CampaignHeader.tsx
+++ b/app/components/campaign/CampaignHeader.tsx
@@ -36,6 +36,9 @@ import { RevertConfirmation, REVERT_MODAL_ID } from "./RevertConfirmation";
 import { SPACE } from "../../lib/ui/spacing";
 import type { CampaignDetailProps } from "./props";
 
+/** Links the "More actions" button to the menu it opens. */
+const MORE_MENU_ID = "campaign-more-actions";
+
 export function CampaignHeader({
   rollback,
   practice,
@@ -139,43 +142,74 @@ export function CampaignHeader({
           </s-button>
         )}
 
-        {/* Copy it and file it away. Both tertiary, and last: they are about the campaign
-            as a record rather than about the prices, so they must not compete with the
-            one button that writes to a storefront.
+        {/* Everything that files the campaign rather than prices it, behind one control.
+
+            The row rendered up to six buttons at once — Apply, Resume, Revert or "Review
+            N edited", Duplicate, Contact support, Archive — and three of those are about
+            the campaign as a record. A merchant scanning for the one button that writes
+            to a storefront had to read past them every time.
+
+            Nothing that writes a price is ever in here. That is the rule, and
+            `campaign-header.test.tsx` holds it: an overflow is where an action goes when
+            it is *not* what the page is for, and a merchant who has to open a menu to
+            find Apply has been given the wrong menu.
 
             Duplicate is not recurrence, which this app already has. Recurrence re-arms
-            *this* campaign for its next occurrence and keeps one history; duplicate is
-            how next month's different sale gets built out of last month's sale that
-            worked. NA offers `Copy to new job` in place of recurrence; Sami offers both,
-            and both is right.
+            the same sale; Duplicate is how next month's different sale gets built out of
+            last month's sale that worked. NA offers `Copy to new job` in place of
+            recurrence; Sami offers both, and both is right.
 
             There is no delete anywhere, and that is deliberate rather than missing: the
             ledger hangs off this campaign's runs, so deleting the row would erase the
             record of every price we ever wrote for it. Archive keeps all of it and takes
-            the campaign out of the list. `delete-guard.test.ts` holds the line. */}
-        <fetcher.Form method="post">
-          <input type="hidden" name="intent" value="duplicate" />
-          <s-button type="submit" variant="tertiary" icon="duplicate" loading={busy || undefined}>
+            the campaign out of the list. `delete-guard.test.ts` holds the line.
+
+            `command` as well as `commandFor`, which is the scar `HelpNote` records: in
+            `polaris.js` the activator's click handler is built only when both are
+            present, so `commandFor` alone renders a button that is focusable and inert —
+            no error, no warning. */}
+        <s-button
+          variant="tertiary"
+          icon="menu-horizontal"
+          commandFor={MORE_MENU_ID}
+          command="--toggle"
+          loading={busy || undefined}
+        >
+          More actions
+        </s-button>
+
+        {/* Buttons only. Polaris' own types say of `s-menu`: "Only Button components are
+            allowed as children of a Menu… Any other component placed here will be
+            ignored" — so the two form posts that used to wrap their submits are
+            `fetcher.submit` calls instead. A `<form>` in here would be dropped silently,
+            which is the failure mode this app has been bitten by twice. */}
+        <s-menu id={MORE_MENU_ID} accessibilityLabel="More actions for this campaign">
+          <s-button
+            icon="duplicate"
+            onClick={() => fetcher.submit({ intent: "duplicate" }, { method: "post" })}
+          >
             Duplicate
           </s-button>
-        </fetcher.Form>
 
-        {/* Only where the campaign is in a state a merchant might need help with. On a
-            draft it would be a support button next to a form nobody has submitted yet;
-            on Held or Partial it is beside the two states this product is *about*, and
-            the ones whose questions are hardest to ask without a run id. */}
-        {needsAttention ? (
-          <s-button variant="tertiary" icon="chat" href={supportHref(campaignId)}>
-            Contact support
-          </s-button>
-        ) : null}
-
-        <fetcher.Form method="post">
-          <input type="hidden" name="intent" value={archived ? "unarchive" : "archive"} />
-          <s-button type="submit" variant="tertiary" icon="archive" loading={busy || undefined}>
+          <s-button
+            icon="archive"
+            onClick={() =>
+              fetcher.submit({ intent: archived ? "unarchive" : "archive" }, { method: "post" })
+            }
+          >
             {archived ? "Restore" : "Archive"}
           </s-button>
-        </fetcher.Form>
+
+          {/* Only where the campaign is in a state a merchant might need help with. On a
+              draft it would be a support link beside a form nobody has submitted yet; on
+              Held or Partial it is beside the two states this product is *about*, and the
+              ones whose questions are hardest to ask without a run id. */}
+          {needsAttention ? (
+            <s-button icon="chat" href={supportHref(campaignId)}>
+              Contact support
+            </s-button>
+          ) : null}
+        </s-menu>
       </ActionRow>
     </s-grid>
 

--- a/app/components/campaign/campaign-header.test.tsx
+++ b/app/components/campaign/campaign-header.test.tsx
@@ -493,3 +493,68 @@ describe("support from where the problem is", () => {
     expect(render(<CampaignHeader {...props()} />)).not.toContain("Contact support");
   });
 });
+
+describe("the overflow holds what files a campaign, never what prices one", () => {
+  /**
+   * The header rendered up to six buttons at once — Apply, Resume, Revert or "Review N
+   * edited", Duplicate, Contact support, Archive. Three of those are about the campaign
+   * as a record, and a merchant scanning for the one button that writes to a storefront
+   * had to read past them every time.
+   *
+   * The rule, which is the part that must not drift: an overflow is where an action goes
+   * when it is *not* what the page is for. A merchant who has to open a menu to find
+   * Apply has been given the wrong menu.
+   */
+  const html = render(<CampaignHeader {...props({ needsAttention: true })} />);
+  const menu = html.slice(html.indexOf("<s-menu"), html.indexOf("</s-menu>"));
+
+  it("renders a menu rather than three more buttons in the row", () => {
+    expect(html).toContain("<s-menu");
+    expect(html).toContain("More actions");
+  });
+
+  it("opens it with both commandFor and command", () => {
+    // `polaris.js` builds the activator's click handler only when both are present, so
+    // `commandFor` alone is a button that is focusable and inert — no error, no warning.
+    // `HelpNote` records the same scar.
+    //
+    // Scoped to the activator's own tag rather than to everything above the menu: the
+    // header already has two modal openers carrying `command="--show"`, and a looser
+    // match reads one of theirs and passes with this one's missing. Found by deleting it
+    // and watching the test stay green.
+    const start = html.indexOf('commandFor="campaign-more-actions"');
+    const activator = html.slice(html.lastIndexOf("<s-button", start), html.indexOf(">", start));
+
+    expect(start).toBeGreaterThan(-1);
+    expect(activator).toMatch(/command="--(toggle|show)"/);
+  });
+
+  it("puts Duplicate, Archive and support inside it", () => {
+    expect(menu).toContain("Duplicate");
+    expect(menu).toContain("Archive");
+    expect(menu).toContain("Contact support");
+  });
+
+  it("keeps every price-writing action out of it", () => {
+    for (const action of ["Apply to storefront", "Resume", "Revert"]) {
+      expect(menu, `${action} is behind an overflow`).not.toContain(action);
+    }
+  });
+
+  it("holds only buttons, because a menu silently drops anything else", () => {
+    // Polaris' own types: "Only Button components are allowed as children of a Menu…
+    // Any other component placed here will be ignored." The two form posts that used to
+    // wrap their submits are `fetcher.submit` calls for exactly this reason, and a
+    // `<form>` reintroduced here would vanish with no error.
+    expect(menu).not.toMatch(/<form[\s>]/);
+  });
+
+  it("still offers support only where the campaign needs a decision", () => {
+    const quiet = render(<CampaignHeader {...props()} />);
+    const quietMenu = quiet.slice(quiet.indexOf("<s-menu"), quiet.indexOf("</s-menu>"));
+
+    expect(quietMenu).toContain("Duplicate");
+    expect(quietMenu).not.toContain("Contact support");
+  });
+});
+


### PR DESCRIPTION
The campaign header rendered up to six buttons in one row — Apply to storefront, Resume,
Revert (or "Review N edited before reverting"), Duplicate, Contact support, Archive. Three
of those are about the campaign as a *record*, and a merchant scanning for the one button
that writes to a storefront read past them every time.

Duplicate, Archive/Restore and Contact support are behind "More actions" now. `s-menu` is
in the Polaris set and this app had never used it.

**The rule the test holds, rather than the arrangement:** an overflow is where an action
goes when it is *not* what the page is for. A merchant who has to open a menu to find Apply
has been given the wrong menu, so nothing that writes a price is ever in there.

### Two things about `s-menu` that would have failed silently

- **Its children must be Buttons.** Polaris' own types: *"Only Button components are allowed
  as children of a Menu… Any other component placed here will be ignored."* So the two form
  posts that used to wrap their submits are `fetcher.submit` calls. A `<form>` reintroduced
  in there would vanish with no error, and the test refuses one.
- **`command` is required as well as `commandFor`.** `polaris.js` builds the activator's
  click handler only when both are present, so `commandFor` alone is a button that is
  focusable and inert. `HelpNote` records the same scar.

The assertion for that second one **passed against a deliberately broken header the first
time**: it searched everything above the menu, and the header already has two modal openers
carrying `command="--show"`, so it read one of theirs. Scoped to the activator's own tag
now, and re-mutated.

### Checks

- 3472 unit tests, typecheck, lint and build pass.
- Mutation-tested three ways: dropping `command`, moving Revert into the menu, and putting
  a `<form>` back inside it each fail.
- `s-menu` is new to this app, so this gets opened in the admin straight after merge — the
  same discipline that caught #560 and had it reverted the same hour.

Part of #543.

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)