### PR TITLE
Give the checklist's Why? a column of its own (#582)

### DIFF
--- a/app/components/AsyncState.tsx
+++ b/app/components/AsyncState.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
 import { PAD, SPACE } from "../lib/ui/spacing";
+import { ActionRow } from "./ActionRow";
+import { MEASURE } from "./FieldGrid";
 import { Secondary } from "./Type";
 
 /**
@@ -37,15 +39,28 @@ export interface EmptyStateProps {
  */
 export function EmptyState({ title, description, action }: EmptyStateProps) {
   return (
-    <s-box paddingBlock={PAD.block}>
-      <s-stack gap={SPACE.item} alignItems="center">
+    /* Left, on the card's own edge — not centred.
+    
+       Centring is right for a full-page empty state with an illustration, standing on
+       its own. Inside a card whose heading is hard left two inches above it, it reads as
+       a different component that has wandered in: on Diagnostics the "Recent failures"
+       card ran a left-aligned heading, then a gap, then a centred title and a centred
+       paragraph floating in the middle of the card. The same shape was on Variants,
+       Baselines, Campaigns, Segments, Activity and Price drift — most of the app's first
+       run.
+    
+       The measure stays. It is what stops the description running the width of a table,
+       and it is the reason this was given a box in the first place; it just no longer
+       has to be centred to have one. */
+    <s-box paddingBlock={PAD.block} maxInlineSize={MEASURE}>
+      <s-stack gap={SPACE.item}>
         <s-heading>{title}</s-heading>
-        {description ? (
-          <s-box maxInlineSize="520px">
-            <Secondary>{description}</Secondary>
-          </s-box>
+        {description ? <Secondary>{description}</Secondary> : null}
+        {action ? (
+          <ActionRow>
+            <s-button href={action.href}>{action.label}</s-button>
+          </ActionRow>
         ) : null}
-        {action ? <s-button href={action.href}>{action.label}</s-button> : null}
       </s-stack>
     </s-box>
   );

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { ActionRow } from "./ActionRow";
+import { MEASURE } from "./FieldGrid";
 import { Lede, Secondary } from "./Type";
 import { SPACE } from "../lib/ui/spacing";
 
@@ -64,12 +65,25 @@ export function Card({
   actions?: ReactNode;
   children?: ReactNode;
 }) {
+  /* The card's prose stops where its fields stop.
+
+     A settings card's fields end at the measure and its lede ran the full width of the
+     card, so one card had two right edges — the fields looked like they had given up a
+     quarter of the space while the sentence above them had not. Prose has its own reason
+     to be capped anyway: a line of text the width of this card is past the measure at
+     which a reader reliably finds the start of the next one.
+
+     Only the prose. A table, a preview or a set of tiles is content whose width is its
+     own business, and capping those is how a card ends up with a column of white space
+     down its right-hand side. */
   const intro =
     lede || secondary ? (
-      <s-stack gap={SPACE.tight}>
-        {lede ? <Lede>{lede}</Lede> : null}
-        {secondary ? <Secondary>{secondary}</Secondary> : null}
-      </s-stack>
+      <s-box maxInlineSize={MEASURE}>
+        <s-stack gap={SPACE.tight}>
+          {lede ? <Lede>{lede}</Lede> : null}
+          {secondary ? <Secondary>{secondary}</Secondary> : null}
+        </s-stack>
+      </s-box>
     ) : null;
 
   return (

--- a/app/components/FieldGrid.tsx
+++ b/app/components/FieldGrid.tsx
@@ -29,6 +29,22 @@ export const FIELD = {
 } as const;
 
 /**
+ * How wide a card's content is allowed to be — its measure — and the one number every
+ * part of a card shares.
+ *
+ * Two `medium` columns and the gap between them. Derived rather than typed, because the
+ * flat `720px` it replaces was neither: it was wider than two fields need and narrower
+ * than the card, so on a settings card the fields stopped a quarter short of the right
+ * edge while **the prose above them ran the full width**. Two right edges in one card is
+ * what actually read as odd — not the gutter, which is correct. A field the width of a
+ * card is the failure this whole module exists to prevent.
+ *
+ * `calc` rather than arithmetic here: `SPACE.section` is a Polaris token, not a number,
+ * so the gap is only known to the browser.
+ */
+export const MEASURE = `calc(${FIELD.medium} * 2 + var(--s-space-base, 1rem))`;
+
+/**
  * One control, at the width of what it holds.
  *
  * A wrapper rather than a prop because Polaris fields have no width of their own — the
@@ -88,7 +104,9 @@ export function FieldGrid({ children }: { children: ReactNode }) {
       // percentage needs. Capping the grid rather than each field keeps the two columns
       // the same width, so the labels down each side stay in line -- fields sized
       // individually inside a grid would be tidy on their own and ragged together.
-      maxInlineSize="720px"
+      // The card's measure, shared with its prose so the two have one right edge. See
+      // `MEASURE`: the flat number this replaces was arbitrary in both directions.
+      maxInlineSize={MEASURE}
       // One comma. Polaris splits a responsive value on it to separate "when the query
       // matches" from "otherwise", so `repeat(2, 1fr)` is unparseable and falls back to
       // `none` — which stacks everything full width again, i.e. looks exactly like the

--- a/app/components/FieldGrid.tsx
+++ b/app/components/FieldGrid.tsx
@@ -39,10 +39,22 @@ export const FIELD = {
  * what actually read as odd — not the gutter, which is correct. A field the width of a
  * card is the failure this whole module exists to prevent.
  *
- * `calc` rather than arithmetic here: `SPACE.section` is a Polaris token, not a number,
- * so the gap is only known to the browser.
+ * ## Why this is arithmetic and not `calc()`
+ *
+ * `calc(...)` is what you would write, and Polaris will not take it: every size prop is
+ * typed `` `${number}px` | `${number}%` | '0' ``, so a `calc` string is a type error —
+ * and the first attempt at this shipped one, which typechecked clean only because a
+ * corrupted `.react-router/types` was failing the run before it reached these files.
+ *
+ * So the gap is a number here. `GRID_GAP` is Polaris' `base` space token in pixels, and
+ * it is the one value in this file that has to be kept in step with something outside it
+ * — hence the name and this paragraph rather than a bare `16`.
  */
-export const MEASURE = `calc(${FIELD.medium} * 2 + var(--s-space-base, 1rem))`;
+const GRID_GAP = 16;
+
+const px = (value: string) => Number.parseInt(value, 10);
+
+export const MEASURE = `${px(FIELD.medium) * 2 + GRID_GAP}px` as const;
 
 /**
  * One control, at the width of what it holds.

--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -146,3 +146,32 @@ describe("a shop that has finished", () => {
     ).toBe("");
   });
 });
+
+describe("the checklist reads as a list", () => {
+  /**
+   * "Why?" and the action shared one grid cell, and a cell sized `auto` is as wide as its
+   * contents — so where "Why?" landed depended on how wide *that row's* button happened to
+   * be. On the deployed build the three sat at three different x positions about a hundred
+   * pixels apart, and the eye read three ragged rows rather than a list.
+   *
+   * A column each fixes both halves: "Why?" lines up down the card, and the actions share
+   * an edge because they share a column.
+   */
+  const html = render(fresh);
+
+  it("gives Why? and the action a column each", () => {
+    expect(html).toMatch(/gridtemplatecolumns="[^"]*auto 1fr auto auto"/i);
+  });
+
+  it("does not put them back in one cell", () => {
+    // The shape that caused it: both inside a single `ActionRow`. One `ActionRow` per row
+    // is still right — it holds the action — but "Why?" is outside it.
+    const row = html.slice(html.indexOf("Capture your baselines"));
+    const why = row.indexOf("Why?");
+    const actionRow = row.indexOf("Sync catalogue");
+
+    expect(why).toBeGreaterThan(-1);
+    expect(actionRow).toBeGreaterThan(why);
+  });
+});
+

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -143,7 +143,19 @@ function Step({
         // One comma only. Polaris splits a responsive value on the comma to separate
         // "when the query matches" from "otherwise", so a second one anywhere in the
         // value stops the whole thing parsing and it falls back to `none`.
-        gridTemplateColumns="@container (inline-size <= 500px) auto 1fr, auto 1fr auto"
+        // Four columns, not three. "Why?" and the action shared one cell, and a cell
+        // sized `auto` is as wide as its contents — so where "Why?" landed depended on how
+        // wide *that row's* button happened to be. On the deployed build the three sat at
+        // three different x positions about a hundred pixels apart, and the eye read three
+        // ragged rows rather than a list.
+        //
+        // A column each fixes both halves: "Why?" lines up down the card, and the actions
+        // share an edge because they share a column.
+        //
+        // One comma only. Polaris splits a responsive value on the comma to separate
+        // "when the query matches" from "otherwise", so a second one anywhere in the
+        // value stops the whole thing parsing and it falls back to `none`.
+        gridTemplateColumns="@container (inline-size <= 500px) auto 1fr, auto 1fr auto auto"
         gap={SPACE.item}
         alignItems="center"
       >
@@ -159,26 +171,27 @@ function Step({
           {isNext ? <s-badge tone="info">Next</s-badge> : null}
         </s-stack>
 
-        {/* Why before the action, deliberately: when the row wraps it is the action
-            that should fall to the next line, not the explanation, which would then read
-            as belonging to the step below it. */}
+        {/* Its own column, and before the action deliberately: when the row wraps it is
+            the action that should fall to the next line, not the explanation, which would
+            then read as belonging to the step below it.
+
+            Not on a finished step: the reasoning for work already done is the one thing on
+            this card nobody needs.
+
+            An icon on the toggle, because a tertiary control is text with no border and
+            "Why?" beside a real button read as a caption for it. The same question mark
+            `HelpNote` uses, so the two say "this is help" the same way. */}
+        {step.done ? null : (
+          <s-button
+            variant="tertiary"
+            icon="question-circle"
+            onClick={() => setWhy((open) => !open)}
+          >
+            {why ? "Hide why" : "Why?"}
+          </s-button>
+        )}
+
         <ActionRow>
-          {/* Not on a finished step. The reasoning for work already done is the one
-              thing on this card nobody needs, and on a completed row — which has no
-              action beside it — it was also the only thing left hanging off the right
-              edge, so the column of actions read as ragged. */}
-          {/* An icon on the toggle, because a tertiary control is text with no border
-              and "Why?" beside a real button read as a caption for it. The same question
-              mark `HelpNote` uses, so the two say "this is help" the same way. */}
-          {step.done ? null : (
-            <s-button
-              variant="tertiary"
-              icon="question-circle"
-              onClick={() => setWhy((open) => !open)}
-            >
-              {why ? "Hide why" : "Why?"}
-            </s-button>
-          )}
           {/* Black on the step being asked for, bordered on the ones after it. A
               checklist whose every row shouts equally is a checklist that has not said
               what to do next — which is the only thing it is for. See `ActionRow` for

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -54,7 +54,7 @@ describe("an empty state is an answer, not a missing table", () => {
     // this component's own — see `MEASURE`.
     const html = render(<EmptyState title="No variants yet" description={"a ".repeat(200)} />);
 
-    expect(html).toMatch(/maxinlinesize="calc\(/i);
+    expect(html).toMatch(/maxinlinesize="\d+px"/i);
   });
 
   it("renders a way out only when there is one", () => {

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -31,19 +31,30 @@ const render = (node: React.ReactElement) =>
   renderToStaticMarkup(<StaticRouter location="/app/prices">{node}</StaticRouter>);
 
 describe("an empty state is an answer, not a missing table", () => {
-  it("centres the title and gives it room, so it does not read as a render that failed", () => {
+  it("gives the words room, so it does not read as a render that failed", () => {
     const html = render(<EmptyState title="No baselines captured yet" />);
 
     expect(html).toContain("No baselines captured yet");
-    expect(html).toMatch(/alignitems="center"/i);
     // Block padding: the words have to sit in space that was obviously left for them.
     expect(html).toMatch(/paddingblock="large-200"/i);
   });
 
+  it("sits on the card's own left edge rather than in the middle of it", () => {
+    // Centring is right for a full-page empty state standing on its own. Inside a card
+    // whose heading is hard left two inches above it, a centred block reads as a
+    // different component that has wandered in — which is how Diagnostics looked, and
+    // Variants, Baselines, Campaigns, Segments, Activity and Price drift with it.
+    const html = render(<EmptyState title="No baselines captured yet" />);
+
+    expect(html).not.toMatch(/alignitems="center"/i);
+  });
+
   it("caps the measure of its body copy", () => {
+    // The card's measure, shared with its prose and its fields, rather than a number of
+    // this component's own — see `MEASURE`.
     const html = render(<EmptyState title="No variants yet" description={"a ".repeat(200)} />);
 
-    expect(html).toMatch(/maxinlinesize="520px"/i);
+    expect(html).toMatch(/maxinlinesize="calc\(/i);
   });
 
   it("renders a way out only when there is one", () => {

--- a/app/components/field-grid.test.ts
+++ b/app/components/field-grid.test.ts
@@ -82,8 +82,16 @@ describe("a single control is sized the same way", () => {
     // Two right edges in one card is what read as odd — the gutter itself is correct,
     // because a field the width of a card is the failure this module exists to prevent.
     expect(grid).toContain("export const MEASURE");
-    expect(grid).toMatch(/MEASURE = `calc\(\$\{FIELD\.medium\} \* 2/);
+    expect(grid).toMatch(/MEASURE = `\$\{px\(FIELD\.medium\) \* 2 \+ GRID_GAP\}px`/);
     expect(grid).toContain("maxInlineSize={MEASURE}");
+  });
+
+  it("expresses it in pixels, because Polaris will not take a calc", () => {
+    // Every size prop is typed `${number}px | ${number}% | '0'`. The first attempt at
+    // this shipped a `calc(...)` string, which typechecked clean only because a corrupted
+    // `.react-router/types` was failing the run before it reached these files.
+    expect(grid).not.toContain("calc(");
+    expect(grid).toContain("const GRID_GAP");
   });
 
   it("shares that measure with the prose above the fields", () => {

--- a/app/components/field-grid.test.ts
+++ b/app/components/field-grid.test.ts
@@ -75,8 +75,22 @@ describe("a single control is sized the same way", () => {
     expect(grid).toMatch(/long:\s*"\d+px"/);
   });
 
-  it("caps the grid too, because two columns of a wide card are still too wide", () => {
-    expect(grid).toMatch(/maxInlineSize="\d+px"/);
+  it("caps the grid to a measure derived from the field widths", () => {
+    // It was a flat `720px`, which was arbitrary in both directions: wider than two
+    // fields need and narrower than the card, so a settings card's fields stopped a
+    // quarter short of the right edge while the prose above them ran the full width.
+    // Two right edges in one card is what read as odd — the gutter itself is correct,
+    // because a field the width of a card is the failure this module exists to prevent.
+    expect(grid).toContain("export const MEASURE");
+    expect(grid).toMatch(/MEASURE = `calc\(\$\{FIELD\.medium\} \* 2/);
+    expect(grid).toContain("maxInlineSize={MEASURE}");
+  });
+
+  it("shares that measure with the prose above the fields", () => {
+    // The whole point: one card, one right edge.
+    const card = sourceOf(process.cwd(), "app", "components", "Card.tsx");
+
+    expect(card).toContain("maxInlineSize={MEASURE}");
   });
 
   it("gives a single field a definite width, not a ceiling", () => {


### PR DESCRIPTION
"Why?" and the action shared one grid cell, and a cell sized `auto` is as wide as its
contents — so where "Why?" landed depended on how wide *that row's* button happened to be.
On the deployed build the three sat at three different x positions about a hundred pixels
apart, and the eye read three ragged rows rather than a list.

A column each fixes both halves: "Why?" lines up down the card, and the actions share an
edge because they share a column — which is the checklist's share of #586, where the three
buttons were 180px, 278px and 283px with ragged left edges.

- Mutation-tested: going back to three columns fails the guard.
- Stacked on #597, which carries the measure fix this branch was cut from.

Part of #575.

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)