### PR TITLE
One grid for the whole checklist, so its columns are columns (#586)

### DIFF
--- a/app/components/Fact.tsx
+++ b/app/components/Fact.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+import { Caption } from "./Type";
+import { SPACE } from "../lib/ui/spacing";
+
+/**
+ * A fact about this shop, with what it is called above it.
+ *
+ * "Last synced / 2 hours ago", "Plan / Free · campaigns up to 500 variants", "Oldest
+ * baseline captured / 12 August". The same shape was written out three ways — a stack
+ * with a subdued `s-text` above a plain one on Home, a bordered tile in `CountsRow`, and
+ * a third arrangement on the campaign page — so three parts of the app rendered "a value
+ * and what it is called" differently.
+ *
+ * ## The label goes above, not beside
+ *
+ * Beside, the two compete for the same line and the eye has to work out which is which —
+ * which is what two loose paragraphs did here before anything named this shape. Above,
+ * the caption is unambiguously subordinate to the thing under it, and a column of facts
+ * reads as a column.
+ *
+ * ## Why the value is not a component
+ *
+ * It is whatever it is: a date, a count, a sentence, a badge. Wrapping it would mean
+ * guessing, and the one thing that must be consistent — the caption — already is.
+ *
+ * ## What belongs in `detail`
+ *
+ * The line that qualifies the value rather than restating it: "Your whole catalogue is 0
+ * variants, so no campaign can reach the limit." It is tied to the fact rather than
+ * floating after it, which is what stops a card of facts reading as one long paragraph
+ * with occasional bold words.
+ */
+export function Fact({
+  label,
+  children,
+  detail,
+  action,
+}: {
+  /** What the value is called. */
+  label: string;
+  /** The value: a date, a count, a sentence, a badge. */
+  children: ReactNode;
+  /** One line qualifying the value, if it needs one. */
+  detail?: ReactNode;
+  /** Something to do about this fact, if there is anything. */
+  action?: ReactNode;
+}) {
+  return (
+    <s-stack gap={SPACE.tight}>
+      <Caption>{label}</Caption>
+      {children}
+      {detail ? <Caption>{detail}</Caption> : null}
+      {action}
+    </s-stack>
+  );
+}

--- a/app/components/OnboardingCard.test.tsx
+++ b/app/components/OnboardingCard.test.tsx
@@ -163,6 +163,25 @@ describe("the checklist reads as a list", () => {
     expect(html).toMatch(/gridtemplatecolumns="[^"]*auto 1fr auto auto"/i);
   });
 
+  it("puts every row in one grid, because columns only line up inside one", () => {
+    // Giving "Why?" its own column was necessary and not sufficient. Each step used to
+    // render its own grid, so on the deployed build the three "Why?" controls still sat
+    // at 608, 510 and 504 and the three buttons' left edges at 721, 626 and 621.
+    // `UpcomingCampaigns` records the same lesson: one grid for every row, not a grid
+    // per row.
+    expect(html.match(/<s-grid[ >]/g) ?? []).toHaveLength(1);
+  });
+
+  it("spans the row with the things that belong to the whole step", () => {
+    // The rule between steps and the opened explanation are about the step, not about
+    // the column they sit under.
+    const open = renderToStaticMarkup(
+      <OnboardingCard state={onboarding({ ...fresh, hasBaselines: true })} actions={{ sync: SYNC }} />,
+    );
+
+    expect(open).toMatch(/gridcolumn="span 4"/i);
+  });
+
   it("does not put them back in one cell", () => {
     // The shape that caused it: both inside a single `ActionRow`. One `ActionRow` per row
     // is still right — it holds the action — but "Why?" is outside it.

--- a/app/components/OnboardingCard.tsx
+++ b/app/components/OnboardingCard.tsx
@@ -84,21 +84,37 @@ export function OnboardingCard({
           <s-text color="subdued">Nothing here changes a price until you apply one.</s-text>
         </s-stack>
 
-        <s-stack gap={SPACE.item}>
+        {/* One grid for every row, not a grid per row.
+
+            `UpcomingCampaigns` records this exact lesson and it had not been applied here:
+            "Columns sized per row would place each campaign's name wherever its own badge
+            happened to end — and three names at three different distances from the edge
+            read as three unrelated things rather than as a list."
+
+            Giving "Why?" its own column was necessary and not sufficient. A grid's columns
+            only line up *within one grid*, and each step was rendering its own — so on the
+            deployed build the three "Why?" controls still sat at 608, 510 and 504, and the
+            three buttons' left edges at 721, 626 and 621. One grid is what makes a column
+            a column.
+
+            Four columns: the status glyph, the title, the disclosure, the action. Each
+            step contributes exactly four cells, and the two things that span the row —
+            the rule between steps and the opened explanation — say so. */}
+        <s-grid
+          gridTemplateColumns="@container (inline-size <= 500px) auto 1fr, auto 1fr auto auto"
+          gap={SPACE.item}
+          alignItems="center"
+        >
           {state.steps.map((step, index) => (
-            <s-stack key={step.id} gap={SPACE.item}>
-              {/* A rule between steps rather than a border around each. The separator is
-                  the same information as the box — where one step stops — at a fraction
-                  of the ink, and it does not nest a card inside a card. */}
-              {index > 0 ? <s-divider /> : null}
-              <Step
-                step={step}
-                isNext={step.id === state.next?.id}
-                action={actions?.[step.id]}
-              />
-            </s-stack>
+            <Step
+              key={step.id}
+              step={step}
+              isNext={step.id === state.next?.id}
+              action={actions?.[step.id]}
+              divided={index > 0}
+            />
           ))}
-        </s-stack>
+        </s-grid>
       </s-stack>
     </Card>
   );
@@ -126,95 +142,90 @@ function Step({
   step,
   isNext,
   action,
+  divided,
 }: {
   step: OnboardingStep;
   isNext: boolean;
   action?: ReactNode;
+  /** A rule above this step, for every row but the first. */
+  divided: boolean;
 }) {
   const [why, setWhy] = useState(false);
 
   return (
-    <s-stack gap={SPACE.tight}>
-      <s-grid
-        // Three columns, collapsing to two. `auto 1fr auto` keeps the status glyph and
-        // the action tight to their content and gives the title everything left over,
-        // which is what stops the row from breaking into three.
-        //
-        // One comma only. Polaris splits a responsive value on the comma to separate
-        // "when the query matches" from "otherwise", so a second one anywhere in the
-        // value stops the whole thing parsing and it falls back to `none`.
-        // Four columns, not three. "Why?" and the action shared one cell, and a cell
-        // sized `auto` is as wide as its contents — so where "Why?" landed depended on how
-        // wide *that row's* button happened to be. On the deployed build the three sat at
-        // three different x positions about a hundred pixels apart, and the eye read three
-        // ragged rows rather than a list.
-        //
-        // A column each fixes both halves: "Why?" lines up down the card, and the actions
-        // share an edge because they share a column.
-        //
-        // One comma only. Polaris splits a responsive value on the comma to separate
-        // "when the query matches" from "otherwise", so a second one anywhere in the
-        // value stops the whole thing parsing and it falls back to `none`.
-        gridTemplateColumns="@container (inline-size <= 500px) auto 1fr, auto 1fr auto auto"
-        gap={SPACE.item}
-        alignItems="center"
-      >
-        <StatusIcon done={step.done} isNext={isNext} />
+    <>
+      {/* A rule between steps rather than a border around each. The separator is the same
+          information as the box — where one step stops — at a fraction of the ink, and it
+          does not nest a card inside a card. Spanning the row, because it separates whole
+          steps rather than one column of them. */}
+      {divided ? (
+        <s-grid-item gridColumn="span 4">
+          <s-divider />
+        </s-grid-item>
+      ) : null}
 
-        <s-stack direction="inline" gap={SPACE.item} alignItems="center">
-          {/* Subdued once done. A finished step should still be findable — it is the
-              evidence the checklist is being honest — without competing with the step
-              the merchant is actually being asked to do. */}
-          <s-text type={step.done ? undefined : "strong"} color={step.done ? "subdued" : undefined}>
-            {step.title}
-          </s-text>
-          {isNext ? <s-badge tone="info">Next</s-badge> : null}
-        </s-stack>
+      <StatusIcon done={step.done} isNext={isNext} />
 
-        {/* Its own column, and before the action deliberately: when the row wraps it is
-            the action that should fall to the next line, not the explanation, which would
-            then read as belonging to the step below it.
+      <s-stack direction="inline" gap={SPACE.item} alignItems="center">
+        {/* Subdued once done. A finished step should still be findable — it is the
+            evidence the checklist is being honest — without competing with the step the
+            merchant is actually being asked to do. */}
+        <s-text type={step.done ? undefined : "strong"} color={step.done ? "subdued" : undefined}>
+          {step.title}
+        </s-text>
+        {isNext ? <s-badge tone="info">Next</s-badge> : null}
+      </s-stack>
 
-            Not on a finished step: the reasoning for work already done is the one thing on
-            this card nobody needs.
+      {/* Its own column, and before the action deliberately: when the row wraps it is the
+          action that should fall to the next line, not the explanation, which would then
+          read as belonging to the step below it.
 
-            An icon on the toggle, because a tertiary control is text with no border and
-            "Why?" beside a real button read as a caption for it. The same question mark
-            `HelpNote` uses, so the two say "this is help" the same way. */}
-        {step.done ? null : (
-          <s-button
-            variant="tertiary"
-            icon="question-circle"
-            onClick={() => setWhy((open) => !open)}
-          >
-            {why ? "Hide why" : "Why?"}
+          Not on a finished step: the reasoning for work already done is the one thing on
+          this card nobody needs.
+
+          An icon on the toggle, because a tertiary control is text with no border and
+          "Why?" beside a real button read as a caption for it. The same question mark
+          `HelpNote` uses, so the two say "this is help" the same way. */}
+      {step.done ? (
+        <s-box />
+      ) : (
+        <s-button
+          variant="tertiary"
+          icon="question-circle"
+          onClick={() => setWhy((open) => !open)}
+        >
+          {why ? "Hide why" : "Why?"}
+        </s-button>
+      )}
+
+      <ActionRow>
+        {/* Black on the step being asked for, bordered on the ones after it. A checklist
+            whose every row shouts equally is a checklist that has not said what to do
+            next — which is the only thing it is for. See `ActionRow` for the vocabulary.
+
+            The page's own control wins where it supplied one. A finished step keeps none
+            either way: `onboarding()` drops the href and the label once a step is done,
+            and a page that hands over a form has to do the same or the checklist would
+            offer to redo work it has just ticked off. */}
+        {step.done ? null : action}
+        {!action && step.href && step.cta ? (
+          <s-button href={step.href} variant={isNext ? "primary" : "secondary"}>
+            {step.cta}
           </s-button>
-        )}
-
-        <ActionRow>
-          {/* Black on the step being asked for, bordered on the ones after it. A
-              checklist whose every row shouts equally is a checklist that has not said
-              what to do next — which is the only thing it is for. See `ActionRow` for
-              the vocabulary. */}
-          {/* The page's own control wins where it supplied one. A finished step keeps
-              none either way: `onboarding()` drops the href and the label once a step is
-              done, and a page that hands over a form has to do the same or the checklist
-              would offer to redo work it has just ticked off. */}
-          {step.done ? null : action}
-          {!action && step.href && step.cta ? (
-            <s-button href={step.href} variant={isNext ? "primary" : "secondary"}>
-              {step.cta}
-            </s-button>
-          ) : null}
-        </ActionRow>
-      </s-grid>
+        ) : null}
+      </ActionRow>
 
       {/* Progressive disclosure, not a link away. The reasoning belongs next to the step
           it explains — sending a merchant to a docs page to find out why they are being
-          asked to sync is how they end up not syncing. */}
+          asked to sync is how they end up not syncing.
+
+          Spanning the row: it explains the whole step, not the column it opened from. */}
       {why ? (
-        <Secondary>{step.detail}</Secondary>
+        <s-grid-item gridColumn="span 4">
+          <Secondary>{step.detail}</Secondary>
+        </s-grid-item>
       ) : null}
-    </s-stack>
+    </>
   );
 }
+

--- a/app/lib/ui/fact.test.ts
+++ b/app/lib/ui/fact.test.ts
@@ -1,0 +1,75 @@
+/**
+ * "A value and what it is called" is rendered one way.
+ *
+ * It was three. Home's store card wrote a subdued `s-text` above a plain one and repeated
+ * the shape for each fact; `CountsRow` drew the same pair inside a bordered tile; and the
+ * campaign page arranged it a third way. Three parts of the app answering the same
+ * question differently is how a page stops looking like one app.
+ *
+ * The caption goes above the value rather than beside it. Beside, the two compete for one
+ * line and the eye has to work out which is which — which is exactly what two loose
+ * paragraphs did on Home before anything named this shape.
+ */
+
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { sourceOf } from "../testing/source";
+
+const APP = join(process.cwd(), "app");
+
+function sources(dir: string): Array<{ path: string; source: string }> {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sources(path);
+    if (!entry.name.endsWith(".tsx") || entry.name.includes(".test.")) return [];
+    return [{ path: path.replace(`${APP}/`, ""), source: sourceOf(path) }];
+  });
+}
+
+describe("the labelled fact", () => {
+  const fact = sourceOf(join(APP, "components", "Fact.tsx"));
+
+  it("puts the caption above the value", () => {
+    const body = fact.slice(fact.indexOf("<s-stack"));
+
+    expect(body.indexOf("<Caption>{label}")).toBeLessThan(body.indexOf("{children}"));
+  });
+
+  it("uses the shared caption rank rather than its own grey", () => {
+    expect(fact).toContain('from "./Type"');
+    expect(fact).not.toContain('color="subdued"');
+  });
+
+  it("keeps the qualifying line tied to the fact rather than floating after it", () => {
+    expect(fact).toContain("{detail ?");
+  });
+});
+
+describe("nobody writes it out by hand", () => {
+  /**
+   * The shape being refused: a stack whose first child is a subdued `s-text` and whose
+   * second is a plain one. That is `Fact`, and writing it out is how the third rendering
+   * of it appears.
+   */
+  const HAND_ROLLED =
+    /<s-stack gap=\{SPACE\.tight\}>\s*<s-text color="subdued">[^<]*<\/s-text>\s*<s-text[ >]/;
+
+  it("finds the files, so this cannot pass by checking nothing", () => {
+    expect(sources(APP).length).toBeGreaterThanOrEqual(40);
+  });
+
+  it("holds across the app", () => {
+    const offenders = sources(APP)
+      .filter(({ path }) => path !== "components/Fact.tsx")
+      .filter(({ source }) => HAND_ROLLED.test(source.replace(/\n\s*/g, "\n")))
+      .map(({ path }) => path);
+
+    expect(
+      offenders,
+      "a subdued label above a value is a `Fact` — writing it out is how the third rendering appears",
+    ).toEqual([]);
+  });
+});

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -35,6 +35,7 @@ import { planUsage } from "../services/plan-usage.server";
 import { usageLine } from "../lib/billing/usage-line";
 import { Secondary } from "../components/Type";
 import { Card } from "../components/Card";
+import { Fact } from "../components/Fact";
 
 export const loader = withGuard("/app", async ({ request }: LoaderFunctionArgs) => {
   const { session } = await authenticate.admin(request);
@@ -707,14 +708,13 @@ export default function Dashboard() {
               box can take is a near-white grey, so at 100% — which is where a healthy
               shop lives — a full bar and an empty one were the same picture. The two
               tiles above are the same fact, unambiguously. */}
-          <s-stack gap={SPACE.tight}>
-            <s-text color="subdued">Oldest baseline captured</s-text>
+          <Fact label="Oldest baseline captured">
             <s-text>
               {health.oldestCapturedAt
                 ? formatDay(health.oldestCapturedAt, timeZone)
                 : "None captured"}
             </s-text>
-          </s-stack>
+          </Fact>
 
           {health.withBaseline > health.variants ? (
             <Secondary>
@@ -746,13 +746,9 @@ export default function Dashboard() {
             <s-text type="strong">{shopDomain}</s-text>
           </s-grid>
 
-          {/* Label above value, the same shape as a stat tile without the box. Two loose
-              paragraphs said the same words and left the reader to work out which of them
-              was the label. */}
-          <s-stack gap={SPACE.tight}>
-            <s-text color="subdued">Last synced</s-text>
+          <Fact label="Last synced">
             <s-text>{syncedAt ? formatAgo(syncedAt, now, timeZone) : "Not yet synced"}</s-text>
-          </s-stack>
+          </Fact>
 
           {/* The plan, and what it covers, before it ever refuses anything.
               
@@ -761,18 +757,16 @@ export default function Dashboard() {
               worst moment, and the one where it reads as a fault rather than as a plan.
               It sits in the store card because it is a fact about this shop, which is the
               only thing this column is for. */}
-          <s-stack gap={SPACE.tight}>
-            <s-text color="subdued">Plan</s-text>
+          <Fact
+            label="Plan"
+            detail={usage.detail}
+            /* A link. It sits under the sentence about the plan, inside a card of facts
+               rather than in a row of actions, so it is read rather than looked for — and
+               as plain dark text it was indistinguishable from the sentence above it. */
+            action={<s-link href="/app/settings/plan">See plans</s-link>}
+          >
             <s-text type={usage.attention ? "strong" : undefined}>{usage.headline}</s-text>
-            <s-text color="subdued">{usage.detail}</s-text>
-            <ActionRow>
-              {/* A link. It sits under the sentence about the plan, inside a card of
-                  facts rather than in a row of actions, so it is read rather than looked
-                  for — and as plain dark text it was indistinguishable from the sentence
-                  above it. */}
-              <s-link href="/app/settings/plan">See plans</s-link>
-            </ActionRow>
-          </s-stack>
+          </Fact>
 
           {/* The action belongs with the fact it acts on. It used to sit in the catalogue
               card, two columns away from the sentence saying how stale the catalogue


### PR DESCRIPTION
#582 gave "Why?" its own column, which was **necessary and not sufficient**: a grid's
columns only line up *within one grid*, and each step was rendering its own. On the deployed
build afterwards the three "Why?" controls still sat at 608, 510 and 504, and the three
buttons' left edges at 721, 626 and 621. Only their right edges agreed, because each row's
last column happened to end at the card's edge.

`UpcomingCampaigns` records this exact lesson and it had not been applied here:

> Columns sized per row would place each campaign's name wherever its own badge happened to
> end — and three names at three different distances from the edge read as three unrelated
> things rather than as a list.

One grid, four columns, each step contributing four cells. The two things that belong to a
whole step rather than to one column of it — the rule between steps and the opened
explanation — span the row and say so.

### The rest of #586 turned out not to be work

- **Costs' pair.** "Check without changing" is black and "Change these costs" is
  critical-toned because one is safe and one writes prices, with the dry run as the default.
  Two treatments because they are two different things — the point rather than a mistake.
- **Button-versus-field heights.** Polaris' own: `ButtonProps` has `variant`, `tone`, `icon`,
  `inlineSize` and `disabled`, and no size, so there is no API through which to match them.
  Recorded on #581 when that ticket was closed as not-a-bug.

- 3538 unit tests, typecheck, lint and build pass.
- Mutation-tested: going back to a grid per row fails.

Part of #575. Stacked on #606.

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)