### PR TITLE
A table, its caption and its pager are one object (#584)

### DIFF
--- a/app/components/LedgerTable.tsx
+++ b/app/components/LedgerTable.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import type { LedgerRow } from "../services/campaigns/index.server";
 import { LEDGER_TONE, toneFor } from "./tone";
 import { RowState } from "./RowState";
+import { TableBlock } from "./TableBlock";
 
 /**
  * Every row we wrote, with what it was and what we intended.
@@ -37,7 +38,18 @@ export function LedgerTable({
   renderAction?: (row: LedgerRow) => ReactNode;
 }) {
   return (
-    <>
+    <TableBlock
+      pagination={
+        total === undefined ? null : (
+          <ShowingSome
+            shown={rows.length}
+            total={total}
+            noun="rows"
+            suffix="The export has every one of them."
+          />
+        )
+      }
+    >
     <s-table>
       <s-table-header-row>
         <s-table-header listSlot="primary">Variant</s-table-header>
@@ -69,15 +81,7 @@ export function LedgerTable({
         ))}
       </s-table-body>
     </s-table>
-    {total === undefined ? null : (
-      <ShowingSome
-        shown={rows.length}
-        total={total}
-        noun="rows"
-        suffix="The export has every one of them."
-      />
-    )}
-    </>
+    </TableBlock>
   );
 }
 

--- a/app/components/PreviewTable.tsx
+++ b/app/components/PreviewTable.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from "./AsyncState";
 import { ShowingSome } from "./Pagination";
 import type { MarketPreview, PreviewRow } from "../services/campaigns/index.server";
 import { PREVIEW_TONE, toneFor } from "./tone";
+import { TableBlock } from "./TableBlock";
 
 /**
  * Before/after for each variant a campaign would change, one column per surface.
@@ -40,7 +41,18 @@ export function PreviewTable({
   }
 
   return (
-    <>
+    <TableBlock
+      pagination={
+        total === undefined ? null : (
+          <ShowingSome
+            shown={rows.length}
+            total={total}
+            noun="rows"
+            suffix="Every row is priced the same way, and the export has all of them."
+          />
+        )
+      }
+    >
     <s-table>
       <s-table-header-row>
         <s-table-header listSlot="primary">Variant</s-table-header>
@@ -101,15 +113,7 @@ export function PreviewTable({
         ))}
       </s-table-body>
     </s-table>
-    {total === undefined ? null : (
-      <ShowingSome
-        shown={rows.length}
-        total={total}
-        noun="rows"
-        suffix="Every row is priced the same way, and the export has all of them."
-      />
-    )}
-    </>
+    </TableBlock>
   );
 }
 

--- a/app/components/RollbackReportTable.tsx
+++ b/app/components/RollbackReportTable.tsx
@@ -3,6 +3,7 @@ import { Blank } from "./Blank";
 import { ShowingSome } from "./Pagination";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { RowState } from "./RowState";
+import { TableBlock } from "./TableBlock";
 
 /**
  * What reverting would do, row by row, with the drifted ones first.
@@ -51,7 +52,15 @@ export function RollbackReportTable({ rows }: { rows: RollbackRow[] }) {
 
   return (
     <>
-    <s-table>
+        <TableBlock
+      pagination={<ShowingSome
+      shown={shown.length}
+      total={rows.length}
+      noun="rows"
+      suffix="The rest are unchanged and revert without argument; the export lists every one."
+    />}
+    >
+<s-table>
       <s-table-header-row>
         <s-table-header listSlot="primary">Variant</s-table-header>
         <s-table-header listSlot="inline">State</s-table-header>
@@ -93,12 +102,7 @@ export function RollbackReportTable({ rows }: { rows: RollbackRow[] }) {
         ))}
       </s-table-body>
     </s-table>
-    <ShowingSome
-      shown={shown.length}
-      total={rows.length}
-      noun="rows"
-      suffix="The rest are unchanged and revert without argument; the export lists every one."
-    />
+    </TableBlock>
     </>
   );
 }

--- a/app/components/TableBlock.tsx
+++ b/app/components/TableBlock.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * A table, the sentence that qualifies it and its pagination, as one object.
+ *
+ * They were three separate children of the card, spaced by the card's own rhythm — the
+ * gap meant for the distance between a paragraph and the fields under it. So on Variants
+ * the rows, "Amounts are your store's base price, in USD." and "51–100 of 3,412" sat as
+ * far apart as two unrelated blocks, and none of them read as belonging to the rows above.
+ *
+ * The parts already existed and were shared: `Pagination`, `ShowingSome`, and a caption
+ * written out per route as a loose paragraph. What did not exist was anything binding them
+ * to the table they describe.
+ *
+ * ## Why the caption is above the pagination and below the table
+ *
+ * A caption qualifies the rows — what currency, what surface, what is excluded — so it is
+ * read with them. Pagination is a control, and a control that moves you off the rows
+ * belongs after everything that describes them. Routes had it both ways round; this settles
+ * it.
+ *
+ * ## The gap
+ *
+ * `SPACE.item`, deliberately smaller than the card's own rhythm. Three things at the card's
+ * rhythm are three things; at item rhythm they are one thing with two footnotes, which is
+ * what they are.
+ */
+export function TableBlock({
+  children,
+  caption,
+  pagination,
+}: {
+  /** The table itself. */
+  children: ReactNode;
+  /** What qualifies the rows: a currency, a surface, what is not shown. */
+  caption?: ReactNode;
+  /** `Pagination` or `ShowingSome` — whichever this table has. */
+  pagination?: ReactNode;
+}) {
+  return (
+    <s-stack gap={SPACE.item}>
+      {children}
+      {caption}
+      {pagination}
+    </s-stack>
+  );
+}

--- a/app/lib/ui/table-block.test.ts
+++ b/app/lib/ui/table-block.test.ts
@@ -1,0 +1,73 @@
+/**
+ * A table, its caption and its pagination are one object.
+ *
+ * They were three separate children of the card, spaced by the card's own rhythm — the gap
+ * meant for the distance between a paragraph and the fields under it. So on Variants the
+ * rows, "Amounts are your store's base price, in USD." and "51–100 of 3,412" sat as far
+ * apart as two unrelated blocks, and none of them read as belonging to the rows above.
+ *
+ * The parts already existed and were shared: `Pagination`, `ShowingSome`, and a caption
+ * written out per route. What did not exist was anything binding them to the table they
+ * describe, which is why the order differed between routes too.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const APP = join(process.cwd(), "app");
+
+function sources(dir: string): Array<{ path: string; source: string }> {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [{ path: path.replace(`${APP}/`, ""), source: sourceOf(path) }];
+  });
+}
+
+const files = sources(APP);
+
+describe("every pager belongs to a table", () => {
+  it("finds the files, so this cannot pass by checking nothing", () => {
+    const paged = files.filter(
+      ({ source }) => source.includes("<Pagination") || source.includes("<ShowingSome"),
+    );
+
+    expect(paged.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("nobody renders a pager outside a TableBlock", () => {
+    // Loose, it is a control floating a card's-width away from the rows it pages.
+    const offenders = files
+      .filter(({ path }) => path !== "components/TableBlock.tsx" && path !== "components/Pagination.tsx")
+      .filter(({ source }) => source.includes("<Pagination") || source.includes("<ShowingSome"))
+      .filter(({ source }) => !source.includes("<TableBlock"))
+      .map(({ path }) => path);
+
+    expect(offenders, "a pager with no table is a control with nothing to control").toEqual([]);
+  });
+});
+
+describe("the block itself", () => {
+  const block = sourceOf(join(APP, "components", "TableBlock.tsx"));
+
+  it("holds the three together at a tighter gap than the card's", () => {
+    // Three things at the card's rhythm are three things. At item rhythm they are one
+    // thing with two footnotes, which is what they are.
+    expect(block).toContain("gap={SPACE.item}");
+  });
+
+  it("puts the caption with the rows and the pager after both", () => {
+    // A caption qualifies the rows, so it is read with them. Pagination is a control that
+    // moves you off the rows, so it comes after everything describing them. Routes had it
+    // both ways round before this settled it.
+    const body = block.slice(block.indexOf("<s-stack"));
+
+    expect(body.indexOf("{children}")).toBeLessThan(body.indexOf("{caption}"));
+    expect(body.indexOf("{caption}")).toBeLessThan(body.indexOf("{pagination}"));
+  });
+});

--- a/app/routes/app.activity.tsx
+++ b/app/routes/app.activity.tsx
@@ -30,6 +30,7 @@ import { FieldGrid } from "../components/FieldGrid";
 import { HelpNote } from "../components/HelpNote";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { SPACE } from "../lib/ui/spacing";
+import { TableBlock } from "../components/TableBlock";
 
 const FILTER_FIELDS = ["actor", "action", "from", "to"] as const;
 
@@ -152,9 +153,13 @@ export default function Activity() {
               </s-button>
             </ActionRow>
 
-            <ActivityTable entries={entries} timeZone={timeZone} />
-
-            <Pagination page={page} total={total} pageSize={PAGE_SIZE} noun="entries" />
+            <TableBlock
+              pagination={
+                <Pagination page={page} total={total} pageSize={PAGE_SIZE} noun="entries" />
+              }
+            >
+              <ActivityTable entries={entries} timeZone={timeZone} />
+            </TableBlock>
           </>
         )}
       </s-section>

--- a/app/routes/app.prices._index.tsx
+++ b/app/routes/app.prices._index.tsx
@@ -18,6 +18,7 @@ import { PageShell } from "../components/PageShell";
 import { HelpNote } from "../components/HelpNote";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { Secondary } from "../components/Type";
+import { TableBlock } from "../components/TableBlock";
 
 const PAGE_SIZE = ROWS_PER_VIEW;
 
@@ -134,7 +135,15 @@ export default function Catalog() {
           )
         ) : (
           <>
-            <s-table>
+                        <TableBlock
+              caption={
+<Secondary>
+              Amounts are your store&rsquo;s base price, in {currency}.
+            </Secondary>
+              }
+              pagination={<Pagination page={page} total={total} pageSize={pageSize} />}
+            >
+<s-table>
               <s-table-header-row>
                 <s-table-header listSlot="primary">Variant</s-table-header>
                 <s-table-header listSlot="secondary">SKU</s-table-header>
@@ -190,12 +199,7 @@ export default function Catalog() {
                 ))}
               </s-table-body>
             </s-table>
-
-            <Secondary>
-              Amounts are your store&rsquo;s base price, in {currency}.
-            </Secondary>
-
-            <Pagination page={page} total={total} pageSize={pageSize} />
+            </TableBlock>
           </>
         )}
       </s-section>

--- a/app/routes/app.prices.baselines._index.tsx
+++ b/app/routes/app.prices.baselines._index.tsx
@@ -49,6 +49,7 @@ import { HelpNote } from "../components/HelpNote";
 import { ROWS_PER_VIEW } from "../lib/ui/table-budget";
 import { SPACE } from "../lib/ui/spacing";
 import { Card } from "../components/Card";
+import { TableBlock } from "../components/TableBlock";
 
 const FILTER_FIELDS = ["q", "vendor", "source", "diverged", "variant"] as const;
 
@@ -247,9 +248,13 @@ export default function Baselines() {
                 </s-button>
               </ActionRow>
 
-              <BaselineTable rows={rows} onShowHistory={show} />
-
-              <Pagination page={page} total={total} pageSize={ROWS_PER_VIEW} noun="baselines" />
+              <TableBlock
+                pagination={
+                  <Pagination page={page} total={total} pageSize={ROWS_PER_VIEW} noun="baselines" />
+                }
+              >
+                <BaselineTable rows={rows} onShowHistory={show} />
+              </TableBlock>
             </>
           )}
         </s-stack>

--- a/app/routes/app.prices.drift.tsx
+++ b/app/routes/app.prices.drift.tsx
@@ -27,6 +27,7 @@ import { ShowingSome } from "../components/Pagination";
 import { HelpNote } from "../components/HelpNote";
 import prisma from "../db.server";
 import { Secondary } from "../components/Type";
+import { TableBlock } from "../components/TableBlock";
 
 export const loader = withGuard("/app/prices/drift", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -92,7 +93,15 @@ export default function DriftQueue() {
               should happen to each.
             </s-paragraph>
 
-            <s-table>
+                        <TableBlock
+              pagination={<ShowingSome
+              shown={events.length}
+              total={pending}
+              noun="drifted prices"
+              suffix="Resolve these and the next appear."
+            />}
+            >
+<s-table>
               <s-table-header-row>
                 <s-table-header listSlot="primary">Variant</s-table-header>
                 <s-table-header listSlot="labeled" format="currency">Campaign set</s-table-header>
@@ -106,13 +115,7 @@ export default function DriftQueue() {
                 ))}
               </s-table-body>
             </s-table>
-
-            <ShowingSome
-              shown={events.length}
-              total={pending}
-              noun="drifted prices"
-              suffix="Resolve these and the next appear."
-            />
+            </TableBlock>
           </>
         )}
       </s-section>

--- a/app/routes/app.prices.live.tsx
+++ b/app/routes/app.prices.live.tsx
@@ -26,6 +26,7 @@ import { PageShell } from "../components/PageShell";
 import { Field } from "../components/FieldGrid";
 import { SPACE } from "../lib/ui/spacing";
 import { Card } from "../components/Card";
+import { TableBlock } from "../components/TableBlock";
 
 /** Filters that ride in the query string, so a merchant can bookmark a view. */
 export const RECONCILE_FIELDS = ["q", "surface", "campaign", "state"] as const;
@@ -213,13 +214,16 @@ export default function Reconciliation() {
         </fetcher.Form>
       </Card>
 
-      <Card heading="Prices">    <ReconciliationTable rows={rows} clearHref={clearedSearch(params, RECONCILE_FIELDS)} />
-
+      <Card heading="Prices">
         {/* This page has been paged server-side since it was written and had no pager, so
             row 26 was unreachable by anything but typing `?page=2` into a URL a merchant
             cannot see. The loader already read the parameter and the service already
             returned the total; only the control was missing. */}
-        <Pagination page={page} total={total} pageSize={ROWS_PER_VIEW} noun="prices" />
+        <TableBlock
+          pagination={<Pagination page={page} total={total} pageSize={ROWS_PER_VIEW} noun="prices" />}
+        >
+          <ReconciliationTable rows={rows} clearHref={clearedSearch(params, RECONCILE_FIELDS)} />
+        </TableBlock>
 
         <s-button
           type="button"

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -37,6 +37,7 @@ import { ShowingSome } from "../components/Pagination";
 import { HelpNote } from "../components/HelpNote";
 import { Secondary } from "../components/Type";
 import { Card } from "../components/Card";
+import { TableBlock } from "../components/TableBlock";
 
 export const loader = withGuard("/app/settings/segments", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -439,7 +440,14 @@ function ImportReport({ report }: { report: NonNullable<ActionData["report"]> })
               left out. Picking one for you could put the wrong product on sale.
             </s-paragraph>
           </s-banner>
-          <s-table>
+                    <TableBlock
+            pagination={<ShowingSome
+            shown={Math.min(report.ambiguous.length, ROWS_PER_VIEW)}
+            total={report.ambiguous.length}
+            noun="rows"
+          />}
+          >
+<s-table>
             <s-table-header-row>
               <s-table-header listSlot="kicker" format="numeric">Line</s-table-header>
               <s-table-header listSlot="primary">Value</s-table-header>
@@ -455,11 +463,7 @@ function ImportReport({ report }: { report: NonNullable<ActionData["report"]> })
               ))}
             </s-table-body>
           </s-table>
-          <ShowingSome
-            shown={Math.min(report.ambiguous.length, ROWS_PER_VIEW)}
-            total={report.ambiguous.length}
-            noun="rows"
-          />
+          </TableBlock>
         </>
       ) : null}
 
@@ -471,7 +475,14 @@ function ImportReport({ report }: { report: NonNullable<ActionData["report"]> })
               nothing in your catalogue:
             </s-text>
           </s-paragraph>
-          <s-table>
+                    <TableBlock
+            pagination={<ShowingSome
+            shown={Math.min(report.unmatched.length, ROWS_PER_VIEW)}
+            total={report.unmatched.length}
+            noun="rows"
+          />}
+          >
+<s-table>
             <s-table-header-row>
               <s-table-header listSlot="kicker" format="numeric">Line</s-table-header>
               <s-table-header listSlot="primary">Value</s-table-header>
@@ -485,11 +496,7 @@ function ImportReport({ report }: { report: NonNullable<ActionData["report"]> })
               ))}
             </s-table-body>
           </s-table>
-          <ShowingSome
-            shown={Math.min(report.unmatched.length, ROWS_PER_VIEW)}
-            total={report.unmatched.length}
-            noun="rows"
-          />
+          </TableBlock>
         </>
       ) : null}
 


### PR DESCRIPTION
They were three separate children of the card, spaced by the card's own rhythm — the gap
meant for the distance between a paragraph and the fields under it. On Variants the rows,
"Amounts are your store's base price, in USD." and "51–100 of 3,412" sat as far apart as two
unrelated blocks, and none of them read as belonging to the rows above.

The parts already existed and were shared: `Pagination`, `ShowingSome`, and a caption
written out per route as a loose paragraph. What did not exist was anything binding them to
the table they describe — which is also why the order differed between routes.

`TableBlock` settles both:

- **The caption goes with the rows**, because it qualifies them.
- **The pager goes after everything that describes them**, because it is a control that
  moves you off them.
- **The gap is `SPACE.item`**, deliberately tighter than the card's. Three things at the
  card's rhythm are three things; at item rhythm they are one thing with two footnotes,
  which is what they are.

Nine tables converted, including the four that render through a component — Activity,
Baselines, What's live and the ledger — where the pager was a sibling of `<ActivityTable/>`
rather than of a `<s-table>`.

One thing this turned up: the mechanical `Card` conversion in #578 had left
`<Card heading="Prices">    <ReconciliationTable …/>` on a single line in
`app.prices.live.tsx`. Fixed here, since the file was being edited anyway.

### Checks

- 3523 unit tests, typecheck, lint and build pass.
- Mutation-tested three ways: a loose pager, the caption above the rows, and the card's
  rhythm inside the block each fail.

Part of #575.

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)