### PR TITLE
Clear the generated types before regenerating them (#599)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prisma": "prisma",
     "graphql-codegen": "graphql-codegen",
     "vite": "vite",
-    "typecheck": "react-router typegen && tsc --noEmit",
+    "typecheck": "rm -rf .react-router/types && react-router typegen && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "worker": "tsx scripts/worker.ts",


### PR DESCRIPTION
`.react-router/types/` accumulates macOS duplicate files — `+future 3.ts`,
`+server-build.d 4.ts` — from typegen runs that race or are interrupted. Each produces a
`TS6200: Definitions of the following identifiers conflict` against its original, and
errors are reported sorted by path, so `.react-router/…` comes out before `app/…`. A dozen
duplicates is a dozen lines of noise ahead of anything real.

**`tsc` was not hiding anything.** I originally filed this claiming it stopped at the
conflict and never reached `app/`. Reproduced deliberately — a real type error in
`app/components/Blank.tsx`, duplicates present — and both are reported:

```
.react-router/types/+server-build.d 2.ts(3,1): error TS6200: Definitions of the following …
app/components/Blank.tsx(20,3): error TS2322: Type 'Element' is not assignable to type 'number'.
```

What hid them was reading the output through `head -4`, because a full run here is slow
enough that I was skimming. Three type errors reached a PR that way, and the correction is
recorded on the ticket rather than quietly fixed.

So this is a tidy-up, not a correctness fix, and worth having on both counts: the noise goes
at its source, and the local command matches CI, which typechecks from a clean checkout and
never sees a duplicate.

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)