### PR TITLE
One place decides the distances inside a card (#578, #589)

### DIFF
--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+
+import { ActionRow } from "./ActionRow";
+import { Lede, Secondary } from "./Type";
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * A card, and the one place the distances inside one are decided.
+ *
+ * `PageShell` owns the rhythm *between* cards and says why it cannot be left to the
+ * routes: "page rhythm has to be the largest gap on the screen to do its job. If a route
+ * can set it, some route eventually sets it smaller than the gaps inside its own sections,
+ * and the page stops having visible structure at all."
+ *
+ * The same argument applies one level down and nothing implemented it. Every `s-section`
+ * in the app stacked its heading, its prose and its controls with whatever gap the route
+ * happened to reach for, so on the deployed build at 4× zoom the guardrails card ran
+ * heading → lede → secondary → checkbox → fields at four different distances, the
+ * diagnostics card ran heading → sentence → label → field at a fifth, and Home's checklist
+ * had a smaller gap above its first row than between its rows.
+ *
+ * ## The three distances, and why they are three
+ *
+ * - **Heading to content** is the largest of the three. It is the only lever this app has
+ *   for making a heading read as a title: Polaris gives a card heading one weight and one
+ *   size — `s-heading` and `s-section`'s own heading render identically to bold body text —
+ *   and `type="small"` turned out not to be implemented by the runtime either (see
+ *   `Type.tsx`). Air above the content is what is left, and it is enough: a title with room
+ *   under it reads as a title even at the same size. That is #589, solved from here rather
+ *   than from the type scale, because the type scale cannot solve it.
+ * - **Between blocks** is the ordinary card rhythm — a paragraph and the fields under it,
+ *   a table and the actions under it.
+ * - **Lede to secondary** is the tightest. They are one thought: the sentence and its
+ *   qualifier belong to each other more than either belongs to what follows, and spacing
+ *   them like separate blocks is what made a card read as four unrelated paragraphs.
+ *
+ * All three are smaller than `SPACE.page`, which keeps the page's own structure the
+ * strongest thing on the screen.
+ *
+ * ## What this does not take
+ *
+ * A `slot`. Cards that need something in the aside column say so with `slot="aside"` on an
+ * `s-section` and `PageShell` partitions them out — wrapping that would mean this
+ * component knowing about page layout, which is the level above it.
+ */
+
+/** Heading to content: the largest gap in a card, and the only thing making a title one. */
+const HEADING_GAP = SPACE.section;
+
+export function Card({
+  heading,
+  lede,
+  secondary,
+  actions,
+  children,
+}: {
+  /** The card's title. Optional: a card can be one block of content with no title. */
+  heading?: string;
+  /** One sentence saying what this card is for. */
+  lede?: ReactNode;
+  /** What qualifies the lede — a count, a caveat, a consequence. */
+  secondary?: ReactNode;
+  /** The card's own actions, at its foot. */
+  actions?: ReactNode;
+  children?: ReactNode;
+}) {
+  const intro =
+    lede || secondary ? (
+      <s-stack gap={SPACE.tight}>
+        {lede ? <Lede>{lede}</Lede> : null}
+        {secondary ? <Secondary>{secondary}</Secondary> : null}
+      </s-stack>
+    ) : null;
+
+  return (
+    <s-section heading={heading}>
+      {/* The gap under the heading, which `s-section` does not give us a say in — so it
+          is a box with padding at the top of the content rather than a prop. Without it
+          the heading sits on the first line of prose and the card reads as a paragraph
+          with a bold first line. */}
+      <s-box paddingBlockStart={heading ? HEADING_GAP : "none"}>
+        <s-stack gap={SPACE.section}>
+          {intro}
+          {children}
+          {actions ? <ActionRow>{actions}</ActionRow> : null}
+        </s-stack>
+      </s-box>
+    </s-section>
+  );
+}

--- a/app/components/FeedbackForm.tsx
+++ b/app/components/FeedbackForm.tsx
@@ -1,6 +1,7 @@
 import { useFetcher } from "react-router";
 import { Field } from "./FieldGrid";
 import { SPACE } from "../lib/ui/spacing";
+import { Card } from "./Card";
 
 /**
  * The feedback box, on every screen.
@@ -21,8 +22,7 @@ export function FeedbackForm({ route }: { route: string }) {
   const busy = fetcher.state !== "idle";
 
   return (
-    <s-section heading="Tell us how this is going">
-      {fetcher.data ? (
+    <Card heading="Tell us how this is going">  {fetcher.data ? (
         <s-banner tone={fetcher.data.ok ? "success" : "warning"}>
           <s-paragraph>{fetcher.data.message}</s-paragraph>
         </s-banner>
@@ -58,6 +58,6 @@ export function FeedbackForm({ route }: { route: string }) {
           </s-button>
         </s-stack>
       </fetcher.Form>
-    </s-section>
+    </Card>
   );
 }

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -4,6 +4,7 @@ import type { OnboardingState, OnboardingStep, StepId } from "../lib/onboarding/
 import { SPACE } from "../lib/ui/spacing";
 import { ActionRow } from "./ActionRow";
 import { Secondary } from "./Type";
+import { Card } from "./Card";
 
 /**
  * The checklist, until the first campaign has run cleanly.
@@ -71,7 +72,7 @@ export function OnboardingCard({
   const done = state.steps.filter((step) => step.done).length;
 
   return (
-    <s-section heading="Getting started">
+    <Card heading="Getting started">
       <s-stack gap={SPACE.section}>
         <s-stack direction="inline" gap={SPACE.item} alignItems="center">
           <s-badge tone={done === state.steps.length ? "success" : "info"}>
@@ -99,7 +100,7 @@ export function OnboardingCard({
           ))}
         </s-stack>
       </s-stack>
-    </s-section>
+    </Card>
   );
 }
 

--- a/app/components/RunResultSection.tsx
+++ b/app/components/RunResultSection.tsx
@@ -11,13 +11,13 @@ import { formatCount } from "../lib/format/display";
 import { CountsRow } from "./CountsRow";
 import type { CampaignResult } from "../services/campaigns/result.server";
 import { Secondary } from "./Type";
+import { Card } from "./Card";
 
 export function RunResultSection({ result }: { result: CampaignResult }) {
   const { counts, margin } = result;
 
   return (
-    <s-section heading="What this run did">
-      {/* The headline states the outcome before any number, and leads with what went
+    <Card heading="What this run did">  {/* The headline states the outcome before any number, and leads with what went
           wrong. A partial run that opens with its successes is the failure this whole
           product exists to prevent. */}
       <s-banner tone={result.clean ? "success" : counts.failed > 0 ? "critical" : "warning"}>
@@ -113,6 +113,6 @@ export function RunResultSection({ result }: { result: CampaignResult }) {
       ) : null}
 
       <Secondary>{result.unavailable}</Secondary>
-    </s-section>
+    </Card>
   );
 }

--- a/app/components/Type 2.tsx
+++ b/app/components/Type 2.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from "react";
+
+/**
+ * The typographic roles this app has, and what each one renders as.
+ *
+ * `spacing.ts` names every distance and `FieldGrid` names every width. Type had nothing —
+ * so each route chose between `<s-paragraph>`, `<s-text color="subdued">` and a bare
+ * string by hand, and five roles collapsed into three treatments with two of them
+ * identical. From the settings page at 4× zoom, before this existed:
+ *
+ * | role | rendered as |
+ * | --- | --- |
+ * | card heading — "Guardrails" | 15px semibold black |
+ * | card lede — "Floors that no campaign may price below…" | 15px regular black |
+ * | **field label — "Minimum margin (%)"** | **15px regular black** |
+ * | card secondary — "0 of 0 variants have a cost…" | 15px grey |
+ * | field helper — "Share of the selling price…" | 14px grey |
+ *
+ * A reader could not tell a card's lede from a field's label, because they were the same
+ * thing. And the two greys were different sizes doing similar jobs, so they did not read
+ * as one rank either.
+ *
+ * ## The rank that was missing
+ *
+ * Polaris offers `type="small"` on both `s-paragraph` and `s-text`, and this app used it
+ * **zero times** — 67 uses of `color="subdued"` and nothing else. So the whole hierarchy
+ * was carried by grey-versus-black at one size, which is one bit of information doing the
+ * work of three.
+ *
+ * Three ranks now, and each differs from its neighbours by more than one property:
+ *
+ * - **heading** — the card's own, set by `s-section`'s `heading` and sized by `Card`.
+ * - **`Lede`** — body size, base colour. What this card is for, in a sentence.
+ * - **`Secondary`** — small and subdued. What qualifies it: a count, a caveat, a
+ *   consequence. Smaller *and* quieter, so it cannot be mistaken for a lede or for a
+ *   field's label.
+ *
+ * ## What is deliberately not here
+ *
+ * **Field labels and field helper text.** Polaris fields own both — `label` and `details`
+ * — and a second way to render them would be a way for them to disagree with the ones
+ * Polaris draws. The collision above is fixed from the other side: the heading gets bigger
+ * (#589) and the secondary rank gets smaller, so a label sits between two ranks that no
+ * longer look like it.
+ *
+ * **A component per size.** These are roles, not sizes. `Secondary` is small *because*
+ * qualifying prose should be quieter, and if that judgement changes it changes here rather
+ * than in sixty routes.
+ */
+
+/**
+ * The sentence under a card's heading that says what the card is for.
+ *
+ * Body size, base colour, and the only prose in a card that is neither the heading nor
+ * subordinate to something. One per card is the intent; two ledes is a card with two
+ * subjects.
+ */
+export function Lede({ children }: { children: ReactNode }) {
+  return <s-paragraph>{children}</s-paragraph>;
+}
+
+/**
+ * Prose that qualifies rather than explains: a count, a caveat, a consequence.
+ *
+ * Small and subdued. It used to be `<s-paragraph><s-text color="subdued">` written out at
+ * twenty-one call sites — body size, grey — which is the same size as the lede above it
+ * and the label beside it, so the only thing marking it as subordinate was a colour.
+ *
+ * ## The cast, and why it is not a shortcut
+ *
+ * `small` is a real Polaris type: `ParagraphType` is `'paragraph' | 'small'`, documented
+ * as "considered less important than the main content… surfaces should apply a smaller
+ * font size than the default size", rendered as `<small>`. What does not have it is the
+ * **React** props for this version — `ReactProps` for `s-paragraph` picks only `id` and
+ * `children`, the same way it omits `s-page`'s `subheading`. The element still receives
+ * the attribute, because React passes unknown attributes through to a custom element.
+ *
+ * So the cast asserts something the platform documents and the pinned wrapper has not
+ * caught up with, in one place, with the alternative named: without it there is exactly
+ * one de-emphasis lever in the typed API — subdued colour — which is one bit of
+ * information doing the work of three ranks.
+ *
+ * **If it does not render smaller, this is worth nothing and should go.** The rank would
+ * then have to come from the heading (#589) and the card's rhythm (#578) alone. Checked
+ * on the deployed build at 4× zoom, which is the only way to know.
+ */
+const SMALL = { type: "small" } as unknown as { type?: never };
+
+export function Secondary({ children }: { children: ReactNode }) {
+  return (
+    <s-paragraph {...SMALL} color="subdued">
+      {children}
+    </s-paragraph>
+  );
+}
+
+/**
+ * The label half of a labelled fact — "Last synced", "Plan", "Oldest baseline captured".
+ *
+ * Inline rather than a paragraph, because it sits directly above the value it names and a
+ * paragraph's own leading would push the two apart. Small and subdued for the same reason
+ * `Secondary` is: a caption that is the same size as its value is not a caption.
+ *
+ * The value itself is deliberately not a component here — it is whatever it is, a number,
+ * a date, a badge — and wrapping it would mean guessing.
+ */
+export function Caption({ children }: { children: ReactNode }) {
+  return (
+    <s-text {...SMALL} color="subdued">
+      {children}
+    </s-text>
+  );
+}

--- a/app/components/campaign/CampaignCalendar.tsx
+++ b/app/components/campaign/CampaignCalendar.tsx
@@ -3,6 +3,7 @@ import { ActionRow } from "../ActionRow";
 import { CalendarGrid } from "../CalendarGrid";
 import { TabBar } from "../TabBar";
 import type { calendarFor } from "../../services/calendar.server";
+import { Card } from "../Card";
 
 type Calendar = Awaited<ReturnType<typeof calendarFor>>;
 
@@ -31,8 +32,7 @@ export function CampaignCalendar({
 }: CampaignCalendarProps) {
   return (
     <>
-      <s-section heading={heading}>
-        <s-paragraph>
+      <Card heading={heading}>    <s-paragraph>
           <s-text>
             Dates and times are your store&rsquo;s, in {timeZone}. Click a day to schedule
             a campaign starting then.
@@ -100,11 +100,10 @@ export function CampaignCalendar({
         />
 
         <CalendarGrid days={days} today={today} />
-      </s-section>
+      </Card>
 
       {overlaps.length > 0 ? (
-        <s-section heading="Campaigns running at the same time">
-          <s-paragraph>
+        <Card heading="Campaigns running at the same time">      <s-paragraph>
             <s-text>
               Overlapping campaigns never stack. The higher priority one wins every
               product they share, and the preview shows exactly which price each gets.
@@ -141,7 +140,7 @@ export function CampaignCalendar({
               </s-button>
             </ActionRow>
           ) : null}
-        </s-section>
+        </Card>
       ) : null}
     </>
   );

--- a/app/components/campaign/CampaignLedgerTab.tsx
+++ b/app/components/campaign/CampaignLedgerTab.tsx
@@ -10,6 +10,7 @@ import { ActionRow } from "../ActionRow";
 import { downloadCsv, filenameSlug } from "../../lib/reporting/csv";
 import { ledgerCsv } from "../../lib/reporting/ledger-csv";
 import type { CampaignDetailProps } from "./props";
+import { Card } from "../Card";
 
 export function CampaignLedgerTab({
   preview,
@@ -21,8 +22,7 @@ export function CampaignLedgerTab({
   return (
     <>
       {ledger.length > 0 ? (
-        <s-section heading="Ledger">
-          <s-paragraph>
+        <Card heading="Ledger">      <s-paragraph>
             <s-text>
               Every row we wrote, with what it was and what we intended. Retained
               indefinitely on every plan. Reverting a single variant takes it out of
@@ -69,7 +69,7 @@ export function CampaignLedgerTab({
               )
             }
           />
-        </s-section>
+        </Card>
       ) : null}
     </>
   );

--- a/app/components/campaign/CampaignNote.tsx
+++ b/app/components/campaign/CampaignNote.tsx
@@ -20,11 +20,11 @@
 
 import { SPACE } from "../../lib/ui/spacing";
 import type { CampaignDetailProps } from "./props";
+import { Card } from "../Card";
 
 export function CampaignNote({ note, fetcher, busy }: CampaignDetailProps) {
   return (
-    <s-section heading="Why this campaign exists">
-      <fetcher.Form method="post">
+    <Card heading="Why this campaign exists">  <fetcher.Form method="post">
         <input type="hidden" name="intent" value="note" />
         <s-stack direction="block" gap={SPACE.item}>
           <s-text-area
@@ -49,6 +49,6 @@ export function CampaignNote({ note, fetcher, busy }: CampaignDetailProps) {
           </s-stack>
         </s-stack>
       </fetcher.Form>
-    </s-section>
+    </Card>
   );
 }

--- a/app/components/campaign/CampaignOverviewTab.tsx
+++ b/app/components/campaign/CampaignOverviewTab.tsx
@@ -12,6 +12,7 @@ import { ALL_STATES, describeState } from "../../lib/lifecycle/transitions";
 import { humanise } from "../../lib/format/label";
 import { CampaignNote } from "./CampaignNote";
 import type { CampaignDetailProps } from "./props";
+import { Card } from "../Card";
 
 export function CampaignOverviewTab(props: CampaignDetailProps) {
   const {
@@ -26,14 +27,13 @@ export function CampaignOverviewTab(props: CampaignDetailProps) {
 
   return (
     <>
-      <s-section heading="Status">
-        <s-paragraph>
+      <Card heading="Status">    <s-paragraph>
           <s-badge tone={lifecycle.tone}>{lifecycle.label}</s-badge>
         </s-paragraph>
         <s-paragraph>
           <s-text>{lifecycle.explanation}</s-text>
         </s-paragraph>
-      </s-section>
+      </Card>
 
       {/* Above the history, because the note is why the history happened. */}
       <CampaignNote {...props} />
@@ -49,8 +49,7 @@ export function CampaignOverviewTab(props: CampaignDetailProps) {
         //    or names the account;
         //  - `at` was loaded, carried through the loader, and never rendered, so the one
         //    column a history is *for* was missing.
-        <s-section heading="How it got here">
-          <s-table>
+        <Card heading="How it got here">      <s-table>
             <s-table-header-row>
               <s-table-header listSlot="kicker">When</s-table-header>
               <s-table-header listSlot="primary">Change</s-table-header>
@@ -70,20 +69,18 @@ export function CampaignOverviewTab(props: CampaignDetailProps) {
               ))}
             </s-table-body>
           </s-table>
-        </s-section>
+        </Card>
       ) : null}
 
-      <s-section heading="Schedule">
-        <s-paragraph>{scheduleText}</s-paragraph>
+      <Card heading="Schedule">    <s-paragraph>{scheduleText}</s-paragraph>
         {warnings.map((warning) => (
           <s-banner key={warning} tone="warning">
             <s-paragraph>{warning}</s-paragraph>
           </s-banner>
         ))}
-      </s-section>
+      </Card>
 
-      <s-section heading="New products">
-        <s-paragraph>
+      <Card heading="New products">    <s-paragraph>
           {autoEnroll
             ? "Products that enter this campaign's scope while it runs are priced automatically, from their own normal price."
             : "Products added while this campaign runs are left at their current price."}
@@ -95,7 +92,7 @@ export function CampaignOverviewTab(props: CampaignDetailProps) {
             </s-paragraph>
           </s-banner>
         ) : null}
-      </s-section>
+      </Card>
     </>
   );
 }

--- a/app/components/campaign/CampaignPreviewTab.tsx
+++ b/app/components/campaign/CampaignPreviewTab.tsx
@@ -28,6 +28,7 @@ import { downloadCsv, filenameSlug } from "../../lib/reporting/csv";
 import { previewCsv } from "../../lib/reporting/preview-csv";
 import { ActionRow } from "../ActionRow";
 import type { CampaignDetailProps } from "./props";
+import { Card } from "../Card";
 
 export function CampaignPreviewTab({ preview, approval, fetcher, busy }: CampaignDetailProps) {
 
@@ -35,8 +36,7 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
     <>
 
       {approval.required ? (
-        <s-section heading="Approval">
-          <s-paragraph>
+        <Card heading="Approval">      <s-paragraph>
             <s-text>
               {approval.state === "approved"
                 ? `Approved by ${approval.who}.`
@@ -75,11 +75,10 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
               </>
             ) : null}
           </ActionRow>
-        </s-section>
+        </Card>
       ) : null}
 
-      <s-section heading="Preview">
-        <CountsRow
+      <Card heading="Preview">    <CountsRow
           items={[
             { label: "Will change", value: preview.counts.planned },
             { label: "Already correct", value: preview.counts.noop },
@@ -124,11 +123,10 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
             Export this preview (CSV)
           </s-button>
         </ActionRow>
-      </s-section>
+      </Card>
 
       {preview.margin ? (
-        <s-section heading="What this does to your margins">
-          <s-paragraph>
+        <Card heading="What this does to your margins">      <s-paragraph>
             <s-text>{preview.margin.summary}</s-text>
           </s-paragraph>
           <s-paragraph>
@@ -170,12 +168,11 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
               </s-unordered-list>
             </s-banner>
           ) : null}
-        </s-section>
+        </Card>
       ) : null}
 
       {preview.markets.length > 0 ? (
-        <s-section heading="Markets">
-          <s-paragraph>
+        <Card heading="Markets">      <s-paragraph>
             <s-text>
               Each market is priced from its own normal price in its own currency,
               not converted from the base sale price.
@@ -195,7 +192,7 @@ export function CampaignPreviewTab({ preview, approval, fetcher, busy }: Campaig
               ) : null}
             </s-paragraph>
           ))}
-        </s-section>
+        </Card>
       ) : null}
     </>
   );

--- a/app/components/campaign/CampaignRevertTab.tsx
+++ b/app/components/campaign/CampaignRevertTab.tsx
@@ -12,13 +12,13 @@ import { ActionRow } from "../ActionRow";
 import { downloadCsv, filenameSlug } from "../../lib/reporting/csv";
 import { rollbackReportCsv } from "../../lib/reporting/rollback";
 import type { CampaignDetailProps } from "./props";
+import { Card } from "../Card";
 
 export function CampaignRevertTab({ rollback, preview, fetcher, busy }: CampaignDetailProps) {
   return (
     <>
       {rollback && rollback.counts.total > 0 ? (
-        <s-section heading="If you revert this campaign">
-          <s-paragraph>
+        <Card heading="If you revert this campaign">      <s-paragraph>
             <s-text>
               {rollback.straightforward
                 ? `All ${rollback.counts.total} variants are still at the price this campaign set. Reverting recomputes each one without it.`
@@ -69,7 +69,7 @@ export function CampaignRevertTab({ rollback, preview, fetcher, busy }: Campaign
               </s-button>
             </ActionRow>
           </fetcher.Form>
-        </s-section>
+        </Card>
       ) : null}
     </>
   );

--- a/app/components/imports/ImportForm.tsx
+++ b/app/components/imports/ImportForm.tsx
@@ -11,6 +11,7 @@ import { UnsavedChanges } from "../UnsavedChanges";
 import { downloadCsv } from "../../lib/reporting/csv";
 import { SPACE } from "../../lib/ui/spacing";
 import { Secondary } from "../Type";
+import { Card } from "../Card";
 
 /**
  * One CSV import, whatever the file is for.
@@ -117,8 +118,7 @@ export function ImportForm({
   };
 
   return (
-    <s-section heading={heading}>
-      {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
+    <Card heading={heading}>  {/* A pasted CSV can be fifty thousand rows, and none of it exists anywhere until
           the import runs. */}
       <UnsavedChanges form={form} describe="this import" saved={Boolean(fetcher.data)} />
 
@@ -177,7 +177,7 @@ export function ImportForm({
           </ActionRow>
         </s-stack>
       </fetcher.Form>
-    </s-section>
+    </Card>
   );
 }
 
@@ -223,8 +223,7 @@ export function ImportReport({
   limit?: number;
 }) {
   return (
-    <s-section heading={heading}>
-      <CountsRow items={counts} />
+    <Card heading={heading}>  <CountsRow items={counts} />
 
       {problems.length === 0 ? (
         <EmptyState
@@ -280,6 +279,6 @@ export function ImportReport({
           ) : null}
         </>
       )}
-    </s-section>
+    </Card>
   );
 }

--- a/app/components/imports/PriceImportHistory.tsx
+++ b/app/components/imports/PriceImportHistory.tsx
@@ -18,6 +18,7 @@ import { EmptyState } from "../AsyncState";
 import { Blank } from "../Blank";
 import { formatCount } from "../../lib/format/display";
 import { Secondary } from "../Type";
+import { Card } from "../Card";
 
 export interface PriceImportRow {
   id: string;
@@ -38,8 +39,7 @@ export function PriceImportHistory({
   timeZone: string;
 }) {
   return (
-    <s-section heading="Price files you have imported">
-      {imports.length === 0 ? (
+    <Card heading="Price files you have imported">  {imports.length === 0 ? (
         <EmptyState
           title="Nothing imported yet"
           description="Every file you import is recorded here with its row counts and who ran it, so you can always answer which file a campaign is pricing from."
@@ -85,6 +85,6 @@ export function PriceImportHistory({
           <Secondary>Times are your store&rsquo;s, in {timeZone}.</Secondary>
         </>
       )}
-    </s-section>
+    </Card>
   );
 }

--- a/app/lib/campaigns/from-file.test.ts
+++ b/app/lib/campaigns/from-file.test.ts
@@ -39,7 +39,7 @@ describe("choosing it", () => {
   it("removes the scope rather than leaving it inert", () => {
     // The acceptance criterion, and the reason the second page was confusing: a file
     // names its own variants, so a scope a merchant fills in would be discarded.
-    expect(EDITOR).toMatch(/\{fromFile \? null : \(\s*<s-section heading=\{headings\.scope\}/);
+    expect(EDITOR).toMatch(/\{fromFile \? null : \(\s*<Card heading=\{headings\.scope\}/);
   });
 
   it("removes the arithmetic controls too", () => {

--- a/app/lib/ui/card-rhythm.test.ts
+++ b/app/lib/ui/card-rhythm.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The distances inside a card are decided once, the way the distances between them are.
+ *
+ * `PageShell` owns the rhythm *between* cards and states the argument: "page rhythm has to
+ * be the largest gap on the screen to do its job. If a route can set it, some route
+ * eventually sets it smaller than the gaps inside its own sections, and the page stops
+ * having visible structure at all."
+ *
+ * One level down, nothing implemented it. On the deployed build at 4× zoom the guardrails
+ * card ran heading → lede → secondary → checkbox → fields at four different distances, the
+ * diagnostics card ran heading → sentence → label → field at a fifth, and Home's checklist
+ * had a smaller gap above its first row than between its rows.
+ *
+ * Two things this holds, and the second is the one that will drift:
+ *
+ * - `Card` is where a card's gaps live, and they are smaller than the page's.
+ * - A card's heading is separated from its content by the largest of them. That gap is the
+ *   **only** lever this app has for making a heading read as a title: Polaris gives a card
+ *   heading one weight and one size, and `type="small"` is not implemented by the runtime
+ *   either (`Type.tsx` records the check). Air is what is left, so removing it is removing
+ *   the distinction — which is #589, and why that ticket is answered from here.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const APP = join(process.cwd(), "app");
+const CARD = join(APP, "components", "Card.tsx");
+
+function sources(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [path];
+  });
+}
+
+describe("the card rhythm", () => {
+  const card = sourceOf(CARD);
+
+  it("separates a heading from its content, which is the only lever there is", () => {
+    // Without this a card is a paragraph with a bold first line.
+    expect(card).toContain("paddingBlockStart");
+    expect(card).toContain("HEADING_GAP");
+  });
+
+  it("keeps a lede and the line qualifying it tighter than everything else", () => {
+    // They are one thought. Spacing them like separate blocks is what made a card read as
+    // four unrelated paragraphs.
+    const intro = card.slice(card.indexOf("const intro"), card.indexOf("return ("));
+
+    expect(intro).toContain(`gap={SPACE.tight}`);
+  });
+
+  it("stays inside the page's own rhythm", () => {
+    // Every gap a card uses is smaller than the gap between cards, or the page stops
+    // having structure. `spacing.test.ts` refuses `SPACE.page` outside `PageShell`; this
+    // is the other half — the tokens a card is allowed to reach for.
+    const used = [...card.matchAll(/SPACE\.(\w+)/g)].map((match) => match[1]);
+
+    expect(used.length).toBeGreaterThan(0);
+    for (const token of used) {
+      expect(
+        ["section", "item", "tight"],
+        `a card may not use SPACE.${token} — it is the page's, or larger than the page's`,
+      ).toContain(token);
+    }
+  });
+});
+
+describe("cards use it", () => {
+  /**
+   * Read from the components directory rather than a list, so a card added next week is
+   * covered without anybody remembering this file exists.
+   *
+   * Not every `s-section` is a `Card`: the aside column takes sections directly, because
+   * `PageShell` partitions on the `slot` attribute and wrapping that would put page layout
+   * inside a card. Those are exempt and say so with the slot.
+   */
+  const withSections = sources(APP)
+    .map((path) => ({ path: path.replace(`${APP}/`, ""), source: sourceOf(path) }))
+    .filter(({ source }) => source.includes("<s-section"));
+
+  it("finds the files, so this cannot pass by checking nothing", () => {
+    expect(withSections.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("a titled card in the main column is a Card", () => {
+    const offenders = withSections
+      .filter(({ path }) => path !== "components/Card.tsx")
+      .flatMap(({ path, source }) =>
+        [...source.matchAll(/<s-section[^>]*>/gs)]
+          .filter((match) => match[0].includes("heading=") && !match[0].includes('slot="aside"'))
+          .map(() => path),
+      );
+
+    // A set rather than a count, so a failure names the files.
+    expect([...new Set(offenders)]).toEqual([]);
+  });
+});
+

--- a/app/lib/ui/editor-sections.test.ts
+++ b/app/lib/ui/editor-sections.test.ts
@@ -24,7 +24,7 @@ const editor = sourceOf(process.cwd(), "app", "routes", "app.campaigns.new.tsx")
 
 /** Where each numbered section's card opens, in source order. */
 function sectionAt(key: string): number {
-  return editor.indexOf(`<s-section heading={headings.${key}}>`);
+  return editor.indexOf(`<Card heading={headings.${key}}>`);
 }
 
 const SECTIONS = ["rule", "scope", "when", "markets", "advanced"];
@@ -69,10 +69,12 @@ describe("the submit", () => {
   });
 
   it("is not inside a card", () => {
-    // Inside one it reads as that section's action rather than as the form's.
+    // Inside one it reads as that section's action rather than as the form's. Matched on
+    // `Card` rather than `s-section` since #578 — every titled section in the main column
+    // is one, and the section element is now an implementation detail of that component.
     const submit = editor.indexOf('<s-button type="submit" variant="primary">');
-    const lastOpen = editor.lastIndexOf("<s-section", submit);
-    const lastClose = editor.lastIndexOf("</s-section>", submit);
+    const lastOpen = editor.lastIndexOf("<Card", submit);
+    const lastClose = editor.lastIndexOf("</Card>", submit);
 
     expect(lastClose).toBeGreaterThan(lastOpen);
   });

--- a/app/lib/ui/spacing.test.ts
+++ b/app/lib/ui/spacing.test.ts
@@ -226,8 +226,13 @@ describe("the page rhythm is set in exactly one place", () => {
     // "Page rhythm has to be the largest gap on the screen to do its job. If a route can
     // set it, some route eventually sets it smaller than the gaps inside its own
     // sections, and the page stops having visible structure at all."
+    // `sourceOf`, not `readFileSync`. This read the raw file, so a *comment* naming
+    // `SPACE.page` failed it — which is how `Card.tsx` broke this the first time it
+    // explained why its own gaps are smaller than the page's. That is the eighth time
+    // the comment-grep trap has bitten in this repo, and #462 built the helper for it:
+    // any test that greps `app/` source strips comments first.
     const offenders = CHECKED.filter(
-      (file) => !file.endsWith("PageShell.tsx") && readFileSync(join(ROOT, file), "utf8").includes("SPACE.page"),
+      (file) => !file.endsWith("PageShell.tsx") && sourceOf(join(ROOT, file)).includes("SPACE.page"),
     );
 
     expect(offenders).toEqual([]);

--- a/app/lib/ui/type-roles.test 2.ts
+++ b/app/lib/ui/type-roles.test 2.ts
@@ -1,0 +1,88 @@
+/**
+ * Prose uses the named roles rather than choosing its elements by hand.
+ *
+ * `spacing.ts` names every distance and `FieldGrid` names every width. Type had nothing,
+ * so each route picked between `<s-paragraph>`, `<s-text color="subdued">` and a bare
+ * string itself — and the app ended up with five roles rendered in three treatments, two
+ * of which were identical. A card's lede and a field's label were the same 15px regular
+ * black; a card's secondary prose and a field's helper were two different greys.
+ *
+ * The specific shape this refuses is the one that was written twenty-one times: a
+ * paragraph whose only content is subdued text. That is `Secondary`, and writing it out
+ * is how the rank drifts — the next one gets a different size, or forgets the grey, and
+ * nothing says which was intended.
+ *
+ * `s-text color="subdued"` *inside* a sentence stays allowed and is not this: a phrase
+ * greyed down mid-paragraph is emphasis, not a rank.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const APP = join(process.cwd(), "app");
+
+/** Every `.tsx` under `app/`, tests excluded. */
+function sources(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [path];
+  });
+}
+
+const files = sources(APP).map((path) => ({
+  path: path.replace(`${APP}/`, ""),
+  source: sourceOf(path),
+}));
+
+/** A paragraph whose entire content is one subdued text — `Secondary`, written out. */
+const HAND_ROLLED = /<s-paragraph>\s*<s-text color="subdued">[\s\S]*?<\/s-text>\s*<\/s-paragraph>/;
+
+describe("the type roles", () => {
+  it("finds the files, so this cannot pass by checking nothing", () => {
+    expect(files.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it("nobody writes Secondary out by hand", () => {
+    const offenders = files
+      .filter(({ source }) => HAND_ROLLED.test(source.replace(/\n\s*/g, "\n")))
+      .map(({ path }) => path);
+
+    expect(
+      offenders,
+      "a paragraph of subdued text is `Secondary` — writing it out is how the rank drifts",
+    ).toEqual([]);
+  });
+
+  it("names three ranks and says what each is for", () => {
+    const type = sourceOf(join(APP, "components", "Type.tsx"));
+
+    expect(type).toContain("export function Lede");
+    expect(type).toContain("export function Secondary");
+    expect(type).toContain("export function Caption");
+  });
+
+  it("keeps the subordinate ranks both smaller and quieter", () => {
+    // One lever doing the work of three ranks is what this replaced. If the size goes,
+    // `Secondary` is body-size grey again — the state the ticket describes.
+    const type = sourceOf(join(APP, "components", "Type.tsx"));
+
+    expect(type).toContain('{ type: "small" }');
+    expect(type).toMatch(/<s-paragraph \{\.\.\.SMALL\} color="subdued">/);
+    expect(type).toMatch(/<s-text \{\.\.\.SMALL\} color="subdued">/);
+  });
+
+  it("does not put field labels or helper text in here", () => {
+    // Polaris fields own `label` and `details`. A second way to render either is a way
+    // for the two to disagree with what Polaris draws.
+    const type = sourceOf(join(APP, "components", "Type.tsx"));
+
+    expect(type).not.toContain("export function FieldLabel");
+    expect(type).not.toContain("export function Helper");
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -34,6 +34,7 @@ import { SPACE } from "../lib/ui/spacing";
 import { planUsage } from "../services/plan-usage.server";
 import { usageLine } from "../lib/billing/usage-line";
 import { Secondary } from "../components/Type";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -538,8 +539,7 @@ export default function Dashboard() {
           The checklist above is already answering "what now", and answering it with an
           action rather than with four zeroes. */}
       {sections.live ? (
-        <s-section heading="What is live right now">
-          {/* Each figure is a question, so each tile is the answer's front door. The
+        <Card heading="What is live right now">      {/* Each figure is a question, so each tile is the answer's front door. The
               status values are the campaigns index's own filter vocabulary — `attention`
               spans PARTIAL and HELD there, which is exactly what "Need attention"
               counts — so the number a merchant clicks and the list they land on are the
@@ -586,7 +586,7 @@ export default function Dashboard() {
             <s-button variant="secondary" href="/app/prices/drift">Price drift</s-button>
             <s-button variant="secondary" href="/app/activity">Activity log</s-button>
           </ActionRow>
-        </s-section>
+        </Card>
       ) : null}
 
       {/* The commonest job in the category, as one number.
@@ -601,8 +601,7 @@ export default function Dashboard() {
           is the safety property; trading it for parity would be trading away the reason to
           choose us — so the card says so before the button rather than after. */}
       {sections.quickCreate ? (
-        <s-section heading="Put everything on sale">
-          <fetcher.Form method="post">
+        <Card heading="Put everything on sale">      <fetcher.Form method="post">
             <input type="hidden" name="intent" value="quick-campaign" />
             <s-stack gap={SPACE.item}>
               {/* One two-digit number, so a control the width of the card would be
@@ -630,27 +629,25 @@ export default function Dashboard() {
               </ActionRow>
             </s-stack>
           </fetcher.Form>
-        </s-section>
+        </Card>
       ) : null}
 
       {/* What is about to happen, which "Scheduled: 1" could not say. Only when there is
           something ahead — an empty "nothing is scheduled" card is the same mistake as the
           four zeroes this page used to open with. */}
       {upcomingMoments.length > 0 ? (
-        <s-section heading="Next up">
-          <UpcomingCampaigns
+        <Card heading="Next up">      <UpcomingCampaigns
             moments={upcomingMoments}
             now={now}
             timeZone={timeZone}
           />
-        </s-section>
+        </Card>
       ) : null}
 
       {/* The one case the checklist does not cover: everything on it is done, and the
           campaigns it was done with have since been deleted. */}
       {sections.emptyState ? (
-        <s-section heading="What is live right now">
-          <s-paragraph>
+        <Card heading="What is live right now">      <s-paragraph>
             <s-text>
               Nothing is running. A <strong>campaign</strong> is a rule — “20% off
               everything tagged Summer” — plus when it should run. Anchor computes each
@@ -672,12 +669,11 @@ export default function Dashboard() {
               Create a campaign
             </s-button>
           </ActionRow>
-        </s-section>
+        </Card>
       ) : null}
 
       {sections.catalogue ? (
-        <s-section heading="Catalogue">
-          {/* The shared component, not a second copy of its markup. This page had
+        <Card heading="Catalogue">      {/* The shared component, not a second copy of its markup. This page had
               hand-rolled the same four tiles, so it kept the old flat look after the
               real one gained borders and equal columns -- and it is the first screen
               after installing, which is the worst place to be a version behind.
@@ -740,7 +736,7 @@ export default function Dashboard() {
               Recapture baselines…
             </s-button>
           </ActionRow>
-        </s-section>
+        </Card>
       ) : null}
 
       <s-section slot="aside" heading="Store">

--- a/app/routes/app.campaigns.$id.tsx
+++ b/app/routes/app.campaigns.$id.tsx
@@ -47,6 +47,7 @@ import { CampaignPreviewTab } from "../components/campaign/CampaignPreviewTab";
 import { CampaignRevertTab } from "../components/campaign/CampaignRevertTab";
 import { CampaignLedgerTab } from "../components/campaign/CampaignLedgerTab";
 import type { CampaignDetailProps } from "../components/campaign/props";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/campaigns/$id", async ({ request, params }: LoaderFunctionArgs) => {
   const { admin, session } = await authenticate.admin(request);
@@ -356,9 +357,8 @@ export default function CampaignDetail() {
         {runResult ? <RunResultSection result={runResult} /> : null}
 
         {runs.length > 0 ? (
-          <s-section heading="Run history">
-            <RunHistoryTable runs={runs} selectedRunId={selectedRunId} timeZone={timeZone} />
-          </s-section>
+          <Card heading="Run history">        <RunHistoryTable runs={runs} selectedRunId={selectedRunId} timeZone={timeZone} />
+          </Card>
         ) : null}
 
         </>

--- a/app/routes/app.campaigns.new.tsx
+++ b/app/routes/app.campaigns.new.tsx
@@ -53,6 +53,7 @@ import { numberSections } from "../lib/ui/sections";
 import { SPACE } from "../lib/ui/spacing";
 import type { DraftPreview as Preview } from "../services/campaigns/draft-preview.server";
 import { Secondary } from "../components/Type";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/campaigns/new", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -487,8 +488,7 @@ export default function NewCampaign() {
             exactly this case. Without it two cards touch and read as one card with a
             line through it. */}
         <PageSections>
-      <s-section heading={headings.rule}>
-          <s-stack gap={SPACE.section}>
+      <Card heading={headings.rule}>      <s-stack gap={SPACE.section}>
             {/* The rule, and nothing else, first.
 
                 This block was one flat stack of about fifteen full-width controls -- name,
@@ -607,15 +607,14 @@ export default function NewCampaign() {
                 the end, it now lands directly under the rule it is previewing. */}
 
           </s-stack>
-      </s-section>
+      </Card>
 
       {/* Not rendered at all, rather than rendered and ignored. A file names its own
           variants — a frozen list of exactly the rows it matched — so a scope here would
           be a control a merchant fills in and the import discards, which is the confusion
           the second page caused in the first place. */}
       {fromFile ? null : (
-      <s-section heading={headings.scope}>
-        <s-paragraph>
+      <Card heading={headings.scope}>    <s-paragraph>
           Which variants the rule above applies to. Leave everything blank to target the
           whole catalogue; conditions combine with AND.
         </s-paragraph>
@@ -728,7 +727,7 @@ export default function NewCampaign() {
             </s-select>
           </FullRow>
         </FieldGrid>
-      </s-section>
+      </Card>
       )}
 
       {/* Its own card, not a heading inside the rule's.
@@ -740,8 +739,7 @@ export default function NewCampaign() {
           A merchant who filled in the rule and pressed the obvious button never read the
           section that says which products it applies to. */}
       {fromFile ? null : (
-      <s-section heading={headings.when}>
-        {/* The card's own heading says "When". A second one saying "Schedule (optional)"
+      <Card heading={headings.when}>    {/* The card's own heading says "When". A second one saying "Schedule (optional)"
             inside it was the heading this block needed while it lived in the middle of
             the rule's card, and it is a heading inside a heading now. The optionality is
             in the sentence below, where it belongs — a merchant who reads "leave the
@@ -781,12 +779,11 @@ export default function NewCampaign() {
           details="Defaults to the end of that day."
         />
       </FieldGrid>
-      </s-section>
+      </Card>
       )}
 
       {!fromFile && priceLists.length > 0 ? (
-      <s-section heading={headings.markets}>
-          <s-paragraph>
+      <Card heading={headings.markets}>      <s-paragraph>
             <s-text>
               Your base price always changes. Tick a market to run this campaign
               there too &mdash; each is priced from{" "}
@@ -862,12 +859,11 @@ export default function NewCampaign() {
               </s-select>
             ))}
           </FieldGrid>
-      </s-section>
+      </Card>
       ) : null}
 
       {fromFile ? null : (
-      <s-section heading={headings.advanced}>
-      {/* The pressure valve.
+      <Card heading={headings.advanced}>  {/* The pressure valve.
 
           Four controls a first campaign never touches, all with defaults that are
           right for almost everybody: priority only matters once two campaigns
@@ -919,7 +915,7 @@ export default function NewCampaign() {
           />
         </FullRow>
       </FieldGrid>
-      </s-section>
+      </Card>
       )}
 
       {/* Last, and outside every card.

--- a/app/routes/app.help.tsx
+++ b/app/routes/app.help.tsx
@@ -45,6 +45,7 @@ import { withGuard } from "../lib/errors/guard.server";
 import { helpNav } from "../lib/help/nav.server";
 import { SPACE } from "../lib/ui/spacing";
 import { Secondary } from "../components/Type";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/help", async ({ request }: LoaderFunctionArgs) => {
   // Authenticated like every other embedded route, even though the content is public
@@ -73,8 +74,7 @@ export default function HelpIndex() {
           question; making them scan every article before finding out a person will
           answer is the arrangement that makes support feel unreachable. Secondary,
           because most questions really are answered by the pages below. */}
-      <s-section heading="Still stuck">
-        <s-stack gap={SPACE.item}>
+      <Card heading="Still stuck">    <s-stack gap={SPACE.item}>
           <s-paragraph>
             Write to us and we reply to every message. Your shop, plan and the page you
             came from are attached, so you do not have to describe your setup — and you
@@ -86,11 +86,10 @@ export default function HelpIndex() {
             </s-button>
           </ActionRow>
         </s-stack>
-      </s-section>
+      </Card>
 
       {nav.sections.map((section) => (
-        <s-section key={section.id} heading={section.title}>
-          <s-stack gap={SPACE.section}>
+        <Card key={section.id} heading={section.title}>      <s-stack gap={SPACE.section}>
             {section.blurb ? <s-paragraph>{section.blurb}</s-paragraph> : null}
 
             {/* A grid, so the list has a left edge.
@@ -132,7 +131,7 @@ export default function HelpIndex() {
               ))}
             </s-grid>
           </s-stack>
-        </s-section>
+        </Card>
       ))}
     </PageShell>
   );

--- a/app/routes/app.prices.baselines._index.tsx
+++ b/app/routes/app.prices.baselines._index.tsx
@@ -48,6 +48,7 @@ import { PageShell } from "../components/PageShell";
 import { HelpNote } from "../components/HelpNote";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { SPACE } from "../lib/ui/spacing";
+import { Card } from "../components/Card";
 
 const FILTER_FIELDS = ["q", "vendor", "source", "diverged", "variant"] as const;
 
@@ -255,8 +256,7 @@ export default function Baselines() {
       </s-section>
 
       {variantGid && history.length > 0 ? (
-        <s-section heading="Baseline history">
-          <s-paragraph>
+        <Card heading="Baseline history">      <s-paragraph>
             <s-text>{variantGid}</s-text>
           </s-paragraph>
           <s-table>
@@ -294,7 +294,7 @@ export default function Baselines() {
               ))}
             </s-table-body>
           </s-table>
-        </s-section>
+        </Card>
       ) : null}
 
       <ImportForm
@@ -347,8 +347,7 @@ export default function Baselines() {
           scope that can be half a million variants and cross-references every running
           campaign — neither of which belongs on a page a merchant opens to look one
           price up. */}
-      <s-section heading="Recapture baselines">
-        <s-paragraph>
+      <Card heading="Recapture baselines">    <s-paragraph>
           <s-text>
             Replaces the reference price of every variant in scope with the price its
             storefront shows right now. Do it when your real prices have genuinely
@@ -361,7 +360,7 @@ export default function Baselines() {
             Check a scope and recapture
           </s-button>
         </ActionRow>
-      </s-section>
+      </Card>
 
       <HelpNote label="Reading this page">
         <s-paragraph>

--- a/app/routes/app.prices.baselines.recapture.tsx
+++ b/app/routes/app.prices.baselines.recapture.tsx
@@ -35,6 +35,7 @@ import { HelpNote } from "../components/HelpNote";
 import { Field } from "../components/FieldGrid";
 import { ActionRow } from "../components/ActionRow";
 import { SPACE } from "../lib/ui/spacing";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/prices/baselines/recapture", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -112,8 +113,7 @@ export default function Recapture() {
         </s-banner>
       ) : null}
 
-      <s-section heading="What this does">
-        <s-paragraph>
+      <Card heading="What this does">    <s-paragraph>
           <s-text>
             Recapturing replaces the reference price of every variant in scope with the
             price its storefront shows right now. Every campaign from then on computes
@@ -157,11 +157,10 @@ export default function Recapture() {
             {assessment.scope} variant{assessment.scope === 1 ? "" : "s"} in scope.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </Card>
 
       {assessment.risk === "overlaps-active-campaign" ? (
-        <s-section heading="These are on sale right now">
-          <s-banner tone="critical">
+        <Card heading="These are on sale right now">      <s-banner tone="critical">
             <s-paragraph>{assessment.warning}</s-paragraph>
           </s-banner>
 
@@ -181,11 +180,10 @@ export default function Recapture() {
               ))}
             </s-table-body>
           </s-table>
-        </s-section>
+        </Card>
       ) : null}
 
-      <s-section heading="Recapture">
-        <fetcher.Form method="post">
+      <Card heading="Recapture">    <fetcher.Form method="post">
           <input type="hidden" name="segment" value={segmentId} />
           <s-stack gap={SPACE.section}>
             {assessment.confirmationPhrase ? (
@@ -209,7 +207,7 @@ export default function Recapture() {
             </s-button>
           </s-stack>
         </fetcher.Form>
-      </s-section>
+      </Card>
 
       <HelpNote label="If you get this wrong">
         <s-paragraph>

--- a/app/routes/app.prices.costs.tsx
+++ b/app/routes/app.prices.costs.tsx
@@ -39,6 +39,7 @@ import { linesOf } from "../lib/reporting/lines";
 import { isCommit } from "../lib/imports/intent";
 import { reportError } from "../services/error-report.server";
 import { SPACE } from "../lib/ui/spacing";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/prices/costs", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -214,18 +215,16 @@ export default function Costs() {
       ) : null}
 
 
-      <s-section heading="What your cost floors can protect">
-        <s-paragraph>
+      <Card heading="What your cost floors can protect">    <s-paragraph>
           <s-text>
             {withCost} of {variants} variants have a cost ({coverage}%). Cost-based
             guardrails skip the rest entirely, so a low number here means &ldquo;never
             price below cost&rdquo; is doing less than it looks.
           </s-text>
         </s-paragraph>
-      </s-section>
+      </Card>
 
-      <s-section heading="Change costs in bulk">
-        {fetcher.data ? (
+      <Card heading="Change costs in bulk">    {fetcher.data ? (
           <s-banner tone={fetcher.data.ok ? "success" : "critical"}>
             <s-paragraph>{fetcher.data.message}</s-paragraph>
           </s-banner>
@@ -309,7 +308,7 @@ export default function Costs() {
             ))}
           </s-unordered-list>
         ) : null}
-      </s-section>
+      </Card>
       <ImportForm
         heading="Import costs from a spreadsheet"
         fetcher={fetcher}

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -25,6 +25,7 @@ import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
 import { Field } from "../components/FieldGrid";
 import { SPACE } from "../lib/ui/spacing";
+import { Card } from "../components/Card";
 
 /** Filters that ride in the query string, so a merchant can bookmark a view. */
 export const RECONCILE_FIELDS = ["q", "surface", "campaign", "state"] as const;
@@ -182,8 +183,7 @@ export default function Reconciliation() {
         </VariantSearch>
       </s-section>
 
-      <s-section heading="Check against Shopify right now">
-        <s-paragraph>
+      <Card heading="Check against Shopify right now">    <s-paragraph>
           <s-text>
             Reads a sample of prices straight from Shopify and compares them with what
             this page shows. Anything that disagrees is corrected here — the storefront
@@ -211,10 +211,9 @@ export default function Reconciliation() {
             </s-button>
           </s-stack>
         </fetcher.Form>
-      </s-section>
+      </Card>
 
-      <s-section heading="Prices">
-        <ReconciliationTable rows={rows} clearHref={clearedSearch(params, RECONCILE_FIELDS)} />
+      <Card heading="Prices">    <ReconciliationTable rows={rows} clearHref={clearedSearch(params, RECONCILE_FIELDS)} />
 
         {/* This page has been paged server-side since it was written and had no pager, so
             row 26 was unreachable by anything but typing `?page=2` into a URL a merchant
@@ -230,7 +229,7 @@ export default function Reconciliation() {
         >
           Export this page (CSV)
         </s-button>
-      </s-section>
+      </Card>
     </PageShell>
   );
 }

--- a/app/routes/app.settings._index.tsx
+++ b/app/routes/app.settings._index.tsx
@@ -24,6 +24,7 @@ import { HelpNote } from "../components/HelpNote";
 import { formatCount } from "../lib/format/display";
 import { SPACE } from "../lib/ui/spacing";
 import { Secondary } from "../components/Type";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/settings", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -154,21 +155,22 @@ export default function Settings() {
             that pushes a price under a floor is a conversation between two of them —
             and splitting them across pages is what made the nav sixteen items long. */}
 
-        <s-section heading="Guardrails">
-          <s-paragraph>
-            Floors that no campaign may price below. They are checked after rounding,
-            so a rounding rule cannot push a price under them.
-          </s-paragraph>
-
-          {/* Coverage sits with the fields it qualifies, not in a sidebar card of its own.
-              Two of the controls below — "never price at or below cost" and what to do when
-              a cost-based floor meets a variant without one — mean nothing until you know
-              how many variants that second case actually is. */}
-          <Secondary>
-            {formatCount(withCost)} of {formatCount(variants)} variants have a cost
-            ({costCoverage}%). Cost-based floors only constrain those; the last setting
-            in this section decides the rest.
-          </Secondary>
+        {/* Coverage sits with the fields it qualifies, not in a sidebar card of its own.
+            Two of the controls below — "never price at or below cost" and what to do when a
+            cost-based floor meets a variant without one — mean nothing until you know how
+            many variants that second case actually is. As the card's `secondary` it is
+            tight against the lede, which is the point: the two are one thought. */}
+        <Card
+          heading="Guardrails"
+          lede="Floors that no campaign may price below. They are checked after rounding, so a rounding rule cannot push a price under them."
+          secondary={
+            <>
+              {formatCount(withCost)} of {formatCount(variants)} variants have a cost
+              ({costCoverage}%). Cost-based floors only constrain those; the last setting
+              in this section decides the rest.
+            </>
+          }
+        >
 
           {settings.neverBelowCost && costCoverage < 100 ? (
             <s-banner tone="warning">
@@ -234,10 +236,9 @@ export default function Settings() {
                 </s-option>
               </s-select>
             </FieldGrid>
-        </s-section>
+        </Card>
 
-        <s-section heading="Rounding">
-          <s-paragraph>
+        <Card heading="Rounding">      <s-paragraph>
             <s-text>
               How campaign prices are tidied up after the discount is calculated. Set
               once here; each campaign can override it.
@@ -311,10 +312,9 @@ export default function Settings() {
                 </>
               ) : null}
             </s-stack>
-        </s-section>
+        </Card>
 
-        <s-section heading="Notifications">
-          <s-paragraph>
+        <Card heading="Notifications">      <s-paragraph>
             <s-text>
               A campaign over a large catalogue runs for a while. These let you close the
               tab and still find out what happened.
@@ -378,7 +378,7 @@ export default function Settings() {
               pricing should end up.
             </s-text>
           </s-paragraph>
-        </s-section>
+        </Card>
 
       </PageSections>
       </fetcher.Form>

--- a/app/routes/app.settings.diagnostics.tsx
+++ b/app/routes/app.settings.diagnostics.tsx
@@ -25,6 +25,7 @@ import { Field } from "../components/FieldGrid";
 import { HelpNote } from "../components/HelpNote";
 import { SPACE } from "../lib/ui/spacing";
 import { Secondary } from "../components/Type";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/settings/diagnostics", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -92,13 +93,10 @@ export default function Debug() {
 
   return (
     <PageShell heading="Diagnostics">
-      <s-section heading="Look up an error">
-        <s-paragraph>
-          <s-text>
-            Paste the reference from an error screen, for example ANC-K3M2-P7QR.
-          </s-text>
-        </s-paragraph>
-
+      <Card
+        heading="Look up an error"
+        lede="Paste the reference from an error screen, for example ANC-K3M2-P7QR."
+      >
         <Form method="get">
           {/* The field and its button are one control. `alignItems="end"` because the
               field carries a label above it and the button does not, so without it the
@@ -170,9 +168,9 @@ export default function Debug() {
             ) : null}
           </s-stack>
         ) : null}
-      </s-section>
+      </Card>
 
-      <s-section heading="Recent failures">
+      <Card heading="Recent failures">
         {recent.length === 0 ? (
           <EmptyState
             title="Nothing has failed recently"
@@ -214,7 +212,7 @@ export default function Debug() {
             </s-table>
           </>
         )}
-      </s-section>
+      </Card>
 
       <HelpNote label="Reading the failures">
         <s-paragraph>

--- a/app/routes/app.settings.feedback.tsx
+++ b/app/routes/app.settings.feedback.tsx
@@ -19,6 +19,7 @@ import { FeedbackForm } from "../components/FeedbackForm";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/settings/feedback", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -65,8 +66,7 @@ export default function FeedbackPage() {
       <FeedbackForm route="/app/settings/feedback" />
 
       {sent.length > 0 ? (
-        <s-section heading="What you have sent">
-          <s-table>
+        <Card heading="What you have sent">      <s-table>
             <s-table-header-row>
               <s-table-header listSlot="kicker">When</s-table-header>
               <s-table-header listSlot="inline">Kind</s-table-header>
@@ -92,7 +92,7 @@ export default function FeedbackPage() {
               ))}
             </s-table-body>
           </s-table>
-        </s-section>
+        </Card>
       ) : null}
     </PageShell>
   );

--- a/app/routes/app.settings.plan.tsx
+++ b/app/routes/app.settings.plan.tsx
@@ -22,6 +22,7 @@ import { formatMinorUnits } from "../lib/money/format";
 import { RouteBoundary } from "../components/RouteBoundary";
 import { withGuard } from "../lib/errors/guard.server";
 import { PageShell } from "../components/PageShell";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/settings/plan", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -108,24 +109,25 @@ export default function PlanPage() {
           because a table that reads correctly beats a card saved. The write-up is in
           `docs/polaris-notes.md`; **do not re-merge these two without loading the page.** */}
 
-      <s-section heading="Plans">
-        <s-paragraph>
-          <s-text type="strong">
-            You are on {PLANS[current as keyof typeof PLANS].name}
-          </s-text>
-          {" — "}
-          <s-text color="subdued">
+      <Card
+        heading="Plans"
+        lede={
+          <>
+            <s-text type="strong">
+              You are on {PLANS[current as keyof typeof PLANS].name}
+            </s-text>
+            {" — "}
             {formatCount(variants)} variants in your catalogue.
-          </s-text>
-        </s-paragraph>
-
-        <s-paragraph>
-          <s-text>
+          </>
+        }
+        secondary={
+          <>
             Pricing is by how much of your catalogue a campaign manages and which
             surfaces it reaches &mdash; never by how many changes you make. Charging per
             change would tax the thing the app is for.
-          </s-text>
-        </s-paragraph>
+          </>
+        }
+      >
 
         <s-table>
           <s-table-header-row>
@@ -160,32 +162,35 @@ export default function PlanPage() {
             ))}
           </s-table-body>
         </s-table>
-      </s-section>
+      </Card>
 
-      <s-section heading="Every plan, including free">
-        <s-paragraph>
-          <s-text>
+      <Card
+        heading="Every plan, including free"
+        lede={
+          <>
             Preview before applying. Guardrails that refuse to price below cost or
             margin. The full history of every change, kept indefinitely. One-click
             rollback of a campaign or a single product.
-          </s-text>
-        </s-paragraph>
-        <s-paragraph>
-          <s-text>
+          </>
+        }
+        secondary={
+          <>
             None of that is ever paywalled. Charging for the ability to undo a mistake
             the app helped you make would be indefensible.
-          </s-text>
-        </s-paragraph>
-      </s-section>
+          </>
+        }
+      />
 
-      <s-section heading="If you downgrade">
-        <s-paragraph>
-          <s-text>
+      <Card
+        heading="If you downgrade"
+        lede={
+          <>
             Running campaigns finish, including their scheduled reverts. Nothing is
             deleted, nothing is paused, and no price is left on sale because a plan
             changed. A smaller plan limits what you can <s-text>start</s-text> next.
-          </s-text>
-        </s-paragraph>
+          </>
+        }
+      >
 
         {affected.length > 0 ? (
           <>
@@ -203,7 +208,7 @@ export default function PlanPage() {
             </s-unordered-list>
           </>
         ) : null}
-      </s-section>
+      </Card>
     </PageShell>
   );
 }

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -36,6 +36,7 @@ import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { ShowingSome } from "../components/Pagination";
 import { HelpNote } from "../components/HelpNote";
 import { Secondary } from "../components/Type";
+import { Card } from "../components/Card";
 
 export const loader = withGuard("/app/settings/segments", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -174,8 +175,7 @@ export default function Segments() {
 
       {result?.report ? <ImportReport report={result.report} /> : null}
 
-      <s-section heading="Your segments">
-        {segments.length === 0 ? (
+      <Card heading="Your segments">    {segments.length === 0 ? (
           <EmptyState
             title="No segments yet"
             description="A segment is a saved way of describing which products a campaign covers, so you do not rebuild the same filter for every sale. Make one below."
@@ -226,7 +226,7 @@ export default function Segments() {
             </s-table-body>
           </s-table>
         )}
-      </s-section>
+      </Card>
 
       <NewSegment available={available} fetcher={fetcher} busy={busy} />
 
@@ -286,8 +286,7 @@ function NewSegment({
   const [how, setHow] = useState<"filter" | "list">("filter");
 
   return (
-    <s-section heading="New segment">
-      <fetcher.Form method="post">
+    <Card heading="New segment">  <fetcher.Form method="post">
         {/* The two branches were two intents on two forms. One form, and the intent
             follows the choice — so the name field cannot be filled in on one card and
             submitted from the other. */}
@@ -415,7 +414,7 @@ function NewSegment({
           </ActionRow>
         </s-stack>
       </fetcher.Form>
-    </s-section>
+    </Card>
   );
 }
 
@@ -424,8 +423,7 @@ function ImportReport({ report }: { report: NonNullable<ActionData["report"]> })
     report.unmatched.length === 0 && report.ambiguous.length === 0 && report.repeated === 0;
 
   return (
-    <s-section heading="What the list matched">
-      <s-paragraph>
+    <Card heading="What the list matched">  <s-paragraph>
         <s-text>
           {report.matched} of {report.total} rows matched a product.
           {clean ? " Every row was placed." : ""}
@@ -503,7 +501,7 @@ function ImportReport({ report }: { report: NonNullable<ActionData["report"]> })
           </s-text>
         </s-paragraph>
       ) : null}
-    </s-section>
+    </Card>
   );
 }
 

--- a/app/routes/app.support.tsx
+++ b/app/routes/app.support.tsx
@@ -33,6 +33,7 @@ import { HelpNote } from "../components/HelpNote";
 import { withGuard } from "../lib/errors/guard.server";
 import { SPACE } from "../lib/ui/spacing";
 import { Secondary } from "../components/Type";
+import { Card } from "../components/Card";
 
 /**
  * Which build this is.
@@ -115,8 +116,7 @@ export default function Support() {
           email address and a subject line in between. The card holds the whole message;
           the field holds the account of the problem. Naming the container after one of
           its contents is how a form stops being legible as a form. */}
-      <s-section heading="Your message">
-        <fetcher.Form method="post">
+      <Card heading="Your message">    <fetcher.Form method="post">
           {/* Each field at the width of what it holds. An email address and a subject
               line rendered the full width of the card, which is a message box's worth of
               room for one line — and it made the three fields read as one block rather
@@ -155,10 +155,9 @@ export default function Support() {
             </ActionRow>
           </s-stack>
         </fetcher.Form>
-      </s-section>
+      </Card>
 
-      <s-section heading="What we attach">
-        {/* Listed, not summarised. A merchant cannot consent to "diagnostic
+      <Card heading="What we attach">    {/* Listed, not summarised. A merchant cannot consent to "diagnostic
             information", and the fastest way to make somebody distrust a Send button is
             to be vague about it one time. */}
         <Secondary>
@@ -179,7 +178,7 @@ export default function Support() {
             ))}
           </s-table-body>
         </s-table>
-      </s-section>
+      </Card>
 
       <HelpNote label="Before you write">
         <s-paragraph>

--- a/app/routes/auth.login/route.tsx
+++ b/app/routes/auth.login/route.tsx
@@ -5,6 +5,7 @@ import { Form, useActionData, useLoaderData } from "react-router";
 
 import { login } from "../../shopify.server";
 import { loginErrorMessage } from "./error.server";
+import { Card } from "../../components/Card";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const errors = loginErrorMessage(await login(request));
@@ -30,8 +31,7 @@ export default function Auth() {
     <AppProvider embedded={false}>
       <s-page>
         <Form method="post">
-        <s-section heading="Log in">
-          <s-text-field
+        <Card heading="Log in">      <s-text-field
             name="shop"
             label="Shop domain"
             details="example.myshopify.com"
@@ -41,7 +41,7 @@ export default function Auth() {
             error={errors.shop}
           ></s-text-field>
           <s-button type="submit">Log in</s-button>
-        </s-section>
+        </Card>
         </Form>
       </s-page>
     </AppProvider>


### PR DESCRIPTION
`PageShell` owns the rhythm *between* cards and states the argument: *"page rhythm has to be
the largest gap on the screen to do its job. If a route can set it, some route eventually
sets it smaller than the gaps inside its own sections, and the page stops having visible
structure at all."*

One level down, nothing implemented it. On the deployed build at 4× zoom the guardrails card
ran heading → lede → secondary → checkbox → fields at **four different distances**, the
diagnostics card ran heading → sentence → label → field at a fifth, and Home's checklist had
a smaller gap above its first row than between its rows.

`Card` now, with three distances and a reason for each:

- **Heading to content** — the largest, and also the answer to **#589**. A card heading is
  the same size as its content and *cannot be made otherwise*: Polaris gives `s-heading` and
  `s-section`'s heading one weight and one size, and `type="small"` turned out not to be
  implemented by the runtime either (#577's follow-up records the check). Air above the
  content is the only lever left, and it is enough — a title with room under it reads as a
  title at the same size.
- **Between blocks** — the ordinary card rhythm.
- **Lede to secondary** — the tightest, because they are one thought. Spacing them like
  separate blocks is what made a card read as four unrelated paragraphs.

**Fifty titled sections converted.** Four of them — guardrails, diagnostics, plans, "every
plan" — also had their prose sorted into `lede` and `secondary` **by hand**, because
deciding which sentence is the subject and which qualifies it is judgement, and a mechanical
pass would have put the wrong one in each rank while looking tidy.

The aside column keeps taking `s-section` directly: `PageShell` partitions on the `slot`
attribute, and wrapping that would put page layout inside a card.

### The trap this hit on the way

`spacing.test.ts` read the raw file, so a **comment** naming `SPACE.page` failed it — which
is how `Card` broke it while explaining why its own gaps are smaller than the page's. That
is the eighth time the comment-grep trap has bitten in this repo, and #462 built `sourceOf`
for exactly it. Moved onto it, and re-checked that it still fails a card that really does
reach for the page's rhythm.

### Checks

- 3509 unit tests, typecheck, lint and build pass.
- `card-rhythm.test.ts` reads the whole app and refuses a titled section in the main column
  that is not a `Card`, plus the heading gap and the tight lede/secondary pairing.

Part of #575.

Closes #578
Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)