### PR TITLE
One rendering of "a value and what it is called" (#587)

### DIFF
--- a/app/components/Fact.tsx
+++ b/app/components/Fact.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+import { Caption } from "./Type";
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * A fact about this shop, with what it is called above it.
+ *
+ * "Last synced / 2 hours ago", "Plan / Free · campaigns up to 500 variants", "Oldest
+ * baseline captured / 12 August". The same shape was written out three ways — a stack
+ * with a subdued `s-text` above a plain one on Home, a bordered tile in `CountsRow`, and
+ * a third arrangement on the campaign page — so three parts of the app rendered "a value
+ * and what it is called" differently.
+ *
+ * ## The label goes above, not beside
+ *
+ * Beside, the two compete for the same line and the eye has to work out which is which —
+ * which is what two loose paragraphs did here before anything named this shape. Above,
+ * the caption is unambiguously subordinate to the thing under it, and a column of facts
+ * reads as a column.
+ *
+ * ## Why the value is not a component
+ *
+ * It is whatever it is: a date, a count, a sentence, a badge. Wrapping it would mean
+ * guessing, and the one thing that must be consistent — the caption — already is.
+ *
+ * ## What belongs in `detail`
+ *
+ * The line that qualifies the value rather than restating it: "Your whole catalogue is 0
+ * variants, so no campaign can reach the limit." It is tied to the fact rather than
+ * floating after it, which is what stops a card of facts reading as one long paragraph
+ * with occasional bold words.
+ */
+export function Fact({
+  label,
+  children,
+  detail,
+  action,
+}: {
+  /** What the value is called. */
+  label: string;
+  /** The value: a date, a count, a sentence, a badge. */
+  children: ReactNode;
+  /** One line qualifying the value, if it needs one. */
+  detail?: ReactNode;
+  /** Something to do about this fact, if there is anything. */
+  action?: ReactNode;
+}) {
+  return (
+    <s-stack gap={SPACE.tight}>
+      <Caption>{label}</Caption>
+      {children}
+      {detail ? <Caption>{detail}</Caption> : null}
+      {action}
+    </s-stack>
+  );
+}

--- a/app/lib/ui/fact.test.ts
+++ b/app/lib/ui/fact.test.ts
@@ -1,0 +1,75 @@
+/**
+ * "A value and what it is called" is rendered one way.
+ *
+ * It was three. Home's store card wrote a subdued `s-text` above a plain one and repeated
+ * the shape for each fact; `CountsRow` drew the same pair inside a bordered tile; and the
+ * campaign page arranged it a third way. Three parts of the app answering the same
+ * question differently is how a page stops looking like one app.
+ *
+ * The caption goes above the value rather than beside it. Beside, the two compete for one
+ * line and the eye has to work out which is which — which is exactly what two loose
+ * paragraphs did on Home before anything named this shape.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const APP = join(process.cwd(), "app");
+
+function sources(dir: string): Array<{ path: string; source: string }> {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [{ path: path.replace(`${APP}/`, ""), source: sourceOf(path) }];
+  });
+}
+
+describe("the labelled fact", () => {
+  const fact = sourceOf(join(APP, "components", "Fact.tsx"));
+
+  it("puts the caption above the value", () => {
+    const body = fact.slice(fact.indexOf("<s-stack"));
+
+    expect(body.indexOf("<Caption>{label}")).toBeLessThan(body.indexOf("{children}"));
+  });
+
+  it("uses the shared caption rank rather than its own grey", () => {
+    expect(fact).toContain('from "./Type"');
+    expect(fact).not.toContain('color="subdued"');
+  });
+
+  it("keeps the qualifying line tied to the fact rather than floating after it", () => {
+    expect(fact).toContain("{detail ?");
+  });
+});
+
+describe("nobody writes it out by hand", () => {
+  /**
+   * The shape being refused: a stack whose first child is a subdued `s-text` and whose
+   * second is a plain one. That is `Fact`, and writing it out is how the third rendering
+   * of it appears.
+   */
+  const HAND_ROLLED =
+    /<s-stack gap=\{SPACE\.tight\}>\s*<s-text color="subdued">[^<]*<\/s-text>\s*<s-text[ >]/;
+
+  it("finds the files, so this cannot pass by checking nothing", () => {
+    expect(sources(APP).length).toBeGreaterThanOrEqual(40);
+  });
+
+  it("holds across the app", () => {
+    const offenders = sources(APP)
+      .filter(({ path }) => path !== "components/Fact.tsx")
+      .filter(({ source }) => HAND_ROLLED.test(source.replace(/\n\s*/g, "\n")))
+      .map(({ path }) => path);
+
+    expect(
+      offenders,
+      "a subdued label above a value is a `Fact` — writing it out is how the third rendering appears",
+    ).toEqual([]);
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -35,6 +35,7 @@ import { planUsage } from "../services/plan-usage.server";
 import { usageLine } from "../lib/billing/usage-line";
 import { Secondary } from "../components/Type";
 import { Card } from "../components/Card";
+import { Fact } from "../components/Fact";
 
 export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -707,14 +708,13 @@ export default function Dashboard() {
               box can take is a near-white grey, so at 100% — which is where a healthy
               shop lives — a full bar and an empty one were the same picture. The two
               tiles above are the same fact, unambiguously. */}
-          <s-stack gap={SPACE.tight}>
-            <s-text color="subdued">Oldest baseline captured</s-text>
+          <Fact label="Oldest baseline captured">
             <s-text>
               {health.oldestCapturedAt
                 ? formatDay(health.oldestCapturedAt, timeZone)
                 : "None captured"}
             </s-text>
-          </s-stack>
+          </Fact>
 
           {health.withBaseline > health.variants ? (
             <Secondary>
@@ -746,13 +746,9 @@ export default function Dashboard() {
             <s-text type="strong">{shopDomain}</s-text>
           </s-grid>
 
-          {/* Label above value, the same shape as a stat tile without the box. Two loose
-              paragraphs said the same words and left the reader to work out which of them
-              was the label. */}
-          <s-stack gap={SPACE.tight}>
-            <s-text color="subdued">Last synced</s-text>
+          <Fact label="Last synced">
             <s-text>{syncedAt ? formatAgo(syncedAt, now, timeZone) : "Not yet synced"}</s-text>
-          </s-stack>
+          </Fact>
 
           {/* The plan, and what it covers, before it ever refuses anything.
               
@@ -761,18 +757,16 @@ export default function Dashboard() {
               worst moment, and the one where it reads as a fault rather than as a plan.
               It sits in the store card because it is a fact about this shop, which is the
               only thing this column is for. */}
-          <s-stack gap={SPACE.tight}>
-            <s-text color="subdued">Plan</s-text>
+          <Fact
+            label="Plan"
+            detail={usage.detail}
+            /* A link. It sits under the sentence about the plan, inside a card of facts
+               rather than in a row of actions, so it is read rather than looked for — and
+               as plain dark text it was indistinguishable from the sentence above it. */
+            action={<s-link href="/app/settings/plan">See plans</s-link>}
+          >
             <s-text type={usage.attention ? "strong" : undefined}>{usage.headline}</s-text>
-            <s-text color="subdued">{usage.detail}</s-text>
-            <ActionRow>
-              {/* A link. It sits under the sentence about the plan, inside a card of
-                  facts rather than in a row of actions, so it is read rather than looked
-                  for — and as plain dark text it was indistinguishable from the sentence
-                  above it. */}
-              <s-link href="/app/settings/plan">See plans</s-link>
-            </ActionRow>
-          </s-stack>
+          </Fact>
 
           {/* The action belongs with the fact it acts on. It used to sit in the catalogue
               card, two columns away from the sentence saying how stale the catalogue


### PR DESCRIPTION
There were three. Home's store card wrote a subdued `s-text` above a plain one and repeated
the shape per fact; `CountsRow` drew the same pair inside a bordered tile; the campaign page
arranged it a third way. Three parts of the app answering the same question differently is
how a page stops looking like one app.

`Fact` now, and Home's three — last synced, plan, oldest baseline captured — use it. **The
caption goes above the value**, not beside it: beside, the two compete for one line and the
eye has to work out which is which, which is exactly what two loose paragraphs did here
before anything named the shape.

Two things it deliberately does not do:

- **The value is not a component.** It is a date, a count, a sentence or a badge, and
  wrapping it would mean guessing.
- **The caption uses the shared `Caption` rank** from `Type` rather than choosing its own
  grey, so there is still exactly one decision about what subdued means.

`detail` is for the line that qualifies a value rather than restating it — "Your whole
catalogue is 0 variants, so no campaign can reach the limit." Tied to its fact instead of
floating after it, which is what stopped the store card reading as one long paragraph with
occasional bold words.

`CountsRow` keeps its own arrangement and is not covered by the guard: a tile is a fact with
a border and a figure sized to be read across a row, which is a different job from a line in
a column. Said out loud rather than left as an inconsistency somebody has to rediscover.

- Mutation-tested: hand-rolling the shape again, and putting the caption below the value,
  each fail.

Part of #575.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)