### PR TITLE
A row action is quiet when it reveals and bordered when it changes (#585)

### DIFF
--- a/app/components/ActionRow.tsx
+++ b/app/components/ActionRow.tsx
@@ -41,6 +41,21 @@ import { SPACE } from "../lib/ui/spacing";
  *   row would be more ink than the rows. The icon is what makes it a control rather than
  *   a caption, so it is not optional; `action-row.test.tsx` refuses one without.
  *
+ * ## Inside a table row
+ *
+ * The same four, with one extra question, because a table is scanned rather than read and
+ * whatever is in the last column is repeated on every row.
+ *
+ * **A row action is quiet when it only reveals, and bordered when it changes something.**
+ * Baselines' History opens a panel and closes it again, so it is tertiary; Duplicate makes
+ * a campaign, Revert writes a price, and the drift queue's three decide what happens to a
+ * price that moved — so those are secondary.
+ *
+ * That line was not being held: Price drift bordered its three from the start while the
+ * campaigns list left Duplicate as text, so two tables were following different rules for
+ * the same kind of control. `action-row.test.tsx` refuses a form submit inside a table
+ * cell that renders as text.
+ *
  * `s-button` takes an `href`, so a secondary button that navigates is still an anchor —
  * middle-click and "open in new tab" behave the way a merchant expects, whichever of
  * these it is.

--- a/app/components/action-row.test.tsx
+++ b/app/components/action-row.test.tsx
@@ -55,6 +55,26 @@ describe("the action vocabulary", () => {
     ).toEqual([]);
   });
 
+  it("does not leave a row action that changes something looking like text", () => {
+    // A table is scanned, not read, and whatever sits in the last column is repeated on
+    // every row. A row action is quiet when it only reveals — Baselines' History opens a
+    // panel and closes it again — and bordered when it changes state.
+    //
+    // Price drift bordered its three from the start while the campaigns list left
+    // Duplicate as text, so two tables were following different rules for the same kind
+    // of control.
+    const offenders = sources(APP).flatMap(({ path, text }) =>
+      [...text.matchAll(/<s-table-cell>[\s\S]*?<\/s-table-cell>/g)]
+        .filter((cell) => /<s-button[^>]*type="submit"[^>]*variant="tertiary"/s.test(cell[0]))
+        .map(() => path),
+    );
+
+    expect(
+      [...new Set(offenders)],
+      "a row action that submits changes something, so it is bordered",
+    ).toEqual([]);
+  });
+
   it("keeps a link for navigation rather than for actions", () => {
     // The other half of the rule. An `s-link` is content you read and then click, so it
     // goes somewhere; a link with no destination is a button wearing the wrong clothes.

--- a/app/components/campaign/CampaignListView.tsx
+++ b/app/components/campaign/CampaignListView.tsx
@@ -246,7 +246,13 @@ export function CampaignListView({
                         <fetcher.Form method="post">
                           <input type="hidden" name="intent" value="duplicate" />
                           <input type="hidden" name="campaignId" value={campaign.id} />
-                          <s-button type="submit" variant="tertiary" icon="duplicate">
+                          {/* Bordered, because it makes something. A row's action is
+                              quiet when it only reveals — Baselines' History opens a panel
+                              and closes it again — and bordered when it changes state, and
+                              duplicating creates a campaign. Price drift already bordered
+                              its three, so the two tables were following different rules
+                              for the same kind of control. */}
+                          <s-button type="submit" variant="secondary" icon="duplicate">
                             Duplicate
                           </s-button>
                         </fetcher.Form>

--- a/app/routes/app.settings.segments.tsx
+++ b/app/routes/app.settings.segments.tsx
@@ -216,7 +216,16 @@ export default function Segments() {
                       <fetcher.Form method="post">
                         <input type="hidden" name="intent" value="delete" />
                         <input type="hidden" name="segmentId" value={segment.id} />
-                        <s-button type="submit" tone="critical" variant="tertiary" icon="delete" loading={busy || undefined}>
+                        {/* Bordered, like every other row action that changes something.
+                            Deleting a segment is the most consequential thing this table
+                            does, and it was the quietest control on the page. */}
+                        <s-button
+                          type="submit"
+                          tone="critical"
+                          variant="secondary"
+                          icon="delete"
+                          loading={busy || undefined}
+                        >
                           Delete
                         </s-button>
                       </fetcher.Form>


### PR DESCRIPTION
Two tables were following different rules for the same kind of control. Price drift bordered
its three resolutions from the start; the campaigns list left **Duplicate** as text with an
icon, and Segments left **Delete** — the most consequential thing that table does — as the
quietest control on the page.

The rule, written into `ActionRow` beside the rest of the vocabulary: a table is scanned
rather than read, and whatever sits in the last column is repeated on every row, so the
question is what the action *does*.

| action | treatment | why |
| --- | --- | --- |
| Baselines' History | tertiary | opens a panel and closes it again |
| Duplicate | secondary | makes a campaign |
| Delete a segment | secondary | removes one |
| Revert this variant | secondary | writes a price |
| Drift's three | secondary | decide what happens to a price that moved |

`action-row.test.tsx` refuses a form submit inside a table cell that renders as text, which
is the shape both offenders had.

- 3524 unit tests, typecheck, lint and build pass.
- Mutation-tested: putting Duplicate back to tertiary fails.

Part of #575.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)