### PR TITLE
An empty state no longer stacks its room on the card's (#602)

### DIFF
--- a/app/components/AsyncState.tsx
+++ b/app/components/AsyncState.tsx
@@ -51,8 +51,15 @@ export function EmptyState({ title, description, action }: EmptyStateProps) {
     
        The measure stays. It is what stops the description running the width of a table,
        and it is the reason this was given a box in the first place; it just no longer
-       has to be centred to have one. */
-    <s-box paddingBlock={PAD.block} maxInlineSize={MEASURE}>
+       has to be centred to have one.
+
+       Padding at the **end** only. It used to be on both edges, so that the words "sit in
+       space that was obviously left for them" — right for a centred block floating in the
+       middle of a card, and wrong the moment it moved to the card's own left edge: `Card`
+       already puts a deliberate gap under its heading, and the two stacked into about
+       110px of nothing between two headings four words apart. Below is still the empty
+       state's own business, because nothing under it is being separated from anything. */
+    <s-box paddingBlockEnd={PAD.block} maxInlineSize={MEASURE}>
       <s-stack gap={SPACE.item}>
         <s-heading>{title}</s-heading>
         {description ? <Secondary>{description}</Secondary> : null}

--- a/app/components/empty-state.test.tsx
+++ b/app/components/empty-state.test.tsx
@@ -31,12 +31,16 @@ const render = (node: React.ReactElement) =>
   renderToStaticMarkup(<StaticRouter location="/app/prices">{node}</StaticRouter>);
 
 describe("an empty state is an answer, not a missing table", () => {
-  it("gives the words room, so it does not read as a render that failed", () => {
+  it("gives the words room below, and lets the card own the room above", () => {
     const html = render(<EmptyState title="No baselines captured yet" />);
 
     expect(html).toContain("No baselines captured yet");
-    // Block padding: the words have to sit in space that was obviously left for them.
-    expect(html).toMatch(/paddingblock="large-200"/i);
+    expect(html).toMatch(/paddingblockend="large-200"/i);
+    // Not both edges. `Card` already puts a deliberate gap under its heading — it is the
+    // only lever this app has for making a heading read as a title — and padding at the
+    // start too stacked the two into about 110px of nothing between two headings four
+    // words apart.
+    expect(html).not.toMatch(/paddingblock="/i);
   });
 
   it("sits on the card's own left edge rather than in the middle of it", () => {


### PR DESCRIPTION
#580 moved empty states from the middle of a card to its left edge, which was right. It
left a gap that was not.

`Card` puts a deliberate space under its heading — the only lever this app has for making a
heading read as a title (#578, #589) — and `EmptyState` separately padded **both** its own
edges, so the words would "sit in space that was obviously left for them". That was correct
for a centred block floating in the middle of a card. The moment it moved to the card's own
edge the two stacked: on Diagnostics the "Recent failures" heading and the empty state's
heading ended up about **110px apart with nothing between them**, four words of text either
side of it.

Padding at the end only. Below is still the empty state's own business, because nothing
under it is being separated from anything.

Found by opening the page after merging #580 — the third regression this epic has caught
that way, after #560 and the measure's `calc`.

- Mutation-tested: putting the padding back on both edges fails.

Part of #575.

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)