### PR TITLE
Make the things that navigate look like they navigate (#576)

### DIFF
--- a/app/components/ActionRow.tsx
+++ b/app/components/ActionRow.tsx
@@ -10,27 +10,40 @@ import { SPACE } from "../lib/ui/spacing";
  * The app was written almost entirely in links. Every way out of a card — a page to
  * visit, a row to open, a queue to review, a spreadsheet to import — was the same blue
  * underlined phrase, so a screen with four of them offered four things of apparently
- * equal weight and no clue which one it wanted you to press. Blue text is also the one
- * treatment Polaris reserves for *inline* links, where colour is the only thing marking a
- * word inside a sentence as clickable; spending it on standalone actions wastes it and
- * leaves a page looking like a bibliography.
+ * equal weight and no clue which one it wanted you to press.
  *
- * Four treatments, in descending loudness:
+ * The first answer to that was to remove the blue: `variant="tertiary"` — dark text with
+ * no chrome — became the replacement for almost every link in the app. Rendered, that is
+ * **plain static text**. "Why?", "See plans", "See everything", "Show archived", and every
+ * campaign name in the list read as captions, and a merchant had no way to know that a
+ * campaign's name was the way into it.
  *
+ * Both of those are the same mistake from opposite ends: **loudness was being used to
+ * carry two different things at once** — how much a page wants something pressed, and
+ * whether it can be pressed at all. The second is not negotiable. Hierarchy is what
+ * answers the four-equal-links problem, and one primary per card already provides it.
+ *
+ * So the question a caller answers is *what kind of thing is this*, and the loudness
+ * follows:
+ *
+ * - **`s-link`** — navigation that is part of the content. A name in a table row, an
+ *   article title in a list, a word inside a sentence. These are **read, then clicked**:
+ *   the merchant is looking at the thing itself, and the link is the thing. Blue, because
+ *   colour is what marks a word among words.
  * - **`variant="primary"`** — the black button. The one thing a page or card most wants
- *   done: the next step in getting started, "Create campaign", "Sync catalogue". At most
+ *   done: "Create campaign", "Sync catalogue", the next step in getting started. At most
  *   one per card; two black buttons is the same failure as four blue links.
- * - **`variant="secondary"`** (the default) — a real alternative, and every action inside
- *   a banner. Bordered, quiet, unmistakably pressable.
- * - **`variant="tertiary"`** — dark text with no chrome. Navigation and row-level actions
- *   that must not compete: "See everything", "Open", "View ledger", a product name that
- *   leads to the Shopify admin. This is the replacement for most of the old links, and
- *   the reason the pages stopped being blue.
- * - **`s-link`** — kept for exactly two things: a link *inside a sentence*, where colour
- *   is doing necessary work, and the App Bridge nav menu, which must be anchors.
+ * - **`variant="secondary"`** (the default) — a standalone action or destination that
+ *   sits in a row of them. These are **looked for, then clicked**: the merchant has
+ *   finished reading and wants to do something. Bordered, quiet, unmistakably pressable.
+ * - **`variant="tertiary"`** — text with no border, **and only ever with an icon**. For a
+ *   control repeated on every row of a table or every item of a list, where a border per
+ *   row would be more ink than the rows. The icon is what makes it a control rather than
+ *   a caption, so it is not optional; `action-row.test.tsx` refuses one without.
  *
- * `s-button` takes an `href`, so a tertiary button that navigates is still an anchor —
- * middle-click and "open in new tab" behave the way a merchant expects.
+ * `s-button` takes an `href`, so a secondary button that navigates is still an anchor —
+ * middle-click and "open in new tab" behave the way a merchant expects, whichever of
+ * these it is.
  *
  * ## Why a component rather than a stack written out each time
  *

--- a/app/components/BaselineTable.tsx
+++ b/app/components/BaselineTable.tsx
@@ -54,7 +54,7 @@ export function BaselineTable({
                   anything else on the row. Two buttons that do the same kind of job are
                   an ActionRow. */}
               <ActionRow>
-                <s-button variant="tertiary" onClick={() => onShowHistory(row.variantGid)}>
+                <s-button variant="tertiary" icon="clock" onClick={() => onShowHistory(row.variantGid)}>
                   History
                 </s-button>
                 {/* The same treatment as History beside it, which it was not: one cell

--- a/app/components/DraftPreview.tsx
+++ b/app/components/DraftPreview.tsx
@@ -158,7 +158,7 @@ export function DraftPreview({
               for a word *inside* a sentence where colour is doing necessary work; this
               is a standalone way out of the card, which is what tertiary is for. */}
           <ActionRow>
-            <s-button variant="tertiary" href="/app/prices/drift">
+            <s-button variant="secondary" href="/app/prices/drift">
               Review drifted prices
             </s-button>
           </ActionRow>
@@ -245,7 +245,7 @@ export function DraftPreview({
               button under its inline preview. */}
           {fullPreviewHref ? (
             <ActionRow>
-              <s-button variant="tertiary" href={fullPreviewHref}>
+              <s-button variant="secondary" href={fullPreviewHref}>
                 See all {formatCount(preview.changing + preview.alreadyCorrect + preview.skipped)} rows
               </s-button>
             </ActionRow>

--- a/app/components/ErrorScreen.tsx
+++ b/app/components/ErrorScreen.tsx
@@ -61,7 +61,7 @@ export function ErrorScreen({
               Try again
             </s-button>
             <s-button href="/app">Back to dashboard</s-button>
-            <s-button variant="tertiary" href={helpPathFor(code)} target="_blank">
+            <s-button variant="secondary" href={helpPathFor(code)} target="_blank">
               {helpLabelFor(code)}
             </s-button>
           </ActionRow>

--- a/app/components/LastRunSummary.tsx
+++ b/app/components/LastRunSummary.tsx
@@ -61,9 +61,7 @@ export function LastRunSummary({
           </s-text>
         </s-stack>
 
-        <s-button variant="tertiary" href={`/app/campaigns/${run.campaignId}`}>
-          View campaign
-        </s-button>
+        <s-link href={`/app/campaigns/${run.campaignId}`}>View campaign</s-link>
       </s-grid>
     </s-box>
   );

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -166,8 +166,15 @@ function Step({
               thing on this card nobody needs, and on a completed row — which has no
               action beside it — it was also the only thing left hanging off the right
               edge, so the column of actions read as ragged. */}
+          {/* An icon on the toggle, because a tertiary control is text with no border
+              and "Why?" beside a real button read as a caption for it. The same question
+              mark `HelpNote` uses, so the two say "this is help" the same way. */}
           {step.done ? null : (
-            <s-button variant="tertiary" onClick={() => setWhy((open) => !open)}>
+            <s-button
+              variant="tertiary"
+              icon="question-circle"
+              onClick={() => setWhy((open) => !open)}
+            >
               {why ? "Hide why" : "Why?"}
             </s-button>
           )}

--- a/app/components/ReconciliationTable.tsx
+++ b/app/components/ReconciliationTable.tsx
@@ -67,9 +67,7 @@ export function ReconciliationTable({
             <s-table-cell>{row.baseline ?? <Blank />}</s-table-cell>
             <s-table-cell>
               {row.campaignId ? (
-                <s-button variant="tertiary" href={`/app/campaigns/${row.campaignId}`}>
-                  {row.campaignName}
-                </s-button>
+                <s-link href={`/app/campaigns/${row.campaignId}`}>{row.campaignName}</s-link>
               ) : (
                 <Blank />
               )}

--- a/app/components/RunHistoryTable.tsx
+++ b/app/components/RunHistoryTable.tsx
@@ -42,9 +42,7 @@ export function RunHistoryTable({ runs, selectedRunId, timeZone }: Props) {
               {run.id === selectedRunId ? (
                 <s-text>Showing</s-text>
               ) : (
-                <s-button variant="tertiary" href={`?run=${run.id}`}>
-                  View ledger
-                </s-button>
+                <s-link href={`?run=${run.id}`}>View ledger</s-link>
               )}
             </s-table-cell>
           </s-table-row>

--- a/app/components/UnsavedChanges.tsx
+++ b/app/components/UnsavedChanges.tsx
@@ -111,7 +111,7 @@ export function UnsavedChanges({
         <s-button variant="primary" onClick={() => blocker.reset?.()}>
           Stay on this page
         </s-button>
-        <s-button variant="tertiary" onClick={() => blocker.proceed?.()}>
+        <s-button variant="secondary" onClick={() => blocker.proceed?.()}>
           Leave and discard
         </s-button>
       </ActionRow>

--- a/app/components/UpcomingCampaigns.tsx
+++ b/app/components/UpcomingCampaigns.tsx
@@ -44,9 +44,7 @@ export function UpcomingCampaigns({
             {humanise(moment.status)}
           </s-badge>
 
-          <s-button variant="tertiary" href={`/app/campaigns/${moment.id}`}>
-            {moment.name}
-          </s-button>
+          <s-link href={`/app/campaigns/${moment.id}`}>{moment.name}</s-link>
 
           {/* The timing is pinned to the far edge, so the column of "in 3 days" reads
               down the page as one thing whatever the names do. */}

--- a/app/components/action-row.test.tsx
+++ b/app/components/action-row.test.tsx
@@ -1,11 +1,20 @@
 /**
  * The app's action vocabulary, guarded.
  *
- * Every way out of a card used to be the same blue underlined phrase, so a screen with
- * four of them offered four things of equal weight and no clue which one it wanted
- * pressed. `ActionRow` documents the replacement — primary, secondary, tertiary — and
- * this is what stops the links growing back one route at a time, which is exactly how
- * they arrived.
+ * It has been wrong in both directions. First every way out of a card was the same blue
+ * underlined phrase, so a screen with four of them offered four things of apparently equal
+ * weight. Then the fix removed the blue everywhere: `variant="tertiary"` — text with no
+ * chrome — became the replacement for almost every link, and "Why?", "See plans" and every
+ * campaign name in the list rendered as **plain static text**.
+ *
+ * Both are the same mistake from opposite ends. Loudness was carrying two things at once:
+ * how much a page wants something pressed, and whether it can be pressed at all. The
+ * second is not negotiable, and hierarchy — one primary per card — is what answers the
+ * four-equal-links problem.
+ *
+ * So this file no longer bans a link. It holds the two rules that keep the vocabulary
+ * legible: a tertiary control carries an icon, because that is the only thing separating
+ * it from a caption; and a card offers at most one black button.
  */
 
 import { readdirSync } from "node:fs";
@@ -20,24 +29,6 @@ import { SPACE } from "../lib/ui/spacing";
 
 const APP = join(process.cwd(), "app");
 
-/**
- * Where a bare `s-link` is still correct.
- *
- * The App Bridge nav menu must be anchors — Shopify reads them to build the sidebar, and
- * a button there renders nothing.
- *
- * A link *inside a sentence* is the other legitimate use, where colour is the only thing
- * marking a word mid-paragraph as clickable. Adding one means adding the file here, which
- * is the point: it should be a decision somebody made, not a habit that returned.
- *
- * `OverlapPanel` is the first, and it is the case the paragraph above describes. It reads
- * "**Autumn sale** keeps 1,240 of them — it outranks this campaign", and the campaign's
- * name is the subject of that sentence. A button in the middle of it would break the
- * sentence into three pieces to make one word clickable, and the sentence is the whole
- * point: it is the statement about overlap that no competitor can make.
- */
-const MAY_USE_LINKS = ["routes/app.tsx", "components/OverlapPanel.tsx"];
-
 function sources(dir: string): Array<{ path: string; text: string }> {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const path = join(dir, entry.name);
@@ -48,16 +39,32 @@ function sources(dir: string): Array<{ path: string; text: string }> {
 }
 
 describe("the action vocabulary", () => {
-  it("keeps blue links out of everything but the nav", () => {
-    const linking = sources(APP)
-      .filter(({ text }) => text.includes("<s-link"))
-      .map(({ path }) => path)
-      .filter((path) => !MAY_USE_LINKS.includes(path));
+  it("gives every tertiary control an icon", () => {
+    // Tertiary is text with no border. Without an icon it is indistinguishable from a
+    // caption, which is how a campaign name, "Why?" and "See plans" all came to look
+    // like labels. The icon is what makes it a control, so it is not optional.
+    const offenders = sources(APP).flatMap(({ path, text }) =>
+      [...text.matchAll(/<s-button[^>]*?>/gs)]
+        .filter((match) => match[0].includes('variant="tertiary"') && !match[0].includes("icon="))
+        .map(() => path),
+    );
 
     expect(
-      linking,
-      "use a button — primary, secondary or tertiary — and see ActionRow for which",
+      [...new Set(offenders)],
+      "a tertiary button with no icon renders as plain text — give it an icon, or make it secondary or a link",
     ).toEqual([]);
+  });
+
+  it("keeps a link for navigation rather than for actions", () => {
+    // The other half of the rule. An `s-link` is content you read and then click, so it
+    // goes somewhere; a link with no destination is a button wearing the wrong clothes.
+    const offenders = sources(APP).flatMap(({ path, text }) =>
+      [...text.matchAll(/<s-link[^>]*?>/gs)]
+        .filter((match) => !match[0].includes("href"))
+        .map(() => path),
+    );
+
+    expect(offenders, "an s-link with no href is an action, not navigation").toEqual([]);
   });
 
   it("offers at most one black button per card", () => {

--- a/app/components/campaign/CampaignCalendar.tsx
+++ b/app/components/campaign/CampaignCalendar.tsx
@@ -78,8 +78,12 @@ export function CampaignCalendar({
               >
                 Previous
               </s-button>
+              {/* An icon, like the two either side of it. The rule is that a tertiary
+                  control carries one — without it this is the only piece of plain text in
+                  a row of three controls, which reads as a label between two buttons. */}
               <s-button
                 variant="tertiary"
+                icon="calendar"
                 href={`/app/campaigns?view=calendar&period=${period}&on=${today}`}
               >
                 Today
@@ -125,8 +129,10 @@ export function CampaignCalendar({
               the app stopped using, and there is one of these per overlap. */}
           {overlaps.some((overlap) => overlap.sharedVariants > 0) ? (
             <ActionRow>
+              {/* Secondary: it sits in a row of actions rather than inside the prose,
+                  so it is looked for rather than read. */}
               <s-button
-                variant="tertiary"
+                variant="secondary"
                 href={`/app/campaigns/${
                   overlaps.find((overlap) => overlap.sharedVariants > 0)?.a.id
                 }`}

--- a/app/components/campaign/CampaignLedgerTab.tsx
+++ b/app/components/campaign/CampaignLedgerTab.tsx
@@ -57,7 +57,10 @@ export function CampaignLedgerTab({
                 <fetcher.Form method="post">
                   <input type="hidden" name="intent" value="revert-variant" />
                   <input type="hidden" name="variantGid" value={row.variantGid} />
-                  <s-button type="submit" variant="tertiary" loading={busy || undefined}>
+                  {/* Secondary. It is the only control in the row and it writes a
+                      price, so it is the last thing in the app that should render as
+                      text. */}
+                  <s-button type="submit" variant="secondary" loading={busy || undefined}>
                     Revert this variant
                   </s-button>
                 </fetcher.Form>

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -208,9 +208,12 @@ export function CampaignListView({
                           for a word inside a sentence, and names a row-leading title as
                           exactly what tertiary is for. It keeps an anchor's behaviour,
                           so middle-click still opens a tab. */}
-                      <s-button variant="tertiary" href={`/app/campaigns/${campaign.id}`}>
-                        {campaign.name}
-                      </s-button>
+                      {/* A link, because it is the row's identity and the way in. As a
+                          tertiary button it rendered as plain text, so the only thing in
+                          the table that opens a campaign looked like a caption — and a
+                          merchant scanning the list had nothing telling them the name was
+                          clickable at all. */}
+                      <s-link href={`/app/campaigns/${campaign.id}`}>{campaign.name}</s-link>
                       {/* Only in the archive view, where every row has it, and on a
                           campaign that turns up in a search from the active list —
                           which is the case that would otherwise be confusing, because

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -403,7 +403,7 @@ export default function Dashboard() {
               <input type="hidden" name="intent" value="resolve-notice" />
               <input type="hidden" name="noticeId" value={notice.id} />
               <input type="hidden" name="resolution" value="ignored" />
-              <s-button type="submit" variant="tertiary" loading={busy || undefined}>
+              <s-button type="submit" variant="secondary" loading={busy || undefined}>
                 Leave it as it is
               </s-button>
             </fetcher.Form>
@@ -578,9 +578,13 @@ export default function Dashboard() {
             >
               Create campaign
             </s-button>
-            <s-button variant="tertiary" href="/app/campaigns">Campaigns</s-button>
-            <s-button variant="tertiary" href="/app/prices/drift">Price drift</s-button>
-            <s-button variant="tertiary" href="/app/activity">Activity log</s-button>
+            {/* Secondary, not tertiary. These are three destinations in a row of
+                actions — looked for, then clicked — and as tertiary they rendered as
+                three pieces of plain text beside a real button, which reads as a caption
+                under it rather than as three places to go. */}
+            <s-button variant="secondary" href="/app/campaigns">Campaigns</s-button>
+            <s-button variant="secondary" href="/app/prices/drift">Price drift</s-button>
+            <s-button variant="secondary" href="/app/activity">Activity log</s-button>
           </ActionRow>
         </s-section>
       ) : null}
@@ -620,7 +624,7 @@ export default function Dashboard() {
                 <s-button type="submit" variant="primary" loading={busy || undefined}>
                   Create the draft
                 </s-button>
-                <s-button variant="tertiary" href="/app/campaigns/new">
+                <s-button variant="secondary" href="/app/campaigns/new">
                   Or set a scope, a schedule and more
                 </s-button>
               </ActionRow>
@@ -725,14 +729,14 @@ export default function Dashboard() {
           ) : null}
 
           <ActionRow>
-            <s-button variant="tertiary" href="/app/prices">
+            <s-button variant="secondary" href="/app/prices">
               Browse variants and baselines
             </s-button>
             {/* Tertiary, and the only action on this page deliberately kept quiet. One
                 click was not enough ceremony for the most destructive operation in the
                 app, and a bordered button next to the coverage figure would read as the
                 thing to do about it. */}
-            <s-button variant="tertiary" href="/app/prices/baselines/recapture">
+            <s-button variant="secondary" href="/app/prices/baselines/recapture">
               Recapture baselines…
             </s-button>
           </ActionRow>
@@ -766,9 +770,11 @@ export default function Dashboard() {
             <s-text type={usage.attention ? "strong" : undefined}>{usage.headline}</s-text>
             <s-text color="subdued">{usage.detail}</s-text>
             <ActionRow>
-              <s-button variant="tertiary" href="/app/settings/plan">
-                See plans
-              </s-button>
+              {/* A link. It sits under the sentence about the plan, inside a card of
+                  facts rather than in a row of actions, so it is read rather than looked
+                  for — and as plain dark text it was indistinguishable from the sentence
+                  above it. */}
+              <s-link href="/app/settings/plan">See plans</s-link>
             </ActionRow>
           </s-stack>
 

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -116,14 +116,13 @@ export default function HelpIndex() {
                       served from our own origin inside the frame as well as outside it,
                       and a new tab because the destination is not an embedded page — see
                       the note at the top of this file for what happens when it is not. */}
-                  <s-button
-                    variant="tertiary"
-                    icon="external"
-                    href={`${HELP_ROUTE}/${item.slug}`}
-                    target="_blank"
-                  >
+                  {/* Links, not tertiary buttons. A reading list is content: the
+                      titles are what the merchant is scanning, and a list of them in
+                      plain dark text is a list of things that do not look like they go
+                      anywhere. */}
+                  <s-link href={`${HELP_ROUTE}/${item.slug}`} target="_blank">
                     {item.title}
-                  </s-button>
+                  </s-link>
                   {/* Always rendered, even when there is no blurb: the grid places
                       children in order, so a skipped cell would pull the next article's
                       title into the blurb column and every row after it would be one

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -225,6 +225,7 @@ export default function Reconciliation() {
         <s-button
           type="button"
           variant="tertiary"
+          icon="download"
           onClick={() => downloadCsv("anchor-reconciliation.csv", reconciliationCsv(rows))}
         >
           Export this page (CSV)

--- a/app/routes/app.settings.diagnostics.tsx
+++ b/app/routes/app.settings.diagnostics.tsx
@@ -198,12 +198,9 @@ export default function Debug() {
                   <s-table-row key={row.errorId}>
                     <s-table-cell>{row.createdAt}</s-table-cell>
                     <s-table-cell>
-                      <s-button
-                        variant="tertiary"
-                        href={`/app/settings/diagnostics?id=${row.errorId}`}
-                      >
+                      <s-link href={`/app/settings/diagnostics?id=${row.errorId}`}>
                         {row.errorId}
-                      </s-button>
+                      </s-link>
                     </s-table-cell>
                     <s-table-cell>
                       <s-badge tone={row.retryable ? "warning" : "critical"}>

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -215,7 +215,7 @@ export default function Segments() {
                       <fetcher.Form method="post">
                         <input type="hidden" name="intent" value="delete" />
                         <input type="hidden" name="segmentId" value={segment.id} />
-                        <s-button type="submit" tone="critical" variant="tertiary" loading={busy || undefined}>
+                        <s-button type="submit" tone="critical" variant="tertiary" icon="delete" loading={busy || undefined}>
                           Delete
                         </s-button>
                       </fetcher.Form>


### PR DESCRIPTION
`ActionRow`'s vocabulary made `variant="tertiary"` — *"dark text with no chrome"* — the
replacement for almost every link in the app. Rendered, that is **plain static text**.

At 4× zoom on the deployed build, these were indistinguishable from captions: "Why?", "See
plans", "See everything", "Show archived", "Browse variants and baselines", every **campaign
name** in the list, every help article title, and the only control in a ledger row. A
merchant had no way to know a campaign's name was the way into it.

The rule it replaced was answering a real problem, and its own comment states it well: a
page of four blue links offers four things of apparently equal weight and no clue which one
it wants pressed.

**Both are the same mistake from opposite ends.** Loudness was carrying two things at once —
how much a page wants something pressed, and whether it can be pressed at all. The second is
not negotiable, and hierarchy is what answers the four-links problem, which one primary per
card already provides.

So the question a caller answers is *what kind of thing is this*, and the loudness follows:

| treatment | for | because |
| --- | --- | --- |
| `s-link` | a name in a row, an article title, a word in a sentence | read, then clicked |
| primary | the one thing the card most wants done | still one per card |
| secondary | a standalone action or destination in a row of them | looked for, then clicked |
| tertiary | a control repeated on every row, **and only ever with an icon** | the icon is what makes it a control rather than a caption |

Twenty call sites moved. Names and row destinations became links; standalone actions became
secondary; the four remaining tertiary controls gained the icon that earns them the
treatment — including the calendar's "Today", which was the only plain text in a row of
three controls.

### The guard changed shape rather than being deleted

`action-row.test.tsx` no longer bans a link. It holds the two rules that keep the vocabulary
legible: a tertiary control carries an icon, and an `s-link` has an href — a link with no
destination is a button wearing the wrong clothes. At most one black button per card is
unchanged.

### Checks

- 3493 unit tests, typecheck, lint and build pass.
- Mutation-tested: an iconless tertiary and a hrefless link each fail the guard.

Part of #575.

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)