### PR TITLE
One card, one right edge (#579, #580)

### DIFF
--- a/app/components/AsyncState.tsx
+++ b/app/components/AsyncState.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
 import { PAD, SPACE } from "../lib/ui/spacing";
+import { ActionRow } from "./ActionRow";
+import { MEASURE } from "./FieldGrid";
 import { Secondary } from "./Type";
 
 /**
@@ -37,15 +39,28 @@ export interface EmptyStateProps {
  */
 export function EmptyState({ title, description, action }: EmptyStateProps) {
   return (
-    <s-box paddingBlock={PAD.block}>
-      <s-stack gap={SPACE.item} alignItems="center">
+    /* Left, on the card's own edge — not centred.
+    
+       Centring is right for a full-page empty state with an illustration, standing on
+       its own. Inside a card whose heading is hard left two inches above it, it reads as
+       a different component that has wandered in: on Diagnostics the "Recent failures"
+       card ran a left-aligned heading, then a gap, then a centred title and a centred
+       paragraph floating in the middle of the card. The same shape was on Variants,
+       Baselines, Campaigns, Segments, Activity and Price drift — most of the app's first
+       run.
+    
+       The measure stays. It is what stops the description running the width of a table,
+       and it is the reason this was given a box in the first place; it just no longer
+       has to be centred to have one. */
+    <s-box paddingBlock={PAD.block} maxInlineSize={MEASURE}>
+      <s-stack gap={SPACE.item}>
         <s-heading>{title}</s-heading>
-        {description ? (
-          <s-box maxInlineSize="520px">
-            <Secondary>{description}</Secondary>
-          </s-box>
+        {description ? <Secondary>{description}</Secondary> : null}
+        {action ? (
+          <ActionRow>
+            <s-button href={action.href}>{action.label}</s-button>
+          </ActionRow>
         ) : null}
-        {action ? <s-button href={action.href}>{action.label}</s-button> : null}
       </s-stack>
     </s-box>
   );

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { ActionRow } from "./ActionRow";
+import { MEASURE } from "./FieldGrid";
 import { Lede, Secondary } from "./Type";
 import { SPACE } from "../lib/ui/spacing";
 
@@ -64,12 +65,25 @@ export function Card({
   actions?: ReactNode;
   children?: ReactNode;
 }) {
+  /* The card's prose stops where its fields stop.
+
+     A settings card's fields end at the measure and its lede ran the full width of the
+     card, so one card had two right edges — the fields looked like they had given up a
+     quarter of the space while the sentence above them had not. Prose has its own reason
+     to be capped anyway: a line of text the width of this card is past the measure at
+     which a reader reliably finds the start of the next one.
+
+     Only the prose. A table, a preview or a set of tiles is content whose width is its
+     own business, and capping those is how a card ends up with a column of white space
+     down its right-hand side. */
   const intro =
     lede || secondary ? (
-      <s-stack gap={SPACE.tight}>
-        {lede ? <Lede>{lede}</Lede> : null}
-        {secondary ? <Secondary>{secondary}</Secondary> : null}
-      </s-stack>
+      <s-box maxInlineSize={MEASURE}>
+        <s-stack gap={SPACE.tight}>
+          {lede ? <Lede>{lede}</Lede> : null}
+          {secondary ? <Secondary>{secondary}</Secondary> : null}
+        </s-stack>
+      </s-box>
     ) : null;
 
   return (

--- a/app/components/FieldGrid.tsx
+++ b/app/components/FieldGrid.tsx
@@ -29,6 +29,22 @@ export const FIELD = {
 } as const;
 
 /**
+ * How wide a card's content is allowed to be — its measure — and the one number every
+ * part of a card shares.
+ *
+ * Two `medium` columns and the gap between them. Derived rather than typed, because the
+ * flat `720px` it replaces was neither: it was wider than two fields need and narrower
+ * than the card, so on a settings card the fields stopped a quarter short of the right
+ * edge while **the prose above them ran the full width**. Two right edges in one card is
+ * what actually read as odd — not the gutter, which is correct. A field the width of a
+ * card is the failure this whole module exists to prevent.
+ *
+ * `calc` rather than arithmetic here: `SPACE.section` is a Polaris token, not a number,
+ * so the gap is only known to the browser.
+ */
+export const MEASURE = `calc(${FIELD.medium} * 2 + var(--s-space-base, 1rem))`;
+
+/**
  * One control, at the width of what it holds.
  *
  * A wrapper rather than a prop because Polaris fields have no width of their own — the
@@ -88,7 +104,9 @@ export function FieldGrid({ children }: { children: ReactNode }) {
       // percentage needs. Capping the grid rather than each field keeps the two columns
       // the same width, so the labels down each side stay in line -- fields sized
       // individually inside a grid would be tidy on their own and ragged together.
-      maxInlineSize="720px"
+      // The card's measure, shared with its prose so the two have one right edge. See
+      // `MEASURE`: the flat number this replaces was arbitrary in both directions.
+      maxInlineSize={MEASURE}
       // One comma. Polaris splits a responsive value on it to separate "when the query
       // matches" from "otherwise", so `repeat(2, 1fr)` is unparseable and falls back to
       // `none` — which stacks everything full width again, i.e. looks exactly like the

--- a/app/components/FieldGrid.tsx
+++ b/app/components/FieldGrid.tsx
@@ -39,10 +39,22 @@ export const FIELD = {
  * what actually read as odd — not the gutter, which is correct. A field the width of a
  * card is the failure this whole module exists to prevent.
  *
- * `calc` rather than arithmetic here: `SPACE.section` is a Polaris token, not a number,
- * so the gap is only known to the browser.
+ * ## Why this is arithmetic and not `calc()`
+ *
+ * `calc(...)` is what you would write, and Polaris will not take it: every size prop is
+ * typed `` `${number}px` | `${number}%` | '0' ``, so a `calc` string is a type error —
+ * and the first attempt at this shipped one, which typechecked clean only because a
+ * corrupted `.react-router/types` was failing the run before it reached these files.
+ *
+ * So the gap is a number here. `GRID_GAP` is Polaris' `base` space token in pixels, and
+ * it is the one value in this file that has to be kept in step with something outside it
+ * — hence the name and this paragraph rather than a bare `16`.
  */
-export const MEASURE = `calc(${FIELD.medium} * 2 + var(--s-space-base, 1rem))`;
+const GRID_GAP = 16;
+
+const px = (value: string) => Number.parseInt(value, 10);
+
+export const MEASURE = `${px(FIELD.medium) * 2 + GRID_GAP}px` as const;
 
 /**
  * One control, at the width of what it holds.

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -54,7 +54,7 @@ describe("an empty state is an answer, not a missing table", () => {
     // this component's own — see `MEASURE`.
     const html = render(<EmptyState title="No variants yet" description={"a ".repeat(200)} />);
 
-    expect(html).toMatch(/maxinlinesize="calc\(/i);
+    expect(html).toMatch(/maxinlinesize="\d+px"/i);
   });
 
   it("renders a way out only when there is one", () => {

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -31,19 +31,30 @@ const render = (node: React.ReactElement) =>
   renderToStaticMarkup(<StaticRouter location="/app/prices">{node}</StaticRouter>);
 
 describe("an empty state is an answer, not a missing table", () => {
-  it("centres the title and gives it room, so it does not read as a render that failed", () => {
+  it("gives the words room, so it does not read as a render that failed", () => {
     const html = render(<EmptyState title="No baselines captured yet" />);
 
     expect(html).toContain("No baselines captured yet");
-    expect(html).toMatch(/alignitems="center"/i);
     // Block padding: the words have to sit in space that was obviously left for them.
     expect(html).toMatch(/paddingblock="large-200"/i);
   });
 
+  it("sits on the card's own left edge rather than in the middle of it", () => {
+    // Centring is right for a full-page empty state standing on its own. Inside a card
+    // whose heading is hard left two inches above it, a centred block reads as a
+    // different component that has wandered in — which is how Diagnostics looked, and
+    // Variants, Baselines, Campaigns, Segments, Activity and Price drift with it.
+    const html = render(<EmptyState title="No baselines captured yet" />);
+
+    expect(html).not.toMatch(/alignitems="center"/i);
+  });
+
   it("caps the measure of its body copy", () => {
+    // The card's measure, shared with its prose and its fields, rather than a number of
+    // this component's own — see `MEASURE`.
     const html = render(<EmptyState title="No variants yet" description={"a ".repeat(200)} />);
 
-    expect(html).toMatch(/maxinlinesize="520px"/i);
+    expect(html).toMatch(/maxinlinesize="calc\(/i);
   });
 
   it("renders a way out only when there is one", () => {

--- a/app/components/field-grid.test.ts
+++ b/app/components/field-grid.test.ts
@@ -82,8 +82,16 @@ describe("a single control is sized the same way", () => {
     // Two right edges in one card is what read as odd — the gutter itself is correct,
     // because a field the width of a card is the failure this module exists to prevent.
     expect(grid).toContain("export const MEASURE");
-    expect(grid).toMatch(/MEASURE = `calc\(\$\{FIELD\.medium\} \* 2/);
+    expect(grid).toMatch(/MEASURE = `\$\{px\(FIELD\.medium\) \* 2 \+ GRID_GAP\}px`/);
     expect(grid).toContain("maxInlineSize={MEASURE}");
+  });
+
+  it("expresses it in pixels, because Polaris will not take a calc", () => {
+    // Every size prop is typed `${number}px | ${number}% | '0'`. The first attempt at
+    // this shipped a `calc(...)` string, which typechecked clean only because a corrupted
+    // `.react-router/types` was failing the run before it reached these files.
+    expect(grid).not.toContain("calc(");
+    expect(grid).toContain("const GRID_GAP");
   });
 
   it("shares that measure with the prose above the fields", () => {

--- a/app/components/field-grid.test.ts
+++ b/app/components/field-grid.test.ts
@@ -75,8 +75,22 @@ describe("a single control is sized the same way", () => {
     expect(grid).toMatch(/long:\s*"\d+px"/);
   });
 
-  it("caps the grid too, because two columns of a wide card are still too wide", () => {
-    expect(grid).toMatch(/maxInlineSize="\d+px"/);
+  it("caps the grid to a measure derived from the field widths", () => {
+    // It was a flat `720px`, which was arbitrary in both directions: wider than two
+    // fields need and narrower than the card, so a settings card's fields stopped a
+    // quarter short of the right edge while the prose above them ran the full width.
+    // Two right edges in one card is what read as odd — the gutter itself is correct,
+    // because a field the width of a card is the failure this module exists to prevent.
+    expect(grid).toContain("export const MEASURE");
+    expect(grid).toMatch(/MEASURE = `calc\(\$\{FIELD\.medium\} \* 2/);
+    expect(grid).toContain("maxInlineSize={MEASURE}");
+  });
+
+  it("shares that measure with the prose above the fields", () => {
+    // The whole point: one card, one right edge.
+    const card = sourceOf(process.cwd(), "app", "components", "Card.tsx");
+
+    expect(card).toContain("maxInlineSize={MEASURE}");
   });
 
   it("gives a single field a definite width, not a ceiling", () => {


### PR DESCRIPTION
Two findings that turned out to be the same one.

### A card had two right edges

`FieldGrid` capped itself at a flat **720px**, which was arbitrary in both directions —
wider than two fields need and narrower than the card. On a settings card the fields
stopped a quarter short of the right edge **while the prose above them ran the full width**.

The gutter itself is correct: a field the width of a card is the failure that module exists
to prevent. What read as odd is the two edges. So the cap is derived — two `medium` columns
and the gap between them — and `Card` gives its prose the same measure. The number is
explained now, and the sentence and the fields under it line up.

Only the prose. A table, a preview or a row of tiles is content whose width is its own
business, and capping those is how a card ends up with a column of white space down its
right-hand side.

### Every empty state was centred inside a left-aligned card

On Diagnostics the "Recent failures" card ran a left-aligned heading, then a gap, then a
centred title and a centred paragraph floating in the middle. The same shape was on
Variants, Baselines, Campaigns, Segments, Activity and Price drift — most of the app's
first run.

Centring is right for a full-page empty state standing on its own. Inside a card whose
heading is hard left two inches above it, it reads as a different component that wandered
in. Left now, on the same measure as everything else in a card, so an empty card and a full
one have the same edges.

### Checks

- 3511 unit tests, typecheck, lint and build pass.
- Mutation-tested three ways: uncapping the prose, restoring the flat `720px`, and centring
  the empty state again each fail.

Part of #575.

Closes #579
Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)